### PR TITLE
[WFLY-490] Misc read-resource-description improvements

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -245,6 +245,7 @@ public class ModelDescriptionConstants {
     public static final String PROPERTY = "property";
     public static final String PROTOCOL = "protocol";
     public static final String PROXIES = "proxies";
+    public static final String READ = "read";
     public static final String READ_ATTRIBUTE_OPERATION = "read-attribute";
     public static final String READ_CHILDREN_NAMES_OPERATION = "read-children-names";
     public static final String READ_CHILDREN_TYPES_OPERATION = "read-children-types";
@@ -381,6 +382,7 @@ public class ModelDescriptionConstants {
     public static final String VAULT_OPTION = "vault-option";
     public static final String VAULT_OPTIONS = "vault-options";
     public static final String WILDCARD = "wildcard";
+    public static final String WRITE = "write";
     public static final String WRITE_ATTRIBUTE_OPERATION = "write-attribute";
     public static final String XML_NAMESPACES = "xml-namespaces";
 

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -92,12 +92,6 @@ public class GlobalOperationHandlers {
             .setDefaultValue(new ModelNode(false))
             .build();
 
-    static final SimpleAttributeDefinition ACCESS_CONTROL = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.ACCESS_CONTROL, ModelType.BOOLEAN)
-            .setAllowNull(true)
-            .setDefaultValue(new ModelNode(false))
-            .build();
-
-
     static final SimpleAttributeDefinition NAME = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.NAME, ModelType.STRING)
             .setValidator(new StringLengthValidator(1))
             .setAllowNull(false)

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -552,6 +552,14 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                 if (nodeDescription.hasDefined(ModelDescriptionConstants.OPERATIONS)) {
                     nodeDescription.get(ModelDescriptionConstants.OPERATIONS).clear();
                 }
+                if (nodeDescription.hasDefined(CHILDREN)) {
+                    for (String child: nodeDescription.get(CHILDREN).keys()) {
+                        ModelNode childNode = nodeDescription.get(CHILDREN, child);
+                        if (childNode.isDefined()) {
+                            childNode.remove(ModelDescriptionConstants.DESCRIPTION);
+                        }
+                    }
+                }
             }
             context.getResult().set(nodeDescription);
             context.stepCompleted();

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -32,10 +32,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAI
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODEL_DESCRIPTION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART_REQUIRED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STORAGE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE;
 import static org.jboss.as.controller.operations.global.GlobalOperationHandlers.ACCESS_CONTROL;
 import static org.jboss.as.controller.operations.global.GlobalOperationHandlers.INCLUDE_ALIASES;
 import static org.jboss.as.controller.operations.global.GlobalOperationHandlers.LOCALE;
@@ -443,7 +445,7 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
 
         private void addAttributeAuthorizationResult(ModelNode result, String attributeName, ResourceAuthorization authResp, ActionEffect actionEffect) {
             AuthorizationResult authorizationResult = authResp.getAttributeResult(attributeName, actionEffect);
-            result.get(actionEffect.toString()).set(authorizationResult.getDecision() == Decision.PERMIT);
+            result.get(actionEffect == ActionEffect.READ_CONFIG || actionEffect == ActionEffect.READ_RUNTIME ? READ : WRITE).set(authorizationResult.getDecision() == Decision.PERMIT);
         }
 
         private void addOperationAuthorizationResult(OperationContext context, ModelNode result, ModelNode operation, String operationName) {

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
@@ -186,7 +186,6 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         rootResource.removeChild(ONE_B);
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.MAINTAINER, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
-        System.out.println(result);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         checkResourcePermissions(accessControl.defaultControl, true, true);
     }
@@ -245,8 +244,6 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         registerOneChildRootResource();
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.MONITOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
-        System.out.println(op);
-        System.out.println(result);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         checkResourcePermissions(accessControl.defaultControl, true, false);
     }
@@ -1697,6 +1694,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         Assert.assertFalse(desc.has(ACCESS_CONTROL));
 
         Assert.assertEquals("description", desc.get(ModelDescriptionConstants.DESCRIPTION).asString());
