### PR TITLE
[WFLY-1710] XA recovery warning after HornetQ fail-back

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
@@ -25,6 +25,7 @@ package org.jboss.as.messaging.jms;
 import static org.jboss.as.messaging.BinderServiceUtil.installAliasBinderService;
 import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
+import static org.jboss.as.messaging.MessagingServices.getHornetQServiceName;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -45,6 +46,7 @@ import org.jboss.as.connector.services.resourceadapters.ResourceAdapterActivator
 import org.jboss.as.connector.services.resourceadapters.deployment.registry.ResourceAdapterDeploymentRegistry;
 import org.jboss.as.connector.subsystems.jca.JcaSubsystemConfiguration;
 import org.jboss.as.connector.util.ConnectorServices;
+import org.jboss.as.messaging.HornetQActivationService;
 import org.jboss.as.messaging.JGroupsChannelLocator;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.NamingService;
@@ -290,6 +292,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
 
             ServiceController<ResourceAdapterDeployment> controller = serviceTarget
                     .addService(ConnectorServices.RESOURCE_ADAPTER_ACTIVATOR_SERVICE.append(name), activator)
+                    .addDependency(HornetQActivationService.getHornetQActivationServiceName(getHornetQServiceName(hqServerName)))
                     .addDependency(ConnectorServices.IRONJACAMAR_MDR, AS7MetadataRepository.class,
                             activator.getMdrInjector())
                     .addDependency(ConnectorServices.RA_REPOSITORY_SERVICE, ResourceAdapterRepository.class,
@@ -308,7 +311,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
                             activator.getCcmInjector()).addDependency(NamingService.SERVICE_NAME)
                     .addDependency(TxnServices.JBOSS_TXN_TRANSACTION_MANAGER)
                     .addDependency(ConnectorServices.BOOTSTRAP_CONTEXT_SERVICE.append("default"))
-                    .setInitialMode(ServiceController.Mode.ACTIVE).install();
+                    .setInitialMode(ServiceController.Mode.PASSIVE).install();
 
             createJNDIAliases(jndiName, jndiAliases, controller);
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
@@ -127,6 +127,9 @@ public class HornetQBackupActivationTestCase {
         checkJMSTopic(backupClient, jmsTopicName, false);
         checkConnectionFactory(backupClient, false);
 
+        System.out.println("===================");
+        System.out.println("STOP LIVE SERVER...");
+        System.out.println("===================");
         // shutdown live server
         container.stop(LIVE_SERVER);
         // let some time for the backup to detect the failure
@@ -138,6 +141,9 @@ public class HornetQBackupActivationTestCase {
         checkJMSTopic(backupClient, jmsTopicName, true);
         checkConnectionFactory(backupClient, true);
 
+        System.out.println("====================");
+        System.out.println("START LIVE SERVER...");
+        System.out.println("====================");
         // restart the live server
         container.start(LIVE_SERVER);
         // let some time for the backup to detect the live node and failback
@@ -153,6 +159,21 @@ public class HornetQBackupActivationTestCase {
         checkJMSQueue(backupClient, jmsQueueName, false);
         checkJMSTopic(backupClient, jmsTopicName, false);
         checkConnectionFactory(backupClient, false);
+
+        System.out.println("=============================");
+        System.out.println("RETURN TO NORMAL OPERATION...");
+        System.out.println("=============================");
+
+        // https://issues.jboss.org/browse/WFLY-1710
+        // set the boolean to true to verify that there are no
+        // XA recovery warnings anymore
+        if (false) {
+            Thread.sleep(36000);
+
+            System.out.println("=============================");
+            System.out.println("DONE...");
+            System.out.println("=============================");
+        }
     }
 
     // https://issues.jboss.org/browse/AS7-6840
@@ -173,22 +194,34 @@ public class HornetQBackupActivationTestCase {
         checkJMSTopic(backupClient, jmsTopicName, false);
         checkConnectionFactory(backupClient, false);
 
+        System.out.println("===================");
+        System.out.println("STOP LIVE SERVER...");
+        System.out.println("===================");
         // shutdown live server
         container.stop(LIVE_SERVER);
+
         // let some time for the backup to detect the failure
         waitForHornetQServerActivation(backupClient, true, TimeoutUtil.adjust(ACTIVATION_TIMEOUT));
         checkHornetQServerStartedAndActiveAttributes(backupClient, true, true);
 
+        System.out.println("====================");
+        System.out.println("START LIVE SERVER...");
+        System.out.println("====================");
         // restart the live server
         container.start(LIVE_SERVER);
+
         // let some time for the backup to detect the live node and failback
         waitForHornetQServerActivation(liveClient, true, TimeoutUtil.adjust(ACTIVATION_TIMEOUT));
         checkHornetQServerStartedAndActiveAttributes(liveClient, true, true);
         waitForHornetQServerActivation(backupClient, false, TimeoutUtil.adjust(ACTIVATION_TIMEOUT));
         checkHornetQServerStartedAndActiveAttributes(backupClient, true, false);
 
+        System.out.println("==============================");
+        System.out.println("STOP LIVE SERVER A 2ND TIME...");
+        System.out.println("==============================");
         // shutdown live servera 2nd time
         container.stop(LIVE_SERVER);
+
         // let some time for the backup to detect the failure
         waitForHornetQServerActivation(backupClient, true, TimeoutUtil.adjust(ACTIVATION_TIMEOUT));
         checkHornetQServerStartedAndActiveAttributes(backupClient, true, true);
@@ -250,7 +283,6 @@ public class HornetQBackupActivationTestCase {
         ModelNode operation = new ModelNode();
         operation.get(OP_ADDR).setEmptyList();
         operation.get(OP).set("reload");
-        operation.get("blocking").set(true);
         try {
             execute(client, operation);
         } catch(IOException e) {
@@ -478,13 +510,11 @@ public class HornetQBackupActivationTestCase {
 
     private static ModelNode execute(ModelControllerClient client, ModelNode operation) throws IOException {
         ModelNode result = client.execute(operation);
-        System.out.println(operation.toJSONString(false) + "\n=>\n" + result.toJSONString(false));
         return result;
     }
 
     private static void executeWithFailure(ModelControllerClient client, ModelNode operation) throws IOException {
         ModelNode result = client.execute(operation);
-        System.out.println(operation.toJSONString(false) + "\n=>\n" + result.toJSONString(false));
         assertEquals(result.toJSONString(true), FAILED, result.get(OUTCOME).asString());
         assertTrue(result.toJSONString(true), result.get(FAILURE_DESCRIPTION).asString().contains("JBAS011678"));
         assertFalse(result.has(RESULT));


### PR DESCRIPTION
When a HornetQ server is deactivated (after a backup server has failed
over and the original live server is restarted), remove the
corresponding HornetQActivationService (instead of flagging it as
PASSIVE) so that all dependents services are stopped.

Add a HornetQActivationService dependency to the
ResourceAdapterActivatorService started in
PooledConnectionFactoryService.createService()
