### PR TITLE
[WFLY-1696] Add a --no-local-auth option on starting the CLI

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
@@ -60,6 +60,9 @@ public abstract class CommandContextFactory {
     public abstract CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
             String username, char[] password, boolean initConsole, final int connectionTimeout) throws CliInitializationException;
 
+    public abstract CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
+            String username, char[] password, boolean disableLocalAuth, boolean initConsole, final int connectionTimeout) throws CliInitializationException;
+
     public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
             String username, char[] password,
             InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -24,6 +24,7 @@ package org.jboss.as.cli.impl;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -104,6 +105,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
     private final Object lock = new Object();
 
     private final CallbackHandler handler;
+    private final Map<String, String> saslOptions;
     private final SSLContext sslContext;
     private final ConnectionCloseHandler closeHandler;
 
@@ -113,7 +115,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
     private boolean closed;
 
     CLIModelControllerClient(final String protocol, CallbackHandler handler, String hostName, int connectionTimeout,
-            final ConnectionCloseHandler closeHandler, int port, SSLContext sslContext) throws IOException {
+            final ConnectionCloseHandler closeHandler, int port, Map<String, String> saslOptions, SSLContext sslContext) throws IOException {
         this.handler = handler;
         this.sslContext = sslContext;
         this.closeHandler = closeHandler;
@@ -130,6 +132,8 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
         }, executorService, this);
 
         channelConfig = new ProtocolChannelClient.Configuration();
+        this.saslOptions = saslOptions;
+        channelConfig.setSaslOptions(saslOptions);
         try {
             channelConfig.setUri(new URI(protocol +"://" + formatPossibleIpv6Address(hostName) +  ":" + port));
         } catch (URISyntaxException e) {
@@ -154,7 +158,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
 
                 final ProtocolChannelClient setup = ProtocolChannelClient.create(channelConfig);
                 final ChannelCloseHandler channelCloseHandler = new ChannelCloseHandler();
-                strategy = ManagementClientChannelStrategy.create(setup, channelAssociation, handler, null, sslContext,
+                strategy = ManagementClientChannelStrategy.create(setup, channelAssociation, handler, saslOptions, sslContext,
                         channelCloseHandler);
                 channelCloseHandler.setOriginalStrategy(strategy);
             }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -61,6 +61,7 @@ public class CliLauncher {
             boolean version = false;
             String username = null;
             char[] password = null;
+            boolean noLocalAuth = false;
             int connectionTimeout = -1;
 
             for(String arg : args) {
@@ -174,8 +175,11 @@ public class CliLauncher {
                     commands = Collections.singletonList(value);
                 } else if (arg.startsWith("--user=")) {
                     username = arg.startsWith("--") ? arg.substring(7) : arg.substring(5);
+                    noLocalAuth = true;
                 } else if (arg.startsWith("--password=")) {
                     password = (arg.startsWith("--") ? arg.substring(11) : arg.substring(9)).toCharArray();
+                } else if (arg.equals("--no-local-auth")) {
+                    noLocalAuth = true;
                 } else if (arg.startsWith("--timeout=")) {
                     if (connectionTimeout > 0) {
                         argError = "Duplicate argument '--timeout'";
@@ -242,31 +246,31 @@ public class CliLauncher {
             }
 
             if(version) {
-                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, false, connect, connectionTimeout);
+                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, noLocalAuth, false, connect, connectionTimeout);
                 VersionHandler.INSTANCE.handle(cmdCtx);
                 return;
             }
 
             if(file != null) {
-                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, false, connect, connectionTimeout);
+                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, noLocalAuth, false, connect, connectionTimeout);
                 processFile(file, cmdCtx);
                 return;
             }
 
             if(commands != null) {
-                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, false, connect, connectionTimeout);
+                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, noLocalAuth, false, connect, connectionTimeout);
                 processCommands(commands, cmdCtx);
                 return;
             }
 
             if (gui) {
-                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, false, true, connectionTimeout);
+                cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, noLocalAuth, false, true, connectionTimeout);
                 processGui(cmdCtx);
                 return;
             }
 
             // Interactive mode
