### PR TITLE
HAL-60: Fix for broken logout

### DIFF
--- a/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiCheckHandler.java
+++ b/domain-http/interface/src/main/java/org/jboss/as/domain/http/server/DomainApiCheckHandler.java
@@ -21,7 +21,15 @@
 */
 package org.jboss.as.domain.http.server;
 
+import static io.undertow.util.Headers.HOST;
+import static io.undertow.util.Headers.LOCATION;
+import static io.undertow.util.Headers.REFERER;
 import static org.jboss.as.domain.http.server.HttpServerLogger.ROOT_LOGGER;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import io.undertow.security.api.SecurityContext;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.handlers.BlockingHandler;
@@ -31,9 +39,11 @@ import io.undertow.util.Headers;
 import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 
+import io.undertow.util.StatusCodes;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.ControlledProcessStateService;
 import org.jboss.as.controller.ModelController;
+import org.jboss.as.domain.http.server.security.LogoutHandler;
 import org.jboss.as.domain.http.server.security.SubjectDoAsHandler;
 
 /**
@@ -99,7 +109,14 @@ class DomainApiCheckHandler implements HttpHandler {
     }
 
     private boolean commonChecks(HttpServerExchange exchange) throws Exception {
-     // AS7-2284 If we are starting or stopping, tell caller the service is unavailable and to try again
+
+        // Check for context flag set by LogoutHandler
+        if (exchange.getQueryParameters().containsKey(LogoutHandler.CONTEXT)) {
+            contextLogout(exchange);
+            return false;
+        }
+
+        // AS7-2284 If we are starting or stopping, tell caller the service is unavailable and to try again
         // later. If "stopping" it's either a reload, in which case trying again will eventually succeed,
         // or it's a true process stop eventually the server will have stopped.
         @SuppressWarnings("deprecation")
@@ -146,5 +163,35 @@ class DomainApiCheckHandler implements HttpHandler {
             }
         }
         return true;
+    }
+
+    private void contextLogout(final HttpServerExchange exchange) {
+        SecurityContext context = exchange.getAttachment(SecurityContext.ATTACHMENT_KEY);
+        context.logout();
+
+        final HeaderMap requestHeaders = exchange.getRequestHeaders();
+        final HeaderMap responseHeaders = exchange.getResponseHeaders();
+
+        String host = null;
+        String protocol = "http";
+        String referrer = responseHeaders.getFirst(REFERER);
+        if (referrer != null) {
+            try {
+                URI uri = new URI(referrer);
+                protocol = uri.getScheme();
+                host = uri.getHost() + (uri.getPort() == -1 ? "" : ":" + String.valueOf(uri.getPort()));
+            } catch (URISyntaxException e) {}
+        }
+        if (host == null) {
+            host = requestHeaders.getFirst(HOST);
+            if (host == null) {
+                exchange.setResponseCode(StatusCodes.INTERNAL_SERVER_ERROR);
+                return;
+            }
+        }
+
+        // Back to LogoutHandler to do the rest of the redirect magic...
+        responseHeaders.add(LOCATION, protocol + "://" + host + "/logout?" + LogoutHandler.REDIRECT);
+        exchange.setResponseCode(StatusCodes.TEMPORARY_REDIRECT);
     }
 }


### PR DESCRIPTION
To fix the broken logout I added a call to `SecurityContext.logout()` in `DomainApiCheckHandler`. After that the original `LogoutHandler` steps are processed. Without that additional `SecurityContext.logout()` the logout does not work anymore in Chrome and Safari.

Don't know if there's another way to get rid of the digest authentication. Any feedback, thoughts and objections are welcome.
