### PR TITLE
Add EC2-specific config files to standalone/configuration

### DIFF
--- a/build/build-configs.xml
+++ b/build/build-configs.xml
@@ -66,6 +66,28 @@
            paramOutputFile="${generated.configs.domain}/domain.xml"/>
 
       <!-- Example configs -->
+      <sequential>
+          <xslt 
+                in="${generated.configs.src.dir}/configuration/standalone/subsystems-full-ha.xml" 
+                out="${project.build.directory}/generated-subsystems/examples/standalone/subsystems-ec2-full-ha.xml"
+                style="${generated.configs.src.dir}/configuration/examples/xslt/supplement-ec2.xsl"/>
+          <generate-server-config
+                paramTemplateFile="configuration/standalone/template.xml"
+                paramSubsystemsFileBaseDir="${project.build.directory}/generated-subsystems/"
+                paramSubsystemsFile="examples/standalone/subsystems-ec2-full-ha.xml"
+                paramOutputFile="${generated.configs.examples}/standalone-ec2-full-ha.xml"/>
+      </sequential>
+      <sequential>
+          <xslt
+                in="${generated.configs.src.dir}/configuration/standalone/subsystems-ha.xml"
+                out="${project.build.directory}/generated-subsystems/examples/standalone/subsystems-ec2-ha.xml"
+                style="${generated.configs.src.dir}/configuration/examples/xslt/supplement-ec2.xsl"/>
+          <generate-server-config
+                paramTemplateFile="configuration/standalone/template.xml"
+                paramSubsystemsFileBaseDir="${project.build.directory}/generated-subsystems/"
+                paramSubsystemsFile="examples/standalone/subsystems-ec2-ha.xml"
+                paramOutputFile="${generated.configs.examples}/standalone-ec2-ha.xml"/>
+      </sequential>
       <generate-server-config 
            paramTemplateFile="configuration/standalone/template.xml" 
            paramSubsystemsFile="configuration/examples/subsystems-hornetq-colocated.xml"
@@ -92,11 +114,12 @@
       <attribute name="paramTemplateFile"/>
       <attribute name="paramSubsystemsFile"/>
       <attribute name="paramOutputFile"/> 
+      <attribute name="paramSubsystemsFileBaseDir" default="${generated.configs.src.dir}/"/>
 
     	<sequential>
     		<generate-configuration 
     			paramTemplateFile="@{paramTemplateFile}"
-    		   paramSubsystemsFile="@{paramSubsystemsFile}"
+    		   paramSubsystemsFile="@{paramSubsystemsFileBaseDir}@{paramSubsystemsFile}"
     		   paramOutputFile="@{paramOutputFile}"
     		   className="StandaloneMain"/>
       </sequential>
@@ -110,7 +133,7 @@
       <sequential>
          <generate-configuration 
             paramTemplateFile="@{paramTemplateFile}"
-            paramSubsystemsFile="@{paramSubsystemsFile}"
+            paramSubsystemsFile="${generated.configs.src.dir}/@{paramSubsystemsFile}"
             paramOutputFile="@{paramOutputFile}"
             className="DomainMain"/>
       </sequential>
@@ -133,7 +156,7 @@
             
             <arg value="${generated.configs.src.dir}"/>
             <arg value="${generated.configs.src.dir}/@{paramTemplateFile}"/>
-            <arg value="${generated.configs.src.dir}/@{paramSubsystemsFile}"/>
+            <arg value="@{paramSubsystemsFile}"/>
             <arg value="@{paramOutputFile}"/>
          </java>
       </sequential>

--- a/build/src/main/resources/configuration/examples/xslt/supplement-ec2.xsl
+++ b/build/src/main/resources/configuration/examples/xslt/supplement-ec2.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+ 
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+   <!-- xsl:output method="xml" indent="yes"/ -->
+
+   <xsl:template match="@*|node()">
+      <xsl:copy>
+         <xsl:apply-templates select="@*|node()" />
+      </xsl:copy>
+   </xsl:template>
+
+   <xsl:template match="*[local-name() = 'subsystem' and contains(concat(text(), '&#xA;'), '/jgroups.xml&#xA;')]">
+      <xsl:copy>
+         <xsl:attribute name="supplement">
+            <xsl:value-of select="'ec2'"/>
+         </xsl:attribute>
+         <xsl:apply-templates select="@*|node()" />
+      </xsl:copy>
+   </xsl:template>
+
+</xsl:stylesheet>