+        Assert.assertTrue(desc.get(CHILDREN, TWO.getKey(), ModelDescriptionConstants.DESCRIPTION).isDefined());
 
         Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
         Set<String> attributes = desc.get(ModelDescriptionConstants.ATTRIBUTES).keys();
@@ -1741,6 +1739,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         Assert.assertEquals(true, defaultOperations.get(OP_CONFIG_RW_NONE));
 
         Assert.assertEquals("description", desc.get(ModelDescriptionConstants.DESCRIPTION).asString());
+        Assert.assertTrue(desc.get(CHILDREN, TWO.getKey(), ModelDescriptionConstants.DESCRIPTION).isDefined());
 
         Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
         Set<String> attributes = desc.get(ModelDescriptionConstants.ATTRIBUTES).keys();
@@ -1793,6 +1792,8 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.DESCRIPTION));
         Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
         Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.OPERATIONS));
+        Assert.assertFalse(desc.get(CHILDREN, TWO.getKey(), ModelDescriptionConstants.DESCRIPTION).isDefined());
+
 
         desc = getChildDescription(desc, TWO);
         accessControl = getResourceAccessControl(desc);
@@ -1830,7 +1831,6 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, true);
         op.get(ACCESS_CONTROL).set(accessControl.toString());
         ModelNode desc = executeForResult(op);
-        System.out.println(desc);
         return getChildDescription(desc, ONE);
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
@@ -64,6 +64,7 @@ import org.jboss.as.controller.access.constraint.VaultExpressionSensitivityConfi
 import org.jboss.as.controller.access.constraint.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.constraint.management.ConstrainedResourceDefinition;
 import org.jboss.as.controller.access.constraint.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
@@ -722,11 +723,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE));
         Map<String, ModelNode> attributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_ACCESS_READ_WRITE, ATTR_READ_WRITE, ATTR_WRITE, ATTR_READ, ATTR_NONE);
-        checkAttributePermissions(attributes, ATTR_ACCESS_READ_WRITE, false, false, null, null);
-        checkAttributePermissions(attributes, ATTR_READ_WRITE, false, false, null, null);
-        checkAttributePermissions(attributes, ATTR_WRITE, true, false, null, null);
-        checkAttributePermissions(attributes, ATTR_READ, false, false, null, null);
-        checkAttributePermissions(attributes, ATTR_NONE, true, false, null, null);
+        checkAttributePermissions(attributes, ATTR_ACCESS_READ_WRITE, false, false);
+        checkAttributePermissions(attributes, ATTR_READ_WRITE, false, false);
+        checkAttributePermissions(attributes, ATTR_WRITE, true, false);
+        checkAttributePermissions(attributes, ATTR_READ, false, false);
+        checkAttributePermissions(attributes, ATTR_NONE, true, false);
     }
 
     @Test
@@ -737,11 +738,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE));
         Map<String, ModelNode> attributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_ACCESS_READ_WRITE, ATTR_READ_WRITE, ATTR_WRITE, ATTR_READ, ATTR_NONE);
-        checkAttributePermissions(attributes, ATTR_ACCESS_READ_WRITE, false, false, null, null);
-        checkAttributePermissions(attributes, ATTR_READ_WRITE, false, false, null, null);
-        checkAttributePermissions(attributes, ATTR_WRITE, true, false, null, null);
-        checkAttributePermissions(attributes, ATTR_READ, false, true, null, null);
-        checkAttributePermissions(attributes, ATTR_NONE, true, true, null, null);
+        checkAttributePermissions(attributes, ATTR_ACCESS_READ_WRITE, false, false);
+        checkAttributePermissions(attributes, ATTR_READ_WRITE, false, false);
+        checkAttributePermissions(attributes, ATTR_WRITE, true, false);
+        checkAttributePermissions(attributes, ATTR_READ, false, true);
+        checkAttributePermissions(attributes, ATTR_NONE, true, true);
     }
 
     @Test
