### PR TITLE
WFLY-456 Audit log fixes

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
@@ -36,6 +36,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.core-security"/>
+        <module name="org.jboss.as.domain-management"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.remoting" />
         <module name="org.wildfly.security.manager"/>

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -360,23 +360,21 @@ abstract class AbstractOperationContext implements OperationContext {
      */
     void logAuditRecord() {
         if (!auditLogged) {
-            if (auditLogger.getLoggerStatus() != AuditLogger.Status.DISABLED) {
-                try {
-                    Subject subject = SubjectUtils.getCurrent();
-                    auditLogger.log(
-                            !isModelAffected(),
-                            isBooting(),
-                            resultAction,
-                            getCallerUserId(subject),
-                            getDomainUUID(),
-                            getSubjectAccessMechanism(subject),
-                            getSubjectInetAddress(subject),
-                            getModel(),
-                            controllerOperations);
-                    auditLogged = true;
-                } catch (Exception e) {
-                    ControllerLogger.MGMT_OP_LOGGER.failedToUpdateAuditLog(e);
-                }
+            try {
+                Subject subject = SubjectUtils.getCurrent();
+                auditLogger.log(
+                        !isModelAffected(),
+                        isBooting(),
+                        resultAction,
+                        getCallerUserId(subject),
+                        getDomainUUID(),
+                        getSubjectAccessMechanism(subject),
+                        getSubjectInetAddress(subject),
+                        getModel(),
+                        controllerOperations);
+                auditLogged = true;
+            } catch (Exception e) {
+                ControllerLogger.MGMT_OP_LOGGER.failedToUpdateAuditLog(e);
             }
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/audit/AuditLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/AuditLogger.java
@@ -52,8 +52,6 @@ public interface AuditLogger {
         DISABLED
     }
 
-    Status getLoggerStatus();
-
     void log(boolean readOnly, boolean booting, OperationContext.ResultAction resultAction, String userId,
              String domainUUID, AccessMechanism accessMechanism, InetAddress remoteAddress, final Resource resultantModel, List<ModelNode> operations);
 
@@ -81,7 +79,6 @@ public interface AuditLogger {
         public void setLogBoot(boolean logBoot) {
         }
 
-        @Override
         public Status getLoggerStatus() {
             return Status.DISABLED;
         }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AbstractAuditLogHandlerTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AbstractAuditLogHandlerTestCase.java
@@ -1,0 +1,449 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.security.auditlog;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_LENGTH;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MESSAGE_TRANSFER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROTOCOL;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSLOG_FORMAT;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.net.InetAddress;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.jboss.as.controller.CompositeOperationHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.access.DelegatingConfigurableAuthorizer;
+import org.jboss.as.controller.audit.ManagedAuditLogger;
+import org.jboss.as.controller.audit.ManagedAuditLoggerImpl;
+import org.jboss.as.controller.audit.SyslogAuditLogHandler;
+import org.jboss.as.controller.audit.SyslogAuditLogHandler.Transport;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.services.path.PathManagerService;
+import org.jboss.as.controller.services.path.PathResourceDefinition;
+import org.jboss.as.domain.management.CoreManagementResourceDefinition;
+import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
+import org.jboss.as.domain.management.audit.AuditLogHandlerResourceDefinition;
+import org.jboss.as.domain.management.audit.AuditLogLoggerResourceDefinition;
+import org.jboss.as.domain.management.audit.EnvironmentNameReader;
+import org.jboss.as.domain.management.audit.FileAuditLogHandlerResourceDefinition;
+import org.jboss.as.domain.management.audit.SyslogAuditLogProtocolResourceDefinition;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logmanager.handlers.SyslogHandler;
+import org.jboss.msc.service.AbstractServiceListener;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.junit.After;
+import org.junit.Assert;
+import org.xnio.IoUtils;
+
+/**
+ * Don't use core-model test for this. It does not support runtime, and more importantly for backwards compatibility the audit logger cannot be used
+ *
+ * @author: Kabir Khan
+ */
+public class AbstractAuditLogHandlerTestCase extends AbstractControllerTestBase {
+    protected static final PathAddress AUDIT_ADDR = PathAddress.pathAddress(CoreManagementResourceDefinition.PATH_ELEMENT, AccessAuditResourceDefinition.PATH_ELEMENT);
+    protected static final int SYSLOG_PORT = 6666;
+    protected static final int SYSLOG_PORT2 = 6667;
+
+    volatile PathManagerService pathManagerService;
+    volatile ManagedAuditLogger auditLogger;
+    volatile File logDir;
+
+    protected final List<ModelNode> bootOperations = new ArrayList<ModelNode>();
+
+    public AbstractAuditLogHandlerTestCase(boolean enabled) {
+
+        bootOperations.add(Util.createAddOperation(AUDIT_ADDR));
+        ModelNode add = Util.createAddOperation(createJsonFormatterAddress("test-formatter"));
+        bootOperations.add(add);
+
+        add = createAddFileHandlerOperation("test-file", "test-formatter", "test-file.log");
+        add.get(FileAuditLogHandlerResourceDefinition.MAX_FAILURE_COUNT.getName()).set(3);
+        bootOperations.add(add);
+
+        add = Util.createAddOperation(
+                AUDIT_ADDR.append(AuditLogLoggerResourceDefinition.PATH_ELEMENT));
+        add.get(ModelDescriptionConstants.ENABLED).set(enabled);
+        add.get(ModelDescriptionConstants.LOG_READ_ONLY).set(true);
+        bootOperations.add(add);
+        bootOperations.add(createAddHandlerReferenceOperation("test-file"));
+    }
+
+
+    @After
+    public void clearDependencies(){
+        auditLogger = null;
+        logDir = null;
+    }
+
+    protected ManagedAuditLogger getAuditLogger(){
+        if (auditLogger == null){
+            auditLogger = new ManagedAuditLoggerImpl("8.0.0", true);
+        }
+        return auditLogger;
+    }
+
+    protected void checkHandlerRuntimeFailureMetrics(ModelNode handler, int maxFailureCount, int failureCount, boolean disabled) {
+        Assert.assertEquals(maxFailureCount, handler.get(AuditLogHandlerResourceDefinition.MAX_FAILURE_COUNT.getName()).asInt());
+        Assert.assertEquals(failureCount, handler.get(AuditLogHandlerResourceDefinition.FAILURE_COUNT.getName()).asInt());
+        Assert.assertEquals(disabled, handler.get(AuditLogHandlerResourceDefinition.DISABLED_DUE_TO_FAILURE.getName()).asBoolean());
+    }
+
+    protected String stripSyslogHeader(byte[] bytes) throws UnsupportedEncodingException {
+        String s = new String(bytes, "utf-8");
+        int i = s.indexOf(" - - ");
+        return s.substring(i + 6);
+    }
+
+    protected ModelNode getSyslogRecord(byte[] bytes) throws UnsupportedEncodingException {
+        String msg = new String(bytes, "utf-8");
+        return getSyslogRecord(msg);
+    }
+
+    protected ModelNode getSyslogRecord(String msg) {
+        msg = msg.substring(msg.indexOf('{')).replace("#012", "\n");
+        return ModelNode.fromJSONString(msg);
+    }
+
+    protected void checkOpsEqual(ModelNode rawDmr, ModelNode fromLog) {
+        ModelNode expected = ModelNode.fromJSONString(rawDmr.toJSONString(true));
+        Assert.assertEquals(expected, fromLog);
+
+    }
+
+    private final Pattern DATE_STAMP_PATTERN = Pattern.compile("\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d - \\{");
+
+    protected List<ModelNode> readFile(File file, int expectedRecords) throws IOException {
+        List<ModelNode> list = new ArrayList<ModelNode>();
+        final BufferedReader reader = new BufferedReader(new FileReader(file));
+        try {
+            StringWriter writer = null;
+            String line = reader.readLine();
+            while (line != null) {
+                if (DATE_STAMP_PATTERN.matcher(line).matches()) {
+                    if (writer != null) {
+                        list.add(ModelNode.fromJSONString(writer.getBuffer().toString()));
+                    }
+                    writer = new StringWriter();
+                    writer.append("{");
+                } else {
+                    writer.append("\n" + line);
+                }
+                line = reader.readLine();
+            }
+            if (writer != null) {
+                list.add(ModelNode.fromJSONString(writer.getBuffer().toString()));
+            }
+        } finally {
+            IoUtils.safeClose(reader);
+        }
+        Assert.assertEquals(list.toString(), expectedRecords, list.size());
+        return list;
+    }
+
+    protected String readFullFileRecord(File file) throws IOException {
+        final BufferedReader reader = new BufferedReader(new FileReader(file));
+        try {
+            boolean firstLine = true;
+            StringWriter writer = new StringWriter();
+            String line = reader.readLine();
+            while (line != null) {
+                if (!firstLine) {
+                    writer.append("\n");
+                } else {
+                    firstLine = false;
+                }
+                writer.append(line);
+                line = reader.readLine();
+            }
+            return writer.toString();
+        } finally {
+            IoUtils.safeClose(reader);
+        }
+    }
+
+    protected ModelNode createAuditLogWriteAttributeOperation(String attr, boolean value) {
+        return Util.getWriteAttributeOperation(AUDIT_ADDR.append(AuditLogLoggerResourceDefinition.PATH_ELEMENT), attr, new ModelNode(value));
+    }
+
+    protected ModelNode createAddFileHandlerOperation(String handlerName, String formatterName, String fileName) {
+        ModelNode op = Util.createAddOperation(createFileHandlerAddress(handlerName));
+        op.get(ModelDescriptionConstants.RELATIVE_TO).set("log.dir");
+        op.get(ModelDescriptionConstants.PATH).set(fileName);
+        op.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
+        return op;
+    }
+
+    protected ModelNode createRemoveFileHandlerOperation(String handlerName) {
+        return Util.createRemoveOperation(createFileHandlerAddress(handlerName));
+    }
+
+    protected PathAddress createFileHandlerAddress(String handlerName){
+        return AUDIT_ADDR.append(PathElement.pathElement(ModelDescriptionConstants.FILE_HANDLER, handlerName));
+    }
+
+    protected ModelNode createRemoveJsonFormatterOperation(String formatterName) {
+        return Util.createRemoveOperation(createJsonFormatterAddress(formatterName));
+    }
+
+    protected PathAddress createJsonFormatterAddress(String formatterName) {
+        return AUDIT_ADDR.append(
+                PathElement.pathElement(ModelDescriptionConstants.JSON_FORMATTER, formatterName));
+    }
+
+
+    protected ModelNode createAddSyslogHandlerUdpOperation(String handlerName, String formatterName, InetAddress addr, int port, SyslogHandler.SyslogType syslogFormat, int maxLength){
+        ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        composite.get(OP_ADDR).setEmptyList();
+        composite.get(STEPS).setEmptyList();
+
+        ModelNode handler = Util.createAddOperation(createSyslogHandlerAddress(handlerName));
+        if (syslogFormat != null){
+            handler.get(SYSLOG_FORMAT).set(syslogFormat.toString());
+        }
+        if (maxLength > 0) {
+            handler.get(MAX_LENGTH).set(maxLength);
+        }
+        handler.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
+        composite.get(STEPS).add(handler);
+
+        ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.UDP));
+        protocol.get(HOST).set(addr.getHostName());
+        protocol.get(PORT).set(port);
+        composite.get(STEPS).add(protocol);
+
+        return composite;
+    }
+
+    protected ModelNode createAddSyslogHandlerTcpOperation(String handlerName, String formatterName, InetAddress addr, int port, SyslogHandler.SyslogType syslogFormat, SyslogAuditLogHandler.MessageTransfer transfer){
+        ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        composite.get(OP_ADDR).setEmptyList();
+        composite.get(STEPS).setEmptyList();
+
+        ModelNode handler = Util.createAddOperation(createSyslogHandlerAddress(handlerName));
+        if (syslogFormat != null){
+            handler.get(SYSLOG_FORMAT).set(syslogFormat.toString());
+        }
+        handler.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
+        composite.get(STEPS).add(handler);
+
+        ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.TCP));
+        protocol.get(HOST).set(addr.getHostName());
+        protocol.get(PORT).set(port);
+        if (transfer != null) {
+            protocol.get(MESSAGE_TRANSFER).set(transfer.name());
+        }
+        composite.get(STEPS).add(protocol);
+
+        return composite;
+    }
+
+    protected ModelNode createAddSyslogHandlerTlsOperation(String handlerName, String formatterName, InetAddress addr, int port, SyslogHandler.SyslogType syslogFormat,
+            SyslogAuditLogHandler.MessageTransfer transfer, File truststorePath, String trustPwd, File clientCertPath, String clientCertPwd){
+        ModelNode composite = new ModelNode();
+        composite.get(OP).set(COMPOSITE);
+        composite.get(OP_ADDR).setEmptyList();
+        composite.get(STEPS).setEmptyList();
+
+        ModelNode handler = Util.createAddOperation(createSyslogHandlerAddress(handlerName));
+        if (syslogFormat != null){
+            handler.get(SYSLOG_FORMAT).set(syslogFormat.toString());
+        }
+        handler.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
+        composite.get(STEPS).add(handler);
+
+        ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.TLS));
+        protocol.get(HOST).set(addr.getHostName());
+        protocol.get(PORT).set(port);
+        if (transfer != null) {
+            protocol.get(MESSAGE_TRANSFER).set(transfer.name());
+        }
+        composite.get(STEPS).add(protocol);
+
+        ModelNode truststore = Util.createAddOperation(
+                createSyslogHandlerProtocolAddress("syslog-test", Transport.TLS).append(
+                        PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.TRUSTSTORE)));
+        truststore.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PATH.getName()).set(truststorePath.getAbsolutePath());
+        truststore.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PASSWORD.getName()).set(trustPwd);
+        composite.get(STEPS).add(truststore);
+
+        if (clientCertPath != null) {
+            ModelNode clientCert = Util.createAddOperation(createSyslogHandlerProtocolAddress("syslog-test", Transport.TLS).append(
+                    PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.CLIENT_CERT_STORE)));
+            clientCert.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PATH.getName()).set(clientCertPath.getAbsolutePath());
+            clientCert.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PASSWORD.getName()).set(clientCertPwd);
+            composite.get(STEPS).add(clientCert);
+        }
+        return composite;
+    }
+
+    protected PathAddress createSyslogHandlerAddress(String handlerName){
+        return AUDIT_ADDR.append(PathElement.pathElement(ModelDescriptionConstants.SYSLOG_HANDLER, handlerName));
+    }
+
+    protected PathAddress createSyslogHandlerProtocolAddress(String handlerName, SyslogAuditLogHandler.Transport transport){
+        return AUDIT_ADDR.append(
+                PathElement.pathElement(ModelDescriptionConstants.SYSLOG_HANDLER, handlerName),
+                PathElement.pathElement(PROTOCOL, transport.name().toLowerCase()));
+    }
+
+    protected ModelNode createAddHandlerReferenceOperation(String name){
+        return Util.createAddOperation(createHandlerReferenceAddress(name));
+    }
+
+    protected ModelNode createRemoveHandlerReferenceOperation(String name){
+        return Util.createRemoveOperation(createHandlerReferenceAddress(name));
+    }
+
+    protected PathAddress createHandlerReferenceAddress(String name){
+        return AUDIT_ADDR.append(
+                        AuditLogLoggerResourceDefinition.PATH_ELEMENT,
+                        PathElement.pathElement(ModelDescriptionConstants.HANDLER, name));
+    }
+
+    protected List<ModelNode> checkBootRecordHeader(ModelNode bootRecord, int ops, String type, boolean readOnly, boolean booting, boolean success) {
+        Assert.assertEquals("core", bootRecord.get("type").asString());
+        Assert.assertEquals(readOnly, bootRecord.get("r/o").asBoolean());
+        Assert.assertEquals(booting, bootRecord.get("booting").asBoolean());
+        Assert.assertFalse(bootRecord.get("user").isDefined());
+        Assert.assertFalse(bootRecord.get("domainUUID").isDefined());
+        Assert.assertFalse(bootRecord.get("access").isDefined());
+        Assert.assertFalse(bootRecord.get("remote-address").isDefined());
+        Assert.assertEquals(success, bootRecord.get("success").asBoolean());
+        List<ModelNode> operations = bootRecord.get("ops").asList();
+        Assert.assertEquals(ops, operations.size());
+        return operations;
+    }
+
+
+    @Override
+    protected void addBootOperations(List<ModelNode> bootOperations) {
+        bootOperations.addAll(this.bootOperations);
+    }
+
+    protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
+        if (logDir == null){
+            logDir = new File(".");
+            logDir = new File(logDir, "target");
+            logDir = new File(logDir, "audit-log-test-log-dir").getAbsoluteFile();
+            if (!logDir.exists()){
+                logDir.mkdirs();
+            }
+        }
+
+        for (File file : logDir.listFiles()){
+            file.delete();
+        }
+
+        pathManagerService = new PathManagerService() {
+            {
+                super.addHardcodedAbsolutePath(getContainer(), "log.dir", logDir.getAbsolutePath());
+            }
+        };
+        GlobalOperationHandlers.registerGlobalOperations(registration, processType);
+        registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
+
+        TestServiceListener listener = new TestServiceListener();
+        listener.reset(1);
+        getContainer().addService(PathManagerService.SERVICE_NAME, pathManagerService)
+                .addListener(listener)
+                .install();
+
+        try {
+            listener.latch.await(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+
+        registration.registerSubModel(PathResourceDefinition.createSpecified(pathManagerService));
+        registration.registerSubModel(CoreManagementResourceDefinition.forStandaloneServer(new DelegatingConfigurableAuthorizer(), getAuditLogger(), pathManagerService, new EnvironmentNameReader() {
+            public boolean isServer() {
+                return true;
+            }
+
+            public String getServerName() {
+                return "Test";
+            }
+
+            public String getHostName() {
+                return null;
+            }
+
+            public String getProductName() {
+                return null;
+            }
+        }));
+
+
+        pathManagerService.addPathManagerResources(rootResource);
+        rootResource.registerChild(CoreManagementResourceDefinition.PATH_ELEMENT, Resource.Factory.create());
+    }
+
+
+    private class TestServiceListener extends AbstractServiceListener<Object> {
+
+        volatile CountDownLatch latch;
+        Map<ServiceController.Transition, ServiceName> services = Collections.synchronizedMap(new LinkedHashMap<ServiceController.Transition, ServiceName>());
+
+
+        void reset(int count) {
+            latch = new CountDownLatch(count);
+            services.clear();
+        }
+
+        public void transition(ServiceController<? extends Object> controller, ServiceController.Transition transition) {
+            if (transition == ServiceController.Transition.STARTING_to_UP || transition == ServiceController.Transition.REMOVING_to_REMOVED) {
+                services.put(transition, controller.getName());
+                latch.countDown();
+            }
+        }
+    }
+}

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogHandlerBootDisabledTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogHandlerBootDisabledTestCase.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.security.auditlog;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+
+import java.io.File;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.domain.management.audit.AuditLogLoggerResourceDefinition;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Don't use core-model test for this. It does not support runtime, and more importantly for backwards compatibility the audit logger cannot be used
+ *
+ * @author: Kabir Khan
+ */
+public class AuditLogHandlerBootDisabledTestCase extends AbstractAuditLogHandlerTestCase {
+    public AuditLogHandlerBootDisabledTestCase() {
+        super(false);
+    }
+
+    @Test
+    public void testAuditLoggerBootUp() throws Exception {
+        File file = new File(logDir, "test-file.log");
+        Assert.assertFalse(file.exists());
+    }
+
+    @Test
+    public void testEnableAndDisableAuditLogger() throws Exception {
+        File file = new File(logDir, "test-file.log");
+        Assert.assertFalse(file.exists());
+
+        ModelNode op = createAuditLogWriteAttributeOperation(AuditLogLoggerResourceDefinition.ENABLED.getName(), true);
+        executeForResult(op);
+        List<ModelNode> records = readFile(file, 1);
+        List<ModelNode> ops = checkBootRecordHeader(records.get(0), 1, "core", false, false, true);
+        checkOpsEqual(op, ops.get(0));
+
+        op = Util.createOperation(READ_RESOURCE_OPERATION, PathAddress.EMPTY_ADDRESS);
+        executeForResult(op);
+        readFile(file, 2);
+
+        op = createAuditLogWriteAttributeOperation(AuditLogLoggerResourceDefinition.ENABLED.getName(), false);
+        executeForResult(op);
+        records = readFile(file, 3);
+        ops = checkBootRecordHeader(records.get(2), 1, "core", false, false, true);
+        checkOpsEqual(op, ops.get(0));
+    }
+
+    @Test
+    public void testCanRemoveFormatter() throws Exception {
+        File file = new File(logDir, "test-file.log");
+        Assert.assertFalse(file.exists());
+
+        ModelNode op = createRemoveHandlerReferenceOperation("test-file");
+        executeForResult(op);
+    }
+}

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogHandlerBootEnabledTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AuditLogHandlerBootEnabledTestCase.java
@@ -23,115 +23,39 @@
 package org.jboss.as.domain.management.security.auditlog;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MAX_LENGTH;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MESSAGE_TRANSFER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROTOCOL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSLOG_FORMAT;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
 import java.net.InetAddress;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.access.DelegatingConfigurableAuthorizer;
