### PR TITLE
[WFLY-1889] The schema containing WildFly 8 specific features should be bumped to version 2.0

### DIFF
--- a/build/src/main/resources/bin/jboss-cli.xml
+++ b/build/src/main/resources/bin/jboss-cli.xml
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 
 <!--
-   JBoss AS7 Command-line Interface configuration.
+   WildFly Command-line Interface configuration.
 -->
-<jboss-cli xmlns="urn:jboss:cli:1.3">
+<jboss-cli xmlns="urn:jboss:cli:2.0">
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
@@ -23,8 +23,8 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="urn:jboss:cli:1.3"
-           targetNamespace="urn:jboss:cli:1.3"
+           xmlns="urn:jboss:cli:2.0"
+           targetNamespace="urn:jboss:cli:2.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
         >

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -140,7 +140,6 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
             channelConfig.setConnectionTimeout(connectionTimeout);
         }
         channelConfig.setEndpoint(endpoint);
-
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -334,16 +334,16 @@ class CliConfigImpl implements CliConfig {
             }
 
             Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
-            switch (readerNS) {
-                case CLI_1_0:
-                case CLI_1_1:
-                case CLI_1_2:
-                case CLI_1_3:
+            for (Namespace current : Namespace.cliValues()) {
+                if (readerNS.equals(current)) {
+                    // Convert to a switch statement if the top level element changes - for now all supported
+                    // namespaces are equal at this point.
                     readCLIElement_1_0(reader, readerNS, config);
-                    break;
-                default:
-                    throw new XMLStreamException("Unexpected element: " + localName);
+                    return;
+                }
+
             }
+            throw new XMLStreamException("Unexpected element: " + localName);
         }
 
         public void readCLIElement_1_0(XMLExtendedStreamReader reader, Namespace expectedNs, CliConfigImpl config) throws XMLStreamException {

--- a/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/Namespace.java
@@ -46,12 +46,12 @@ public enum Namespace {
 
     CLI_1_2("urn:jboss:cli:1.2"),
 
-    CLI_1_3("urn:jboss:cli:1.3");
+    CLI_2_0("urn:jboss:cli:2.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = CLI_1_2;
+    public static final Namespace CURRENT = CLI_2_0;
 
     private final String name;
 


### PR DESCRIPTION
This will leave the 1.x versions available for EAP 6