--- a/build/src/main/resources/configuration/subsystems/jgroups.xml
+++ b/build/src/main/resources/configuration/subsystems/jgroups.xml
@@ -1,16 +1,20 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
+<config default-supplement="default">
    <extension-module>org.jboss.as.clustering.jgroups</extension-module>
    <subsystem xmlns="urn:jboss:domain:jgroups:2.0" default-stack="udp">
        <stack name="udp">
-           <transport type="UDP" socket-binding="jgroups-udp"/>
-           <protocol type="PING"/>
+           <transport type="UDP" socket-binding="jgroups-udp">
+               <?UDPOPTS?>
+           </transport>
+           <?UDPDISCOVERY?>
            <protocol type="MERGE3"/>
            <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
            <protocol type="FD"/>
            <protocol type="VERIFY_SUSPECT"/>
-           <protocol type="pbcast.NAKACK2"/>
+           <protocol type="pbcast.NAKACK2">
+               <?UDPNAKACKOPTS?>
+           </protocol>
            <protocol type="UNICAST2"/>
            <protocol type="pbcast.STABLE"/>
            <protocol type="pbcast.GMS"/>
@@ -21,12 +25,14 @@
        </stack>
        <stack name="tcp">
            <transport type="TCP" socket-binding="jgroups-tcp"/>
-           <protocol type="MPING" socket-binding="jgroups-mping"/>
+           <?TCPDISCOVERY?>
            <protocol type="MERGE2"/>
            <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
            <protocol type="FD"/>
            <protocol type="VERIFY_SUSPECT"/>
-           <protocol type="pbcast.NAKACK2"/>
+           <protocol type="pbcast.NAKACK2">
+               <?TCPNAKACKOPTS?>
+           </protocol>
            <protocol type="UNICAST2"/>
            <protocol type="pbcast.STABLE"/>
            <protocol type="pbcast.GMS"/>
@@ -35,6 +41,44 @@
            <protocol type="RSVP"/>
        </stack>
    </subsystem>
+   <supplement name="default">
+       <replacement placeholder="TCPDISCOVERY">
+           <protocol type="MPING" socket-binding="jgroups-mping"/>
+       </replacement>
+       <replacement placeholder="UDPDISCOVERY">
+           <protocol type="PING"/>
+       </replacement>
+   </supplement>
+   <supplement name="nomcast">
+       <replacement placeholder="UDPOPTS">
+           <property name="ip_mcast">false</property>
+       </replacement>
+       <replacement placeholder="TCPNAKACKOPTS">
+           <property name="use_mcast_xmit">false</property>
+           <property name="use_mcast_xmit_req">false</property>
+       </replacement>
+       <replacement placeholder="UDPNAKACKOPTS">
+           <property name="use_mcast_xmit">false</property>
+           <property name="use_mcast_xmit_req">false</property>
+        </replacement>
+   </supplement>
+   <supplement name="s3ping">
+       <replacement placeholder="TCPDISCOVERY">
+           <protocol type="S3_PING">
+               <property name="access_key">${jboss.jgroups.s3_ping.access_key}</property>
+               <property name="secret_access_key">${jboss.jgroups.s3_ping.secret_access_key}</property>
+               <property name="location">${jboss.jgroups.s3_ping.bucket}</property>
+           </protocol>
+       </replacement>
+       <replacement placeholder="UDPDISCOVERY">
+           <protocol type="S3_PING">
+               <property name="access_key">${jboss.jgroups.s3_ping.access_key}</property>
+               <property name="secret_access_key">${jboss.jgroups.s3_ping.secret_access_key}</property>
+               <property name="location">${jboss.jgroups.s3_ping.bucket}</property>
+           </protocol>
+       </replacement>
+   </supplement>
+   <supplement name="ec2" includes="nomcast s3ping"/>
    <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
    <socket-binding name="jgroups-tcp" port="7600"/>
    <socket-binding name="jgroups-tcp-fd" port="57600"/>

