### PR TITLE
[WFLY-1783] adding profile for stub generation for IIOP naming on IBM JDK

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -33,6 +33,7 @@
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
         <version.apacheds>2.0.0-M7</version.apacheds>
         <version.apacheds.shared>1.0.0-M12</version.apacheds.shared>
+        <version.exec.maven.plugin>1.2.1</version.exec.maven.plugin>
     </properties>
 
     <dependencies>
@@ -394,6 +395,49 @@
                 </plugins>
             </build>
         </profile>
+        
+        <!-- IIOP/CORBA stub generation - manual stub generation for IBM JDK -->                    
+        <profile>
+            <id>ibmjdk.profile</id>
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>IBM Corporation</value>
+               </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>${version.exec.maven.plugin}</version>
+                        <executions>
+                            <!-- There is no similar option as -Dcom.sun.CORBA.ORBUseDynamicStub=true for IBM JDK
+                                  we need to create stub do it manually with rmic tools -->
+                            <execution>
+                                <id>ibmjdk.iiop.stub-creation</id>
+                                <phase>test-compile</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>rmic</executable>
+                                    <workingDirectory>target/test-classes</workingDirectory>
+                                    <arguments>
+                                        <argument>-iiop</argument>
+                                        <argument>-classpath</argument>
+                                        <argument>${jboss.dist}/bin/client/jboss-client.jar:.</argument>
+                                        <argument>org.jboss.as.test.integration.ejb.iiop.naming.IIOPNamingHome</argument>
+                                        <argument>org.jboss.as.test.integration.ejb.iiop.naming.IIOPStatefulNamingHome</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
 
         <!-- When -Dtest=... is set, only the default surefire execution with standalone-full.xml will run. -->
         <profile>


### PR DESCRIPTION
The IIOP naming test is failing when is run on IBM JDK. This adds profile which generates necessary stubs for that test when it's run on IBM JDK.
I haven't found any parameter/possibility how to force ibm jdk to generate stubs on the fly.
