### PR TITLE
WFLY-789 BZ913117 - making usage of aio in transactions configurable and disabled by default

### DIFF
--- a/build/src/main/resources/configuration/subsystems/transactions.xml
+++ b/build/src/main/resources/configuration/subsystems/transactions.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.transactions</extension-module>
-   <subsystem xmlns="urn:jboss:domain:transactions:1.3">
+   <subsystem xmlns="urn:jboss:domain:transactions:2.0">
        <core-environment>
            <process-id>
                <uuid/>

--- a/build/src/main/resources/docs/schema/jboss-as-txn_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-txn_2_0.xsd
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:jboss:domain:transactions:2.0"
+            xmlns="urn:jboss:domain:transactions:2.0"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.0">
+
+    <!-- The transaction subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The configuration of the transactions subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="core-environment" type="core-environment" maxOccurs="1"/>
+            <xs:element name="recovery-environment" type="recovery-environment" maxOccurs="1"/>
+            <xs:element name="coordinator-environment" type="coordinator-environment" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="object-store" type="object-store" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="jts" type="jts-Type" minOccurs="0" maxOccurs="1"/>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="use-hornetq-store" type="use-hornetq-store-Type" minOccurs="0" maxOccurs="1"/>
+                <xs:element name="jdbc-store" type="jdbc-store-Type" minOccurs="0" maxOccurs="1"/>
+            </xs:choice>
+        </xs:sequence>
+
+
+    </xs:complexType>
+
+    <xs:complexType name="recovery-environment">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The recovery environment configuration.
+
+                The "socket-binding" attribute is used to reference the correct socket binding to use for the
+                recovery environment.
+                The "status-socket-binding" attribute is used to reference the correct socket binding to use for the
+                transaction status manager.
+                The "recovery-listener" attribute sets if recovery system should listen on a network socket or not.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="socket-binding" type="xs:string" />
+        <xs:attribute name="status-socket-binding" type="xs:string" />
+        <xs:attribute name="recovery-listener" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="core-environment">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The core environment configuration.
+
+                The process-id element specifies the process id implemention.
+                The "node-identifier" attribute is used to set the node identifier on the core environment.
+
+                The "path" attribute denotes a relative or absolute filesystem path denoting where the transaction
+                manager core should store data.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="process-id" type="process-id" />
+        </xs:all>
+        <xs:attribute name="node-identifier" type="xs:string" default="1"/>
+        <xs:attribute name="path" type="xs:string" default="var"/>
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir"/>
+    </xs:complexType>
+    <xs:complexType name="process-id">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The process identifer implementation
+                The "node-identifier" attribute is used to set the node identifier on the core environment.
+                The "socket-process-id-max-ports" attribute is used to set the max ports on the core environment.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="uuid" type="uuid" />
+            <xs:element name="socket" type="socket-id" />
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="uuid">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The UUID based process identifer implementation
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+    <xs:complexType name="socket-id">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The socket based process identifer implementation
+                The "socket-binding" attribute is used to specify the port to bind to.
+                The "socket-process-id-max-ports" attribute is used to set the max ports on the core environment.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="socket-binding" type="xs:string" use="required"/>
+        <xs:attribute name="socket-process-id-max-ports" type="xs:int" default="10" />
+    </xs:complexType>
+
+    <xs:attribute name="socket-process-id-max-ports" type="xs:int" default="10" />
+
+    <xs:complexType name="coordinator-environment">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The coordinator environment configuration.
+                enable-statistics - if recording of transaction statistics is enabled, false otherwise.
+                enable-tsm-status - if the transaction status manager (TSM) service, needed for out of process recovery, should be provided or not.
+                default-timeout - the default transaction lifetime, in seconds.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="enable-statistics" type="xs:boolean" default="false"/>
+        <xs:attribute name="enable-tsm-status" type="xs:boolean" default="false"/>
+        <xs:attribute name="default-timeout" type="xs:int" default="300" />
+    </xs:complexType>
+
+    <xs:complexType name="object-store">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The object store configuration.
+
+                The "path" attribute denotes a relative or absolute filesystem path denoting where the transaction
+                manager object store should store data.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="path" type="xs:string" default="tx-object-store"/>
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir" />
+    </xs:complexType>
+
+    <xs:complexType name="jts-Type">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The flag to enable JTS.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+    </xs:complexType>
+
+    <xs:complexType name="use-hornetq-store-Type">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                The flag to enable the hornetq transaction log store.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="enable-async-io" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Enable AsyncIO for the hornetq transaction log store.
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jdbc-store-Type">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                        The presence of this tag enable the jdbc transaction log store.
+                    ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="action" type="jdbc-store-settings-Type" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                             Configure jdbc store for default action store. If not present defaults are used.
+                                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="communication" type="jdbc-store-settings-Type" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Configure jdbc store for communication store. If not present defaults are used.
+                                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="state" type="jdbc-store-settings-Type" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                           Configure jdbc store for state store. If not present defaults are used.
+                                ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="datasource-jndi-name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Configure datasource jndi used to connect for jdbc store
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="jdbc-store-settings-Type">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                            Settings for jdbc store
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+            <xs:attribute name="table-prefix" type="xs:string" use="optional" />
+            <xs:attribute name="drop-table" type="xs:boolean" use="optional" default="false"/>
+        </xs:complexType>
+
+</xs:schema>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
@@ -392,9 +392,14 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
                 }
             }
         } else if (address.size() > 0 && "transactions".equals(address.getLastElement().getValue())
-                &&  "subsystem".equals(address.getLastElement().getKey()) && attrName.contains("jdbc")) {
-            // Ignore jdbc store attributes unless the store is enabled
-            return !resourceNoDefaults.hasDefined("use-jdbc-store") || !resourceNoDefaults.get("use-jdbc-store").asBoolean();
+                &&  "subsystem".equals(address.getLastElement().getKey())) {
+            if (attrName.contains("jdbc")) {
+                // Ignore jdbc store attributes unless jdbc store is enabled
+                return !resourceNoDefaults.hasDefined("use-jdbc-store") || !resourceNoDefaults.get("use-jdbc-store").asBoolean();
+            } else if (attrName.contains("hornetq")) {
+                // Ignore hornetq store attributes unless hornetq store is enabled
+                return !resourceNoDefaults.hasDefined("use-hornetq-store") || !resourceNoDefaults.get("use-hornetq-store").asBoolean();
+            }
         }
 
         return false;

