### PR TITLE
[WFLY-1755] messaging's expiry-delay address-setting

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_4.xsd
@@ -691,6 +691,7 @@
        <xs:all>
           <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string" />
           <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="expiry-delay" type="xs:long" />
           <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long" />
           <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int" />
           <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long" />

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingAdd.java
@@ -91,6 +91,7 @@ class AddressSettingAdd extends AbstractAddStepHandler {
         settings.setMaxSizeBytes(AddressSettingDefinition.MAX_SIZE_BYTES.resolveModelAttribute(context, config).asLong());
         settings.setMessageCounterHistoryDayLimit(AddressSettingDefinition.MESSAGE_COUNTER_HISTORY_DAY_LIMIT.resolveModelAttribute(context, config).asInt());
         settings.setExpiryAddress(asSimpleString(EXPIRY_ADDRESS.resolveModelAttribute(context, config), null));
+        settings.setExpiryDelay(AddressSettingDefinition.EXPIRY_DELAY.resolveModelAttribute(context, config).asLong());
         settings.setRedeliveryDelay(AddressSettingDefinition.REDELIVERY_DELAY.resolveModelAttribute(context, config).asLong());
         settings.setRedistributionDelay(AddressSettingDefinition.REDISTRIBUTION_DELAY.resolveModelAttribute(context, config).asLong());
         settings.setPageSizeBytes(AddressSettingDefinition.PAGE_SIZE_BYTES.resolveModelAttribute(context, config).asLong());

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingDefinition.java
@@ -59,6 +59,13 @@ public class AddressSettingDefinition extends SimpleResourceDefinition {
             .setAllowExpression(true)
             .build();
 
+    public static final SimpleAttributeDefinition EXPIRY_DELAY = create("expiry-delay", ModelType.LONG)
+            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_EXPIRY_DELAY))
+            .setMeasurementUnit(MILLISECONDS)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .build();
+
     public static final SimpleAttributeDefinition LAST_VALUE_QUEUE = create("last-value-queue", ModelType.BOOLEAN)
             .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_LAST_VALUE_QUEUE))
             .setAllowNull(true)
@@ -124,12 +131,17 @@ public class AddressSettingDefinition extends SimpleResourceDefinition {
             LAST_VALUE_QUEUE, REDISTRIBUTION_DELAY, SEND_TO_DLA_ON_NO_ROUTE
     };
 
+    public static final SimpleAttributeDefinition[] ATTRIBUTES_ADDED_IN_2_0_0 = new SimpleAttributeDefinition[] {
+            EXPIRY_DELAY
+    };
+
     /**
      * Attributes are defined in the <em>same order than in the XSD schema</em>
      */
     static final SimpleAttributeDefinition[] ATTRIBUTES = new SimpleAttributeDefinition[] {
         DEAD_LETTER_ADDRESS,
         EXPIRY_ADDRESS,
+        EXPIRY_DELAY,
         REDELIVERY_DELAY,
         MAX_DELIVERY_ATTEMPTS,
         MAX_SIZE_BYTES,

--- a/messaging/src/main/java/org/jboss/as/messaging/Element.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Element.java
@@ -164,6 +164,7 @@ public enum Element {
    ADDRESS_SETTING(CommonAttributes.ADDRESS_SETTING),
    DEAD_LETTER_ADDRESS(CommonAttributes.DEAD_LETTER_ADDRESS),
    EXPIRY_ADDRESS(CommonAttributes.EXPIRY_ADDRESS),
+   EXPIRY_DELAY(AddressSettingDefinition.EXPIRY_DELAY),
    REDELIVERY_DELAY(AddressSettingDefinition.REDELIVERY_DELAY),
    MAX_DELIVERY_ATTEMPTS(AddressSettingDefinition.MAX_DELIVERY_ATTEMPTS),
    MAX_SIZE_BYTES(AddressSettingDefinition.MAX_SIZE_BYTES),

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
@@ -156,4 +156,15 @@ public class Messaging14SubsystemParser extends Messaging13SubsystemParser {
                 super.handleUnknownBridgeAttribute(reader, element, bridgeAdd);
         }
     }
+
+    @Override
+    protected void handleUnknownAddressSetting(XMLExtendedStreamReader reader, Element element, ModelNode addressSettingsAdd) throws XMLStreamException {
+        switch (element) {
+            case EXPIRY_DELAY:
+                handleElementText(reader, element, addressSettingsAdd);
+                break;
+            default:
+                super.handleUnknownAddressSetting(reader, element, addressSettingsAdd);
+        }
+    }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -1132,7 +1132,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         }
     }
 
