### PR TITLE
WFLY-1815 Distributable SessionManager.getSession(String) implementation is wrong

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
@@ -37,7 +37,6 @@
         <module name="io.undertow.core"/>
         <module name="io.undertow.servlet"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.metadata"/>
         <module name="org.wildfly.clustering.web.spi"/>
     </dependencies>
 </module>

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleImmutableSession.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleImmutableSession.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.clustering.web.infinispan.session;
+
+import org.wildfly.clustering.web.session.ImmutableSession;
+import org.wildfly.clustering.web.session.ImmutableSessionAttributes;
+import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
+import org.wildfly.clustering.web.session.SessionContext;
+
+/**
+ * An immutable "snapshot" of a session which can be accessed outside the scope of a transaction.
+ * @author Paul Ferraro
+ */
+public class SimpleImmutableSession implements ImmutableSession {
+
+    private final String id;
+    private final boolean valid;
+    private final ImmutableSessionMetaData metaData;
+    private final ImmutableSessionAttributes attributes;
+    private final SessionContext context;
+
+    public SimpleImmutableSession(ImmutableSession session) {
+        this.id = session.getId();
+        this.valid = session.isValid();
+        this.metaData = new SimpleImmutableSessionMetaData(session.getMetaData());
+        this.attributes = new SimpleImmutableSessionAttributes(session.getAttributes());
+        this.context = session.getContext();
+    }
+
+    @Override
+    public String getId() {
+        return this.id;
+    }
+
+    @Override
+    public ImmutableSessionMetaData getMetaData() {
+        return this.metaData;
+    }
+
+    @Override
+    public boolean isValid() {
+        return this.valid;
+    }
+
+    @Override
+    public ImmutableSessionAttributes getAttributes() {
+        return this.attributes;
+    }
+
+    @Override
+    public SessionContext getContext() {
+        return this.context;
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleImmutableSessionAttributes.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleImmutableSessionAttributes.java
@@ -19,42 +19,38 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.session;
+package org.wildfly.clustering.web.infinispan.session;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import org.wildfly.clustering.web.session.ImmutableSessionAttributes;
 
 /**
- * Represents a web session.
+ * An immutable "snapshot" of a session's attributes which can be accessed outside the scope of a transaction.
  * @author Paul Ferraro
  */
-public interface Session<L> extends ImmutableSession, AutoCloseable {
-    /**
-     * {@inheritDoc}
-     */
+public class SimpleImmutableSessionAttributes implements ImmutableSessionAttributes {
+
+    private final Map<String, Object> attributes;
+
+    public SimpleImmutableSessionAttributes(ImmutableSessionAttributes attributes) {
+        Map<String, Object> map = new HashMap<>();
+        for (String name: attributes.getAttributeNames()) {
+            this.attributes.put(name, attributes.getAttribute(name));
+        }
+        this.attributes = Collections.unmodifiableMap(map);
+    }
+
     @Override
-    SessionMetaData getMetaData();
+    public Set<String> getAttributeNames() {
+        return this.attributes.keySet();
+    }
 
-    /**
-     * Invalidates this session.
-     * @throws IllegalStateException if this session was already invalidated.
-     */
-    void invalidate();
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    SessionAttributes getAttributes();
-
-    /**
-     * Indicates that the application thread is finished with this session.
-     * This method is intended to be invoked within the context of a batch.
-     */
-    @Override
-    void close();
-
-    /**
-     * Returns the local context of this session.
-     * The local context is *not* replicated to other nodes in the cluster.
-     * @return a local context
-     */
-    L getLocalContext();
+    public Object getAttribute(String name) {
+        return this.attributes.get(name);
+    }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleImmutableSessionMetaData.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleImmutableSessionMetaData.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.clustering.web.infinispan.session;
+
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+import org.wildfly.clustering.web.session.ImmutableSessionMetaData;
+
+/**
+ * An immutable "snapshot" of a session's meta-data which can be accessed outside the scope of a transaction.
+ * @author Paul Ferraro
+ */
+public class SimpleImmutableSessionMetaData implements ImmutableSessionMetaData {
+
+    private final boolean isNew;
+    private final boolean expired;
+    private final Date creationTime;
+    private final Date lastAccessedTime;
+    private final long maxInactiveInterval;
+
+    public SimpleImmutableSessionMetaData(ImmutableSessionMetaData metaData) {
+        this.isNew = metaData.isNew();
+        this.expired = metaData.isExpired();
+        this.creationTime = metaData.getCreationTime();
+        this.lastAccessedTime = metaData.getLastAccessedTime();
+        this.maxInactiveInterval = metaData.getMaxInactiveInterval(TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public boolean isNew() {
+        return this.isNew;
+    }
+
+    @Override
+    public boolean isExpired() {
+        return this.expired;
+    }
+
+    @Override
+    public Date getCreationTime() {
+        return this.creationTime;
+    }
+
+    @Override
+    public Date getLastAccessedTime() {
+        return this.lastAccessedTime;
+    }
+
+    @Override
+    public long getMaxInactiveInterval(TimeUnit unit) {
+        return unit.convert(this.maxInactiveInterval, TimeUnit.MILLISECONDS);
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionMetaDataExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionMetaDataExternalizer.java
@@ -48,7 +48,7 @@ public class SimpleSessionMetaDataExternalizer extends AbstractSimpleExternalize
     }
 
     @Override
-    public SimpleSessionMetaData readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+    public SimpleSessionMetaData readObject(ObjectInput input) throws IOException {
         Date creationTime = new Date(input.readLong());
         Date lastAccessedTime = new Date(input.readLong());
         Time maxInactiveInterval = new Time(input.readInt(), TimeUnit.SECONDS);

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionCacheEntryExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionCacheEntryExternalizer.java
@@ -53,7 +53,7 @@ public class CoarseSessionCacheEntryExternalizer extends AbstractSimpleExternali
     }
 
     @Override
-    public CoarseSessionCacheEntry<Object> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+    public CoarseSessionCacheEntry<Object> readObject(ObjectInput input) throws IOException {
         return new CoarseSessionCacheEntry<>(this.externalizer.readObject(input));
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesCacheKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesCacheKeyExternalizer.java
@@ -44,7 +44,7 @@ public class SessionAttributesCacheKeyExternalizer extends AbstractSimpleExterna
     }
 
     @Override
-    public SessionAttributesCacheKey readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+    public SessionAttributesCacheKey readObject(ObjectInput input) throws IOException {
         return new SessionAttributesCacheKey(input.readUTF());
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionCacheEntryExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionCacheEntryExternalizer.java
@@ -59,7 +59,7 @@ public class FineSessionCacheEntryExternalizer extends AbstractSimpleExternalize
     }
 
     @Override
-    public FineSessionCacheEntry<Object> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+    public FineSessionCacheEntry<Object> readObject(ObjectInput input) throws IOException {
         FineSessionCacheEntry<Object> entry = new FineSessionCacheEntry<>(this.externalizer.readObject(input));
         Set<String> attributes = entry.getAttributes();
         int size = input.readInt();

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeCacheKeyExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeCacheKeyExternalizer.java
@@ -45,7 +45,7 @@ public class SessionAttributeCacheKeyExternalizer extends AbstractSimpleExternal
     }
 
     @Override
-    public SessionAttributeCacheKey readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+    public SessionAttributeCacheKey readObject(ObjectInput input) throws IOException {
         return new SessionAttributeCacheKey(input.readUTF(), input.readUTF());
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseSSOCacheEntryExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseSSOCacheEntryExternalizer.java
@@ -59,7 +59,7 @@ public class CoarseSSOCacheEntryExternalizer extends AbstractSimpleExternalizer<
     }
 
     @Override
-    public CoarseSSOCacheEntry<?> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+    public CoarseSSOCacheEntry<?> readObject(ObjectInput input) throws IOException {
         CoarseSSOCacheEntry<?> entry = new CoarseSSOCacheEntry<>();
         entry.setAuthenticationType(AuthenticationType.values()[input.readByte()]);
         entry.setUser(input.readUTF());

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/ImmutableSession.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/ImmutableSession.java
@@ -33,7 +33,7 @@ public interface ImmutableSession {
     String getId();
 
     /**
-     * Abstraction for session meta information.
+     * Returns this session's meta data.
      * @return this session's meta data
      * @throws IllegalStateException if this session is invalid
      */
@@ -46,14 +46,14 @@ public interface ImmutableSession {
     boolean isValid();
 
     /**
-     * Abstraction for accessing and manipulating session attributes.
+     * Returns this session's attributes.
      * @return this session's attributes
      * @throws IllegalStateException if this session is invalid
      */
     ImmutableSessionAttributes getAttributes();
 
     /**
-     * The application context of this session.
+     * Returns the application context of this session.
      * @return the session's context
      */
     SessionContext getContext();

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
@@ -21,6 +21,7 @@
  */
 package org.wildfly.clustering.web.session;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.wildfly.clustering.web.Batcher;
@@ -36,10 +37,17 @@ public interface SessionManager<L> extends SessionIdentifierFactory, RouteLocato
      */
     void stop();
 
+    /**
+     * Indicates whether or not the session with the specified identifier is known to this session manager.
+     * @param id a unique session identifier
+     * @return true, if the session is known to the manager, false otherwise
+     */
     boolean containsSession(String id);
 
     /**
-     * Returns the session with the specified identifier, or null if none exists
+     * Returns the session with the specified identifier, or null if none exists.
+     * Sessions returned by this method must be closed via {@link Session#close()}.
+     * This method is intended to be invoked within the context of a batch.
      * @param id a session identifier
      * @return an existing web session, or null if none exists
      */
@@ -47,16 +55,12 @@ public interface SessionManager<L> extends SessionIdentifierFactory, RouteLocato
 
     /**
      * Returns the session with the specified identifier, creating one if necessary
+     * Sessions returned by this method must be closed via {@link Session#close()}.
+     * This method is intended to be invoked within the context of a batch.
      * @param id a session identifier
      * @return a new or existing web session
      */
     Session<L> createSession(String id);
-
-    /**
-     * Returns the estimated number of session currently being handled by this session manager.
-     * @return
-     */
-    int size();
 
     /**
      * Returns the default maximum inactive interval, using the specified unit, for all sessions created by this session manager.
@@ -77,4 +81,24 @@ public interface SessionManager<L> extends SessionIdentifierFactory, RouteLocato
      * @return a batcher.
      */
     Batcher getBatcher();
+
+    /**
+     * Returns the identifiers of those sessions that are active on this node.
+     * @return a set of session identifiers.
+     */
+    Set<String> getActiveSessions();
+
+    /**
+     * Returns the identifiers of all sessions on this node, including both active and passive sessions.
+     * @return a set of session identifiers.
+     */
+    Set<String> getLocalSessions();
+
+    /**
+     * Returns a read-only view of the session with the specified identifier.
+     * This method is intended to be invoked within the context of a batch
+     * @param id a unique session identifier
+     * @return a read-only session or null if none exists
+     */
+    ImmutableSession viewSession(String id);
 }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/AbstractSessionAdapter.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/AbstractSessionAdapter.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.clustering.web.undertow.session;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.wildfly.clustering.web.session.ImmutableSession;
+
+import io.undertow.server.session.Session;
+
+/**
+ * Abstract Undertow adapter for a session.
+ * @author Paul Ferraro
+ */
+public abstract class AbstractSessionAdapter<S extends ImmutableSession> implements Session {
+
+    /**
+     * Returns a reference to the delegate session.
+     * @return a session reference
+     */
+    protected abstract S getSession();
+
+    @Override
+    public String getId() {
+        return this.getSession().getId();
+    }
+
+    @Override
+    public long getCreationTime() {
+        return this.getSession().getMetaData().getCreationTime().getTime();
+    }
+
+    @Override
+    public long getLastAccessedTime() {
+        return this.getSession().getMetaData().getLastAccessedTime().getTime();
+    }
+
+    @Override
+    public int getMaxInactiveInterval() {
+        return (int) this.getSession().getMetaData().getMaxInactiveInterval(TimeUnit.SECONDS);
+    }
+
+    @Override
+    public Object getAttribute(String name) {
+        return this.getSession().getAttributes().getAttribute(name);
+    }
+
+    @Override
+    public Set<String> getAttributeNames() {
+        return this.getSession().getAttributes().getAttributeNames();
+    }
+}

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/ImmutableSessionAdapter.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/ImmutableSessionAdapter.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.clustering.web.undertow.session;
+
+import org.wildfly.clustering.web.session.ImmutableSession;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.session.SessionConfig;
+import io.undertow.server.session.SessionManager;
+
+/**
+ * Undertow adapter for an {@link ImmutableSession}.
+ * @author Paul Ferraro
+ */
+public class ImmutableSessionAdapter extends AbstractSessionAdapter<ImmutableSession> {
+
+    private final SessionManager manager;
+    private final ImmutableSession session;
+
+    public ImmutableSessionAdapter(SessionManager manager, ImmutableSession session) {
+        this.manager = manager;
+        this.session = session;
+    }
+
+    @Override
+    public SessionManager getSessionManager() {
+        return this.manager;
+    }
+
+    @Override
+    protected ImmutableSession getSession() {
+        return this.session;
+    }
+
+    @Override
+    public void requestDone(HttpServerExchange serverExchange) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMaxInactiveInterval(int interval) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object setAttribute(String name, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object removeAttribute(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void invalidate(HttpServerExchange exchange) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String changeSessionId(HttpServerExchange exchange, SessionConfig config) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionIdentifierFactoryAdapter.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionIdentifierFactoryAdapter.java
@@ -27,8 +27,7 @@ import org.wildfly.clustering.web.session.SessionIdentifierFactory;
 
 /**
  * Adapts a {@link SessionIdGenerator} to a {@link SessionIdentifierFactory}.
- * @author paul
- *
+ * @author Paul Ferraro
  */
 public class SessionIdentifierFactoryAdapter implements SessionIdentifierFactory {
 

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapterFactory.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapterFactory.java
@@ -21,7 +21,6 @@
  */
 package org.wildfly.clustering.web.undertow.session;
 
-import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.wildfly.clustering.web.session.SessionContext;
 import org.wildfly.clustering.web.session.SessionIdentifierFactory;
 import org.wildfly.clustering.web.session.SessionManager;
@@ -34,14 +33,12 @@ import io.undertow.servlet.api.Deployment;
  * Factory for creating a distributable session manager.
  * @author Paul Ferraro
  */
-public class SessionManagerFacadeFactory implements io.undertow.servlet.api.SessionManagerFactory {
+public class SessionManagerAdapterFactory implements io.undertow.servlet.api.SessionManagerFactory {
 
     private final SessionManagerFactory factory;
-    private final JBossWebMetaData metaData;
 
-    public SessionManagerFacadeFactory(SessionManagerFactory factory, JBossWebMetaData metaData) {
+    public SessionManagerAdapterFactory(SessionManagerFactory factory) {
         this.factory = factory;
-        this.metaData = metaData;
     }
 
     @Override
@@ -49,6 +46,6 @@ public class SessionManagerFacadeFactory implements io.undertow.servlet.api.Sess
         SessionContext context = new SessionContextAdapter(deployment);
         SessionIdentifierFactory factory = new SessionIdentifierFactoryAdapter(new SecureRandomSessionIdGenerator());
         SessionManager<Void> manager = this.factory.createSessionManager(context, factory, null);
-        return new SessionManagerFacade(manager, this.metaData.getReplicationConfig());
+        return new SessionManagerAdapter(manager);
     }
 }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/SessionFacadeTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/SessionFacadeTestCase.java
@@ -41,7 +41,7 @@ import org.wildfly.clustering.web.session.Session;
 import org.wildfly.clustering.web.session.SessionAttributes;
 import org.wildfly.clustering.web.session.SessionManager;
 import org.wildfly.clustering.web.session.SessionMetaData;
-import org.wildfly.clustering.web.undertow.session.SessionFacade;
+import org.wildfly.clustering.web.undertow.session.SessionAdapter;
 import org.wildfly.clustering.web.undertow.session.UndertowSessionManager;
 
 public class SessionFacadeTestCase {
@@ -49,14 +49,14 @@ public class SessionFacadeTestCase {
     private final SessionConfig config = mock(SessionConfig.class);
     private final Session<Void> session = mock(Session.class);
     
-    private final io.undertow.server.session.Session facade = new SessionFacade(this.manager, this.session, this.config);
+    private final io.undertow.server.session.Session adapter = new SessionAdapter(this.manager, this.session, this.config);
     
     @Test
     public void getId() {
         String id = "id";
         when(this.session.getId()).thenReturn(id);
         
-        String result = this.facade.getId();
+        String result = this.adapter.getId();
         
         assertSame(id, result);
     }
@@ -70,7 +70,7 @@ public class SessionFacadeTestCase {
         when(this.manager.getSessionManager()).thenReturn(manager);
         when(manager.getBatcher()).thenReturn(batcher);
 
-        this.facade.requestDone(exchange);
+        this.adapter.requestDone(exchange);
         
         verify(this.session).close();
         verify(batcher).endBatch(true);
@@ -84,7 +84,7 @@ public class SessionFacadeTestCase {
         when(this.session.getMetaData()).thenReturn(metaData);
         when(metaData.getCreationTime()).thenReturn(date);
         
-        long result = this.facade.getCreationTime();
+        long result = this.adapter.getCreationTime();
         
         assertEquals(date.getTime(), result);
     }
@@ -97,7 +97,7 @@ public class SessionFacadeTestCase {
         when(this.session.getMetaData()).thenReturn(metaData);
         when(metaData.getLastAccessedTime()).thenReturn(date);
         
-        long result = this.facade.getLastAccessedTime();
+        long result = this.adapter.getLastAccessedTime();
         
         assertEquals(date.getTime(), result);
     }
@@ -110,7 +110,7 @@ public class SessionFacadeTestCase {
         when(this.session.getMetaData()).thenReturn(metaData);
         when(metaData.getMaxInactiveInterval(TimeUnit.SECONDS)).thenReturn(expected);
         
-        long result = this.facade.getMaxInactiveInterval();
+        long result = this.adapter.getMaxInactiveInterval();
         
         assertEquals(expected, result);
     }
@@ -122,7 +122,7 @@ public class SessionFacadeTestCase {
         
         when(this.session.getMetaData()).thenReturn(metaData);
         
-        this.facade.setMaxInactiveInterval(interval);
+        this.adapter.setMaxInactiveInterval(interval);
         
         verify(metaData).setMaxInactiveInterval(interval, TimeUnit.SECONDS);
     }
@@ -136,7 +136,7 @@ public class SessionFacadeTestCase {
         when(this.session.getAttributes()).thenReturn(attributes);
         when(attributes.getAttribute(name)).thenReturn(expected);
         
-        Object result = this.facade.getAttribute(name);
+        Object result = this.adapter.getAttribute(name);
         
         assertSame(expected, result);
     }
@@ -156,13 +156,13 @@ public class SessionFacadeTestCase {
         when(attributes.setAttribute(name, value)).thenReturn(expected);
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         
-        Object result = this.facade.setAttribute(name, value);
+        Object result = this.adapter.setAttribute(name, value);
         
         assertSame(expected, result);
         
-        verify(listener, never()).attributeAdded(this.facade, name, value);
-        verify(listener).attributeUpdated(this.facade, name, value, expected);
-        verify(listener, never()).attributeRemoved(same(this.facade), same(name), any());
+        verify(listener, never()).attributeAdded(this.adapter, name, value);
+        verify(listener).attributeUpdated(this.adapter, name, value, expected);
+        verify(listener, never()).attributeRemoved(same(this.adapter), same(name), any());
     }
     
     @Test
@@ -179,13 +179,13 @@ public class SessionFacadeTestCase {
         when(attributes.setAttribute(name, value)).thenReturn(expected);
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         
-        Object result = this.facade.setAttribute(name, value);
+        Object result = this.adapter.setAttribute(name, value);
         
         assertSame(expected, result);
         
-        verify(listener).attributeAdded(this.facade, name, value);
-        verify(listener, never()).attributeUpdated(same(this.facade), same(name), same(value), any());
-        verify(listener, never()).attributeRemoved(same(this.facade), same(name), any());
+        verify(listener).attributeAdded(this.adapter, name, value);
+        verify(listener, never()).attributeUpdated(same(this.adapter), same(name), same(value), any());
+        verify(listener, never()).attributeRemoved(same(this.adapter), same(name), any());
     }
     
     @Test
@@ -202,13 +202,13 @@ public class SessionFacadeTestCase {
         when(attributes.removeAttribute(name)).thenReturn(expected);
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         
-        Object result = this.facade.setAttribute(name, value);
+        Object result = this.adapter.setAttribute(name, value);
         
         assertSame(expected, result);
         
-        verify(listener, never()).attributeAdded(this.facade, name, value);
-        verify(listener, never()).attributeUpdated(same(this.facade), same(name), same(value), any());
-        verify(listener).attributeRemoved(this.facade, name, expected);
+        verify(listener, never()).attributeAdded(this.adapter, name, value);
+        verify(listener, never()).attributeUpdated(same(this.adapter), same(name), same(value), any());
+        verify(listener).attributeRemoved(this.adapter, name, expected);
     }
     
     @Test
@@ -225,13 +225,13 @@ public class SessionFacadeTestCase {
         when(attributes.setAttribute(name, value)).thenReturn(expected);
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         
-        Object result = this.facade.setAttribute(name, value);
+        Object result = this.adapter.setAttribute(name, value);
         
         assertSame(expected, result);
         
-        verify(listener, never()).attributeAdded(this.facade, name, value);
-        verify(listener, never()).attributeUpdated(same(this.facade), same(name), same(value), any());
-        verify(listener, never()).attributeRemoved(same(this.facade), same(name), any());
+        verify(listener, never()).attributeAdded(this.adapter, name, value);
+        verify(listener, never()).attributeUpdated(same(this.adapter), same(name), same(value), any());
+        verify(listener, never()).attributeRemoved(same(this.adapter), same(name), any());
     }
     
     @Test
@@ -247,11 +247,11 @@ public class SessionFacadeTestCase {
         when(attributes.removeAttribute(name)).thenReturn(expected);
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         
-        Object result = this.facade.removeAttribute(name);
+        Object result = this.adapter.removeAttribute(name);
         
         assertSame(expected, result);
         
-        verify(listener).attributeRemoved(this.facade, name, expected);
+        verify(listener).attributeRemoved(this.adapter, name, expected);
     }
     
     @Test
@@ -266,11 +266,11 @@ public class SessionFacadeTestCase {
         when(attributes.removeAttribute(name)).thenReturn(null);
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         
-        Object result = this.facade.removeAttribute(name);
+        Object result = this.adapter.removeAttribute(name);
         
         assertNull(result);
         
-        verify(listener, never()).attributeRemoved(same(this.facade), same(name), any());
+        verify(listener, never()).attributeRemoved(same(this.adapter), same(name), any());
     }
     
     @Test
@@ -288,17 +288,17 @@ public class SessionFacadeTestCase {
         when(this.manager.getSessionManager()).thenReturn(manager);
         when(manager.getBatcher()).thenReturn(batcher);
         
-        this.facade.invalidate(exchange);
+        this.adapter.invalidate(exchange);
         
         verify(this.session).invalidate();
         verify(this.config).clearSession(exchange, sessionId);
-        verify(listener).sessionDestroyed(this.facade, exchange, SessionDestroyedReason.INVALIDATED);
+        verify(listener).sessionDestroyed(this.adapter, exchange, SessionDestroyedReason.INVALIDATED);
         verify(batcher).endBatch(true);
     }
     
     @Test
     public void getSessionManager() {
-        assertSame(this.manager, this.facade.getSessionManager());
+        assertSame(this.manager, this.adapter.getSessionManager());
     }
     
     @Test
@@ -336,7 +336,7 @@ public class SessionFacadeTestCase {
         when(manager.locate(sessionId)).thenReturn(route);
         when(this.manager.format(sessionId, route)).thenReturn(routedSessionid);
         
-        String result = this.facade.changeSessionId(exchange, config);
+        String result = this.adapter.changeSessionId(exchange, config);
         
         assertSame(sessionId, result);
         

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowContext.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowContext.java
@@ -87,12 +87,12 @@ public class UndertowContext implements Context {
 
     @Override
     public int getActiveSessionCount() {
-        return this.deployment.getSessionManager().activeSessions();
+        return this.deployment.getSessionManager().getActiveSessions().size();
     }
 
     @Override
     public boolean isDistributable() {
-        return this.deployment.getDeploymentInfo().getSessionManagerFactory() instanceof org.wildfly.clustering.web.undertow.session.SessionManagerFacadeFactory;
+        return this.deployment.getDeploymentInfo().getSessionManagerFactory() instanceof org.wildfly.clustering.web.undertow.session.SessionManagerAdapterFactory;
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -113,7 +113,7 @@ import org.jboss.msc.value.InjectedValue;
 import org.jboss.security.audit.AuditManager;
 import org.jboss.vfs.VirtualFile;
 import org.wildfly.clustering.web.session.SessionManagerFactory;
-import org.wildfly.clustering.web.undertow.session.SessionManagerFacadeFactory;
+import org.wildfly.clustering.web.undertow.session.SessionManagerAdapterFactory;
 import org.wildfly.extension.undertow.JSPConfig;
 import org.wildfly.extension.undertow.ServletContainerService;
 import org.wildfly.extension.undertow.SessionCookieConfig;
@@ -346,7 +346,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
         if (this.mergedMetaData.getDistributable() != null) {
             SessionManagerFactory factory = this.sessionManagerFactory.getOptionalValue();
             if (factory != null) {
-                deploymentInfo.setSessionManagerFactory(new SessionManagerFacadeFactory(factory, this.mergedMetaData));
+                deploymentInfo.setSessionManagerFactory(new SessionManagerAdapterFactory(factory));
             }
         }
     }


### PR DESCRIPTION
In the future, we can avoid these issues if web session clustering changes are merged without my review.
Also:
- Implement new Undertow SessionManager methods.
- Drop more obsolete dependencies.
- More code cleanup.