-import org.jboss.as.controller.audit.ManagedAuditLogger;
-import org.jboss.as.controller.audit.ManagedAuditLoggerImpl;
-import org.jboss.as.controller.audit.SyslogAuditLogHandler;
 import org.jboss.as.controller.audit.SyslogAuditLogHandler.MessageTransfer;
-import org.jboss.as.controller.audit.SyslogAuditLogHandler.Transport;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.controller.services.path.PathManagerService;
-import org.jboss.as.controller.services.path.PathResourceDefinition;
-import org.jboss.as.domain.management.CoreManagementResourceDefinition;
-import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.as.domain.management.audit.AuditLogHandlerResourceDefinition;
 import org.jboss.as.domain.management.audit.AuditLogLoggerResourceDefinition;
-import org.jboss.as.domain.management.audit.EnvironmentNameReader;
 import org.jboss.as.domain.management.audit.FileAuditLogHandlerResourceDefinition;
 import org.jboss.as.domain.management.audit.JsonAuditLogFormatterResourceDefinition;
 import org.jboss.as.domain.management.audit.SyslogAuditLogHandlerResourceDefinition;
-import org.jboss.as.domain.management.audit.SyslogAuditLogProtocolResourceDefinition;
 import org.jboss.dmr.ModelNode;
-import org.jboss.logmanager.handlers.SyslogHandler;
 import org.jboss.logmanager.handlers.SyslogHandler.SyslogType;