@@ -752,11 +753,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE));
         Map<String, ModelNode> attributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_ACCESS_READ_WRITE, ATTR_READ_WRITE, ATTR_WRITE, ATTR_READ, ATTR_NONE);
-        checkAttributePermissions(attributes, ATTR_ACCESS_READ_WRITE, true, true, null, null);
-        checkAttributePermissions(attributes, ATTR_READ_WRITE, true, true, null, null);
-        checkAttributePermissions(attributes, ATTR_WRITE, true, true, null, null);
-        checkAttributePermissions(attributes, ATTR_READ, true, true, null, null);
-        checkAttributePermissions(attributes, ATTR_NONE, true, true, null, null);
+        checkAttributePermissions(attributes, ATTR_ACCESS_READ_WRITE, true, true);
+        checkAttributePermissions(attributes, ATTR_READ_WRITE, true, true);
+        checkAttributePermissions(attributes, ATTR_WRITE, true, true);
+        checkAttributePermissions(attributes, ATTR_READ, true, true);
+        checkAttributePermissions(attributes, ATTR_NONE, true, true);
     }
 
     private void registerAttributeResource(String testName) {
@@ -1341,10 +1342,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE), ONE_A_ADDR);
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, false, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, false, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, false);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, false);
             Map<String, ModelNode> exceptionAttributes = checkAttributeAccessControlNames(accessControl.exceptions.get(ONE_A_ADDR), ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, false, null, null);
+            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, false);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(false, defaultOps.get(ADD));
@@ -1372,10 +1373,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE), ONE_A_ADDR);
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
             Map<String, ModelNode> exceptionAttributes = checkAttributeAccessControlNames(accessControl.exceptions.get(ONE_A_ADDR), ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true, null, null);
+            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(true, defaultOps.get(ADD));
@@ -1405,8 +1406,8 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE));
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(true, defaultOps.get(ADD));
@@ -1433,11 +1434,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE), ONE_A_ADDR);
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, false, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, false, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, false);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, false);
             Map<String, ModelNode> exceptionAttributes = checkAttributeAccessControlNames(accessControl.exceptions.get(ONE_A_ADDR), ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, false, null, null);
-            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, false, false, null, null);
+            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, false);
+            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, false, false);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(false, defaultOps.get(ADD));
@@ -1466,11 +1467,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE), ONE_A_ADDR);
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
             Map<String, ModelNode> exceptionAttributes = checkAttributeAccessControlNames(accessControl.exceptions.get(ONE_A_ADDR), ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, false, true, null, null);
+            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, false, true);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(true, defaultOps.get(ADD));
@@ -1500,8 +1501,8 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE));
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(true, defaultOps.get(ADD));
@@ -1528,8 +1529,8 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE));
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, false, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, false, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, false);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, false);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(false, defaultOps.get(ADD));
@@ -1554,11 +1555,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE), ONE_A_ADDR);
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
             Map<String, ModelNode> exceptionAttributes = checkAttributeAccessControlNames(accessControl.exceptions.get(ONE_A_ADDR), ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, true, false, null, null);
+            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, true, false);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(true, defaultOps.get(ADD));
@@ -1588,8 +1589,8 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE));
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(true, defaultOps.get(ADD));
@@ -1627,8 +1628,8 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE_A));
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
             Assert.assertEquals(true, defaultOps.get(ADD));
@@ -1653,11 +1654,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
 
             ResourceAccessControl accessControl = getResourceAccessControl(getChildDescription(result, ONE_A), ONE_A_ADDR);
             Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true, null, null);
+            checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(defaultAttributes, ATTR_VAULT, true, true);
             Map<String, ModelNode> exceptionAttributes = checkAttributeAccessControlNames(accessControl.exceptions.get(ONE_A_ADDR), ATTR_NONE, ATTR_VAULT);
-            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true, null, null);
-            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, true, false, null, null);
+            checkAttributePermissions(exceptionAttributes, ATTR_NONE, true, true);
+            checkAttributePermissions(exceptionAttributes, ATTR_VAULT, true, false);
 
 
             Map<String, Boolean> defaultOps = checkOperationAccessControlNames(accessControl.defaultControl, ADD, REMOVE);
