### PR TITLE
WFLY-1868 : Removing hard coded string for the case these strings might ...

### DIFF
--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/DuplicateUserCheckStateTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/adduser/DuplicateUserCheckStateTestCase.java
@@ -49,7 +49,7 @@ public class DuplicateUserCheckStateTestCase extends PropertyTestHelper {
                 expectedDisplayText(AddUser.NEW_LINE).
                 expectedDisplayText(MESSAGES.isCorrectPrompt() + " " + MESSAGES.yes() + "/" + MESSAGES.no() + "?").
                 expectedDisplayText(" ").
-                expectedInput("yes").
+                expectedInput(MESSAGES.yes()).
                 expectedDisplayText(MESSAGES.addedUser(values.getUserName(), values.getUserFiles().get(0).getCanonicalPath())).
                 expectedDisplayText(AddUser.NEW_LINE).
                 expectedDisplayText(MESSAGES.addedGroups(values.getUserName(), values.getGroups(),values.getGroupFiles().get(0).getCanonicalPath())).

--- a/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/ModelControllerMBeanTestCase.java
@@ -239,7 +239,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals(JMXExtension.getResourceDescriptionResolver("").getResourceBundle(Locale.getDefault())
+                .getString(CommonAttributes.JMX), info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -321,7 +322,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals(JMXExtension.getResourceDescriptionResolver("").getResourceBundle(Locale.getDefault())
+                .getString(CommonAttributes.JMX), info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(LEGACY_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);
@@ -363,7 +365,8 @@ public class ModelControllerMBeanTestCase extends AbstractSubsystemTest {
         // bundles
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=jmx"));
         Assert.assertNotNull(info);
-        Assert.assertEquals("The configuration of the JMX subsystem.", info.getDescription());
+        Assert.assertEquals(JMXExtension.getResourceDescriptionResolver("").getResourceBundle(Locale.getDefault())
+                .getString(CommonAttributes.JMX), info.getDescription());
 
         info = connection.getMBeanInfo(createObjectName(EXPR_DOMAIN + ":subsystem=test"));
         Assert.assertNotNull(info);

--- a/jmx/src/test/java/org/jboss/as/jmx/model/ExpressionTypeConverterUnitTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/ExpressionTypeConverterUnitTestCase.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jboss.as.jmx.JmxMessages;
 
 import org.jboss.as.jmx.model.TypeConverters.TypeConverter;
 import org.jboss.dmr.ModelNode;
@@ -193,8 +194,8 @@ public class ExpressionTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", String.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", String.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().set("one", "uno")));
         Assert.assertEquals(type, data.getCompositeType());
@@ -217,8 +218,8 @@ public class ExpressionTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", String.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", String.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().set("one", 1)));
         Assert.assertEquals(type, data.getCompositeType());
@@ -637,8 +638,8 @@ public class ExpressionTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", String.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", String.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().setExpression("one", "${this.should.not.exist.!!!!!:uno}")));
         Assert.assertEquals(type, data.getCompositeType());
@@ -661,8 +662,8 @@ public class ExpressionTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", String.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", String.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().set("one", "${this.should.not.exist.!!!!!:1}")));
         Assert.assertEquals(type, data.getCompositeType());

--- a/jmx/src/test/java/org/jboss/as/jmx/model/LegacyTypeConverterUnitTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/model/LegacyTypeConverterUnitTestCase.java
@@ -42,6 +42,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.jboss.as.jmx.JmxMessages;
 
 import org.jboss.as.jmx.model.TypeConverters.TypeConverter;
 import org.jboss.dmr.ModelNode;
@@ -208,8 +209,8 @@ public class LegacyTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", String.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", String.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().set("one", "uno")));
         Assert.assertEquals(type, data.getCompositeType());
@@ -232,8 +233,8 @@ public class LegacyTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", Integer.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", Integer.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().set("one", 1)));
         Assert.assertEquals(type, data.getCompositeType());
@@ -694,8 +695,8 @@ public class LegacyTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", String.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", String.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().setExpression("one", "${this.should.not.exist.!!!!!:uno}")));
         Assert.assertEquals(type, data.getCompositeType());