-import org.jboss.msc.service.AbstractServiceListener;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
-import org.xnio.IoUtils;
 
 /**
  * Don't use core-model test for this. It does not support runtime, and more importantly for backwards compatibility the audit logger cannot be used
  *
  * @author: Kabir Khan
  */
-public class AuditLogHandlerTestCase extends AbstractControllerTestBase {
-    private static final PathAddress AUDIT_ADDR = PathAddress.pathAddress(CoreManagementResourceDefinition.PATH_ELEMENT, AccessAuditResourceDefinition.PATH_ELEMENT);
-    private static final int SYSLOG_PORT = 6666;
-    private static final int SYSLOG_PORT2 = 6667;
-
-    volatile PathManagerService pathManagerService;
-    volatile ManagedAuditLogger auditLogger;
-    volatile File logDir;
-
-    private final List<ModelNode> bootOperations = new ArrayList<ModelNode>();
-
-    public AuditLogHandlerTestCase() {
-
-        bootOperations.add(Util.createAddOperation(AUDIT_ADDR));
-        ModelNode add = Util.createAddOperation(createJsonFormatterAddress("test-formatter"));
-        bootOperations.add(add);
-
-        add = createAddFileHandlerOperation("test-file", "test-formatter", "test-file.log");
-        add.get(FileAuditLogHandlerResourceDefinition.MAX_FAILURE_COUNT.getName()).set(3);
-        bootOperations.add(add);
-
-        add = Util.createAddOperation(
-                AUDIT_ADDR.append(AuditLogLoggerResourceDefinition.PATH_ELEMENT));
-        add.get(ModelDescriptionConstants.LOG_READ_ONLY).set(true);
-        bootOperations.add(add);
-        bootOperations.add(createAddHandlerReferenceOperation("test-file"));
-    }
-
-
-    @After
-    public void clearDependencies(){
-        auditLogger = null;
-        logDir = null;
-    }
-
-    protected ManagedAuditLogger getAuditLogger(){
-        if (auditLogger == null){
-            auditLogger = new ManagedAuditLoggerImpl("8.0.0", true);
-        }
-        return auditLogger;
+public class AuditLogHandlerBootEnabledTestCase extends AbstractAuditLogHandlerTestCase {
+    public AuditLogHandlerBootEnabledTestCase() {
+        super(true);
     }
 
     @Test
@@ -831,325 +755,6 @@ public class AuditLogHandlerTestCase extends AbstractControllerTestBase {
             checkHandlerRuntimeFailureMetrics(result.get(ModelDescriptionConstants.SYSLOG_HANDLER, "syslog"), 4, 0, false);
         } finally {
             server.close();
-        }
-    }
-
-    private void checkHandlerRuntimeFailureMetrics(ModelNode handler, int maxFailureCount, int failureCount, boolean disabled) {
-        Assert.assertEquals(maxFailureCount, handler.get(AuditLogHandlerResourceDefinition.MAX_FAILURE_COUNT.getName()).asInt());
-        Assert.assertEquals(failureCount, handler.get(AuditLogHandlerResourceDefinition.FAILURE_COUNT.getName()).asInt());
-        Assert.assertEquals(disabled, handler.get(AuditLogHandlerResourceDefinition.DISABLED_DUE_TO_FAILURE.getName()).asBoolean());
-    }
-
-    private String stripSyslogHeader(byte[] bytes) throws UnsupportedEncodingException {
-        String s = new String(bytes, "utf-8");
-        int i = s.indexOf(" - - ");
-        return s.substring(i + 6);
-    }
-
-    private ModelNode getSyslogRecord(byte[] bytes) throws UnsupportedEncodingException {
-        String msg = new String(bytes, "utf-8");
-        return getSyslogRecord(msg);
-    }
-
-    private ModelNode getSyslogRecord(String msg) {
-        msg = msg.substring(msg.indexOf('{')).replace("#012", "\n");
-        return ModelNode.fromJSONString(msg);
-    }
-
-    private void checkOpsEqual(ModelNode rawDmr, ModelNode fromLog) {
-        ModelNode expected = ModelNode.fromJSONString(rawDmr.toJSONString(true));
-        Assert.assertEquals(expected, fromLog);
-
-    }
-
-    private final Pattern DATE_STAMP_PATTERN = Pattern.compile("\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d:\\d\\d - \\{");
-
-    private List<ModelNode> readFile(File file, int expectedRecords) throws IOException {
-        List<ModelNode> list = new ArrayList<ModelNode>();
-        final BufferedReader reader = new BufferedReader(new FileReader(file));
-        try {
-            StringWriter writer = null;
-            String line = reader.readLine();
-            while (line != null) {
-                if (DATE_STAMP_PATTERN.matcher(line).matches()) {
-                    if (writer != null) {
-                        list.add(ModelNode.fromJSONString(writer.getBuffer().toString()));
-                    }
-                    writer = new StringWriter();
-                    writer.append("{");
-                } else {
-                    writer.append("\n" + line);
-                }
-                line = reader.readLine();
-            }
-            if (writer != null) {
-                list.add(ModelNode.fromJSONString(writer.getBuffer().toString()));
-            }
-        } finally {
-            IoUtils.safeClose(reader);
-        }
-        Assert.assertEquals(list.toString(), expectedRecords, list.size());
-        return list;
-    }
-
-    private String readFullFileRecord(File file) throws IOException {
-        final BufferedReader reader = new BufferedReader(new FileReader(file));
-        try {
-            boolean firstLine = true;
-            StringWriter writer = new StringWriter();
-            String line = reader.readLine();
-            while (line != null) {
-                if (!firstLine) {
-                    writer.append("\n");
-                } else {
-                    firstLine = false;
-                }
-                writer.append(line);
-                line = reader.readLine();
-            }
-            return writer.toString();
-        } finally {
-            IoUtils.safeClose(reader);
-        }
-    }
-
-    private ModelNode createAuditLogWriteAttributeOperation(String attr, boolean value) {
-        return Util.getWriteAttributeOperation(AUDIT_ADDR.append(AuditLogLoggerResourceDefinition.PATH_ELEMENT), attr, new ModelNode(value));
-    }
-
-    private ModelNode createAddFileHandlerOperation(String handlerName, String formatterName, String fileName) {
-        ModelNode op = Util.createAddOperation(createFileHandlerAddress(handlerName));
-        op.get(ModelDescriptionConstants.RELATIVE_TO).set("log.dir");
-        op.get(ModelDescriptionConstants.PATH).set(fileName);
-        op.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
-        return op;
-    }
-
-    private ModelNode createRemoveFileHandlerOperation(String handlerName) {
-        return Util.createRemoveOperation(createFileHandlerAddress(handlerName));
-    }
-
-    private PathAddress createFileHandlerAddress(String handlerName){
-        return AUDIT_ADDR.append(PathElement.pathElement(ModelDescriptionConstants.FILE_HANDLER, handlerName));
-    }
-
-    private ModelNode createRemoveJsonFormatterOperation(String formatterName) {
-        return Util.createRemoveOperation(createJsonFormatterAddress(formatterName));
-    }
-
-    private PathAddress createJsonFormatterAddress(String formatterName) {
-        return AUDIT_ADDR.append(
-                PathElement.pathElement(ModelDescriptionConstants.JSON_FORMATTER, formatterName));
-    }
-
-
-    private ModelNode createAddSyslogHandlerUdpOperation(String handlerName, String formatterName, InetAddress addr, int port, SyslogHandler.SyslogType syslogFormat, int maxLength){
-        ModelNode composite = new ModelNode();
-        composite.get(OP).set(COMPOSITE);
-        composite.get(OP_ADDR).setEmptyList();
-        composite.get(STEPS).setEmptyList();
-
-        ModelNode handler = Util.createAddOperation(createSyslogHandlerAddress(handlerName));
-        if (syslogFormat != null){
-            handler.get(SYSLOG_FORMAT).set(syslogFormat.toString());
-        }
-        if (maxLength > 0) {
-            handler.get(MAX_LENGTH).set(maxLength);
-        }
-        handler.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
-        composite.get(STEPS).add(handler);
-
-        ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.UDP));
-        protocol.get(HOST).set(addr.getHostName());
-        protocol.get(PORT).set(port);
-        composite.get(STEPS).add(protocol);
-
-        return composite;
-    }
-
-    private ModelNode createAddSyslogHandlerTcpOperation(String handlerName, String formatterName, InetAddress addr, int port, SyslogHandler.SyslogType syslogFormat, SyslogAuditLogHandler.MessageTransfer transfer){
-        ModelNode composite = new ModelNode();
-        composite.get(OP).set(COMPOSITE);
-        composite.get(OP_ADDR).setEmptyList();
-        composite.get(STEPS).setEmptyList();
-
-        ModelNode handler = Util.createAddOperation(createSyslogHandlerAddress(handlerName));
-        if (syslogFormat != null){
-            handler.get(SYSLOG_FORMAT).set(syslogFormat.toString());
-        }
-        handler.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
-        composite.get(STEPS).add(handler);
-
-        ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.TCP));
-        protocol.get(HOST).set(addr.getHostName());
-        protocol.get(PORT).set(port);
-        if (transfer != null) {
-            protocol.get(MESSAGE_TRANSFER).set(transfer.name());
-        }
-        composite.get(STEPS).add(protocol);
-
-        return composite;
-    }
-
-    private ModelNode createAddSyslogHandlerTlsOperation(String handlerName, String formatterName, InetAddress addr, int port, SyslogHandler.SyslogType syslogFormat,
-            SyslogAuditLogHandler.MessageTransfer transfer, File truststorePath, String trustPwd, File clientCertPath, String clientCertPwd){
-        ModelNode composite = new ModelNode();
-        composite.get(OP).set(COMPOSITE);
-        composite.get(OP_ADDR).setEmptyList();
-        composite.get(STEPS).setEmptyList();
-
-        ModelNode handler = Util.createAddOperation(createSyslogHandlerAddress(handlerName));
-        if (syslogFormat != null){
-            handler.get(SYSLOG_FORMAT).set(syslogFormat.toString());
-        }
-        handler.get(ModelDescriptionConstants.FORMATTER).set(formatterName);
-        composite.get(STEPS).add(handler);
-
-        ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.TLS));
-        protocol.get(HOST).set(addr.getHostName());
-        protocol.get(PORT).set(port);
-        if (transfer != null) {
-            protocol.get(MESSAGE_TRANSFER).set(transfer.name());
-        }
-        composite.get(STEPS).add(protocol);
-
-        ModelNode truststore = Util.createAddOperation(
-                createSyslogHandlerProtocolAddress("syslog-test", Transport.TLS).append(
-                        PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.TRUSTSTORE)));
-        truststore.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PATH.getName()).set(truststorePath.getAbsolutePath());
-        truststore.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PASSWORD.getName()).set(trustPwd);
-        composite.get(STEPS).add(truststore);
-
-        if (clientCertPath != null) {
-            ModelNode clientCert = Util.createAddOperation(createSyslogHandlerProtocolAddress("syslog-test", Transport.TLS).append(
-                    PathElement.pathElement(ModelDescriptionConstants.AUTHENTICATION, ModelDescriptionConstants.CLIENT_CERT_STORE)));
-            clientCert.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PATH.getName()).set(clientCertPath.getAbsolutePath());
-            clientCert.get(SyslogAuditLogProtocolResourceDefinition.TlsKeyStore.KEYSTORE_PASSWORD.getName()).set(clientCertPwd);
-            composite.get(STEPS).add(clientCert);
-        }
-        return composite;
-    }
-
-    private PathAddress createSyslogHandlerAddress(String handlerName){
-        return AUDIT_ADDR.append(PathElement.pathElement(ModelDescriptionConstants.SYSLOG_HANDLER, handlerName));
-    }
-
-    private PathAddress createSyslogHandlerProtocolAddress(String handlerName, SyslogAuditLogHandler.Transport transport){
-        return AUDIT_ADDR.append(
-                PathElement.pathElement(ModelDescriptionConstants.SYSLOG_HANDLER, handlerName),
-                PathElement.pathElement(PROTOCOL, transport.name().toLowerCase()));
-    }
-
-    private ModelNode createAddHandlerReferenceOperation(String name){
-        return Util.createAddOperation(createHandlerReferenceAddress(name));
-    }
-
-    private ModelNode createRemoveHandlerReferenceOperation(String name){
-        return Util.createRemoveOperation(createHandlerReferenceAddress(name));
-    }
-
-    private PathAddress createHandlerReferenceAddress(String name){
-        return AUDIT_ADDR.append(
-                        AuditLogLoggerResourceDefinition.PATH_ELEMENT,
-                        PathElement.pathElement(ModelDescriptionConstants.HANDLER, name));
-    }
-
-    private List<ModelNode> checkBootRecordHeader(ModelNode bootRecord, int ops, String type, boolean readOnly, boolean booting, boolean success) {
-        Assert.assertEquals("core", bootRecord.get("type").asString());
-        Assert.assertEquals(readOnly, bootRecord.get("r/o").asBoolean());
-        Assert.assertEquals(booting, bootRecord.get("booting").asBoolean());
-        Assert.assertFalse(bootRecord.get("user").isDefined());
-        Assert.assertFalse(bootRecord.get("domainUUID").isDefined());
-        Assert.assertFalse(bootRecord.get("access").isDefined());
-        Assert.assertFalse(bootRecord.get("remote-address").isDefined());
-        Assert.assertEquals(success, bootRecord.get("success").asBoolean());
-        List<ModelNode> operations = bootRecord.get("ops").asList();
-        Assert.assertEquals(ops, operations.size());
-        return operations;
-    }
-
-
-    @Override
-    protected void addBootOperations(List<ModelNode> bootOperations) {
-        bootOperations.addAll(this.bootOperations);
-    }
-
-    protected void initModel(Resource rootResource, ManagementResourceRegistration registration) {
-        if (logDir == null){
-            logDir = new File(".");
-            logDir = new File(logDir, "target");
-            logDir = new File(logDir, "audit-log-test-log-dir").getAbsoluteFile();
-            if (!logDir.exists()){
-                logDir.mkdirs();
-            }
-        }
-
-        for (File file : logDir.listFiles()){
-            file.delete();
-        }
-
-        pathManagerService = new PathManagerService() {
-            {
-                super.addHardcodedAbsolutePath(getContainer(), "log.dir", logDir.getAbsolutePath());
-            }
-        };
-        GlobalOperationHandlers.registerGlobalOperations(registration, processType);
-        registration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);
-
-        TestServiceListener listener = new TestServiceListener();
-        listener.reset(1);
-        getContainer().addService(PathManagerService.SERVICE_NAME, pathManagerService)
-                .addListener(listener)
-                .install();
-
-        try {
-            listener.latch.await(10, TimeUnit.SECONDS);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-
-        registration.registerSubModel(PathResourceDefinition.createSpecified(pathManagerService));
-        registration.registerSubModel(CoreManagementResourceDefinition.forStandaloneServer(new DelegatingConfigurableAuthorizer(), getAuditLogger(), pathManagerService, new EnvironmentNameReader() {
-            public boolean isServer() {
-                return true;
-            }
-
-            public String getServerName() {
-                return "Test";
-            }
-
-            public String getHostName() {
-                return null;
-            }
-
-            public String getProductName() {
-                return null;
-            }
-        }));
-
-
-        pathManagerService.addPathManagerResources(rootResource);
-        rootResource.registerChild(CoreManagementResourceDefinition.PATH_ELEMENT, Resource.Factory.create());
-    }
-
-
-    private class TestServiceListener extends AbstractServiceListener<Object> {
-
-        volatile CountDownLatch latch;
-        Map<ServiceController.Transition, ServiceName> services = Collections.synchronizedMap(new LinkedHashMap<ServiceController.Transition, ServiceName>());
-
-
-        void reset(int count) {
-            latch = new CountDownLatch(count);
-            services.clear();
-        }
-
-        public void transition(ServiceController<? extends Object> controller, ServiceController.Transition transition) {
-            if (transition == ServiceController.Transition.STARTING_to_UP || transition == ServiceController.Transition.REMOVING_to_REMOVED) {
-                services.put(transition, controller.getName());
-                latch.countDown();
-            }
         }
     }
 }

