### PR TITLE
WFLY-1888 change mod_cluster default metric to cpu (which is a pretty go...

### DIFF
--- a/build/src/main/resources/configuration/subsystems/mod_cluster.xml
+++ b/build/src/main/resources/configuration/subsystems/mod_cluster.xml
@@ -5,7 +5,7 @@
     <subsystem xmlns="urn:jboss:domain:modcluster:1.2">
         <mod-cluster-config advertise-socket="modcluster" connector="ajp">
             <dynamic-load-provider>
-                <load-metric type="busyness"/>
+                <load-metric type="cpu"/>
             </dynamic-load-provider>
         </mod-cluster-config>
     </subsystem>

--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterLogger.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterLogger.java
@@ -86,4 +86,14 @@ interface ModClusterLogger extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 11704, value = "Mod_cluster uses default load balancer provider")
     void useDefaultLoadBalancer();
+
+    /**
+     * Logs if an unsupported metric is configured.
+     *
+     * @param metricName name of the unsupported metric
+     */
+    @LogMessage(level = ERROR)
+    @Message(id = 11705, value = "Configured metric '%s' is not currently supported.")
+    void unsupportedMetric(String metricName);
+
 }

--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemAdd.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemAdd.java
@@ -292,6 +292,15 @@ class ModClusterSubsystemAdd extends AbstractAddStepHandler {
             if (node.hasDefined(CommonAttributes.TYPE)) {
                 String type = TYPE.resolveModelAttribute(context, node).asString();
                 LoadMetricEnum metric = LoadMetricEnum.forType(type);
+
+                if (metric != null && (metric.equals(LoadMetricEnum.BUSY_CONNECTORS)
+                        || metric.equals(LoadMetricEnum.ACTIVE_SESSIONS)
+                        || metric.equals(LoadMetricEnum.SEND_TRAFFIC)
+                        || metric.equals(LoadMetricEnum.RECEIVE_TRAFFIC)
+                        || metric.equals(LoadMetricEnum.REQUEST_COUNT))) {
+                    ROOT_LOGGER.unsupportedMetric(type);
+                }
+
                 loadMetricClass = (metric != null) ? metric.getLoadMetricClass() : null;
             } else {
                 String className = CustomLoadMetricDefinition.CLASS.resolveModelAttribute(context, node).asString();


### PR DESCRIPTION
...od default metric anyway) from currently unsupported busyness

https://issues.jboss.org/browse/WFLY-1888