-            cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, true, connect, connectionTimeout);
+            cmdCtx = initCommandContext(defaultControllerProtocol, defaultControllerHost, defaultControllerPort, username, password, noLocalAuth, true, connect, connectionTimeout);
             cmdCtx.interact();
         } catch(Throwable t) {
             t.printStackTrace();
@@ -282,8 +286,8 @@ public class CliLauncher {
         System.exit(exitCode);
     }
 
-    private static CommandContext initCommandContext(String defaultProtocol, String defaultHost, int defaultPort, String username, char[] password, boolean initConsole, boolean connect, final int connectionTimeout) throws CliInitializationException {
-        final CommandContext cmdCtx = CommandContextFactory.getInstance().newCommandContext(defaultProtocol, defaultHost, defaultPort, username, password, initConsole, connectionTimeout);
+    private static CommandContext initCommandContext(String defaultProtocol, String defaultHost, int defaultPort, String username, char[] password, boolean disableLocalAuth, boolean initConsole, boolean connect, final int connectionTimeout) throws CliInitializationException {
+        final CommandContext cmdCtx = CommandContextFactory.getInstance().newCommandContext(defaultProtocol, defaultHost, defaultPort, username, password, disableLocalAuth, initConsole, connectionTimeout);
         if(connect) {
             try {
                 cmdCtx.connectController();

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -47,7 +47,7 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     @Override
     public CommandContext newCommandContext(String username, char[] password)
             throws CliInitializationException {
-        final CommandContextImpl cmdCtx = new CommandContextImpl(username, password);
+        final CommandContextImpl cmdCtx = new CommandContextImpl(username, password, username != null);
         addShutdownHook(cmdCtx);
         return cmdCtx;
     }
@@ -63,7 +63,7 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerProtocol, String controllerHost,
             int controllerPort, String username, char[] password,
             boolean initConsole, final int connectionTimeout) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, initConsole, connectionTimeout);
+        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, false, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }
@@ -72,7 +72,16 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerHost, int controllerPort,
             String username, char[] password,
             InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, consoleInput, consoleOutput);
+        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, false, consoleInput, consoleOutput);
+        addShutdownHook(ctx);
+        return ctx;
+    }
+
+    @Override
+    public CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
+            String username, char[] password, boolean disableLocalAuth, boolean initConsole, int connectionTimeout)
+            throws CliInitializationException {
+        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, disableLocalAuth, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -186,9 +186,11 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     /** the port of the controller */
     private int controllerPort = -1;
     /** the command line specified username */
-    private String username;
+    private final String username;
     /** the command line specified password */
-    private char[] password;
+    private final char[] password;
+    /** flag to disable the local authentication mechanism */
+    private final boolean disableLocalAuth;
     /** the time to connect to a controller */
     private final int connectionTimeout;
     /** The SSLContext when managed by the CLI */
@@ -243,18 +245,21 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         resolveParameterValues = config.isResolveParameterValues();
         this.connectionTimeout = config.getConnectionTimeout();
         silent = config.isSilent();
+        username = null;
+        password = null;
+        disableLocalAuth = false;
         initSSLContext();
     }
 