--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -104,7 +104,7 @@
                                     <systemPropertyVariables combine.children="append">
                                         <arquillian.launch>clustering-all</arquillian.launch>
                                         <!-- Use combine.children="append" to pick up parent properties automatically. -->
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>${standalone.ha.xml}</jboss.server.config.file.name>
                                         <cacheMode>SYNC</cacheMode>
                                         <stack>tcp</stack>
                                     </systemPropertyVariables>
@@ -199,7 +199,7 @@
                                     </includes>
                                     <systemPropertyVariables combine.children="append">
                                         <arquillian.launch>clustering-all</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>${standalone.ha.xml}</jboss.server.config.file.name>
                                         <cacheMode>ASYNC</cacheMode>
                                         <stack>tcp</stack>
                                     </systemPropertyVariables>
@@ -218,7 +218,7 @@
                                     </includes>
                                     <systemPropertyVariables combine.children="append">
                                         <arquillian.launch>clustering-all</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>${standalone.ha.xml}</jboss.server.config.file.name>
                                         <cacheMode>SYNC</cacheMode>
                                         <stack>udp</stack>
                                     </systemPropertyVariables>
@@ -237,7 +237,7 @@
                                     </includes>
                                     <systemPropertyVariables combine.children="append">
                                         <arquillian.launch>clustering-all</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>${standalone.ha.xml}</jboss.server.config.file.name>
                                         <cacheMode>ASYNC</cacheMode>
                                         <stack>udp</stack>
                                     </systemPropertyVariables>
@@ -261,7 +261,7 @@
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables combine.children="append">
                                         <arquillian.launch>clustering-all</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>${standalone.ha.xml}</jboss.server.config.file.name>
                                         <stack>udp</stack>
                                     </systemPropertyVariables>
 
@@ -454,7 +454,7 @@
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables combine.children="append">
                                         <arquillian.launch>clustering-xsite</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>${standalone.ha.xml}</jboss.server.config.file.name>
                                         <stack>udp</stack>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/testsuite/integration/manualmode/pom.xml
+++ b/testsuite/integration/manualmode/pom.xml
@@ -96,7 +96,7 @@
                                     <!-- Parameters to test cases. -->
                                     <systemPropertyVariables combine.children="append">
                                         <arquillian.launch>manual-mode</arquillian.launch>
-                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <jboss.server.config.file.name>${standalone.ha.xml}</jboss.server.config.file.name>
                                         <!-- needed for SSLEJBRemoteClientTestCase only, however setting them from within the test itself isn't possible -->
                                         <javax.net.ssl.trustStore>${basedir}/src/test/resources/ejb3/ssl/jbossClient.truststore</javax.net.ssl.trustStore>
                                         <javax.net.ssl.keyStore>${basedir}/src/test/resources/ejb3/ssl/jbossClient.keystore</javax.net.ssl.keyStore>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -41,6 +41,9 @@
         <!-- Used to provide an absolute location for the XSLT scripts. -->
         <xslt.scripts.dir>${jbossas.ts.integ.dir}/src/test/xslt</xslt.scripts.dir>
 
+        <!-- used to override HA configuration file names to test with alternative configuration files -->
+        <standalone.ha.xml>standalone-ha.xml</standalone.ha.xml>
+
         <ts.skipTests>${skipTests}</ts.skipTests>
     </properties>
 
@@ -221,6 +224,7 @@
                                     <includes>
                                          <include>standalone-xts.xml</include>
                                          <include>standalone-rts.xml</include>
+                                         <include>standalone-ec2-*.xml</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -114,6 +114,16 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
 //    }
 //
     @Test
+    public void testStandaloneEC2HA() throws Exception {
+        parseXml("docs/examples/configs/standalone-ec2-ha.xml");
+    }
+
+    @Test
+    public void testStandaloneEC2FullHA() throws Exception {
+        parseXml("docs/examples/configs/standalone-ec2-full-ha.xml");
+    }
+
+    @Test
     public void testHornetQColocated() throws Exception {
         parseXml("docs/examples/configs/standalone-hornetq-colocated.xml");
     }