@@ -1748,13 +1749,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         return map;
     }
 
-    private void checkAttributePermissions(Map<String, ModelNode> map, String attrName, Boolean readConfig, Boolean writeConfig, Boolean readRuntime, Boolean writeRuntime) {
+    private void checkAttributePermissions(Map<String, ModelNode> map, String attrName, Boolean read, Boolean write) {
         ModelNode attr = map.get(attrName);
         Assert.assertNotNull(attr);
-        assertEqualsOrNotDefined(attr, ActionEffect.READ_CONFIG.toString(), readConfig);
-        assertEqualsOrNotDefined(attr, ActionEffect.WRITE_CONFIG.toString(), writeConfig);
-        assertEqualsOrNotDefined(attr, ActionEffect.READ_RUNTIME.toString(), readRuntime);
-        assertEqualsOrNotDefined(attr, ActionEffect.WRITE_RUNTIME.toString(), writeRuntime);
+        assertEqualsOrNotDefined(attr, ModelDescriptionConstants.READ, read);
+        assertEqualsOrNotDefined(attr, ModelDescriptionConstants.WRITE.toString(), write);
     }
 
     private Map<String, Boolean> checkOperationAccessControlNames(Map<PathAddress, ModelNode> map, String...operationNames) {

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
@@ -140,7 +140,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         op.get(RECURSIVE).set(false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -150,7 +150,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         op.get(RECURSIVE).set(false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     @Test
@@ -160,7 +160,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         op.get(RECURSIVE).set(false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -173,7 +173,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.MONITOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -186,7 +186,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         System.out.println(result);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     @Test
@@ -198,7 +198,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -208,10 +208,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -220,10 +220,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
     @Test
     public void testRecursiveReadResourceDefinitionNoSensitivityAsAdministrator() throws Exception {
@@ -231,10 +231,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -246,7 +246,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         System.out.println(op);
         System.out.println(result);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -255,7 +255,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.MAINTAINER, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     @Test
@@ -264,7 +264,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles - similar to the testDirectWildcardReadResourceDefinitionNoSensitivityXXX() ones but for a fixed resource
@@ -275,7 +275,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -284,7 +284,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     @Test
@@ -293,7 +293,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -304,7 +304,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
         ModelNode childDesc = getChildDescription(result, ONE);
         assertNonAccessibleDefaultAccessControl(childDesc); //Since access is restricted, the maintainer role cannot access the resources
     }
@@ -315,7 +315,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         assertNonAccessibleDefaultAccessControl(childDesc); //Since access is restricted, the maintainer role cannot access the resources
     }
@@ -326,10 +326,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -356,7 +356,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles - similar to the testDirectWildcardReadResourceDefinitionAccessReadWriteSensitivityAsXXXX() ones but for a fixed resource
@@ -383,7 +383,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -394,11 +394,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -407,11 +407,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
         //Reads and writes are sensitive so we cannot read or write them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -420,10 +420,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -435,7 +435,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -445,7 +445,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads and writes are sensitive so we cannot read or write them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -454,7 +454,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles  - similar to the testDirectWildcardReadResourceDefinitionReadWriteSensitivityAsXXX() ones but for a fixed resource
@@ -465,7 +465,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -475,7 +475,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads and writes are sensitive so we cannot read or write them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -484,7 +484,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -495,10 +495,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
 
     }
 
@@ -508,11 +508,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
         //Writes are sensitive so we cannot write them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
 
     }
 
@@ -522,10 +522,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -537,7 +537,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -547,7 +547,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Writes are sensitive so we cannot write them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -556,7 +556,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles  - similar to the testDirectWildcardReadResourceDefinitionWriteSensitivityAsXXX() ones but for a fixed resource
@@ -568,7 +568,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -578,7 +578,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Writes are sensitive so we cannot write them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
     }
 
     @Test
@@ -587,7 +587,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -599,11 +599,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -613,11 +613,11 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, true, false, true);
+        checkResourcePermissions(accessControl.defaultControl, false, true);
     }
 
     @Test
