### PR TITLE
WFLY-1770 Don't Expose JDT Compiler to Applications

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
@@ -26,6 +26,11 @@
     <resources>
         <!-- Insert resources here -->
     </resources>
+    
+    <exports>
+        <exclude path="org/eclipse/jdt/**"/>
+        <include path="**"/>
+    </exports>
 
     <dependencies>
         <module name="javax.api"/>


### PR DESCRIPTION
Currently the Eclipse JDT compiler is exposed to web applications
because the undertow servlet module exposes all its dependencies.

This can break applications that ship their own version of the Eclipse
JDT compiler like the Cocoon web framework.
- don't export `org/eclipse/jdt/**`

https://issues.jboss.org/browse/WFLY-1770
