### PR TITLE
fix intermittent failure on InjectedJMSContextTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/Definitions.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/Definitions.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.context.auxiliary;
+
+import javax.jms.JMSDestinationDefinition;
+
+import org.jboss.as.test.integration.messaging.jms.context.InjectedJMSContextTestCase;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@JMSDestinationDefinition(
+        name = InjectedJMSContextTestCase.QUEUE_NAME,
+        interfaceName = "javax.jms.Queue",
+        destinationName = "InjectedJMSContextTestCaseQueue"
+)
+public class Definitions {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/TransactedMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/auxiliary/TransactedMDB.java
@@ -63,15 +63,23 @@ public class TransactedMDB implements MessageListener {
     {
        System.out.println("TransactedMDB.onMessage");
         try {
+            // ignore redelivered message
+            if (m.getJMSRedelivered()) {
+                return;
+            }
+
             TextMessage message = (TextMessage)m;
             Destination replyTo = m.getJMSReplyTo();
 
+            System.out.println("got message " + message.getText());
+            System.out.println("replying to " + replyTo);
             context.createProducer()
                    .setJMSCorrelationID(message.getJMSMessageID())
                    .send(replyTo, message.getText());
             System.out.println("sent reply");
             if (m.getBooleanProperty("rollback")) {
                 mdbContext.setRollbackOnly();
+                System.out.println("set mdb as rollback only");
             }
         } catch (Exception e) {
             e.printStackTrace();


### PR DESCRIPTION
- clean up all JMS resources (queues, temp queues)
- use a JMSQueueDefinition instead of the CreateQueueSetupTask
  to deploy the JMS queue required by the test