@@ -718,8 +719,8 @@ public class LegacyTypeConverterUnitTestCase {
         CompositeType type = assertCast(CompositeType.class, converter.getOpenType());
         Set<String> keys = type.keySet();
         Assert.assertEquals(2, keys.size());
-        assertCompositeType(type, "name", String.class.getName(), "The property name");
-        assertCompositeType(type, "value", Integer.class.getName(), "The property value");
+        assertCompositeType(type, "name", String.class.getName(), JmxMessages.MESSAGES.propertyName());
+        assertCompositeType(type, "value", Integer.class.getName(), JmxMessages.MESSAGES.propertyValue());
 
         CompositeData data = assertCast(CompositeData.class, converter.fromModelNode(new ModelNode().setExpression("one", "${this.should.not.exist.!!!!!:1}")));
         Assert.assertEquals(type, data.getCompositeType());

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateAddressOperationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ValidateAddressOperationTestCase.java
@@ -22,13 +22,14 @@
 package org.jboss.as.test.integration.domain.suites;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROBLEM;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALID;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import org.jboss.as.controller.ControllerMessages;
+import org.jboss.as.controller.PathElement;
 
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
@@ -96,7 +97,7 @@ public class ValidateAddressOperationTestCase  {
         assertFalse(value.asBoolean());
         assertTrue(result.hasDefined(PROBLEM));
         final ModelNode problem = result.get(PROBLEM);
-        assertTrue(problem.asString().contains("JBAS014808: Child resource '\"wrong\" => \"illegal\"' not found"));
+        assertTrue(problem.asString().contains(ControllerMessages.MESSAGES.childResourceNotFound(PathElement.pathElement("wrong", "illegal"))));
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ValidateAddressOperationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ValidateAddressOperationTestCase.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.controller.ControllerMessages;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.ValidateAddressOperationHandler;
 import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
@@ -84,6 +86,6 @@ public class ValidateAddressOperationTestCase extends ContainerResourceMgmtTestB
         assertFalse(value.asBoolean());
         assertTrue(result.hasDefined(PROBLEM));
         final ModelNode problem = result.get(PROBLEM);
-        assertTrue(problem.asString().contains("JBAS014808: Child resource '\"wrong\" => \"illegal\"' not found"));
+        assertTrue(problem.asString().contains(ControllerMessages.MESSAGES.childResourceNotFound(PathElement.pathElement("wrong", "illegal"))));
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/BatchTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/BatchTestCase.java
@@ -33,6 +33,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.management.util.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
@@ -159,7 +160,9 @@ public class BatchTestCase extends AbstractCliTestBase {
         cli.sendLine("run-batch", true);
 
         String line = cli.readOutput();
-        assertTrue("Batch did not fail.", line.contains("Composite operation failed and was rolled back"));
+        String expectedErrorCode = ControllerMessages.MESSAGES.compositeOperationFailed();
+        expectedErrorCode = expectedErrorCode.substring(0, expectedErrorCode.indexOf(':'));
+        assertTrue("Batch did not fail.", line.contains(expectedErrorCode));
 
         // check that still none of the archives are deployed
         assertTrue(checkUndeployed(getBaseURL(url) + "deployment0/SimpleServlet"));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/beanvalidation/Reservation.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/beanvalidation/Reservation.java
@@ -33,7 +33,7 @@ public class Reservation {
     @CustomMin
     private int numberOfPeople;
 
-    @NotNull
+    @NotNull(message = "may not be null")
     private String lastName;
 
     public Reservation(int numberOfPeople, String lastName) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/authentication/EJBEndpointAuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ws/authentication/EJBEndpointAuthenticationTestCase.java
@@ -32,6 +32,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.test.integration.ejb.security.EjbSecurityDomainSetup;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -121,7 +122,7 @@ public class EJBEndpointAuthenticationTestCase {
             Assert.fail("Test should fail, user shouldn't be allowed to invoke that method");
         } catch (WebServiceException e) {
             // failure is expected
-            Assert.assertTrue("String 'not allowed' was expected in " + e.getCause().getMessage(), e.getCause().getMessage().contains("not allowed"));
+            Assert.assertEquals(e.getCause().getMessage(), getNotAllowedExceptionMessage("hello"));
         }
     }
     
@@ -162,7 +163,7 @@ public class EJBEndpointAuthenticationTestCase {
             Assert.fail("Test should fail, user shouldn't be allowed to invoke that method");
         } catch (WebServiceException e) {
             // failure is expected
-            Assert.assertTrue("String 'not allowed' was expected in " + e.getCause().getMessage(), e.getCause().getMessage().contains("not allowed"));
+            Assert.assertEquals(e.getCause().getMessage(), getNotAllowedExceptionMessage("helloForRole"));
         }
     }
     
@@ -233,7 +234,7 @@ public class EJBEndpointAuthenticationTestCase {
             Assert.fail("Test should fail, user shouldn't be allowed to invoke that method");
         } catch (WebServiceException e) {
             // failure is expected
-            Assert.assertTrue("String 'not allowed' was expected in " + e.getCause().getMessage(), e.getCause().getMessage().contains("not allowed"));
+            Assert.assertEquals(e.getCause().getMessage(), getNotAllowedExceptionMessage("helloForRoles"));
         }
     }
     
@@ -309,7 +310,7 @@ public class EJBEndpointAuthenticationTestCase {
             Assert.fail("Test should fail, user shouldn't be allowed to invoke that method");
         } catch (WebServiceException e) {
             // failure is expected
-            Assert.assertTrue("String 'not allowed' was expected in " + e.getCause().getMessage(), e.getCause().getMessage().contains("not allowed"));
+            Assert.assertEquals(e.getCause().getMessage(), getNotAllowedExceptionMessage("helloForNone"));
         }
     }
     
@@ -329,7 +330,7 @@ public class EJBEndpointAuthenticationTestCase {
             Assert.fail("Test should fail, user shouldn't be allowed to invoke that method");
         } catch (WebServiceException e) {
             // failure is expected
-            Assert.assertTrue("String 'not allowed' was expected in " + e.getCause().getMessage(), e.getCause().getMessage().contains("not allowed"));
+            Assert.assertEquals(e.getCause().getMessage(), getNotAllowedExceptionMessage("helloForNone"));
         }
     }
     
@@ -349,7 +350,11 @@ public class EJBEndpointAuthenticationTestCase {
             Assert.fail("Test should fail, user shouldn't be allowed to invoke that method");
         } catch (WebServiceException e) {
             // failure is expected
-            Assert.assertTrue("String 'not allowed' was expected in " + e.getCause().getMessage(), e.getCause().getMessage().contains("not allowed"));
+            Assert.assertEquals(e.getCause().getMessage(), getNotAllowedExceptionMessage("helloForNone"));
         }
+    }
+
+    private String getNotAllowedExceptionMessage(String methodName) throws NoSuchMethodException {
+        return EjbMessages.MESSAGES.invocationOfMethodNotAllowed(EJBEndpoint.class.getMethod(methodName, String.class), "EJBEndpoint").getMessage();
     }
 }


### PR DESCRIPTION
...be translated on a non en_US locale.
Some error messages are translated, they should be using the error message code instead of relying on the hardcoded String.