-    static void processAddressSettings(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
+    protected void processAddressSettings(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> operations) throws XMLStreamException {
         String localName = null;
         do {
             reader.nextTag();
@@ -1153,7 +1153,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         } while (reader.hasNext() && localName.equals(Element.ADDRESS_SETTING.getLocalName()));
     }
 
-    static ModelNode parseAddressSettings(final XMLExtendedStreamReader reader) throws XMLStreamException {
+    protected ModelNode parseAddressSettings(final XMLExtendedStreamReader reader) throws XMLStreamException {
         final ModelNode addressSettingsSpec = new ModelNode();
 
         String localName;
@@ -1162,7 +1162,6 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
             localName = reader.getLocalName();
             final Element element = Element.forName(localName);
 
-            SWITCH:
             switch (element) {
                 case DEAD_LETTER_ADDRESS:
                 case EXPIRY_ADDRESS:
@@ -1177,8 +1176,9 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
                 case REDISTRIBUTION_DELAY:
                 case SEND_TO_DLA_ON_NO_ROUTE: {
                     handleElementText(reader, element, addressSettingsSpec);
-                    break SWITCH;
+                    break;
                 } default: {
+                    handleUnknownAddressSetting(reader, element, addressSettingsSpec);
                     break;
                 }
             }
@@ -1187,7 +1187,12 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
         return addressSettingsSpec;
     }
 
-   void parseTransportConfiguration(final XMLExtendedStreamReader reader, final ModelNode operation, final boolean generic) throws XMLStreamException {
+    protected void handleUnknownAddressSetting(XMLExtendedStreamReader reader, Element element, ModelNode addressSettingsAdd)
+            throws XMLStreamException {
+        // do nothing
+    }
+
+    void parseTransportConfiguration(final XMLExtendedStreamReader reader, final ModelNode operation, final boolean generic) throws XMLStreamException {
         while(reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             Element element = Element.forName(reader.getLocalName());
             switch(element) {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
@@ -269,6 +269,12 @@ public class MessagingTransformers {
                 .addRejectCheck(DEFINED, BridgeDefinition.ATTRIBUTES_ADDED_IN_2_0_0)
                 .end();
 
+        hornetqServer.addChildResource(AddressSettingDefinition.PATH)
+                .getAttributeBuilder()
+                .setDiscard(UNDEFINED, AddressSettingDefinition.ATTRIBUTES_ADDED_IN_2_0_0)
+                .addRejectCheck(DEFINED, AddressSettingDefinition.ATTRIBUTES_ADDED_IN_2_0_0)
+                .end();
+
         hornetqServer.rejectChildResource(ServletConnectorDefinition.PATH);
 
         TransformationDescription.Tools.register(subsystemRoot.build(), subsystem, VERSION_1_2_1);

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -187,6 +187,7 @@ address-setting.max-delivery-attempts=Defines how many time a cancelled message 
 address-setting.max-size-bytes=The max bytes size.
 address-setting.message-counter-history-day-limit=Day limit for the message counter history.
 address-setting.expiry-address=Defines where to send a message that has expired.
+address-setting.expiry-delay=Defines the expiration time that will be used for messages using the default expiration time
 address-setting.redelivery-delay=Defines how long to wait before attempting redelivery of a cancelled message
 address-setting.redistribution-delay=Defines how long to wait when the last consumer is closed on a queue before redistributing any messages
 address-setting.page-size-bytes=The paging size.

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_4.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_incompatible_1_4.xml
@@ -266,6 +266,7 @@
                <address-setting match="#">
                   <dead-letter-address>${dead.letter.address:jms.queue.DLQ}</dead-letter-address>
                   <expiry-address>${expiry.address:jms.queue.ExpiryQueue}</expiry-address>
+                  <expiry-delay>${expiry.delay:12345}</expiry-delay>
                   <redelivery-delay>${redelivery.delay:0}</redelivery-delay>
                   <max-delivery-attempts>${max.delivery.attempts:5}</max-delivery-attempts>
                   <max-size-bytes>${max.size.bytes:10485760}</max-size-bytes>


### PR DESCRIPTION
add expiry-delay attribute to the messaging subsystem's address-setting
to provide an expiry delay to any messages sent to an address (if the
message has not already defined such an expiry delay when it is sent).