--- a/jmx/src/main/java/org/jboss/as/jmx/JmxAuditLogHandlerReferenceResourceDefinition.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/JmxAuditLogHandlerReferenceResourceDefinition.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.audit.ManagedAuditLogger;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
@@ -121,6 +122,7 @@ public class JmxAuditLogHandlerReferenceResourceDefinition extends SimpleResourc
 
         private boolean lookForHandler(OperationContext context, String name) {
             PathAddress addr = PathAddress.pathAddress(
+                                    CoreManagementResourceDefinition.PATH_ELEMENT,
                                     AccessAuditResourceDefinition.PATH_ELEMENT);
             PathAddress referenceAddress = addr.append(FILE_HANDLER, name);
             final Resource root = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);

--- a/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
@@ -56,6 +56,7 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
+import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.AttributesPathAddressConfig;
@@ -517,20 +518,7 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
                 "   </audit-log>" +
                 "</subsystem>";
 
-        AdditionalInitialization additionalInit = new BaseAdditionalInitalization() {
-
-            @Override
-            protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource,
-                    ManagementResourceRegistration rootRegistration) {
-                super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration);
-
-                Resource auditLog = Resource.Factory.create();
-                rootResource.registerChild(AccessAuditResourceDefinition.PATH_ELEMENT, auditLog);
-                Resource testHandler = Resource.Factory.create();
-                testHandler.getModel().setEmptyObject();
-                auditLog.registerChild(PathElement.pathElement(FILE_HANDLER, "test"), testHandler);
-            }
-        };
+        AdditionalInitialization additionalInit = new AuditLogInitialization();
 
         KernelServices servicesA = createKernelServicesBuilder(additionalInit).setSubsystemXml(subsystemXml).build();
         Assert.assertTrue(servicesA.isSuccessfulBoot());
