### PR TITLE
WFLY-743 Ability to enable/disable a user

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -498,14 +498,24 @@ public interface DomainManagementMessages {
     String invalidChoiceResponse();
 
     /**
-     * Confirmation if the current user password and roles is about to be updated.
+     * Confirmation if the current user (enabled) is about to be updated.
      *
      * @param user - The name of the user.
      *
      * @return a {@link String} for the message.
      */
-    @Message(id = Message.NONE, value = "User '%s' already exits, would you like to update the existing user password and roles")
-    String aboutToUpdateUser(String user);
+    @Message(id = Message.NONE, value = "User '%s' already exits and is enabled, would you like to... %n a) Update the existing user password and roles %n b) Disable the existing user %n c) Type a new username")
+    String aboutToUpdateEnabledUser(String user);
+
+    /**
+     * Confirmation if the current user (disabled) is about to be updated.
+     *
+     * @param user - The name of the user.
+     *
+     * @return a {@link String} for the message.
+     */
+    @Message(id = Message.NONE, value = "User '%s' already exits and is disabled, would you like to... %n a) Update the existing user password and roles %n b) Enable the existing user %n c) Type a new username")
+    String aboutToUpdateDisabledUser(String user);
 
     /**
      * Message to inform user that the user has been updated to the file identified.
@@ -729,6 +739,14 @@ public interface DomainManagementMessages {
      */
     @Message(id = 15285, value = "The runtime role mapping configuration is inconsistent, the server must be restarted.")
     OperationFailedException inconsistentRbacRuntimeState();
+
+    /**
+     * The error message if the choice response is invalid to the update user state.
+     *
+     * @return a {@link String} for the message.
+     */
+    @Message(id = 15286, value = "Invalid response. (Valid responses are A, a, B, b, C or c)")
+    String invalidChoiceUpdateUserResponse();
 
     /*
      * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementLogger also contains messages in

--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -822,11 +822,25 @@ public interface DomainManagementMessages {
     String argRole();
 
     /**
-     * Instructions for the {@link org.jboss.as.domain.management.security.adduser.AddUser.CommandLineArgument#GROUP} command line argument.
+     * Instructions for the {@link org.jboss.as.domain.management.security.adduser.AddUser.CommandLineArgument#GROUPS} command line argument.
      * @return the message.
      */
     @Message(id = Message.NONE, value = "Comma-separated list of groups for the user.")
     String argGroup();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.adduser.AddUser.CommandLineArgument#ENABLE} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Enable the user")
+    String argEnable();
+
+    /**
+     * Instructions for the {@link org.jboss.as.domain.management.security.adduser.AddUser.CommandLineArgument#DISABLE} command line argument.
+     * @return the message.
+     */
+    @Message(id = Message.NONE, value = "Disable the user")
+    String argDisable();
 
     /**
      * Instructions for the {@link org.jboss.as.domain.management.security.adduser.AddUser.CommandLineArgument#HELP} command line argument.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/AddUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/AddUser.java
@@ -109,11 +109,7 @@ public class AddUser {
             nextState = new ErrorState(theConsole, MESSAGES.noPasswordExiting(), null, stateValues);
             return;
         }
-        if (password == null) {
-            stateValues.setPassword(new char[0]);
-        } else {
-            stateValues.setPassword(password.toCharArray());
-        }
+        stateValues.setPassword(password);
         stateValues.setRealm(realm);
         stateValues.setRealmMode(realmMode);
         stateValues.setFileMode(fileMode);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/AddUserState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/AddUserState.java
@@ -51,7 +51,15 @@ public class AddUserState extends UpdatePropertiesHandler implements State {
 
     @Override
     public State execute() {
-        State nextState = update(stateValues);
+        char[] password = stateValues.getPassword();
+        State nextState;
+        if (password.length == 0) {
+            // The user doesn't exist and the password is empty !
+            nextState = new ErrorState(theConsole, MESSAGES.noPasswordExiting(), null, stateValues);
+        } else {
+            nextState = update(stateValues);
+        }
+
         /*
          * If this is interactive mode and no error occurred offer to display the
          * Base64 password of the user - otherwise the util can end.
@@ -80,6 +88,9 @@ public class AddUserState extends UpdatePropertiesHandler implements State {
             }
             Properties prob = propertiesHandler.getProperties();
             prob.setProperty(entry[0], entry[1]);
+            if (entry.length > 2) {
+                prob.setProperty(entry[0] + "!disable", entry[2]);
+            }
             propertiesHandler.persistProperties();
         } catch (StartException e) {
             throw new IllegalStateException(MESSAGES.unableToAddUser(file.getAbsolutePath(), e.getMessage()));

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/DisplaySecret.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/DisplaySecret.java
@@ -22,10 +22,10 @@
 
 package org.jboss.as.domain.management.security.adduser;
 
+import org.jboss.util.Base64;
+
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
 import static org.jboss.as.domain.management.security.adduser.AddUser.NEW_LINE;
-
-import org.jboss.util.Base64;
 
 /**
  * A state to display the secret element needed for server to server password defintion.
@@ -43,7 +43,7 @@ public class DisplaySecret implements State {
     }
 
     public State execute() {
-        String pwdBase64 = Base64.encodeBytes(new String(stateValues.getPassword()).getBytes());
+        String pwdBase64 = Base64.encodeBytes(stateValues.getPassword().getBytes());
         theConsole.printf(MESSAGES.secretElement(pwdBase64));
         theConsole.printf(NEW_LINE);
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptPasswordState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptPasswordState.java
@@ -59,7 +59,7 @@ public class PromptPasswordState implements State {
                 if (tempChar == null || tempChar.length == 0) {
                     return new ErrorState(theConsole, MESSAGES.noPasswordExiting());
                 }
-                stateValues.setPassword(tempChar);
+                stateValues.setPassword(new String(tempChar));
 
                 return new ValidatePasswordState(theConsole, stateValues);
             } else {
@@ -70,7 +70,7 @@ public class PromptPasswordState implements State {
                     secondTempChar = new char[0]; // If re-entry missed allow fall through to comparison.
                 }
 
-                if (Arrays.equals(stateValues.getPassword(), secondTempChar) == false) {
+                if (Arrays.equals(stateValues.getPassword().toCharArray(), secondTempChar) == false) {
                     // Start again at the first password.
                     return new ErrorState(theConsole, MESSAGES.passwordMisMatch(), new PromptPasswordState(theConsole, stateValues, false));
                 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
@@ -114,7 +114,7 @@ public class PropertyFileFinder implements State {
             UserPropertiesFileLoader pfl = null;
             try {
                 pfl = loadUsersFile(current);
-                foundUsers.addAll(pfl.getProperties().stringPropertyNames());
+                foundUsers.addAll(pfl.getUserNames());
                 if (realmName == null) {
                     realmName = pfl.getRealmName();
                 } else {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinder.java
@@ -109,12 +109,14 @@ public class PropertyFileFinder implements State {
         stateValues.setUserFiles(foundFiles);
 
         String realmName = null;
-        Set<String> foundUsers = new HashSet<String>();
+        Set<String> enabledFoundUsers = new HashSet<String>();
+        Set<String> disabledFoundUsers = new HashSet<String>();
         for (File current : stateValues.getUserFiles()) {
             UserPropertiesFileLoader pfl = null;
             try {
                 pfl = loadUsersFile(current);
-                foundUsers.addAll(pfl.getUserNames());
+                enabledFoundUsers.addAll(pfl.getEnabledUserNames());
+                disabledFoundUsers.addAll(pfl.getDisabledUserNames());
                 if (realmName == null) {
                     realmName = pfl.getRealmName();
                 } else {
@@ -143,7 +145,8 @@ public class PropertyFileFinder implements State {
             stateValues.setRealm(realmName);
             stateValues.setRealmMode(RealmMode.DISCOVERED);
         }
-        stateValues.setKnownUsers(foundUsers);
+        stateValues.setEnabledKnownUsers(enabledFoundUsers);
+        stateValues.setDisabledKnownUsers(disabledFoundUsers);
 
         // TODO - Should we go straight to user validation instead of prompting?
         return stateValues.isInteractive() ? new PromptRealmState(theConsole, stateValues) : new PromptNewUserState(theConsole,

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/RuntimeOptions.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/RuntimeOptions.java
@@ -41,6 +41,16 @@ class RuntimeOptions {
 
     private String groupProperties;
 
+    /**
+     * Enable/Disable mode is active by using --enable or --disable argument
+     */
+    private boolean enableDisableMode = false;
+
+    /**
+     * Disable a user
+     */
+    private boolean disable = false;
+
     public ConsoleWrapper getConsoleWrapper() {
         return consoleWrapper;
     }
@@ -89,4 +99,19 @@ class RuntimeOptions {
         this.groupProperties = groupProperties;
     }
 
+    boolean isEnableDisableMode() {
+        return enableDisableMode;
+    }
+
+    void setEnableDisableMode(boolean enableDisableMode) {
+        this.enableDisableMode = enableDisableMode;
+    }
+
+    boolean isDisable() {
+        return disable;
+    }
+
+    void setDisable(boolean disable) {
+        this.disable = disable;
+    }
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/StateValues.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/StateValues.java
@@ -171,5 +171,4 @@ public class StateValues {
     public RuntimeOptions getOptions() {
         return options;
     }
-
 }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/StateValues.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/StateValues.java
@@ -23,6 +23,7 @@
 package org.jboss.as.domain.management.security.adduser;
 
 import java.io.File;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,13 +43,14 @@ public class StateValues {
     private AddUser.RealmMode realmMode = RealmMode.DEFAULT;
     private String realm;
     private String userName;
-    private char[] password;
+    private String password;
     private AddUser.FileMode fileMode = FileMode.UNDEFINED;
     private String groups;
     private boolean existingUser = false;
     private List<File> userFiles;
     private List<File> groupFiles;
-    private Set<String> knownUsers;
+    private Set<String> enabledKnownUsers = new HashSet<String>();
+    private Set<String> disabledKnownUsers = new HashSet<String>();
     private Map<String, String> knownGroups;
 
     public StateValues() {
@@ -108,11 +110,11 @@ public class StateValues {
         this.userName = userName;
     }
 
-    public char[] getPassword() {
+    public String getPassword() {
         return password;
     }
 
-    public void setPassword(char[] password) {
+    public void setPassword(String password) {
         this.password = password;
     }
 
@@ -152,12 +154,28 @@ public class StateValues {
         return groupFiles != null && groupFiles.size() > 0;
     }
 
-    public Set<String> getKnownUsers() {
-        return knownUsers;
+    public Set<String> getEnabledKnownUsers() {
+        return enabledKnownUsers;
     }
 
-    public void setKnownUsers(Set<String> knownUsers) {
-        this.knownUsers = knownUsers;
+    public void setEnabledKnownUsers(Set<String> enabledKnownUsers) {
+        this.enabledKnownUsers = enabledKnownUsers;
+    }
+
+    public Set<String> getDisabledKnownUsers() {
+        return disabledKnownUsers;
+    }
+
+    public void setDisabledKnownUsers(Set<String> disabledKnownUsers) {
+        this.disabledKnownUsers = disabledKnownUsers;
+    }
+
+    public boolean isExistingEnabledUser() {
+        return getEnabledKnownUsers().contains(getUserName());
+    }
+
+    public boolean isExistingDisabledUser() {
+        return getDisabledKnownUsers().contains(getUserName());
     }
 
     public Map<String, String> getKnownGroups() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/UpdatePropertiesHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/UpdatePropertiesHandler.java
@@ -23,13 +23,17 @@
 
 package org.jboss.as.domain.management.security.adduser;
 
-import static org.jboss.as.domain.management.security.adduser.AddUser.NEW_LINE;
+import org.jboss.as.domain.management.security.PropertiesFileLoader;
+import org.jboss.as.domain.management.security.UserPropertiesFileLoader;
+import org.jboss.msc.service.StartException;
+import org.jboss.sasl.util.UsernamePasswordHashUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Properties;
 
-import org.jboss.sasl.util.UsernamePasswordHashUtil;
+import static org.jboss.as.domain.management.security.adduser.AddUser.NEW_LINE;
 
 public abstract class UpdatePropertiesHandler {
 
@@ -40,14 +44,35 @@ public abstract class UpdatePropertiesHandler {
     }
 
     /**
-     *  Implement the persistence handler for storing the group properties.
+     * Implement the persistence handler for storing the group properties.
      */
-    abstract void persist(String[] entry, File file) throws IOException;
+    void persist(final String key, final String value, final boolean enableDisableMode, final boolean disable, final File file) throws IOException, StartException {
+        persist(key, value, enableDisableMode, disable, file, null);
+    }
 
     /**
      * Implement the persistence handler for storing the user properties.
      */
-    abstract void persist(String[] entry, File file, final String realm) throws IOException;
+    void persist(final String key, final String value, final boolean enableDisableMode, final boolean disable, final File file, final String realm) throws IOException, StartException {
+        final PropertiesFileLoader propertiesHandler = realm == null ? new PropertiesFileLoader(file.getAbsolutePath()) :
+                new UserPropertiesFileLoader(file.getAbsolutePath());
+        try {
+            propertiesHandler.start(null);
+            if (realm != null) {
+                ((UserPropertiesFileLoader) propertiesHandler).setRealmName(realm);
+            }
+            Properties prob = propertiesHandler.getProperties();
+            if (value != null) {
+                prob.setProperty(key, value);
+            }
+            if (enableDisableMode) {
+                prob.setProperty(key + "!disable", String.valueOf(disable));
+            }
+            propertiesHandler.persistProperties();
+        } finally {
+            propertiesHandler.stop(null);
+        }
+    }
 
     /**
      * Customize message for update or add users
@@ -71,21 +96,27 @@ public abstract class UpdatePropertiesHandler {
     abstract String errorMessage(String fileName, Throwable e);
 
     State update(StateValues stateValues) {
-        String[] entry = new String[3];
-
-        try {
-            String hash = new UsernamePasswordHashUtil().generateHashedHexURP(stateValues.getUserName(), stateValues.getRealm(),
-                    stateValues.getPassword());
-            entry[0] = stateValues.getUserName();
-            entry[1] = hash;
-            entry[2] = String.valueOf(stateValues.getOptions().isDisable());
-        } catch (NoSuchAlgorithmException e) {
-            return new ErrorState(theConsole, e.getMessage(), null, stateValues);
+        final String userName = stateValues.getUserName();
+        final boolean enableDisableMode = stateValues.getOptions().isEnableDisableMode();
+        final boolean disable = stateValues.getOptions().isDisable();
+        final String groups = stateValues.getGroups();
+        final String password;
+        if (stateValues.getPassword() != null) {
+            try {
+                password = new UsernamePasswordHashUtil().generateHashedHexURP(
+                        stateValues.getUserName(),
+                        stateValues.getRealm(),
+                        stateValues.getPassword().toCharArray());
+            } catch (NoSuchAlgorithmException e) {
+                return new ErrorState(theConsole, e.getMessage(), null, stateValues);
+            }
+        } else {
+            password = null;
         }
-
+        // Persist username=password
         for (File current : stateValues.getUserFiles()) {
             try {
-                persist(entry, current, stateValues.getRealm());
+                persist(userName, password, enableDisableMode, disable, current, stateValues.getRealm());
                 if (stateValues.isSilent() == false) {
                     theConsole.printf(consoleUserMessage(current.getCanonicalPath()));
                     theConsole.printf(NEW_LINE);
@@ -94,17 +125,16 @@ public abstract class UpdatePropertiesHandler {
                 return new ErrorState(theConsole, errorMessage(current.getAbsolutePath(), e), null, stateValues);
             }
         }
-
-        if (stateValues.groupPropertiesFound() && stateValues.getGroups() != null) {
+        // Persist username=groups
+        if (stateValues.groupPropertiesFound() && (groups != null || enableDisableMode)) {
             for (final File current : stateValues.getGroupFiles()) {
-                String[] groups = {stateValues.getUserName(), stateValues.getGroups(), String.valueOf(stateValues.getOptions().isDisable())};
                 try {
-                    persist(groups, current);
+                    persist(userName, groups, enableDisableMode, disable, current);
                     if (stateValues.isSilent() == false) {
                         theConsole.printf(consoleGroupsMessage(current.getCanonicalPath()));
                         theConsole.printf(NEW_LINE);
                     }
-                } catch (IOException e) {
+                } catch (Exception e) {
                     return new ErrorState(theConsole, errorMessage(current.getAbsolutePath(), e), null, stateValues);
                 }
             }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/UpdatePropertiesHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/UpdatePropertiesHandler.java
@@ -71,13 +71,14 @@ public abstract class UpdatePropertiesHandler {
     abstract String errorMessage(String fileName, Throwable e);
 
     State update(StateValues stateValues) {
-        String[] entry = new String[2];
+        String[] entry = new String[3];
 
         try {
             String hash = new UsernamePasswordHashUtil().generateHashedHexURP(stateValues.getUserName(), stateValues.getRealm(),
                     stateValues.getPassword());
             entry[0] = stateValues.getUserName();
             entry[1] = hash;
+            entry[2] = String.valueOf(stateValues.getOptions().isDisable());
         } catch (NoSuchAlgorithmException e) {
             return new ErrorState(theConsole, e.getMessage(), null, stateValues);
         }
@@ -96,7 +97,7 @@ public abstract class UpdatePropertiesHandler {
 
         if (stateValues.groupPropertiesFound() && stateValues.getGroups() != null) {
             for (final File current : stateValues.getGroupFiles()) {
-                String[] groups = {stateValues.getUserName(), stateValues.getGroups()};
+                String[] groups = {stateValues.getUserName(), stateValues.getGroups(), String.valueOf(stateValues.getOptions().isDisable())};
                 try {
                     persist(groups, current);
                     if (stateValues.isSilent() == false) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/UpdateUser.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/UpdateUser.java
@@ -51,6 +51,7 @@ public class UpdateUser extends UpdatePropertiesHandler implements State {
     @Override
     public State execute() {
         State nextState = update(stateValues);
+
         /*
          * If this is interactive mode and no error occurred offer to display the
          * Base64 password of the user - otherwise the util can end.
@@ -79,6 +80,9 @@ public class UpdateUser extends UpdatePropertiesHandler implements State {
             }
             Properties prob = propertiesHandler.getProperties();
             prob.setProperty(entry[0], entry[1]);
+            if (entry.length > 2) {
+                prob.setProperty(entry[0] + "!disable", entry[2]);
+            }
             propertiesHandler.persistProperties();
         } catch (StartException e) {
             throw new IllegalStateException(MESSAGES.unableToUpdateUser(file.getAbsolutePath(), e.getMessage()));

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidatePasswordState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidatePasswordState.java
@@ -48,11 +48,13 @@ public class ValidatePasswordState extends AbstractValidationState {
 
     @Override
     protected Collection<State> getValidationStates() {
-        List<State> validationStates = new ArrayList<State>(2);
-        validationStates.add(getUsernameMatchState());
-        validationStates.add(getDetailedCheckState());
-
-        return validationStates;
+        if (!stateValues.getOptions().isEnableDisableMode()) {
+            List<State> validationStates = new ArrayList<State>(2);
+            validationStates.add(getUsernameMatchState());
+            validationStates.add(getDetailedCheckState());
+            return validationStates;
+        }
+        return new ArrayList<State>();
     }
 
     private State getRetryState() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidatePasswordState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidatePasswordState.java
@@ -24,7 +24,6 @@ package org.jboss.as.domain.management.security.adduser;
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -66,7 +65,7 @@ public class ValidatePasswordState extends AbstractValidationState {
 
             @Override
             public State execute() {
-                if (Arrays.equals(stateValues.getUserName().toCharArray(), stateValues.getPassword())) {
+                if (stateValues.getUserName().equals(stateValues.getPassword())) {
                     return new ErrorState(theConsole, MESSAGES.usernamePasswordMatch(), getRetryState(), stateValues);
                 }
 
@@ -81,8 +80,7 @@ public class ValidatePasswordState extends AbstractValidationState {
 
             @Override
             public State execute() {
-                PasswordCheckResult result = PasswordCheckUtil.INSTANCE.check(false, stateValues.getUserName(), new String(
-                        stateValues.getPassword()));
+                PasswordCheckResult result = PasswordCheckUtil.INSTANCE.check(false, stateValues.getUserName(), stateValues.getPassword());
                 if (result.getResult() == PasswordCheckResult.Result.WARN && stateValues.isSilentOrNonInteractive() == false) {
                     String message = result.getMessage();
                     String prompt = MESSAGES.sureToSetPassword(new String(stateValues.getPassword()));

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/AddUserTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/AddUserTestCase.java
@@ -23,13 +23,15 @@
 package org.jboss.as.domain.management.security.adduser;
 
 import org.jboss.msc.service.StartException;
+import org.jboss.sasl.util.UsernamePasswordHashUtil;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
 
 import static org.jboss.as.domain.management.DomainManagementMessages.MESSAGES;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 /**
@@ -42,14 +44,10 @@ public class AddUserTestCase extends PropertyTestHelper {
     @Test
     public void testAddUser() throws IOException, StartException {
         values.setGroups(ROLES);
-        AddUserState addUserState = new AddUserState(consoleMock, values);
 
-        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE).
-                expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(), values.getGroupFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE);
-        consoleMock.setResponses(consoleBuilder);
+        AssertConsoleBuilder consoleBuilder = buildAddUserGroupAssertConsole();
+
+        AddUserState addUserState = new AddUserState(consoleMock, values);
         addUserState.update(values);
 
         assertRolePropertyFile(values.getUserName());
@@ -58,130 +56,168 @@ public class AddUserTestCase extends PropertyTestHelper {
         consoleBuilder.validate();
     }
 
-
     @Test
     public void testAddEnabledUser() throws IOException, StartException {
-        values.setUserName("Donny.Donowitz");
-        values.setGroups(ROLES);
-        values.getOptions().setDisable(false);
-        AddUserState addUserState = new AddUserState(consoleMock, values);
-
-        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE).
-                expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(), values.getGroupFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE);
-        consoleMock.setResponses(consoleBuilder);
-        addUserState.update(values);
-
-        assertRolePropertyFile(values.getUserName());
-        assertUserPropertyFile(values.getUserName());
-
-        consoleBuilder.validate();
+        enableUser("Donny.Donowitz", UUID.randomUUID().toString(), ROLES);
     }
 
     @Test
     public void testAddDisabledUser() throws IOException, StartException {
-        values.setGroups(ROLES);
-        values.getOptions().setDisable(true);
-        values.setUserName("Omar.Ulmer");
-        AddUserState addUserState = new AddUserState(consoleMock, values);
-
-        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE).
-                expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(), values.getGroupFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE);
-        consoleMock.setResponses(consoleBuilder);
-        addUserState.update(values);
-
-        assertNull("The user is disabled, the user line must start with #", getPasswordFromUserProperty(values.getUserName()));
-        assertNull("The user is disabled, the roles line must start with #", getRolesFromRoleProperty(values.getUserName()));
-        assertRolePropertyFile(values.getUserName(), true);
-        assertUserPropertyFile(values.getUserName(), true);
-
-        consoleBuilder.validate();
+        disableUser("Hugo.Stiglitz", UUID.randomUUID().toString(), ROLES);
     }
 
     @Test
-    public void testEnableDisabledUser() throws IOException, StartException {
+    public void testEnableDisabledUser_keepRolesPassword() throws IOException, StartException {
         // Disable user
-        values.setGroups(ROLES);
-        values.getOptions().setDisable(true);
-        values.setUserName("Omar.Ulmer");
-        AddUserState addUserState = new AddUserState(consoleMock, values);
-        AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE).
-                expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(), values.getGroupFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE);
-        consoleMock.setResponses(consoleBuilder);
-        addUserState.update(values);
+        disableUser("Omar.Ulmer", UUID.randomUUID().toString(), ROLES);
+        // Enable user with the same roles(groups)/password
+        enableUser("Omar.Ulmer", null, null);
+    }
 
-        assertNull("The user is disabled, the user line must start with #", getPasswordFromUserProperty(values.getUserName()));
-        assertNull("The user is disabled, the roles line must start with #", getRolesFromRoleProperty(values.getUserName()));
-        assertRolePropertyFile(values.getUserName(), true);
-        assertUserPropertyFile(values.getUserName(), true);
-        consoleBuilder.validate();
-
-        int roleFileLineNumber = countLineNumberRoleFile();
-        int userFileLineNumber = countLineNumberUserFile();
-
-        // Enable user
-        values.getOptions().setDisable(false);
-        consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE).
-                expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(), values.getGroupFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE);
-        consoleMock.setResponses(consoleBuilder);
-        addUserState = new AddUserState(consoleMock, values);
-        addUserState.update(values);
-
-        assertRolePropertyFile(values.getUserName());
-        assertUserPropertyFile(values.getUserName());
-        assertEquals("Enabling a role just uncomment the line and must not create a new one", roleFileLineNumber, countLineNumberRoleFile());
-        assertEquals("Enabling a user just uncomment the line and must not create a new one", userFileLineNumber, countLineNumberUserFile());
-        consoleBuilder.validate();
+    @Test
+    public void testEnableDisabledUser_newRolesPassword() throws IOException, StartException {
+        // Disable user
+        disableUser("Guillaume.Grossetie", UUID.randomUUID().toString(), ROLES);
+        // Enable user with a new password and groups
+        enableUser("Guillaume.Grossetie", UUID.randomUUID().toString(), "developer");
     }
 
     @Test
     public void testEnableEnabledUser() throws IOException, StartException {
         // Enable user
-        values.setGroups(ROLES);
-        values.getOptions().setDisable(false);
-        values.setUserName("Aldo.Raine");
+        enableUser("Aldo.Raine", UUID.randomUUID().toString(), ROLES);
+        // (Re)Enable user
+        enableUser("Aldo.Raine", null, null);
+    }
+
+    @Test
+    public void testDisableDisabledUser() throws IOException, StartException {
+        // Disable user
+        disableUser("Archie.Hicox", UUID.randomUUID().toString(), ROLES);
+        // (Re)Disable user
+        disableUser("Archie.Hicox", null, null);
+    }
+
+    private void disableUser(String userName, String password, String groups) throws IOException, StartException {
+        values.setUserName(userName);
+        values.setPassword(password);
+        values.setGroups(groups);
+        values.getOptions().setDisable(true);
+        values.getOptions().setEnableDisableMode(true);
+
+        final String expectedPassword;
+        if (password == null) {
+            // Keep the previous password (already encrypted)
+            expectedPassword = getPassword(values.getUserName());
+        } else {
+            // Encrypt the new password
+            try {
+                expectedPassword = new UsernamePasswordHashUtil().generateHashedHexURP(
+                        values.getUserName(),
+                        values.getRealm(),
+                        password.toCharArray());
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException("", e);
+            }
+        }
+        final String expectedGroups;
+        if (groups == null) {
+            // Keep the previous groups
+            expectedGroups = getRoles(values.getUserName());
+        } else {
+            // Use the defined groups
+            expectedGroups = groups;
+        }
+        // Count the previous number of lines in the role and user files
+        int previousRoleFileLineNumber = countLineNumberRoleFile();
+        int previousUserFileLineNumber = countLineNumberUserFile();
+
+        AssertConsoleBuilder consoleBuilder = buildAddUserGroupAssertConsole();
+
         AddUserState addUserState = new AddUserState(consoleMock, values);
+        addUserState.update(values);
+
+        assertNull("The user is disabled, the user line must start with #", getEnabledUserPassword(values.getUserName()));
+        assertNull("The user is disabled, the roles line must start with #", getEnabledUserRoles(values.getUserName()));
+        assertEnableDisableUser(expectedPassword, expectedGroups, previousRoleFileLineNumber, previousUserFileLineNumber, consoleBuilder);
+    }
+
+    private void enableUser(String userName, String password, String groups) throws IOException, StartException {
+        values.setUserName(userName);
+        values.setPassword(password);
+        values.setGroups(groups);
+        values.getOptions().setDisable(false);
+        values.getOptions().setEnableDisableMode(true);
+
+        final String expectedPassword;
+        if (password == null) {
+            // Keep the previous password (already encrypted)
+            expectedPassword = getPassword(values.getUserName());
+        } else {
+            // Encrypt the new password
+            try {
+                expectedPassword = new UsernamePasswordHashUtil().generateHashedHexURP(
+                        values.getUserName(),
+                        values.getRealm(),
+                        password.toCharArray());
+            } catch (NoSuchAlgorithmException e) {
+                throw new RuntimeException("", e);
+            }
+        }
+        final String expectedGroups;
+        if (groups == null) {
+            // Keep the previous groups
+            expectedGroups = getRoles(values.getUserName());
+        } else {
+            // Use the defined groups
+            expectedGroups = groups;
+        }
+        // Count the previous number of lines in the role and user files
+        int previousRoleFileLineNumber = countLineNumberRoleFile();
+        int previousUserFileLineNumber = countLineNumberUserFile();
+
+        AssertConsoleBuilder consoleBuilder = buildAddUserGroupAssertConsole();
+
+        AddUserState addUserState = new AddUserState(consoleMock, values);
+        addUserState.update(values);
+
+        assertEnableDisableUser(expectedPassword, expectedGroups, previousRoleFileLineNumber, previousUserFileLineNumber, consoleBuilder);
+    }
+
+    /**
+     * Build an "Assert Console" to validate that the output will display "user added" and "groups added".
+     * @return The "Assert Console" built
+     * @throws IOException
+     */
+    private AssertConsoleBuilder buildAddUserGroupAssertConsole() throws IOException {
         AssertConsoleBuilder consoleBuilder = new AssertConsoleBuilder().
                 expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddUser.NEW_LINE).
                 expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(), values.getGroupFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddUser.NEW_LINE);
         consoleMock.setResponses(consoleBuilder);
-        addUserState.update(values);
+        return consoleBuilder;
+    }
 
-        assertRolePropertyFile(values.getUserName());
-        assertUserPropertyFile(values.getUserName());
-        consoleBuilder.validate();
-
-        int roleFileLineNumber = countLineNumberRoleFile();
-        int userFileLineNumber = countLineNumberUserFile();
-
-        // (Re)Enable user
-        values.getOptions().setDisable(false);
-        consoleBuilder = new AssertConsoleBuilder().
-                expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE).
-                expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(), values.getGroupFiles().get(0).getCanonicalPath())).
-                expectedDisplayText(AddUser.NEW_LINE);
-        consoleMock.setResponses(consoleBuilder);
-        addUserState = new AddUserState(consoleMock, values);
-        addUserState.update(values);
-
-        assertRolePropertyFile(values.getUserName());
-        assertUserPropertyFile(values.getUserName());
-        assertEquals("Enabling a role just uncomment the line and must not create a new one", roleFileLineNumber, countLineNumberRoleFile());
-        assertEquals("Enabling a user just uncomment the line and must not create a new one", userFileLineNumber, countLineNumberUserFile());
-        consoleBuilder.validate();
+    /**
+     * Assert that the enabled/disabled user is correctly added to the user and roles files.
+     * @param expectedPassword The expected password
+     * @param expectedGroups The expected groups
+     * @param previousRoleFileLineNumber The number of lines of the roles file before enabling/disabling the user
+     * @param previousUserFileLineNumber The number of lines of the user file before enabling/disabling the user
+     * @param assertConsole The console to validate the output
+     * @throws StartException
+     * @throws IOException
+     */
+    private void assertEnableDisableUser(String expectedPassword, String expectedGroups, int previousRoleFileLineNumber, int previousUserFileLineNumber, AssertConsoleBuilder assertConsole) throws StartException, IOException {
+        assertRolePropertyFile(values.getUserName(), expectedGroups);
+        assertUserPropertyFile(values.getUserName(), expectedPassword);
+        if (previousRoleFileLineNumber > 0) {
+            assertEquals("Enabling/disabling a role just uncomment/comment out the line and must not create a new one", previousRoleFileLineNumber, countLineNumberRoleFile());
+        }
+        if (previousUserFileLineNumber > 0) {
+            assertEquals("Enabling/disabling a user just uncomment/comment out the line and must not create a new one", previousUserFileLineNumber, countLineNumberUserFile());
+        }
+        assertConsole.validate();
     }
 }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyFileFinderTestCase.java
@@ -81,7 +81,7 @@ public class PropertyFileFinderTestCase extends PropertyTestHelper {
         State propertyFileFinder = new PropertyFileFinder(consoleMock, values);
         State nextState = propertyFileFinder.execute();
         assertTrue(nextState instanceof PromptRealmState);
-        assertTrue("Expected to find the "+USER_NAME+" in the list of known users",values.getKnownUsers().contains(USER_NAME));
+        assertTrue("Expected to find the "+USER_NAME+" in the list of known enabled users",values.getEnabledKnownUsers().contains(USER_NAME));
         assertTrue("Expected the values.getPropertiesFiles() contained the "+standaloneMgmtUserFile,values.getUserFiles().contains(standaloneMgmtUserFile));
         assertTrue("Expected the values.getPropertiesFiles() contained the "+domainMgmtUserFile,values.getUserFiles().contains(domainMgmtUserFile));
     }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyPatternTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyPatternTestCase.java
@@ -1,0 +1,58 @@
+package org.jboss.as.domain.management.security.adduser;
+
+import org.jboss.as.domain.management.security.PropertiesFileLoader;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.Assert.assertEquals;
+
+public class PropertyPatternTestCase {
+
+    @Test
+    public void testPropertyPatternMatcher() throws IOException {
+        List<String> content = Arrays.asList(
+                "#Guillaume.Grossetie=developer",
+                "Aldo.Raine@Inglorious-Basterds.com=sergent,2division",
+                "# Comment",
+                "",
+                "#",
+                "#Omar.Ulmer=soldier"
+        );
+        List<String> keys = new ArrayList<String>();
+        List<String> values = new ArrayList<String>();
+        Pattern propertyPattern = PropertiesFileLoader.PROPERTY_PATTERN;
+        for (String line : content) {
+            Matcher matcher = propertyPattern.matcher(line.trim());
+            if (matcher.matches()) {
+                keys.add(matcher.group(1));
+                values.add(matcher.group(2));
+            }
+        }
+        assertEquals(3, keys.size());
+        assertEquals("Guillaume.Grossetie", keys.get(0));
+        assertEquals("Aldo.Raine@Inglorious-Basterds.com", keys.get(1));
+        assertEquals("Omar.Ulmer", keys.get(2));
+
+        assertEquals(3, values.size());
+        assertEquals("developer", values.get(0));
+        assertEquals("sergent,2division", values.get(1));
+        assertEquals("soldier", values.get(2));
+    }
+
+    protected String getUserName(String line) {
+        final String userName;
+        int separatorIndex = line.indexOf('=');
+        if (line.startsWith("#")) {
+            userName = line.substring(1, separatorIndex);
+        } else {
+            userName = line.substring(0, separatorIndex);
+        }
+        return userName;
+    }
+}

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyTestHelper.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/PropertyTestHelper.java
@@ -26,13 +26,18 @@ import org.jboss.as.domain.management.security.PropertiesFileLoader;
 import org.jboss.msc.service.StartException;
 import org.junit.Before;
 
+import java.io.BufferedReader;
+import java.io.Closeable;
 import java.io.File;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Helper for setting up a test case with ConsoleMock, StateValues and
@@ -79,14 +84,162 @@ public class PropertyTestHelper {
     }
 
     protected void assertUserPropertyFile(String userName) throws StartException, IOException {
-        Properties properties = loadProperties(values.getUserFiles().get(0).getAbsolutePath());
-        String password = (String) properties.get(userName);
+        assertUserPropertyFile(userName, false);
+    }
+
+    protected void assertUserPropertyFile(String userName, boolean disable) throws StartException, IOException {
+        final String password;
+        if (disable) {
+            // Read the file line by line and return the password of the user
+            password = getPasswordFromUserFile(userName);
+        } else {
+            // Load the properties and return the password of the user
+            password = getPasswordFromUserProperty(userName);
+        }
         assertNotNull(password);
     }
 
     protected void assertRolePropertyFile(String userName) throws StartException, IOException {
-        Properties properties = loadProperties(values.getGroupFiles().get(0).getAbsolutePath());
-        String roles = (String) properties.get(userName);
-        assertEquals(ROLES,roles);
+        assertRolePropertyFile(userName, false);
+    }
+
+    protected void assertRolePropertyFile(String userName, boolean disable) throws StartException, IOException {
+        final String roles;
+        if (disable) {
+            // Read the file line by line and return the roles of the user
+            roles = getRolesFromRoleFile(userName);
+        } else {
+            // Load the properties and return the roles of the user
+            roles = getRolesFromRoleProperty(userName);
+        }
+        assertEquals(ROLES, roles);
+    }
+
+    /**
+     * Read the properties users file and return the password of the user
+     *
+     * @param userName The name of the user
+     * @return The password of the user
+     * @throws StartException
+     * @throws IOException
+     */
+    protected String getPasswordFromUserProperty(String userName) throws StartException, IOException {
+        return getValueFromProperty(userName, values.getUserFiles().get(0).getAbsolutePath());
+    }
+
+    /**
+     * Read the properties roles file and return the roles of the user
+     *
+     * @param userName The name of the user
+     * @return The roles of the user
+     * @throws StartException
+     * @throws IOException
+     */
+    protected String getRolesFromRoleProperty(String userName) throws StartException, IOException {
+        return getValueFromProperty(userName, values.getGroupFiles().get(0).getAbsolutePath());
+    }
+
+    /**
+     * Load properties from the file and return the value of the username property
+     *
+     * @param userName The name of the user
+     * @param filePath The file path
+     * @return The value of the username property
+     * @throws StartException
+     * @throws IOException
+     */
+    private String getValueFromProperty(String userName, String filePath) throws StartException, IOException {
+        Properties properties = loadProperties(filePath);
+        return (String) properties.get(userName);
+    }
+
+    /**
+     * Read the users file line by line and return the password of the user.
+     *
+     * @param userName The name of the user
+     * @return The password of the user
+     * @throws IOException
+     * @see #getValueFromFile(String, String)
+     */
+    private String getPasswordFromUserFile(String userName) throws IOException {
+        return getValueFromFile(userName, values.getUserFiles().get(0).getAbsolutePath());
+    }
+
+    /**
+     * Read the roles file line by line and return the roles of the user.
+     *
+     * @param userName The name of the user
+     * @return The roles of the user
+     * @throws IOException
+     */
+    private String getRolesFromRoleFile(String userName) throws IOException {
+        return getValueFromFile(userName, values.getGroupFiles().get(0).getAbsolutePath());
+    }
+
+    /**
+     * Count the number of lines in the users file.
+     *
+     * @return The number of lines in the file
+     * @throws IOException
+     */
+    protected int countLineNumberUserFile() throws IOException {
+        return readContent(values.getUserFiles().get(0).getAbsolutePath()).size();
+    }
+
+    /**
+     * Count the number of lines in the roles file
+     *
+     * @return The number of lines in the file
+     * @throws IOException
+     */
+    protected int countLineNumberRoleFile() throws IOException {
+        return readContent(values.getGroupFiles().get(0).getAbsolutePath()).size();
+    }
+
+    /**
+     * Read the file line by line and return the value of the username line.
+     *
+     * @param userName The name of the user
+     * @param filePath The file path
+     * @return The value of the username line
+     * @throws IOException
+     */
+    private String getValueFromFile(String userName, String filePath) throws IOException {
+        List<String> content = readContent(filePath);
+        boolean found = false;
+        String value = null;
+        for (String line : content) {
+            String trimmed = line.trim();
+            if (trimmed.contains("#" + userName)) {
+                found = true;
+                value = trimmed.substring(trimmed.indexOf('=') + 1, trimmed.length());
+                break;
+            }
+        }
+        assertTrue(found);
+        return value;
+    }
+
+    private List<String> readContent(String filePath) throws IOException {
+        List<String> content = new ArrayList<String>();
+        FileReader fileReader = new FileReader(filePath);
+        BufferedReader bufferedFileReader = new BufferedReader(fileReader);
+        try {
+            String line;
+            while ((line = bufferedFileReader.readLine()) != null) {
+                content.add(line);
+            }
+        } finally {
+            safeClose(bufferedFileReader);
+            safeClose(fileReader);
+        }
+        return content;
+    }
+
+    private void safeClose(final Closeable c) {
+        try {
+            c.close();
+        } catch (IOException ignored) {
+        }
     }
 }


### PR DESCRIPTION
`add-user` script has now the ability to enable or disable a user with the command line arguments `--enable` and `--disable`.

When enabling or disabling an existing user, the password is not required. Ex :
`./add-user.bat -u ggrossetie --disable`

The disable / enable mechanism just comment out the disabled user.
