### PR TITLE
[WFLY-1286] Support injection of JMSContext

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -33,6 +33,7 @@
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="javax.enterprise.api"/>
         <module name="javax.jms.api"/>
         <module name="javax.transaction.api"/>
         <module name="org.hornetq"/>
@@ -49,6 +50,7 @@
         <module name="org.jboss.as.server"/>
         <!-- web-common is required only if servlet-connector are used -->
         <module name="org.jboss.as.web-common" optional="true"/>
+        <module name="org.jboss.as.weld"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.metadata"/>
         <module name="org.jboss.modules"/>
@@ -67,5 +69,8 @@
         <!--  JGroups is required only as an option to cluster HornetQ nodes -->
         <module name="org.jboss.as.clustering.jgroups" optional="true"/>
         <module name="org.jgroups" optional="true"/>
+        <module name="org.jboss.weld.api" />
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi" />
     </dependencies>
 </module>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -142,6 +142,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-weld</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.ironjacamar</groupId>
             <artifactId>ironjacamar-common-api</artifactId>
         </dependency>

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -26,6 +26,7 @@ import static org.jboss.logging.annotations.Message.INHERIT;
 
 import java.util.Collection;
 
+import javax.jms.IllegalStateRuntimeException;
 import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.ModelVersion;
@@ -545,4 +546,13 @@ public interface MessagingMessages {
      */
     @Message(id = 11679, value = "The broadcast group '%s' defines reference to nonexistent connector '%s'. Available connectors '%s'.")
     OperationFailedException wrongConnectorRefInBroadCastGroup(final String bgName, final String connectorRef, final Collection<String> presentConnectors);
+
+
+    /**
+     * Create a exception when calling a method not allowed on injected JMSContext.
+     *
+     * @return an {@link IllegalStateRuntimeException} for the error.
+     */
+    @Message(id = 11680, value = "It is not permitted to call this method on injected JMSContext (see JMS 2.0 spec, §12.4.5).")
+    IllegalStateRuntimeException callNotPermittedOnInjectedJMSContext();
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/CDIDeploymentProcessor.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/CDIDeploymentProcessor.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.deployment;
+
+import org.jboss.as.ee.weld.WeldDeploymentMarker;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.weld.deployment.WeldPortableExtensions;
+
+/**
+ * Processor that deploys a CDI portable extension to provide injection of JMSContext resource.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class CDIDeploymentProcessor implements DeploymentUnitProcessor {
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final DeploymentUnit parent = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit.getParent();
+
+        if (WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
+            WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(parent);
+            extensions.registerExtensionInstance(new JMSCDIExtension(), parent);
+        }
+
+    }
+
+    public void undeploy(DeploymentUnit context) {
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/JMSCDIExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/JMSCDIExtension.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.deployment;
+
+import javax.enterprise.event.Observes;
+import javax.enterprise.inject.spi.AnnotatedType;
+import javax.enterprise.inject.spi.BeanManager;
+import javax.enterprise.inject.spi.BeforeBeanDiscovery;
+import javax.enterprise.inject.spi.Extension;
+
+/**
+ * CDI extension to provide injection of JMSContext resources.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class JMSCDIExtension implements Extension {
+
+    void beforeBeanDiscovery(@Observes BeforeBeanDiscovery bbd, BeanManager bm) {
+        AnnotatedType<JMSContextProducer> producer = bm.createAnnotatedType(JMSContextProducer.class);
+        bbd.addAnnotatedType(producer);
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingDependencyProcessor.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingDependencyProcessor.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.deployment;
+
+import org.jboss.as.ee.weld.WeldDeploymentMarker;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ModuleDependency;
+import org.jboss.as.server.deployment.module.ModuleSpecification;
+import org.jboss.modules.Module;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.modules.ModuleLoader;
+
+/**
+ * Processor that add module dependencies for JMS deployments.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class MessagingDependencyProcessor implements DeploymentUnitProcessor {
+
+    /**
+     * We include this module so that the CDI producer method for JMSContext is available for the deployment unit.
+     */
+    public static final ModuleIdentifier AS_MESSAGING = ModuleIdentifier.create("org.jboss.as.messaging");
+
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+
+        if (WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
+            final ModuleSpecification moduleSpecification = deploymentUnit.getAttachment(Attachments.MODULE_SPECIFICATION);
+            final ModuleLoader moduleLoader = Module.getBootModuleLoader();
+            addDependency(moduleSpecification, moduleLoader, AS_MESSAGING);
+        }
+
+    }
+
+    private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
+                               ModuleIdentifier moduleIdentifier) {
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, true, false));
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -339,6 +339,7 @@ public enum Phase {
     public static final int DEPENDENCIES_TRANSACTIONS                   = 0x1100;
     public static final int DEPENDENCIES_JDK                            = 0x1200;
     public static final int DEPENDENCIES_JACORB                         = 0x1300;
+    public static final int DEPENDENCIES_JMS                            = 0x1400;
     public static final int DEPENDENCIES_CMP                            = 0x1500;
     public static final int DEPENDENCIES_JAXR                           = 0x1600;
     public static final int DEPENDENCIES_DRIVERS                        = 0x1700;
@@ -409,6 +410,7 @@ public enum Phase {
     public static final int POST_MODULE_WELD_BEAN_ARCHIVE               = 0x0D00;
     public static final int POST_MODULE_WELD_EXTERNAL_BEAN_ARCHIVE      = 0x0D50;
     public static final int POST_MODULE_WELD_PORTABLE_EXTENSIONS        = 0x0E00;
+    public static final int POST_MODULE_JMS_CDI_EXTENSIONS              = 0x0F00;
     // should come before ejb jndi bindings processor
     public static final int POST_MODULE_EJB_IMPLICIT_NO_INTERFACE_VIEW  = 0x1000;
     public static final int POST_MODULE_EJB_JNDI_BINDINGS               = 0x1100;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/InjectedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/InjectedJMSContextTestCase.java
@@ -1,0 +1,176 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.context;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.jboss.as.test.shared.TimeoutUtil.adjust;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+import java.util.UUID;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.inject.Inject;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSConnectionFactory;
+import javax.jms.JMSContext;
+import javax.jms.JMSPasswordCredential;
+import javax.jms.JMSSessionMode;
+import javax.jms.Queue;
+import javax.jms.TemporaryQueue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.integration.messaging.jms.context.auxiliary.TransactedMessageProducer;
+import org.jboss.as.test.jms.auxiliary.CreateQueueSetupTask;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(CreateQueueSetupTask.class)
+public class InjectedJMSContextTestCase {
+
+    public static final String QUEUE_NAME = "/queue/myAwesomeQueue";
+
+    @Inject
+    @JMSConnectionFactory("/ConnectionFactory")
+    @JMSPasswordCredential(userName="guest",password="guest")
+    @JMSSessionMode(JMSContext.AUTO_ACKNOWLEDGE)
+    private JMSContext context;
+
+    @Resource(mappedName = "/ConnectionFactory")
+    private ConnectionFactory factory;
+
+    @Resource(mappedName = QUEUE_NAME)
+    private Queue queue;
+
+    @EJB
+    private TransactedMessageProducer producerBean;
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "InjectedJMSContextTestCase.jar")
+                .addPackage(JMSOperations.class.getPackage())
+                .addClass(CreateQueueSetupTask.class)
+                .addClass(TimeoutUtil.class)
+                .addPackage(TransactedMessageProducer.class.getPackage())
+                .addAsManifestResource(EmptyAsset.INSTANCE,
+                        "beans.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"),
+                        "MANIFEST.MF");
+    }
+
+    @Test
+    public void testSendAndReceiveWithInjectedContext() {
+        sendAndReceiveWithContext(context);
+    }
+
+    @Test
+    public void testSendAndReceiveWithCreatedContext() {
+        try (
+                JMSContext ctx = factory.createContext()
+        ) {
+            sendAndReceiveWithContext(ctx);
+        }
+    }
+
+    private void sendAndReceiveWithContext(JMSContext ctx) {
+        String text = UUID.randomUUID().toString();
+
+        TemporaryQueue tempQueue = ctx.createTemporaryQueue();
+
+        ctx.createProducer()
+                .send(tempQueue, text);
+
+        assertMessageIsReceived(tempQueue, ctx, text, false);
+    }
+
+    @Test
+    public void testSendWith_REQUIRED_transaction() {
+        sendWith_REQUIRED_transaction(false);
+    }
+
+    @Test
+    public void testSendWith_REQUIRED_transactionAndRollback() {
+        sendWith_REQUIRED_transaction(true);
+    }
+
+    private void sendWith_REQUIRED_transaction(boolean rollback) {
+        String text = UUID.randomUUID().toString();
+
+        TemporaryQueue tempQueue = context.createTemporaryQueue();
+
+        producerBean.sendToDestination(tempQueue, text, rollback);
+
+        assertMessageIsReceived(tempQueue, context, text, rollback);
+    }
+
+    @Test
+    public void testSendAndReceiveFromMDB() {
+        sendAndReceiveFromMDB(false);
+    }
+
+    @Test
+    public void testSendAndReceiveFromMDBWithRollback() {
+        sendAndReceiveFromMDB(true);
+    }
+
+    private void sendAndReceiveFromMDB(boolean rollback) {
+        String text = UUID.randomUUID().toString();
+
+        TemporaryQueue replyTo = context.createTemporaryQueue();
+
+        context.createProducer()
+                .setJMSReplyTo(replyTo)
+                .setProperty("rollback", rollback)
+                .send(queue, text);
+
+        assertMessageIsReceived(replyTo, context, text, rollback);
+    }
+
+    private void assertMessageIsReceived(Destination destination, JMSContext ctx, String expectedText, boolean rollback) {
+        String t = ctx.createConsumer(destination)
+                .receiveBody(String.class, adjust(2000));
+
+        if (rollback) {
+            assertThat(t, is(nullValue()));
+        } else {
+            assertThat(t, is(expectedText));
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/TransactedMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/TransactedMDB.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.context.auxiliary;
+
+import static javax.ejb.TransactionAttributeType.REQUIRED;
+import static javax.ejb.TransactionManagementType.CONTAINER;
+import static org.jboss.as.test.integration.messaging.jms.context.InjectedJMSContextTestCase.QUEUE_NAME;
+
+import javax.annotation.Resource;
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.ejb.MessageDrivenContext;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionManagement;
+import javax.inject.Inject;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@MessageDriven(
+        name = "TransactedMDB",
+        activationConfig = {
+            @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+            @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = QUEUE_NAME)
+        }
+)
+@TransactionManagement(value = CONTAINER)
+@TransactionAttribute(value = REQUIRED)
+public class TransactedMDB implements MessageListener {
+
+    @Inject
+    private JMSContext context;
+
+    @Resource
+    private MessageDrivenContext mdbContext;
+
+    public void onMessage(final Message m)
+    {
+       System.out.println("TransactedMDB.onMessage");
+        try {
+            TextMessage message = (TextMessage)m;
+            Destination replyTo = m.getJMSReplyTo();
+
+            context.createProducer()
+                   .setJMSCorrelationID(message.getJMSMessageID())
+                   .send(replyTo, message.getText());
+            System.out.println("sent reply");
+            if (m.getBooleanProperty("rollback")) {
+                mdbContext.setRollbackOnly();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/TransactedMessageProducer.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/TransactedMessageProducer.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.context.auxiliary;
+
+import static javax.ejb.TransactionAttributeType.REQUIRED;
+
+import javax.annotation.Resource;
+import javax.ejb.SessionContext;
+import javax.ejb.Stateful;
+import javax.ejb.TransactionAttribute;
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@Stateful
+@RequestScoped
+public class TransactedMessageProducer {
+    @Inject
+    private JMSContext context;
+
+    @Resource
+    private SessionContext sessionContext;
+
+    @TransactionAttribute(value = REQUIRED)
+    public void sendToDestination(Destination destination, String text, boolean rollback) {
+        context.createProducer()
+                .send(destination, text);
+        if (rollback) {
+            sessionContext.setRollbackOnly();
+        }
+    }
+}


### PR DESCRIPTION
- add a CDI extension providing a producer for injected JMSContext
  resources
- add a Phase.DEPENDENCIES_JMS phase to add a JMS dependency for
  Weld deployment (so that they can access the JMSContext producer)
- wrap the injected JMSContext to restrict used of methods (JMS 2.0
  spec, §12.4.5)