--- a/transactions/src/main/java/org/jboss/as/txn/service/ArjunaObjectStoreEnvironmentService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/ArjunaObjectStoreEnvironmentService.java
@@ -45,6 +45,7 @@ public class ArjunaObjectStoreEnvironmentService implements Service<Void> {
 
     private final InjectedValue<PathManager> pathManagerInjector = new InjectedValue<PathManager>();
     private final boolean useHornetqJournalStore;
+    private final boolean enableAsyncIO;
     private final String path;
     private final String pathRef;
 
@@ -54,8 +55,9 @@ public class ArjunaObjectStoreEnvironmentService implements Service<Void> {
 
     private volatile PathManager.Callback.Handle callbackHandle;
 
-    public ArjunaObjectStoreEnvironmentService(final boolean useHornetqJournalStore, final String path, final String pathRef, final boolean useJdbcStore, final String dataSourceJndiName, final JdbcStoreConfig jdbcSoreConfig) {
+    public ArjunaObjectStoreEnvironmentService(final boolean useHornetqJournalStore, final boolean enableAsyncIO, final String path, final String pathRef, final boolean useJdbcStore, final String dataSourceJndiName, final JdbcStoreConfig jdbcSoreConfig) {
         this.useHornetqJournalStore = useHornetqJournalStore;
+        this.enableAsyncIO = enableAsyncIO;
         this.path = path;
         this.pathRef = pathRef;
         this.useJdbcStore = useJdbcStore;
@@ -81,6 +83,7 @@ public class ArjunaObjectStoreEnvironmentService implements Service<Void> {
             HornetqJournalEnvironmentBean hornetqJournalEnvironmentBean = BeanPopulator.getDefaultInstance(
                     com.arjuna.ats.internal.arjuna.objectstore.hornetq.HornetqJournalEnvironmentBean.class
             );
+            hornetqJournalEnvironmentBean.setAsyncIO(enableAsyncIO);
             hornetqJournalEnvironmentBean.setStoreDir(objectStoreDir+"/HornetqObjectStore");
             defaultActionStoreObjectStoreEnvironmentBean.setObjectStoreType(
                     "com.arjuna.ats.internal.arjuna.objectstore.hornetq.HornetqObjectStoreAdaptor"

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/Attribute.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/Attribute.java
@@ -46,6 +46,7 @@ enum Attribute {
     DATASOURCE_JNDI_NAME("datasource-jndi-name"),
     TABLE_PREFIX("table-prefix"),
     DROP_TABLE("drop-table"),
+    ENABLE_ASYNC_IO("enable-async-io"),
     ;
     private final String name;
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/CommonAttributes.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/CommonAttributes.java
@@ -42,6 +42,7 @@ interface CommonAttributes {
 
     String JTS = "jts";
     String USEHORNETQSTORE = "use-hornetq-store";
+    String HORNETQ_STORE_ENABLE_ASYNC_IO = "hornetq-store-enable-async-io";
     String USE_JDBC_STORE = "use-jdbc-store";
     String JDBC_STORE_DATASOURCE = "jdbc-store-datasource";
     String JDBC_ACTION_STORE_TABLE_PREFIX = "jdbc-action-store-table-prefix";

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionParticipantDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreTransactionParticipantDefinition.java
@@ -41,7 +41,7 @@ public class LogStoreTransactionParticipantDefinition extends SimpleResourceDefi
     static final LogStoreTransactionParticipantDefinition INSTANCE = new LogStoreTransactionParticipantDefinition();
 
     private LogStoreTransactionParticipantDefinition() {
-        super(TransactionExtension.PARTECIPANT_PATH,
+        super(TransactionExtension.PARTICIPANT_PATH,
                 TransactionExtension.getResourceDescriptionResolver(LogStoreConstants.LOG_STORE, CommonAttributes.TRANSACTION, CommonAttributes.PARTICIPANT));
     }
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/Namespace.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/Namespace.java
@@ -37,13 +37,14 @@ enum Namespace {
     TRANSACTIONS_1_0("urn:jboss:domain:transactions:1.0"),
     TRANSACTIONS_1_1("urn:jboss:domain:transactions:1.1"),
     TRANSACTIONS_1_2("urn:jboss:domain:transactions:1.2"),
-    TRANSACTIONS_1_3("urn:jboss:domain:transactions:1.3")
+    TRANSACTIONS_1_3("urn:jboss:domain:transactions:1.3"),
+    TRANSACTIONS_2_0("urn:jboss:domain:transactions:2.0")
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = TRANSACTIONS_1_3;
+    public static final Namespace CURRENT = TRANSACTIONS_2_0;
 
     private final String name;
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem20Parser.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem20Parser.java
@@ -1,0 +1,451 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.txn.subsystem;
+
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.parsing.ParseUtils.duplicateNamedElement;
+import static org.jboss.as.controller.parsing.ParseUtils.missingOneOf;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
+import static org.jboss.as.controller.parsing.ParseUtils.missingRequiredElement;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
+import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
+import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+
+/**
+ * The {@link XMLElementReader} that handles the Transaction subsystem.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+class TransactionSubsystem20Parser implements XMLStreamConstants, XMLElementReader<List<ModelNode>> {
+
+    public static final TransactionSubsystem20Parser INSTANCE = new TransactionSubsystem20Parser();
+
+    private TransactionSubsystem20Parser() {
+
+    }
+
+    protected boolean choiceObjectStoreEncountered;
+
+    protected Namespace getExpectedNamespace() {
+        return Namespace.TRANSACTIONS_2_0;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readElement(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
+        // no attributes
+        if (reader.getAttributeCount() > 0) {
+            throw unexpectedAttribute(reader, 0);
+        }
+
+        final ModelNode address = new ModelNode();
+        address.add(ModelDescriptionConstants.SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME);
+        address.protect();
+
+        final ModelNode subsystem = new ModelNode();
+        subsystem.get(OP).set(ADD);
+        subsystem.get(OP_ADDR).set(address);
+
+        list.add(subsystem);
+        final ModelNode logStoreAddress = address.clone();
+        final ModelNode logStoreOperation = new ModelNode();
+        logStoreOperation.get(OP).set(ADD);
+        logStoreAddress.add(LogStoreConstants.LOG_STORE, LogStoreConstants.LOG_STORE);
+
+        logStoreAddress.protect();
+
+        logStoreOperation.get(OP_ADDR).set(logStoreAddress);
+        list.add(logStoreOperation);
+
+        // elements
+        final EnumSet<Element> required = EnumSet.of(Element.RECOVERY_ENVIRONMENT, Element.CORE_ENVIRONMENT);
+        final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
+        choiceObjectStoreEncountered = false;
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            if (Namespace.forUri(reader.getNamespaceURI()) != getExpectedNamespace()) {
+                throw unexpectedElement(reader);
+            }
+            final Element element = Element.forName(reader.getLocalName());
+            required.remove(element);
+            if (!encountered.add(element)) {
+                throw unexpectedElement(reader);
+            }
+            readElement(reader, element, list, subsystem, logStoreOperation);
+        }
+        if (!required.isEmpty()) {
+            throw missingRequiredElement(reader, required);
+        }
+    }
+
+    protected void readElement(final XMLExtendedStreamReader reader, final Element element, final List<ModelNode> operations, final ModelNode subsystemOperation, final ModelNode logStoreOperation) throws XMLStreamException {
+        switch (element) {
+            case RECOVERY_ENVIRONMENT: {
+                parseRecoveryEnvironmentElement(reader, subsystemOperation);
+                break;
+            }
+            case CORE_ENVIRONMENT: {
+                parseCoreEnvironmentElement(reader, subsystemOperation);
+                break;
+            }
+            case COORDINATOR_ENVIRONMENT: {
+                parseCoordinatorEnvironmentElement(reader, subsystemOperation);
+                break;
+            }
+            case OBJECT_STORE: {
+                parseObjectStoreEnvironmentElementAndEnrichOperation(reader, subsystemOperation);
+                break;
+            }
+            case JTS: {
+                parseJts(reader, subsystemOperation);
+                break;
+            }
+            case USEHORNETQSTORE: {
+                if (choiceObjectStoreEncountered) {
+                    throw unexpectedElement(reader);
+                }
+                choiceObjectStoreEncountered = true;
+
+                parseUsehornetqstore(reader, logStoreOperation, subsystemOperation);
+                subsystemOperation.get(CommonAttributes.USEHORNETQSTORE).set(true);
+                break;
+            }
+            case JDBC_STORE: {
+                if (choiceObjectStoreEncountered) {
+                    throw unexpectedElement(reader);
+                }
+                choiceObjectStoreEncountered = true;
+
+                parseJdbcStoreElementAndEnrichOperation(reader, subsystemOperation);
+                subsystemOperation.get(CommonAttributes.USE_JDBC_STORE).set(true);
+                break;
+            }
+            default: {
+                throw unexpectedElement(reader);
+            }
+        }
+    }
+
+    protected void parseJts(final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
+        operation.get(CommonAttributes.JTS).set(true);
+        requireNoContent(reader);
+    }
+
+    protected void parseUsehornetqstore(final XMLExtendedStreamReader reader, final ModelNode logStoreOperation, final ModelNode operation) throws XMLStreamException {
+        logStoreOperation.get(LogStoreConstants.LOG_STORE_TYPE.getName()).set("hornetq");
+
+        // Handle attributes
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case ENABLE_ASYNC_IO:
+                    TransactionSubsystemRootResourceDefinition.HORNETQ_STORE_ENABLE_ASYNC_IO.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        // Handle elements
+        requireNoContent(reader);
+    }
+
+    protected void parseObjectStoreEnvironmentElementAndEnrichOperation(final XMLExtendedStreamReader reader, ModelNode operation) throws XMLStreamException {
+
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case RELATIVE_TO:
+                    TransactionSubsystemRootResourceDefinition.OBJECT_STORE_RELATIVE_TO.parseAndSetParameter(value, operation, reader);
+                    break;
+                case PATH:
+                    TransactionSubsystemRootResourceDefinition.OBJECT_STORE_PATH.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        // Handle elements
+        requireNoContent(reader);
+
+    }
+
+    protected void parseJdbcStoreElementAndEnrichOperation(final XMLExtendedStreamReader reader, ModelNode operation) throws XMLStreamException {
+
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case DATASOURCE_JNDI_NAME:
+                    TransactionSubsystemRootResourceDefinition.JDBC_STORE_DATASOURCE.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case JDBC_ACTION_STORE: {
+                    parseJdbcStoreConfigElementAndEnrichOperation(reader, operation, TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_TABLE_PREFIX, TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_DROP_TABLE);
+                    break;
+                }
+                case JDBC_STATE_STORE: {
+                    parseJdbcStoreConfigElementAndEnrichOperation(reader, operation, TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_TABLE_PREFIX, TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_DROP_TABLE);
+                    break;
+                }
+                case JDBC_COMMUNICATION_STORE: {
+                    parseJdbcStoreConfigElementAndEnrichOperation(reader, operation, TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_TABLE_PREFIX, TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_DROP_TABLE);
+                    break;
+                }
+            }
+        }
+
+
+    }
+
+    protected void parseJdbcStoreConfigElementAndEnrichOperation(final XMLExtendedStreamReader reader, final ModelNode operation, final SimpleAttributeDefinition tablePrefix, final SimpleAttributeDefinition dropTable) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case TABLE_PREFIX:
+                    tablePrefix.parseAndSetParameter(value, operation, reader);
+                    break;
+                case DROP_TABLE:
+                    dropTable.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        // Handle elements
+        requireNoContent(reader);
+    }
+
+    protected void parseCoordinatorEnvironmentElement(final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
+
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case ENABLE_STATISTICS:
+                    TransactionSubsystemRootResourceDefinition.ENABLE_STATISTICS.parseAndSetParameter(value, operation, reader);
+                    break;
+                case ENABLE_TSM_STATUS:
+                    TransactionSubsystemRootResourceDefinition.ENABLE_TSM_STATUS.parseAndSetParameter(value, operation, reader);
+                    break;
+                case DEFAULT_TIMEOUT:
+                    TransactionSubsystemRootResourceDefinition.DEFAULT_TIMEOUT.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        // Handle elements
+        requireNoContent(reader);
+
+    }
+
+    /**
+     * Handle the core-environment element and children
+     *
+     * @param reader
+     * @return ModelNode for the core-environment
+     * @throws javax.xml.stream.XMLStreamException
+     *
+     */
+    protected void parseCoreEnvironmentElement(final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
+
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            switch (attribute) {
+                case NODE_IDENTIFIER:
+                    TransactionSubsystemRootResourceDefinition.NODE_IDENTIFIER.parseAndSetParameter(value, operation, reader);
+                    break;
+                case PATH:
+                    TransactionSubsystemRootResourceDefinition.PATH.parseAndSetParameter(value, operation, reader);
+                    break;
+                case RELATIVE_TO:
+                    TransactionSubsystemRootResourceDefinition.RELATIVE_TO.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        // elements
+        final EnumSet<Element> required = EnumSet.of(Element.PROCESS_ID);
+        final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            required.remove(element);
+            switch (element) {
+                case PROCESS_ID: {
+                    if (!encountered.add(element)) {
+                        throw duplicateNamedElement(reader, reader.getLocalName());
+                    }
+                    parseProcessIdEnvironmentElement(reader, operation);
+                    break;
+                }
+                default:
+                    throw unexpectedElement(reader);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequiredElement(reader, required);
+        }
+    }
+
+    /**
+     * Handle the process-id child elements
+     *
+     * @param reader
+     * @param coreEnvironmentAdd
+     * @return
+     * @throws javax.xml.stream.XMLStreamException
+     *
+     */
+    protected void parseProcessIdEnvironmentElement(XMLExtendedStreamReader reader, ModelNode coreEnvironmentAdd) throws XMLStreamException {
+
+        // elements
+        boolean encountered = false;
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            final Element element = Element.forName(reader.getLocalName());
+            switch (element) {
+                case UUID:
+                    if (encountered) {
+                        throw unexpectedElement(reader);
+                    }
+                    encountered = true;
+                    coreEnvironmentAdd.get(TransactionSubsystemRootResourceDefinition.PROCESS_ID_UUID.getName()).set(true);
+                    requireNoContent(reader);
+                    break;
+                case SOCKET: {
+                    if (encountered) {
+                        throw unexpectedElement(reader);
+                    }
+                    encountered = true;
+                    parseSocketProcessIdElement(reader, coreEnvironmentAdd);
+                    break;
+                }
+                default:
+                    throw unexpectedElement(reader);
+            }
+        }
+
+        if (!encountered) {
+            throw missingOneOf(reader, EnumSet.of(Element.UUID, Element.SOCKET));
+        }
+    }
+
+    protected void parseSocketProcessIdElement(XMLExtendedStreamReader reader, ModelNode coreEnvironmentAdd) throws XMLStreamException {
+
+        final int count = reader.getAttributeCount();
+        final EnumSet<Attribute> required = EnumSet.of(Attribute.BINDING);
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case BINDING:
+                    TransactionSubsystemRootResourceDefinition.PROCESS_ID_SOCKET_BINDING.parseAndSetParameter(value, coreEnvironmentAdd, reader);
+                    break;
+                case SOCKET_PROCESS_ID_MAX_PORTS:
+                    TransactionSubsystemRootResourceDefinition.PROCESS_ID_SOCKET_MAX_PORTS.parseAndSetParameter(value, coreEnvironmentAdd, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        // Handle elements
+        requireNoContent(reader);
+    }
+
+    protected void parseRecoveryEnvironmentElement(final XMLExtendedStreamReader reader, final ModelNode operation) throws XMLStreamException {
+
+        Set<Attribute> required = EnumSet.of(Attribute.BINDING, Attribute.STATUS_BINDING);
+        final int count = reader.getAttributeCount();
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final Attribute attribute = Attribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case BINDING:
+                    TransactionSubsystemRootResourceDefinition.BINDING.parseAndSetParameter(value, operation, reader);
+                    break;
+                case STATUS_BINDING:
+                    TransactionSubsystemRootResourceDefinition.STATUS_BINDING.parseAndSetParameter(value, operation, reader);
+                    break;
+                case RECOVERY_LISTENER:
+                    TransactionSubsystemRootResourceDefinition.RECOVERY_LISTENER.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    unexpectedAttribute(reader, i);
+            }
+        }
+
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        // Handle elements
+        requireNoContent(reader);
+
+    }
+
+}

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -117,6 +117,8 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         for (AttributeDefinition ad : TransactionSubsystemRootResourceDefinition.attributes_1_2) {
             ad.validateAndSet(operation, model);
         }
+
+        TransactionSubsystemRootResourceDefinition.HORNETQ_STORE_ENABLE_ASYNC_IO.validateAndSet(operation, model);
     }
 
     private void populateModelWithObjectStoreConfig(ModelNode operation, ModelNode objectStoreModel) throws OperationFailedException {
@@ -276,6 +278,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
                                             ServiceVerificationHandler verificationHandler,
                                             List<ServiceController<?>> controllers) throws OperationFailedException {
         boolean useHornetqJournalStore = model.hasDefined(USEHORNETQSTORE) && model.get(USEHORNETQSTORE).asBoolean();
+        final boolean enableAsyncIO = TransactionSubsystemRootResourceDefinition.HORNETQ_STORE_ENABLE_ASYNC_IO.resolveModelAttribute(context, model).asBoolean();
         final String objectStorePathRef = TransactionSubsystemRootResourceDefinition.OBJECT_STORE_RELATIVE_TO.resolveModelAttribute(context, model).asString();
         final String objectStorePath = TransactionSubsystemRootResourceDefinition.OBJECT_STORE_PATH.resolveModelAttribute(context, model).asString();
 
@@ -301,7 +304,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         ServiceTarget target = context.getServiceTarget();
         // Configure the ObjectStoreEnvironmentBeans
-        final ArjunaObjectStoreEnvironmentService objStoreEnvironmentService = new ArjunaObjectStoreEnvironmentService(useHornetqJournalStore, objectStorePath, objectStorePathRef, useJdbcStore, dataSourceJndiName, confiBuilder.build());
+        final ArjunaObjectStoreEnvironmentService objStoreEnvironmentService = new ArjunaObjectStoreEnvironmentService(useHornetqJournalStore, enableAsyncIO, objectStorePath, objectStorePathRef, useJdbcStore, dataSourceJndiName, confiBuilder.build());
         ServiceBuilder builder = target.addService(TxnServices.JBOSS_TXN_ARJUNA_OBJECTSTORE_ENVIRONMENT, objStoreEnvironmentService)
                 .addDependency(PathManagerService.SERVICE_NAME, PathManager.class, objStoreEnvironmentService.getPathManagerInjector())
                 .addDependency(TxnServices.JBOSS_TXN_CORE_ENVIRONMENT);

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -147,6 +147,12 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
             .setFlags(AttributeAccess.Flag.RESTART_JVM)
             .setAlternatives(CommonAttributes.USE_JDBC_STORE)
             .setAllowExpression(false).build();
+    public static final SimpleAttributeDefinition HORNETQ_STORE_ENABLE_ASYNC_IO = new SimpleAttributeDefinitionBuilder(CommonAttributes.HORNETQ_STORE_ENABLE_ASYNC_IO, ModelType.BOOLEAN, true)
+            .setDefaultValue(new ModelNode().set(false))
+            .setFlags(AttributeAccess.Flag.RESTART_JVM)
+            .setXmlName(Attribute.ENABLE_ASYNC_IO.getLocalName())
+            .setAllowExpression(true)
+            .setRequires(CommonAttributes.USEHORNETQSTORE).build();
 
     public static final SimpleAttributeDefinition USE_JDBC_STORE = new SimpleAttributeDefinitionBuilder(CommonAttributes.USE_JDBC_STORE, ModelType.BOOLEAN, true)
                 .setDefaultValue(new ModelNode(false))
@@ -204,10 +210,14 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
+    // all attributes
     static final AttributeDefinition[] attributes = new AttributeDefinition[] {
             BINDING, STATUS_BINDING, RECOVERY_LISTENER, NODE_IDENTIFIER, PROCESS_ID_UUID, PROCESS_ID_SOCKET_BINDING,
             PROCESS_ID_SOCKET_MAX_PORTS, RELATIVE_TO, PATH, ENABLE_STATISTICS, ENABLE_TSM_STATUS, DEFAULT_TIMEOUT,
-            OBJECT_STORE_RELATIVE_TO, OBJECT_STORE_PATH, JTS, USEHORNETQSTORE
+            OBJECT_STORE_RELATIVE_TO, OBJECT_STORE_PATH, JTS, USEHORNETQSTORE, USE_JDBC_STORE, JDBC_STORE_DATASOURCE,
+            JDBC_ACTION_STORE_DROP_TABLE, JDBC_ACTION_STORE_TABLE_PREFIX, JDBC_COMMUNICATION_STORE_DROP_TABLE,
+            JDBC_COMMUNICATION_STORE_TABLE_PREFIX, JDBC_STATE_STORE_DROP_TABLE, JDBC_STATE_STORE_TABLE_PREFIX,
+            HORNETQ_STORE_ENABLE_ASYNC_IO
     };
 
     static final AttributeDefinition[] ATTRIBUTES_WITH_EXPRESSIONS_AFTER_1_1_0 = new AttributeDefinition[] {
@@ -225,16 +235,11 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
                 JDBC_STATE_STORE_DROP_TABLE, JDBC_STATE_STORE_TABLE_PREFIX
     };
 
-
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         // Register all attributes
         OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(attributes);
         for(final AttributeDefinition def : attributes) {
-            resourceRegistration.registerReadWriteAttribute(def, null, writeHandler);
-        }
-        writeHandler = new ReloadRequiredWriteAttributeHandler(attributes_1_2);
-        for(final AttributeDefinition def : attributes_1_2) {
             resourceRegistration.registerReadWriteAttribute(def, null, writeHandler);
         }
 

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemXMLPersister.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemXMLPersister.java
@@ -1,0 +1,146 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.txn.subsystem;
+
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+import javax.xml.stream.XMLStreamException;
+
+/**
+ * The {@link XMLElementWriter} that handles the Transaction subsystem. As we only write out the most recent version of
+ * a subsystem we only need to keep the latest version around.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+class TransactionSubsystemXMLPersister implements XMLElementWriter<SubsystemMarshallingContext> {
+
+    public static final TransactionSubsystemXMLPersister INSTANCE = new TransactionSubsystemXMLPersister();
+
+    private TransactionSubsystemXMLPersister() {
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeContent(XMLExtendedStreamWriter writer, SubsystemMarshallingContext context) throws XMLStreamException {
+
+        context.startSubsystemElement(Namespace.CURRENT.getUriString(), false);
+
+        ModelNode node = context.getModelNode();
+
+
+        writer.writeStartElement(Element.CORE_ENVIRONMENT.getLocalName());
+
+        TransactionSubsystemRootResourceDefinition.NODE_IDENTIFIER.marshallAsAttribute(node, writer);
+        TransactionSubsystemRootResourceDefinition.PATH.marshallAsAttribute(node, writer);
+        TransactionSubsystemRootResourceDefinition.RELATIVE_TO.marshallAsAttribute(node, writer);
+
+        writeProcessId(writer, node);
+
+        writer.writeEndElement();
+
+        if (TransactionSubsystemRootResourceDefinition.BINDING.isMarshallable(node) ||
+                TransactionSubsystemRootResourceDefinition.STATUS_BINDING.isMarshallable(node) ||
+                TransactionSubsystemRootResourceDefinition.RECOVERY_LISTENER.isMarshallable(node)) {
+            writer.writeStartElement(Element.RECOVERY_ENVIRONMENT.getLocalName());
+            TransactionSubsystemRootResourceDefinition.BINDING.marshallAsAttribute(node, writer);
+
+            TransactionSubsystemRootResourceDefinition.STATUS_BINDING.marshallAsAttribute(node, writer);
+
+            TransactionSubsystemRootResourceDefinition.RECOVERY_LISTENER.marshallAsAttribute(node, writer);
+
+            writer.writeEndElement();
+        }
+        if (TransactionSubsystemRootResourceDefinition.ENABLE_STATISTICS.isMarshallable(node)
+                || TransactionSubsystemRootResourceDefinition.ENABLE_TSM_STATUS.isMarshallable(node)
+                || TransactionSubsystemRootResourceDefinition.DEFAULT_TIMEOUT.isMarshallable(node)) {
+
+            writer.writeStartElement(Element.COORDINATOR_ENVIRONMENT.getLocalName());
+
+            TransactionSubsystemRootResourceDefinition.ENABLE_STATISTICS.marshallAsAttribute(node, writer);
+            TransactionSubsystemRootResourceDefinition.ENABLE_TSM_STATUS.marshallAsAttribute(node, writer);
+            TransactionSubsystemRootResourceDefinition.DEFAULT_TIMEOUT.marshallAsAttribute(node, writer);
+
+            writer.writeEndElement();
+        }
+
+        if (TransactionSubsystemRootResourceDefinition.OBJECT_STORE_RELATIVE_TO.isMarshallable(node)
+                || TransactionSubsystemRootResourceDefinition.OBJECT_STORE_PATH.isMarshallable(node)) {
+            writer.writeStartElement(Element.OBJECT_STORE.getLocalName());
+            TransactionSubsystemRootResourceDefinition.OBJECT_STORE_PATH.marshallAsAttribute(node, writer);
+            TransactionSubsystemRootResourceDefinition.OBJECT_STORE_RELATIVE_TO.marshallAsAttribute(node, writer);
+            writer.writeEndElement();
+        }
+
+        if(node.hasDefined(CommonAttributes.JTS) && node.get(CommonAttributes.JTS).asBoolean()) {
+            writer.writeStartElement(Element.JTS.getLocalName());
+            writer.writeEndElement();
+        }
+
+        if(node.hasDefined(CommonAttributes.USEHORNETQSTORE) && node.get(CommonAttributes.USEHORNETQSTORE).asBoolean()) {
+            writer.writeStartElement(Element.USEHORNETQSTORE.getLocalName());
+            TransactionSubsystemRootResourceDefinition.HORNETQ_STORE_ENABLE_ASYNC_IO.marshallAsAttribute(node, writer);
+            writer.writeEndElement();
+        } else if (node.hasDefined(CommonAttributes.USE_JDBC_STORE) && node.get(CommonAttributes.USE_JDBC_STORE).asBoolean()) {
+            writer.writeStartElement(Element.JDBC_STORE.getLocalName());
+            TransactionSubsystemRootResourceDefinition.JDBC_STORE_DATASOURCE.marshallAsAttribute(node, writer);
+            if (TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_TABLE_PREFIX.isMarshallable(node)
+                    || TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_DROP_TABLE.isMarshallable(node)) {
+                writer.writeEmptyElement(Element.JDBC_ACTION_STORE.getLocalName());
+                TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_TABLE_PREFIX.marshallAsAttribute(node, writer);
+                TransactionSubsystemRootResourceDefinition.JDBC_ACTION_STORE_DROP_TABLE.marshallAsAttribute(node, writer);
+            }
+            if (TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_TABLE_PREFIX.isMarshallable(node)
+                    || TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_DROP_TABLE.isMarshallable(node)) {
+                writer.writeEmptyElement(Element.JDBC_COMMUNICATION_STORE.getLocalName());
+                TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_TABLE_PREFIX.marshallAsAttribute(node, writer);
+                TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_DROP_TABLE.marshallAsAttribute(node, writer);
+            }
+            if (TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_TABLE_PREFIX.isMarshallable(node)
+                    || TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_DROP_TABLE.isMarshallable(node)) {
+                writer.writeEmptyElement(Element.JDBC_STATE_STORE.getLocalName());
+                TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_TABLE_PREFIX.marshallAsAttribute(node, writer);
+                TransactionSubsystemRootResourceDefinition.JDBC_STATE_STORE_DROP_TABLE.marshallAsAttribute(node, writer);
+            }
+            writer.writeEndElement();
+        }
+        writer.writeEndElement();
+    }
+
+    private void writeProcessId(final XMLExtendedStreamWriter writer, final ModelNode value) throws XMLStreamException {
+        writer.writeStartElement(Element.PROCESS_ID.getLocalName());
+        if (value.get(TransactionSubsystemRootResourceDefinition.PROCESS_ID_UUID.getName()).asBoolean(false)) {
+            writer.writeEmptyElement(Element.UUID.getLocalName());
+        } else {
+            writer.writeStartElement(Element.SOCKET.getLocalName());
+            TransactionSubsystemRootResourceDefinition.PROCESS_ID_SOCKET_BINDING.marshallAsAttribute(value, writer);
+            TransactionSubsystemRootResourceDefinition.PROCESS_ID_SOCKET_MAX_PORTS.marshallAsAttribute(value, writer);
+            writer.writeEndElement();
+        }
+        writer.writeEndElement();
+    }
+}

--- a/transactions/src/main/resources/org/jboss/as/txn/subsystem/LocalDescriptions.properties
+++ b/transactions/src/main/resources/org/jboss/as/txn/subsystem/LocalDescriptions.properties
@@ -12,6 +12,7 @@ transactions.path=Denotes a relative or absolute filesystem path denoting where 
 transactions.relative-to=References a global path configuration in the domain model, defaulting to the JBoss Application Server data directory (jboss.server.data.dir). The value of the "path" attribute will treated as relative to this path. Use an empty string to disable the default behavior and force the value of the "path" attribute to be treated as an absolute path.
 transactions.jts=If true this enables the Java Transaction Service
 transactions.use-hornetq-store=Use the HornetQ journal store for writing transaction logs. Set to true to enable and to false to use the default log store type. The default log store is normally one file system file per transaction log. The server should be restarted for this setting to take effect. It's alternative to jdbc based store.
+transactions.hornetq-store-enable-async-io=Whether AsyncIO should be enabled for the HornetQ journal store. Default is false. The server should be restarted for this setting to take effect.
 
 transactions.use-jdbc-store=Use the jdbc store for writing transaction logs. Set to true to enable and to false to use the default log store type. The default log store is normally one file system file per transaction log. The server should be restarted for this setting to take effect. It's alternative to Horneq based store
 transactions.jdbc-store-datasource=Jndi name of non-XA datasource used. Datasource sghould be define in datasources subsystem. The server should be restarted for this setting to take effect.

--- a/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
+++ b/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
@@ -32,6 +32,7 @@ import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinit
 import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.DEFAULT_TIMEOUT;
 import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.ENABLE_STATISTICS;
 import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.ENABLE_TSM_STATUS;
+import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.HORNETQ_STORE_ENABLE_ASYNC_IO;
 import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.NODE_IDENTIFIER;
 import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.OBJECT_STORE_PATH;
 import static org.jboss.as.txn.subsystem.TransactionSubsystemRootResourceDefinition.OBJECT_STORE_RELATIVE_TO;
@@ -114,6 +115,16 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    public void testParser_1_3() throws Exception {
+        standardSubsystemTest("full-1.3.xml");
+    }
+
+    @Test
+    public void testAsyncIOExpressions() throws Exception {
+        standardSubsystemTest("async-io-expressions.xml");
+    }
+
+    @Test
     public void testTransformers110() throws Exception {
         String subsystemXml = readResource("subsystem.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 1, 0);
@@ -150,7 +161,6 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         checkSubsystemModelTransformation(mainServices, modelVersion);
     }
-
 
     @Test
     public void testTransformersFull110() throws Exception {

--- a/transactions/src/test/resources/org/jboss/as/txn/async-io-expressions.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/async-io-expressions.xml
@@ -5,5 +5,5 @@
         </process-id>
     </core-environment>
     <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
-    <jdbc-store datasource-jndi-name="java:jboss/ExampleDS"/>
+    <use-hornetq-store enable-async-io="${test.enable.async.io:true}"/>
 </subsystem>

--- a/transactions/src/test/resources/org/jboss/as/txn/full-1.3.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/full-1.3.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:transactions:2.0">
+<subsystem xmlns="urn:jboss:domain:transactions:1.3">
     <core-environment node-identifier="1" path="var" relative-to="jboss.server.data.dir">
         <process-id>
             <socket socket-binding="txn-socket-id" socket-process-id-max-ports="10"/>

--- a/transactions/src/test/resources/org/jboss/as/txn/full-expressions.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/full-expressions.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:transactions:1.3">
+<subsystem xmlns="urn:jboss:domain:transactions:2.0">
     <core-environment node-identifier="${test.node.identifier:1}" path="${test.path:var}" relative-to="${test.relto:jboss.server.data.dir}">
         <process-id>
             <socket socket-binding="${test.socket-binding:txn-socket-id}" socket-process-id-max-ports="${test.socket.process.id-max.ports:10}"/>

--- a/transactions/src/test/resources/org/jboss/as/txn/jdbc-store-expressions.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/jdbc-store-expressions.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:transactions:1.3">
+<subsystem xmlns="urn:jboss:domain:transactions:2.0">
     <core-environment>
         <process-id>
             <uuid/>

--- a/transactions/src/test/resources/org/jboss/as/txn/jdbc-store.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/jdbc-store.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:transactions:1.3">
+<subsystem xmlns="urn:jboss:domain:transactions:2.0">
     <core-environment>
         <process-id>
             <uuid/>

--- a/transactions/src/test/resources/org/jboss/as/txn/minimal.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/minimal.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:transactions:1.3">
+<subsystem xmlns="urn:jboss:domain:transactions:2.0">
     <core-environment>
         <process-id>
             <uuid/>

--- a/transactions/src/test/resources/org/jboss/as/txn/subsystem.xml
+++ b/transactions/src/test/resources/org/jboss/as/txn/subsystem.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:transactions:1.3">
+<subsystem xmlns="urn:jboss:domain:transactions:2.0">
     <core-environment>
         <process-id>
             <uuid/>


### PR DESCRIPTION
This fix adds a new configuration option for NIO/AIO based HornetQ object store of the transactions subsystem.

https://issues.jboss.org/browse/WFLY-789