@@ -937,28 +925,34 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
                                         ManagementResourceRegistration rootRegistration) {
             super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration);
 
-            Resource auditLogResource = Resource.Factory.create();
-            rootResource.registerChild(AccessAuditResourceDefinition.PATH_ELEMENT, auditLogResource);
+            Resource coreManagement = Resource.Factory.create();
+            rootResource.registerChild(CoreManagementResourceDefinition.PATH_ELEMENT, coreManagement);
+            Resource auditLog = Resource.Factory.create();
+            coreManagement.registerChild(AccessAuditResourceDefinition.PATH_ELEMENT, auditLog);
 
             Resource testFileHandler = Resource.Factory.create();
             testFileHandler.getModel().setEmptyObject();
-            auditLogResource.registerChild(PathElement.pathElement(FILE_HANDLER, "test"), testFileHandler);
+            auditLog.registerChild(PathElement.pathElement(FILE_HANDLER, "test"), testFileHandler);
         }
     }
 
     private static class ManagementAuditLogInitialization extends AdditionalInitialization.ManagementAdditionalInitialization {
+
+        private static final long serialVersionUID = 1L;
 
         @Override
         protected void initializeExtraSubystemsAndModel(ExtensionRegistry extensionRegistry, Resource rootResource,
                                         ManagementResourceRegistration rootRegistration) {
             super.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration);
 
-            Resource auditLogResource = Resource.Factory.create();
-            rootResource.registerChild(AccessAuditResourceDefinition.PATH_ELEMENT, auditLogResource);
+            Resource coreManagement = Resource.Factory.create();
+            rootResource.registerChild(CoreManagementResourceDefinition.PATH_ELEMENT, coreManagement);
+            Resource auditLog = Resource.Factory.create();
+            coreManagement.registerChild(AccessAuditResourceDefinition.PATH_ELEMENT, auditLog);
 
             Resource testFileHandler = Resource.Factory.create();
             testFileHandler.getModel().setEmptyObject();
-            auditLogResource.registerChild(PathElement.pathElement(FILE_HANDLER, "test"), testFileHandler);
+            auditLog.registerChild(PathElement.pathElement(FILE_HANDLER, "test"), testFileHandler);
         }
     }
 


### PR DESCRIPTION
I did not check these before the WildFly 8.0.0.Alpha4 release

1) I hadn't fixed properly trying to remove an audit log handler reference when booted with enabled=false, so I have done this properly and added a test. Previously this would fail with a message saying there was an attempt to both add and update a handler reference

2) The JMX subsystem had not been updated to take into account that the core audit logging configuration was moved to /core-service=management/access=audit