-    CommandContextImpl(String username, char[] password) throws CliInitializationException {
-        this(null, null, -1, username, password, false, -1);
+    CommandContextImpl(String username, char[] password, boolean disableLocalAuth) throws CliInitializationException {
+        this(null, null, -1, username, password, disableLocalAuth, false, -1);
     }
 
     /**
      * Default constructor used for both interactive and non-interactive mode.
      *
      */
-    CommandContextImpl(String defaultControllerProtocol, String defaultControllerHost, int defaultControllerPort, String username, char[] password, boolean initConsole, final int connectionTimeout)
+    CommandContextImpl(String defaultControllerProtocol, String defaultControllerHost, int defaultControllerPort, String username, char[] password, boolean disableLocalAuth, boolean initConsole, final int connectionTimeout)
             throws CliInitializationException {
 
         config = CliConfigImpl.load(this);
@@ -263,6 +268,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
 
         this.username = username;
         this.password = password;
+        this.disableLocalAuth = disableLocalAuth;
         this.connectionTimeout = connectionTimeout != -1 ? connectionTimeout : config.getConnectionTimeout();
 
         if (defaultControllerHost != null) {
@@ -299,7 +305,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     }
 
     CommandContextImpl(String defaultControllerHost, int defaultControllerPort,
-            String username, char[] password,
+            String username, char[] password, boolean disableLocalAuth,
             InputStream consoleInput, OutputStream consoleOutput)
             throws CliInitializationException {
 
@@ -309,6 +315,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
 
         this.username = username;
         this.password = password;
+        this.disableLocalAuth = disableLocalAuth;
         this.connectionTimeout = config.getConnectionTimeout();
 
         if (defaultControllerHost != null) {
@@ -802,7 +809,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                     log.debug("connecting to " + host + ':' + port + " as " + username);
                 }
                 ModelControllerClient tempClient = ModelControllerClientFactory.CUSTOM.
-                        getClient(protocol, host, port, cbh, sslContext, connectionTimeout, this);
+                        getClient(protocol, host, port, cbh, disableLocalAuth, sslContext, connectionTimeout, this);
                 retry = tryConnection(tempClient, host, port);
                 if(!retry) {
                     newClient = tempClient;

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -5,6 +5,7 @@ Usage:
                      [--commands=command_or_operation1,command_or_operation2...]
                      [--command=command_or_operation]
                      [--user=username --password=password]
+                     [--no-local-auth]
                      [--timeout=timeout]
 
  --help (-h)     - prints (this) basic description of the command line utility.
@@ -51,13 +52,19 @@ Usage:
                    can be used to specify the user name as a command line
                    argument. If the argument isn't specified and the
                    authentication is required the user will be prompted to enter
-                   the user name when the connect command is issued.
+                   the user name when the connect command is issued.  Local 
+                   authentication is automatically disabled if a user is specified.
+                   
 
  --password      - specifies the password for authentication while connecting to
                    the controller as a command line argument. If the argument
                    isn't specified and the authentication is required the user
                    will be prompted to enter the password when the connect
                    command is issued.
+                   
+ --no-local-auth - disable the local authentication mechanism which allows the CLI
+                   to demonstrate that it is being executed locally to the server 
+                   being managed through an exchange of tokens using the filesystem.                   
 
  --timeout       - specifies home many milliseconds to wait for a given command
                    to return. The value provided must be a positive integer.

--- a/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/ModelControllerClient.java
@@ -301,6 +301,22 @@ public interface ModelControllerClient extends Closeable {
         /**
          * Create a client instance for a remote address and port and CallbackHandler.
          *
+         * @param protocol    The prototcol to use. If this is http-remoting or https-remoting http upgrade will be used rather than the native remote protocol
+         * @param hostName   the remote host
+         * @param port       the port
+         * @param handler    CallbackHandler to obtain authentication information for the call.
+         * @param sslContext a pre-initialised SSLContext
+         * @param saslOptions Additional options to be passed to the SASL mechanism.
+         * @return A model controller client
+         * @throws UnknownHostException if the host cannot be found
+         */
+        public static ModelControllerClient create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
+            return create(ClientConfigurationImpl.create(protocol, hostName, port, handler, sslContext, connectionTimeout));
+        }
+
+        /**
+         * Create a client instance for a remote address and port and CallbackHandler.
+         *
          * @param hostName    the remote host
          * @param port        the port
          * @param handler     CallbackHandler to obtain authentication information for the call.

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
@@ -197,6 +197,10 @@ public class ClientConfigurationImpl implements ModelControllerClientConfigurati
         return new ClientConfigurationImpl(hostName, port, handler, null, sslContext, createDefaultExecutor(), true, connectionTimeout, protocol);
     }
 
+    public static ModelControllerClientConfiguration create(final String protocol, final String hostName, final int port, final CallbackHandler handler, final SSLContext sslContext, final int connectionTimeout, final Map<String, String> saslOptions) throws UnknownHostException {
+        return new ClientConfigurationImpl(hostName, port, handler, saslOptions, sslContext, createDefaultExecutor(), true, connectionTimeout, protocol);
+    }
+
     public static ModelControllerClientConfiguration create(final String hostName, final int port, final CallbackHandler handler, final Map<String, String> saslOptions) throws UnknownHostException {
         return new ClientConfigurationImpl(hostName, port, handler, saslOptions, null, createDefaultExecutor(), true, null);
     }


### PR DESCRIPTION
This switched off local authentication.

Also disable local authentication if a username is supplied on starting the CLI.
