### PR TITLE
Make 'prog' overrideable and more explicit

### DIFF
--- a/build/src/main/resources/bin/init.d/jboss-as-domain.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-domain.sh
@@ -56,7 +56,9 @@ fi
 
 JBOSS_SCRIPT=$JBOSS_HOME/bin/domain.sh
 
-prog='jboss-as'
+if [ -z "$PROG" ]; then
+  PROG='jboss-as'
+fi
 
 CMD_PREFIX=''
 
@@ -69,11 +71,11 @@ if [ ! -z "$JBOSS_USER" ]; then
 fi
 
 start() {
-  echo -n "Starting $prog: "
+  echo -n "Starting $PROG: "
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo -n "$prog is already running"
+      echo -n "$PROG is already running"
       failure
       echo
       return 1
@@ -117,7 +119,7 @@ start() {
 }
 
 stop() {
-  echo -n $"Stopping $prog: "
+  echo -n $"Stopping $PROG: "
   count=0;
 
   if [ -f $JBOSS_PIDFILE ]; then
@@ -146,14 +148,14 @@ status() {
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo "$prog is running (pid $ppid)"
+      echo "$PROG is running (pid $ppid)"
       return 0
     else
-      echo "$prog dead but pid file exists"
+      echo "$PROG dead but pid file exists"
       return 1
     fi
   fi
-  echo "$prog is not running"
+  echo "$PROG is not running"
   return 3
 }
 

--- a/build/src/main/resources/bin/init.d/jboss-as-domain.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-domain.sh
@@ -57,7 +57,7 @@ fi
 JBOSS_SCRIPT=$JBOSS_HOME/bin/domain.sh
 
 if [ -z "$JBOSS_PROG_NAME" ]; then
-  JBOSS_PROG_NAME='jboss-as'
+  JBOSS_PROG_NAME='WildFly'
 fi
 
 CMD_PREFIX=''

--- a/build/src/main/resources/bin/init.d/jboss-as-domain.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-domain.sh
@@ -56,8 +56,8 @@ fi
 
 JBOSS_SCRIPT=$JBOSS_HOME/bin/domain.sh
 
-if [ -z "$PROG" ]; then
-  PROG='jboss-as'
+if [ -z "$JBOSS_PROG_NAME" ]; then
+  JBOSS_PROG_NAME='jboss-as'
 fi
 
 CMD_PREFIX=''
@@ -71,11 +71,11 @@ if [ ! -z "$JBOSS_USER" ]; then
 fi
 
 start() {
-  echo -n "Starting $PROG: "
+  echo -n "Starting $JBOSS_PROG_NAME: "
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo -n "$PROG is already running"
+      echo -n "$JBOSS_PROG_NAME is already running"
       failure
       echo
       return 1
@@ -119,7 +119,7 @@ start() {
 }
 
 stop() {
-  echo -n $"Stopping $PROG: "
+  echo -n $"Stopping $JBOSS_PROG_NAME: "
   count=0;
 
   if [ -f $JBOSS_PIDFILE ]; then
@@ -148,14 +148,14 @@ status() {
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo "$PROG is running (pid $ppid)"
+      echo "$JBOSS_PROG_NAME is running (pid $ppid)"
       return 0
     else
-      echo "$PROG dead but pid file exists"
+      echo "$JBOSS_PROG_NAME dead but pid file exists"
       return 1
     fi
   fi
-  echo "$PROG is not running"
+  echo "$JBOSS_PROG_NAME is not running"
   return 3
 }
 

--- a/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
@@ -51,8 +51,8 @@ if [ -z "$JBOSS_CONFIG" ]; then
 fi
 
 JBOSS_SCRIPT=$JBOSS_HOME/bin/standalone.sh
-if [ -z "$PROG" ]; then
-  PROG='jboss-as'
+if [ -z "$JBOSS_PROG_NAME" ]; then
+  JBOSS_PROG_NAME='jboss-as'
 fi
 
 CMD_PREFIX=''
@@ -66,11 +66,11 @@ if [ ! -z "$JBOSS_USER" ]; then
 fi
 
 start() {
-  echo -n "Starting $PROG: "
+  echo -n "Starting $JBOSS_PROG_NAME: "
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo -n "$PROG is already running"
+      echo -n "$JBOSS_PROG_NAME is already running"
       failure
       echo
       return 1
@@ -114,7 +114,7 @@ start() {
 }
 
 stop() {
-  echo -n $"Stopping $PROG: "
+  echo -n $"Stopping $JBOSS_PROG_NAME: "
   count=0;
 
   if [ -f $JBOSS_PIDFILE ]; then
@@ -143,14 +143,14 @@ status() {
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo "$PROG is running (pid $ppid)"
+      echo "$JBOSS_PROG_NAME is running (pid $ppid)"
       return 0
     else
-      echo "$PROG dead but pid file exists"
+      echo "$JBOSS_PROG_NAME dead but pid file exists"
       return 1
     fi
   fi
-  echo "$PROG is not running"
+  echo "$JBOSS_PROG_NAME is not running"
   return 3
 }
 

--- a/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
@@ -52,7 +52,7 @@ fi
 
 JBOSS_SCRIPT=$JBOSS_HOME/bin/standalone.sh
 if [ -z "$JBOSS_PROG_NAME" ]; then
-  JBOSS_PROG_NAME='jboss-as'
+  JBOSS_PROG_NAME='WildFly'
 fi
 
 CMD_PREFIX=''

--- a/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
+++ b/build/src/main/resources/bin/init.d/jboss-as-standalone.sh
@@ -51,8 +51,9 @@ if [ -z "$JBOSS_CONFIG" ]; then
 fi
 
 JBOSS_SCRIPT=$JBOSS_HOME/bin/standalone.sh
-
-prog='jboss-as'
+if [ -z "$PROG" ]; then
+  PROG='jboss-as'
+fi
 
 CMD_PREFIX=''
 
@@ -65,14 +66,14 @@ if [ ! -z "$JBOSS_USER" ]; then
 fi
 
 start() {
-  echo -n "Starting $prog: "
+  echo -n "Starting $PROG: "
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo -n "$prog is already running"
+      echo -n "$PROG is already running"
       failure
       echo
-      return 1 
+      return 1
     else
       rm -f $JBOSS_PIDFILE
     fi
@@ -98,22 +99,22 @@ start() {
 
   until [ $count -gt $STARTUP_WAIT ]
   do
-    grep 'JBAS015874:' $JBOSS_CONSOLE_LOG > /dev/null 
+    grep 'JBAS015874:' $JBOSS_CONSOLE_LOG > /dev/null
     if [ $? -eq 0 ] ; then
       launched=true
       break
-    fi 
+    fi
     sleep 1
     let count=$count+1;
   done
-  
+
   success
   echo
   return 0
 }
 
 stop() {
-  echo -n $"Stopping $prog: "
+  echo -n $"Stopping $PROG: "
   count=0;
 
   if [ -f $JBOSS_PIDFILE ]; then
@@ -142,14 +143,14 @@ status() {
   if [ -f $JBOSS_PIDFILE ]; then
     read ppid < $JBOSS_PIDFILE
     if [ `ps --pid $ppid 2> /dev/null | grep -c $ppid 2> /dev/null` -eq '1' ]; then
-      echo "$prog is running (pid $ppid)"
+      echo "$PROG is running (pid $ppid)"
       return 0
     else
-      echo "$prog dead but pid file exists"
+      echo "$PROG dead but pid file exists"
       return 1
     fi
   fi
-  echo "$prog is not running"
+  echo "$PROG is not running"
   return 3
 }
 


### PR DESCRIPTION
Both init.d scripts provided with Wildfly are fairly well designed because the JBOSS_USER, JBOSS_CONFIG and other variables can be override from outside, allowing people to integrate the server within their environment by just adding a script, overriding what needs to be, without changing the script delivered with the products.

However, for reason  unknown to me, the variable 'prog' , which name the service associated with Wildfly, can not be overriden. Those commits do the renaming and also rename the 'prog' variable into something more explicit and following the naming convention of the other overrideable vars.

Hope this helps ! 