@@ -627,10 +627,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -643,7 +643,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -654,7 +654,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, true, false, true);
+        checkResourcePermissions(accessControl.defaultControl, false, true);
     }
 
     @Test
@@ -664,7 +664,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles  - similar to the testDirectWildcardReadResourceDefinitionReadSensitivityAsXXX() ones but for a fixed resource
@@ -677,7 +677,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -688,7 +688,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
         //Reads are sensitive so we cannot read them as the default says we can
-        checkResourcePermissions(accessControl.defaultControl, false, true, false, true);
+        checkResourcePermissions(accessControl.defaultControl, false, true);
     }
 
     @Test
@@ -698,7 +698,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     private void registerOneChildRootResource(SensitiveTargetAccessConstraintDefinition...sensitivityConstraints) {
@@ -949,7 +949,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
         ModelNode childDesc = getChildDescription(result, ONE);
         assertNonAccessibleDefaultAccessControl(childDesc);//Since access is restricted, the monitor role access any of the resources
         childDesc = getChildDescription(childDesc, TWO);
@@ -964,7 +964,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         assertNonAccessibleDefaultAccessControl(childDesc); //Since access is restricted, the maintainer role cannot access the resources
         childDesc = getChildDescription(childDesc, TWO);
@@ -979,13 +979,13 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         childDesc = getChildDescription(childDesc, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -1022,10 +1022,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles  - similar to the testDeepDirectWildcardLevelOneReadResourceDefinitionAccessReadWriteSensitivityAsXXXX() ones but for a fixed resource
@@ -1062,10 +1062,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -1097,7 +1097,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(TWO_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles  - similar to the testDeepDirectWildcardLevelTwoReadResourceDefinitionAccessReadWriteSensitivityAsXXXX() ones but for a fixed resource
@@ -1130,7 +1130,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_TWO_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -1142,13 +1142,13 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, false, true, false);
+        checkResourcePermissions(accessControl.defaultControl, true, false);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
         childDesc = getChildDescription(childDesc, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1159,13 +1159,13 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
         childDesc = getChildDescription(childDesc, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1176,13 +1176,13 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, ONE);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         childDesc = getChildDescription(childDesc, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -1193,10 +1193,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.MONITOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1206,10 +1206,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.MAINTAINER, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1219,10 +1219,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles  - similar to the testDeepDirectWildcardLevelOneReadResourceDefinitionReadWriteSensitivityAsXXXX() ones but for a fixed resource
@@ -1233,10 +1233,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1246,10 +1246,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1259,10 +1259,10 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
         ModelNode childDesc = getChildDescription(result, TWO);
         accessControl = getResourceAccessControl(childDesc);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -1273,7 +1273,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(TWO_ADDR, StandardRole.MONITOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1283,7 +1283,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(TWO_ADDR, StandardRole.MAINTAINER, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1293,7 +1293,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(TWO_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = getWildcardResourceRegistrationResult(executeForResult(op));
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles  - similar to the testDeepDirectWildcardLevelTwoReadResourceDefinitionReadWriteSensitivityAsXXXX() ones but for a fixed resource
@@ -1304,7 +1304,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_TWO_A_ADDR, StandardRole.MONITOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1314,7 +1314,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_TWO_A_ADDR, StandardRole.MAINTAINER, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, false, false, false, false);
+        checkResourcePermissions(accessControl.defaultControl, false, false);
     }
 
     @Test
@@ -1324,7 +1324,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         ModelNode op = createReadResourceDescriptionOperation(ONE_A_TWO_A_ADDR, StandardRole.ADMINISTRATOR, false);
         ModelNode result = executeForResult(op);
         ResourceAccessControl accessControl = getResourceAccessControl(result);
-        checkResourcePermissions(accessControl.defaultControl, true, true, true, true);
+        checkResourcePermissions(accessControl.defaultControl, true, true);
     }
 
     // These three are the same for different roles
@@ -1802,17 +1802,9 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         return realResult.get(RESULT);
     }
 
-    private void checkResourcePermissions(Map<PathAddress, ModelNode> map, boolean readConfig, boolean writeConfig, boolean readRuntime, boolean writeRuntime) {
-        for (ModelNode accessControl : map.values()) {
-            checkResourcePermissions(accessControl, readConfig, writeConfig, readRuntime, writeRuntime);
-        }
-    }
-
-    private void checkResourcePermissions(ModelNode accessControl, boolean readConfig, boolean writeConfig, boolean readRuntime, boolean writeRuntime) {
-        Assert.assertEquals(readConfig, accessControl.get(ActionEffect.READ_CONFIG.toString()).asBoolean());
-        Assert.assertEquals(writeConfig, accessControl.get(ActionEffect.WRITE_CONFIG.toString()).asBoolean());
-        Assert.assertEquals(readRuntime, accessControl.get(ActionEffect.READ_RUNTIME.toString()).asBoolean());
-        Assert.assertEquals(writeRuntime, accessControl.get(ActionEffect.WRITE_RUNTIME.toString()).asBoolean());
+    private void checkResourcePermissions(ModelNode accessControl, boolean read, boolean write) {
+        Assert.assertEquals(read, accessControl.get(ModelDescriptionConstants.READ).asBoolean());
+        Assert.assertEquals(write, accessControl.get(ModelDescriptionConstants.WRITE).asBoolean());
     }
 
     @Override

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/ReadResourceDescriptionAccessControlTestCase.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
@@ -68,6 +69,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.operations.global.ReadResourceDescriptionHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.test.AbstractControllerTestBase;
@@ -1687,6 +1689,151 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
         rootResource.registerChild(ONE_A, resourceA);
     }
 
+    //These three test the impact of the access-control parameter
+    @Test
+    public void testAccessControlNone() throws Exception  {
+        //These should have no access-control element but the normal descriptions
+        ModelNode desc = readModelDescriptionWithAccessControlParameter(ReadResourceDescriptionHandler.AccessControl.NONE);
+        Assert.assertFalse(desc.has(ACCESS_CONTROL));
+
+        Assert.assertEquals("description", desc.get(ModelDescriptionConstants.DESCRIPTION).asString());
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
+        Set<String> attributes = desc.get(ModelDescriptionConstants.ATTRIBUTES).keys();
+        Assert.assertEquals(1, attributes.size());
+        Assert.assertTrue(attributes.contains(ATTR_NONE));
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.OPERATIONS));
+        Set<String> ops = desc.get(ModelDescriptionConstants.OPERATIONS).keys();
+        Assert.assertEquals(3, ops.size());
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.ADD));
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.REMOVE));
+        Assert.assertTrue(ops.contains(OP_CONFIG_RW_NONE));
+
+        desc = getChildDescription(desc, TWO);
+        Assert.assertFalse(desc.has(ACCESS_CONTROL));
+
+        Assert.assertEquals("description", desc.get(ModelDescriptionConstants.DESCRIPTION).asString());
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
+        attributes = desc.get(ModelDescriptionConstants.ATTRIBUTES).keys();
+        Assert.assertEquals(1, attributes.size());
+        Assert.assertTrue(attributes.contains(ATTR_NONE));
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.OPERATIONS));
+        ops = desc.get(ModelDescriptionConstants.OPERATIONS).keys();
+        Assert.assertEquals(3, ops.size());
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.ADD));
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.REMOVE));
+        Assert.assertTrue(ops.contains(OP_CONFIG_RW_NONE));
+    }
+
+    @Test
+    public void testAccessControlCombinedDescriptions() throws Exception  {
+        //These should have the access-control element and the normal descriptions
+        ModelNode desc = readModelDescriptionWithAccessControlParameter(ReadResourceDescriptionHandler.AccessControl.COMBINED_DESCRIPTIONS);
+        ResourceAccessControl accessControl = getResourceAccessControl(desc);
+        Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE);
+        checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+        Map<String, Boolean> defaultOperations = checkOperationAccessControlNames(accessControl.defaultControl, ModelDescriptionConstants.ADD, ModelDescriptionConstants.REMOVE, OP_CONFIG_RW_NONE);
+        Assert.assertEquals(true, defaultOperations.get(ADD));
+        Assert.assertEquals(true, defaultOperations.get(REMOVE));
+        Assert.assertEquals(true, defaultOperations.get(OP_CONFIG_RW_NONE));
+
+        Assert.assertEquals("description", desc.get(ModelDescriptionConstants.DESCRIPTION).asString());
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
+        Set<String> attributes = desc.get(ModelDescriptionConstants.ATTRIBUTES).keys();
+        Assert.assertEquals(1, attributes.size());
+        Assert.assertTrue(attributes.contains(ATTR_NONE));
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.OPERATIONS));
+        Set<String> ops = desc.get(ModelDescriptionConstants.OPERATIONS).keys();
+        Assert.assertEquals(3, ops.size());
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.ADD));
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.REMOVE));
+        Assert.assertTrue(ops.contains(OP_CONFIG_RW_NONE));
+
+        desc = getChildDescription(desc, TWO);
+        accessControl = getResourceAccessControl(desc);
+        defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE);
+        checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+        defaultOperations = checkOperationAccessControlNames(accessControl.defaultControl, ModelDescriptionConstants.ADD, ModelDescriptionConstants.REMOVE, OP_CONFIG_RW_NONE);
+        Assert.assertEquals(true, defaultOperations.get(ADD));
+        Assert.assertEquals(true, defaultOperations.get(REMOVE));
+        Assert.assertEquals(true, defaultOperations.get(OP_CONFIG_RW_NONE));
+
+        Assert.assertEquals("description", desc.get(ModelDescriptionConstants.DESCRIPTION).asString());
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
+        attributes = desc.get(ModelDescriptionConstants.ATTRIBUTES).keys();
+        Assert.assertEquals(1, attributes.size());
+        Assert.assertTrue(attributes.contains(ATTR_NONE));
+
+        Assert.assertTrue(desc.hasDefined(ModelDescriptionConstants.OPERATIONS));
+        ops = desc.get(ModelDescriptionConstants.OPERATIONS).keys();
+        Assert.assertEquals(3, ops.size());
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.ADD));
+        Assert.assertTrue(ops.contains(ModelDescriptionConstants.REMOVE));
+        Assert.assertTrue(ops.contains(OP_CONFIG_RW_NONE));
+    }
+
+    @Test
+    public void testAccessControlTrimDescriptions() throws Exception  {
+        //These should have the access-control element but trim the normal descriptions
+        ModelNode desc = readModelDescriptionWithAccessControlParameter(ReadResourceDescriptionHandler.AccessControl.TRIM_DESCRIPTONS);
+        ResourceAccessControl accessControl = getResourceAccessControl(desc);
+        Map<String, ModelNode> defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE);
+        checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+        Map<String, Boolean> defaultOperations = checkOperationAccessControlNames(accessControl.defaultControl, ModelDescriptionConstants.ADD, ModelDescriptionConstants.REMOVE, OP_CONFIG_RW_NONE);
+        Assert.assertEquals(true, defaultOperations.get(ADD));
+        Assert.assertEquals(true, defaultOperations.get(REMOVE));
+        Assert.assertEquals(true, defaultOperations.get(OP_CONFIG_RW_NONE));
+
+        Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.DESCRIPTION));
+        Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
+        Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.OPERATIONS));
+
+        desc = getChildDescription(desc, TWO);
+        accessControl = getResourceAccessControl(desc);
+        defaultAttributes = checkAttributeAccessControlNames(accessControl.defaultControl, ATTR_NONE);
+        checkAttributePermissions(defaultAttributes, ATTR_NONE, true, true);
+        defaultOperations = checkOperationAccessControlNames(accessControl.defaultControl, ModelDescriptionConstants.ADD, ModelDescriptionConstants.REMOVE, OP_CONFIG_RW_NONE);
+        Assert.assertEquals(true, defaultOperations.get(ADD));
+        Assert.assertEquals(true, defaultOperations.get(REMOVE));
+        Assert.assertEquals(true, defaultOperations.get(OP_CONFIG_RW_NONE));
+
+        Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.DESCRIPTION));
+        Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.ATTRIBUTES));
+        Assert.assertFalse(desc.hasDefined(ModelDescriptionConstants.OPERATIONS));
+    }
+
+    private ModelNode readModelDescriptionWithAccessControlParameter(ReadResourceDescriptionHandler.AccessControl accessControl) throws Exception {
+        ChildResourceDefinition oneChild = new ChildResourceDefinition(ONE);
+        oneChild.addAttribute(ATTR_NONE);
+        oneChild.addOperation(OP_CONFIG_RW_NONE, false, false);
+        ManagementResourceRegistration oneReg = rootRegistration.registerSubModel(oneChild);
+        Resource resourceOneA = Resource.Factory.create();
+        ModelNode modelOneA = resourceOneA.getModel();
+        modelOneA.get(ATTR_NONE).set("uno");
+        rootResource.registerChild(ONE_A, resourceOneA);
+
+        ChildResourceDefinition twoChild = new ChildResourceDefinition(TWO);
+        twoChild.addAttribute(ATTR_NONE);
+        twoChild.addOperation(OP_CONFIG_RW_NONE, false, false);
+        oneReg.registerSubModel(twoChild);
+        Resource resourceTwoA = Resource.Factory.create();
+        ModelNode modelTwoA = resourceOneA.getModel();
+        modelTwoA.get(ATTR_NONE).set("dos");
+        resourceOneA.registerChild(TWO_A, resourceTwoA);
+
+        ModelNode op = createReadResourceDescriptionOperation(PathAddress.EMPTY_ADDRESS, StandardRole.ADMINISTRATOR, true);
+        op.get(ACCESS_CONTROL).set(accessControl.toString());
+        ModelNode desc = executeForResult(op);
+        System.out.println(desc);
+        return getChildDescription(desc, ONE);
+    }
+
     private SensitiveTargetAccessConstraintDefinition createSensitivityConstraint(String name, boolean access, boolean read, boolean write) {
         SensitivityClassification classification = new SensitivityClassification("test", name, access, read, write);
         return new SensitiveTargetAccessConstraintDefinition(classification);
@@ -1821,7 +1968,7 @@ public class ReadResourceDescriptionAccessControlTestCase extends AbstractContro
     private ModelNode createReadResourceDescriptionOperation(PathAddress address, StandardRole role, boolean operations) {
         ModelNode op = Util.createOperation(READ_RESOURCE_DESCRIPTION_OPERATION, address);
         op.get(RECURSIVE).set(true);
-        op.get(ACCESS_CONTROL).set(true);
+        op.get(ACCESS_CONTROL).set(ReadResourceDescriptionHandler.AccessControl.COMBINED_DESCRIPTIONS.toString());
         if (operations) {
             op.get(OPERATIONS).set(true);
             op.get(INHERITED).set(false);


### PR DESCRIPTION
This is all feedback from Heiko Braun. 

1)
In r-r-d access-control for attributes don't separate between read-config/-runtime and write-config/-runtime. Simple 'read' or 'write' will do.

2) The 'attributes' parameter we added did not work so well when :read-resource-description(access-control=true, operations=true) since that then includes all the parameters again for the operations. I've removed the 'attributes' parameter, and made access-control use an enum:
*NONE - default and does not include access-control (similar to access-control=false, before this patch)
*COMBINED_DESCRIPTIONS - includes access-control and the full description (similar to access-control=true, before this patch)
*TRIM_DESCRIPTIONS - includes access-control, but trims the resource description (similar to access-control=true,attributes=false, but also removes the resource description and all operations from the output. If operations=true, the ops are included in the access-control section)
