### PR TITLE
Fix for a thread safety issue in EJB remote protocol handler

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -359,8 +359,10 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
      */
     private void cleanupOnChannelDown() {
         // we no longer are interested in cluster topology updates, so unregister the update listener
-        for (final ClusterTopologyUpdateListener clusterTopologyUpdateListener : this.clusterTopologyUpdateListeners) {
-            clusterTopologyUpdateListener.unregisterListener();
+        synchronized (this.clusterTopologyUpdateListeners) {
+            for (final ClusterTopologyUpdateListener clusterTopologyUpdateListener : this.clusterTopologyUpdateListeners) {
+                clusterTopologyUpdateListener.unregisterListener();
+            }
         }
         this.deploymentRepository.removeListener(this);
         this.clientMappingRegistryCollector.removeListener(this);


### PR DESCRIPTION
This is a small change to fix a potential thread safety issue in VersionOneProtocolChannelReceiver
