### PR TITLE
WFLY-1840 Put Multi-JSF installer into WildFly build

### DIFF
--- a/jsf/multi-jsf-installer/pom.xml
+++ b/jsf/multi-jsf-installer/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ JBoss, Home of Professional Open Source.
+~ Copyright 2013, Red Hat, Inc., and individual contributors
+~ as indicated by the @author tags. See the copyright.txt file in the
+~ distribution for a full listing of individual contributors.
+~
+~ This is free software; you can redistribute it and/or modify it
+~ under the terms of the GNU Lesser General Public License as
+~ published by the Free Software Foundation; either version 2.1 of
+~ the License, or (at your option) any later version.
+~
+~ This software is distributed in the hope that it will be useful,
+~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ Lesser General Public License for more details.
+~
+~ You should have received a copy of the GNU Lesser General Public
+~ License along with this software; if not, write to the Free
+~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-jsf-parent</artifactId>
+        <version>8.0.0.Alpha4-SNAPSHOT</version>
+    </parent>
+
+    <groupId>org.wildfly</groupId>
+    <artifactId>wildfly-jsf-installer</artifactId>
+    <version>8.0.0.Alpha4-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>WildFly: JSF Multi-JSF installer</name>
+    <description>Creates a CLI deployment archive that can install new JSF versions to WildFly.</description>
+
+    <properties>
+        <version.jboss.as>${project.version}</version.jboss.as>
+        <version.weld.core>${version.org.jboss.weld.weld}</version.weld.core>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <profiles>
+        <profile>
+            <id>mojarra-2.x</id>
+            <properties>
+                <jsf-impl-name>mojarra</jsf-impl-name>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun.faces</groupId>
+                    <artifactId>jsf-api</artifactId>
+                    <version>${jsf-version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.faces</groupId>
+                    <artifactId>jsf-impl</artifactId>
+                    <version>${jsf-version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>mojarra-1.2</id>
+            <properties>
+                <jsf-impl-name>mojarra</jsf-impl-name>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.faces</groupId>
+                    <artifactId>jsf-api</artifactId>
+                    <version>${jsf-version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>javax.faces</groupId>
+                    <artifactId>jsf-impl</artifactId>
+                    <version>${jsf-version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>myfaces</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <jsf-impl-name>myfaces</jsf-impl-name>
+                <jsf-version>2.1.12</jsf-version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.apache.myfaces.core</groupId>
+                    <artifactId>myfaces-impl</artifactId>
+                    <version>${jsf-version}</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.apache.myfaces.core</groupId>
+                    <artifactId>myfaces-api</artifactId>
+                    <version>${jsf-version}</version>
+                </dependency>
+
+                <dependency>
+                    <groupId>commons-digester</groupId>
+                    <artifactId>commons-digester</artifactId>
+                </dependency>
+
+            </dependencies>
+        </profile>
+    </profiles>
+
+    <build>
+        <defaultGoal>assembly:single</defaultGoal>
+        <finalName>install-${jsf-impl-name}-${jsf-version}</finalName>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>2.3</version>
+                <executions>
+                    <execution>
+                        <id>make-jsf-instller</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <finalName>install-${jsf-impl-name}-${jsf-version}</finalName>
+                    <descriptors>
+                        <descriptor>src/main/assembly/src.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jsf/multi-jsf-installer/src/main/assembly/src.xml
+++ b/jsf/multi-jsf-installer/src/main/assembly/src.xml
@@ -1,0 +1,42 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+  <!--<id>jar-with-packed-dependencies</id>-->
+  <id>jboss-jsf-installer-${jsf-impl-name}-${jsf-version}</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <outputDirectory>/</outputDirectory>
+      <useProjectArtifact>true</useProjectArtifact>
+      <useTransitiveDependencies>false</useTransitiveDependencies>
+      <unpack>false</unpack>
+      <scope>runtime</scope>
+    </dependencySet>
+  </dependencySets>
+  <fileSets>
+    <fileSet>
+      <outputDirectory>/</outputDirectory>
+      <directory>${project.basedir}/src/main/resources</directory>
+      <filtered>true</filtered>
+      <includes>
+        <include>${jsf-impl-name}*.xml</include>
+        <include>injection-module.xml</include>
+      </includes>
+      <useDefaultExcludes>true</useDefaultExcludes>
+    </fileSet>
+  </fileSets>
+  <files>
+      <file>
+          <source>${project.basedir}/src/main/resources/${jsf-impl-name}-deploy.scr</source>
+          <destName>deploy.scr</destName>
+          <filtered>true</filtered>
+      </file>
+      <file>
+          <source>${project.basedir}/src/main/resources/${jsf-impl-name}-undeploy.scr</source>
+          <destName>undeploy.scr</destName>
+          <filtered>true</filtered>
+      </file>
+  </files>
+</assembly>

--- a/jsf/multi-jsf-installer/src/main/resources/injection-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/injection-module.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jsf-injection" slot="${jsf-impl-name}-${jsf-version}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="../../../../../system/layers/base/org/jboss/as/jsf-injection/main/wildfly-jsf-injection-${version.jboss.as}.jar"/>
+        <resource-root path="../../../../../system/layers/base/org/jboss/as/jsf-injection/main/weld-core-jsf-${version.weld.core}.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="com.sun.jsf-impl" slot="${jsf-impl-name}-${jsf-version}"/>
+        <module name="javax.api"/>
+        <module name="org.jboss.as.web-common"/>
+        <module name="javax.servlet.api"/>
+        <module name="org.jboss.as.ee"/>
+        <module name="javax.enterprise.api"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jboss.weld.core"/>
+
+        <module name="javax.faces.api" slot="${jsf-impl-name}-${jsf-version}"/>
+    </dependencies>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-api-module.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,28 +22,19 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<module xmlns="urn:jboss:module:1.1" name="javax.faces.api" slot="${jsf-impl-name}-${jsf-version}">
+    <dependencies>
+        <module name="com.sun.jsf-impl" slot="${jsf-impl-name}-${jsf-version}"/>
+        <module name="javax.enterprise.api" export="true"/>
+        <module name="javax.servlet.api" export="true"/>
+        <module name="javax.servlet.jsp.api" export="true"/>
+        <module name="javax.servlet.jstl.api" export="true"/>
+        <module name="javax.validation.api" export="true"/>
+        <module name="org.glassfish.javax.el" export="true"/>
+        <module name="javax.api"/>
+    </dependencies>
 
-    <parent>
-        <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
-        <version>8.0.0.Alpha4-SNAPSHOT</version>
-    </parent>
-
-    <groupId>org.wildfly</groupId>
-    <artifactId>wildfly-jsf-parent</artifactId>
-    <version>8.0.0.Alpha4-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
-    <name>WildFly: JSF</name>
-
-    <modules>
-       <module>subsystem</module>
-       <module>injection</module>
-       <module>multi-jsf-installer</module>
-    </modules>
-
-</project>
+    <resources>
+        <resource-root path="jsf-api-${jsf-version}.jar"/>
+    </resources>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-deploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-deploy.scr
@@ -1,0 +1,3 @@
+module add --name=javax.faces.api --slot=mojarra-${jsf-version} --resources=jsf-api-${jsf-version}.jar --module-xml=mojarra-api-module.xml
+module add --name=com.sun.jsf-impl --slot=mojarra-${jsf-version} --resources=jsf-impl-${jsf-version}.jar --module-xml=mojarra-impl-module.xml
+module add --name=org.jboss.as.jsf-injection --slot=mojarra-${jsf-version} --module-xml=injection-module.xml

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,28 +22,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<module xmlns="urn:jboss:module:1.1" name="com.sun.jsf-impl" slot="${jsf-impl-name}-${jsf-version}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
-    <parent>
-        <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
-        <version>8.0.0.Alpha4-SNAPSHOT</version>
-    </parent>
+    <dependencies>
+        <module name="javax.faces.api" slot="${jsf-impl-name}-${jsf-version}"/>
+        <module name="javaee.api"/>
+        <module name="javax.servlet.jstl.api"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.apache.xalan" services="import"/>
+    </dependencies>
 
-    <groupId>org.wildfly</groupId>
-    <artifactId>wildfly-jsf-parent</artifactId>
-    <version>8.0.0.Alpha4-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
-    <name>WildFly: JSF</name>
-
-    <modules>
-       <module>subsystem</module>
-       <module>injection</module>
-       <module>multi-jsf-installer</module>
-    </modules>
-
-</project>
+    <resources>
+        <resource-root path="jsf-impl-${jsf-version}.jar"/>
+    </resources>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-undeploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-undeploy.scr
@@ -1,0 +1,3 @@
+module remove --name=javax.faces.api --slot=mojarra-${jsf-version}
+module remove --name=com.sun.jsf-impl --slot=mojarra-${jsf-version}
+module remove --name=org.jboss.as.jsf-injection --slot=mojarra-${jsf-version}

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-api-module.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,28 +22,23 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<module xmlns="urn:jboss:module:1.1" name="javax.faces.api" slot="${jsf-impl-name}-${jsf-version}">
+    <dependencies>
+        <module name="javax.enterprise.api" export="true"/>
+        <module name="javax.servlet.api" export="true"/>
+        <module name="javax.servlet.jsp.api" export="true"/>
+        <module name="javax.servlet.jstl.api" export="true"/>
+        <module name="javax.validation.api" export="true"/>
+        <module name="org.glassfish.javax.el" export="true"/>
+        <module name="javax.api"/>
 
-    <parent>
-        <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
-        <version>8.0.0.Alpha4-SNAPSHOT</version>
-    </parent>
+        <!-- extra dependencies for MyFaces 1.1
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.commons.el"/>
+        <module name="org.apache.commons.lang"/> -->
+    </dependencies>
 
-    <groupId>org.wildfly</groupId>
-    <artifactId>wildfly-jsf-parent</artifactId>
-    <version>8.0.0.Alpha4-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
-    <name>WildFly: JSF</name>
-
-    <modules>
-       <module>subsystem</module>
-       <module>injection</module>
-       <module>multi-jsf-installer</module>
-    </modules>
-
-</project>
+    <resources>
+        <resource-root path="myfaces-api-${jsf-version}.jar"/>
+    </resources>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-deploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-deploy.scr
@@ -1,0 +1,4 @@
+module add --name=javax.faces.api --slot=myfaces-${jsf-version} --resources=myfaces-api-${jsf-version}.jar --module-xml=myfaces-api-module.xml
+module add --name=com.sun.jsf-impl --slot=myfaces-${jsf-version} --resources=myfaces-impl-${jsf-version}.jar --module-xml=myfaces-impl-module.xml
+module add --name=org.jboss.as.jsf-injection --slot=myfaces-${jsf-version} --module-xml=injection-module.xml
+module add --name=org.apache.commons.digester --slot=main --resources=commons-digester-1.8.jar --module-xml=myfaces-digester-module.xml

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-digester-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-digester-module.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,28 +22,19 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.digester">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
-    <parent>
-        <groupId>org.wildfly</groupId>
-        <artifactId>wildfly-parent</artifactId>
-        <version>8.0.0.Alpha4-SNAPSHOT</version>
-    </parent>
+    <resources>
+        <resource-root path="commons-digester-${version.commons-digester}.jar"/>
+    </resources>
 
-    <groupId>org.wildfly</groupId>
-    <artifactId>wildfly-jsf-parent</artifactId>
-    <version>8.0.0.Alpha4-SNAPSHOT</version>
-    <packaging>pom</packaging>
-
-    <name>WildFly: JSF</name>
-
-    <modules>
-       <module>subsystem</module>
-       <module>injection</module>
-       <module>multi-jsf-installer</module>
-    </modules>
-
-</project>
+    <dependencies>
+        <module name="javax.api"/>
+        <module name="org.apache.commons.collections"/>
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.commons.beanutils"/>
+    </dependencies>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="com.sun.jsf-impl" slot="${jsf-impl-name}-${jsf-version}">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <dependencies>
+        <module name="javax.faces.api" slot="${jsf-impl-name}-${jsf-version}"/>
+        <module name="javaee.api"/>
+        <module name="javax.servlet.jstl.api"/>
+        <module name="org.apache.xerces" services="import"/>
+        <module name="org.apache.xalan" services="import"/>
+
+        <!-- extra dependencies for MyFaces -->
+        <module name="org.apache.commons.collections"/>
+        <module name="org.apache.commons.codec"/>
+        <module name="org.apache.commons.beanutils"/>
+        <module name="org.apache.commons.digester"/>
+
+        <!-- extra dependencies for MyFaces 1.1
+        <module name="org.apache.commons.logging"/>
+        <module name="org.apache.commons.el"/>
+        <module name="org.apache.commons.lang"/> -->
+    </dependencies>
+
+    <resources>
+        <resource-root path="${jsf-impl-name}-impl-${jsf-version}.jar"/>
+    </resources>
+</module>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-undeploy.scr
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-undeploy.scr
@@ -1,0 +1,3 @@
+module remove --name=javax.faces.api --slot=myfaces-${jsf-version}
+module remove --name=com.sun.jsf-impl --slot=myfaces-${jsf-version}
+module remove --name=org.jboss.as.jsf-injection --slot=myfaces-${jsf-version}

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <version.commons-cli>1.2</version.commons-cli>
         <version.commons-codec>1.4</version.commons-codec>
         <version.commons-collections>3.2.1</version.commons-collections>
+        <version.commons-digester>1.8</version.commons-digester>
         <version.commons-io>2.1</version.commons-io>
         <version.commons-configuration>1.6</version.commons-configuration>
         <version.commons-lang>2.6</version.commons-lang>
@@ -1585,6 +1586,26 @@
                 <groupId>commons-collections</groupId>
                 <artifactId>commons-collections</artifactId>
                 <version>${version.commons-collections}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>commons-digester</groupId>
+                <artifactId>commons-digester</artifactId>
+                <version>${version.commons-digester}</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-logging</artifactId>
+                        <groupId>commons-logging</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>commons-beanutils</artifactId>
+                        <groupId>commons-beanutils</groupId>
+                    </exclusion>
+                    <exclusion>
+                        <artifactId>javax.servlet</artifactId>
+                        <groupId>servlet-api</groupId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This installer tool doesn't actually add anything to the WildFly server.  It just creates a CLI Deployment Archive.  

The reasons I want to move it into the build are:
1) The installer creates a CLI deployment archive customized to a particular WildFly version.  Because of that, it has proven to be nearly impossible to maintain the tool outside the WildFly build.
2) My personal GitHub account is certainly not the right place for the tool.
3) With the tool living as part of the WildFly build, we now create a default CLI archive that is capable of installing the latest MyFaces version.  The CLI archive will be automatically uploaded to Nexus where anyone can use it without having to run the tool.

See https://issues.jboss.org/browse/WFLY-1840 for more details.