--- a/testsuite/integration/src/test/scripts/clustering-common-targets.xml
+++ b/testsuite/integration/src/test/scripts/clustering-common-targets.xml
@@ -431,7 +431,7 @@
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                    <include name="**/standalone-ha.xml"/>
+                    <include name="**/standalone*-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
                 </fileset>
@@ -441,7 +441,7 @@
             <!-- Move processed files back. -->
             <move todir="@{output.dir}/@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                   <include name="**/standalone-ha.xml.mod"/>
+                   <include name="**/standalone*-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
                </fileset>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -135,7 +135,7 @@
                 <!-- classpath path="${net.sf.saxon:saxon:jar}"/ -->
                 <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
                     <include name="**/standalone-full.xml"/>
-                    <include name="**/standalone-ha.xml"/>
+                    <include name="**/standalone*-ha.xml"/>
                     <include name="**/standalone.xml"/>
                 </fileset>
                 <param name="managementIPAddress" expression="@{node}"/>
@@ -150,7 +150,7 @@
             <!-- Move processed files back. -->
             <move todir="@{output.dir}/@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                   <include name="**/standalone-ha.xml.mod"/>
+                   <include name="**/standalone*-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
                </fileset>
@@ -185,7 +185,7 @@
                 <!-- can't get this to work -->
                 <!-- classpath path="${net.sf.saxon:saxon:jar}"/ -->
                 <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                    <include name="**/standalone-ha.xml"/>
+                    <include name="**/standalone*-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
                 </fileset>
@@ -197,7 +197,7 @@
             <!-- Move processed files back. -->
             <move todir="@{output.dir}/@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                   <include name="**/standalone-ha.xml.mod"/>
+                   <include name="**/standalone*-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
                </fileset>
@@ -226,7 +226,7 @@
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                    <include name="**/standalone-ha.xml"/>
+                    <include name="**/standalone*-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
                 </fileset>
@@ -235,7 +235,7 @@
             <!-- Move processed files back. -->
             <move todir="@{output.dir}/@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                   <include name="**/standalone-ha.xml.mod"/>
+                   <include name="**/standalone*-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
                </fileset>
@@ -271,7 +271,7 @@
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                    <include name="**/standalone-ha.xml"/>
+                    <include name="**/standalone*-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
                 </fileset>
@@ -286,7 +286,7 @@
             <!-- Move processed files back. -->
             <move todir="@{output.dir}/@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                   <include name="**/standalone-ha.xml.mod"/>
+                   <include name="**/standalone*-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
                </fileset>
@@ -312,7 +312,7 @@
                   extension=".xml.mod"
                   useImplicitFileset="false">
                 <fileset dir="@{output.dir}/@{name}/@{config.dir.name}">
-                    <include name="**/standalone-ha.xml"/>
+                    <include name="**/standalone*-ha.xml"/>
                     <include name="**/standalone.xml"/>
                     <include name="**/standalone-full.xml"/>
                 </fileset>
@@ -323,7 +323,7 @@
             <!-- Move processed files back. -->
             <move todir="@{output.dir}/@{name}/@{config.dir.name}">
                <fileset dir="@{output.dir}/@{name}-tmp/@{config.dir.name}">
-                   <include name="**/standalone-ha.xml.mod"/>
+                   <include name="**/standalone*-ha.xml.mod"/>
                    <include name="**/standalone.xml.mod"/>
                    <include name="**/standalone-full.xml.mod"/>
                </fileset>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-1190

I have added configuration suitable for use inside the EC2 as well I've modified test suite so it is possible to run clustering tests with the EC2 configuration.
Actually I see 2 tests failing when running against the EC2:
org.jboss.as.test.clustering.cluster.ejb3.xpc.StatefulWithXPCFailoverTestCase(SYNC-tcp).testBasicXPC 
org.jboss.as.test.clustering.xsite.XSiteSimpleTestCase.testPutToBackupNotRelayed 

I will look at them anyways but I would like to know if the changes so far look good and can be merged. Since running test suite with standard configuration files works 100% I think it makes more sense to have base ec2 support merged or at least the approach to be accepted before putting more effort into it.
