### PR TITLE
WFLY-1575 : jboss-cli.sh allows creation of an invalid jsse element within a security-domain 

### DIFF
--- a/security/src/main/java/org/jboss/as/security/JSSEResourceDefinition.java
+++ b/security/src/main/java/org/jboss/as/security/JSSEResourceDefinition.java
@@ -38,14 +38,11 @@ import org.jboss.dmr.ModelType;
  */
 public class JSSEResourceDefinition extends SimpleResourceDefinition {
 
-
     static final ObjectTypeAttributeDefinition KEYSTORE = new ObjectTypeAttributeDefinition.Builder(Constants.KEYSTORE, ComplexAttributes.KEY_STORE_FIELDS)
-            .setAttributeMarshaller(new ComplexAttributes.KeyStoreAttributeMarshaller())
-            .build();
+            .setValidator(new ComplexAttributes.KeyStoreAttributeValidator(Constants.KEYSTORE)).setAttributeMarshaller(new ComplexAttributes.KeyStoreAttributeMarshaller()).build();
 
     static final ObjectTypeAttributeDefinition TRUSTSTORE = new ObjectTypeAttributeDefinition.Builder(Constants.TRUSTSTORE, ComplexAttributes.KEY_STORE_FIELDS)
-            .setAttributeMarshaller(new ComplexAttributes.KeyStoreAttributeMarshaller())
-            .build();
+            .setValidator(new ComplexAttributes.KeyStoreAttributeValidator(Constants.TRUSTSTORE)).setAttributeMarshaller(new ComplexAttributes.KeyStoreAttributeMarshaller()).build();
 
     static final ObjectTypeAttributeDefinition KEYMANAGER = new ObjectTypeAttributeDefinition.Builder(Constants.KEY_MANAGER, ComplexAttributes.KEY_MANAGER_FIELDS)
             .setAttributeMarshaller(new ComplexAttributes.KeyManagerAttributeMarshaller())
@@ -79,13 +76,13 @@ public class JSSEResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     private static final AttributeDefinition[] ATTRIBUTES = {KEYSTORE, TRUSTSTORE, KEYMANAGER, TRUSTMANAGER, CLIENT_ALIAS, SERVER_ALIAS, SERVICE_AUTH_TOKEN,
-            CLIENT_AUTH, PROTOCOLS, CIPHER_SUITES, ADDITIONAL_PROPERTIES};
+        CLIENT_AUTH, PROTOCOLS, CIPHER_SUITES, ADDITIONAL_PROPERTIES};
 
     public static final JSSEResourceDefinition INSTANCE = new JSSEResourceDefinition();
 
     private JSSEResourceDefinition() {
         super(SecurityExtension.JSSE_PATH,
-              SecurityExtension.getResourceDescriptionResolver(Constants.JSSE),
+                SecurityExtension.getResourceDescriptionResolver(Constants.JSSE),
                 JSSEResourceDefinitionAdd.INSTANCE,
                 new SecurityDomainReloadRemoveHandler());
     }
@@ -97,6 +94,7 @@ public class JSSEResourceDefinition extends SimpleResourceDefinition {
     }
 
     static class JSSEResourceDefinitionAdd extends SecurityDomainReloadAddHandler {
+
         static final JSSEResourceDefinitionAdd INSTANCE = new JSSEResourceDefinitionAdd();
 
         @Override

--- a/security/src/main/java/org/jboss/as/security/SecurityMessages.java
+++ b/security/src/main/java/org/jboss/as/security/SecurityMessages.java
@@ -301,4 +301,6 @@ public interface SecurityMessages {
     @Message(id = 13331, value = "Required security domain is not available '%s'")
     OperationFailedException requiredSecurityDomainServiceNotAvailable(String securityDomainName);
 
+    @Message(id = 13332, value = "At least one attribute is to be defined")
+    OperationFailedException requiredJSSEConfigurationAttribute();
 }

--- a/security/src/main/java/org/jboss/as/security/SecuritySubsystemParser.java
+++ b/security/src/main/java/org/jboss/as/security/SecuritySubsystemParser.java
@@ -800,6 +800,7 @@ public class SecuritySubsystemParser implements XMLStreamConstants, XMLElementRe
     private void parseJSSE(List<ModelNode> list, PathAddress parentAddress, XMLExtendedStreamReader reader) throws XMLStreamException {
         ModelNode op = appendAddOperation(list, parentAddress, JSSE, CLASSIC);
         EnumSet<Attribute> visited = EnumSet.noneOf(Attribute.class);
+        EnumSet<Attribute> required = EnumSet.noneOf(Attribute.class);
         final int count = reader.getAttributeCount();
         for (int i = 0; i < count; i++) {
             requireNoNamespaceAttribute(reader, i);
@@ -814,18 +815,22 @@ public class SecuritySubsystemParser implements XMLStreamConstants, XMLElementRe
                 }
                 case KEYSTORE_TYPE: {
                     ComplexAttributes.TYPE.parseAndSetParameter(value, op.get(KEYSTORE), reader);
+                    required.add(Attribute.KEYSTORE_PASSWORD);
                     break;
                 }
                 case KEYSTORE_URL: {
                     ComplexAttributes.URL.parseAndSetParameter(value, op.get(KEYSTORE), reader);
+                    required.add(Attribute.KEYSTORE_PASSWORD);
                     break;
                 }
                 case KEYSTORE_PROVIDER: {
                     ComplexAttributes.PROVIDER.parseAndSetParameter(value, op.get(KEYSTORE), reader);
+                    required.add(Attribute.KEYSTORE_PASSWORD);
                     break;
                 }
                 case KEYSTORE_PROVIDER_ARGUMENT: {
                     ComplexAttributes.PROVIDER_ARGUMENT.parseAndSetParameter(value, op.get(KEYSTORE), reader);
+                    required.add(Attribute.KEYSTORE_PASSWORD);
                     break;
                 }
                 case KEY_MANAGER_FACTORY_PROVIDER: {
@@ -843,18 +848,22 @@ public class SecuritySubsystemParser implements XMLStreamConstants, XMLElementRe
                 }
                 case TRUSTSTORE_TYPE: {
                     ComplexAttributes.TYPE.parseAndSetParameter(value, op.get(TRUSTSTORE), reader);
+                    required.add(Attribute.TRUSTSTORE_PASSWORD);
                     break;
                 }
                 case TRUSTSTORE_URL: {
                     ComplexAttributes.URL.parseAndSetParameter(value, op.get(TRUSTSTORE), reader);
+                    required.add(Attribute.TRUSTSTORE_PASSWORD);
                     break;
                 }
                 case TRUSTSTORE_PROVIDER: {
                     ComplexAttributes.PROVIDER.parseAndSetParameter(value, op.get(TRUSTSTORE), reader);
+                    required.add(Attribute.TRUSTSTORE_PASSWORD);
                     break;
                 }
                 case TRUSTSTORE_PROVIDER_ARGUMENT: {
                     ComplexAttributes.PROVIDER_ARGUMENT.parseAndSetParameter(value, op.get(TRUSTSTORE), reader);
+                    required.add(Attribute.TRUSTSTORE_PASSWORD);
                     break;
                 }
                 case TRUST_MANAGER_FACTORY_PROVIDER: {
@@ -894,7 +903,7 @@ public class SecuritySubsystemParser implements XMLStreamConstants, XMLElementRe
             }
         }
 
-        if (visited.size() == 0) {
+        if (!visited.containsAll(required)) {
             throw SecurityMessages.MESSAGES.xmlStreamExceptionMissingAttribute(Attribute.KEYSTORE_PASSWORD.getLocalName(),
                     Attribute.TRUSTSTORE_PASSWORD.getLocalName(), reader.getLocation());
         }

--- a/security/src/test/java/org/jboss/as/security/JSSEExpressionsUnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/JSSEExpressionsUnitTestCase.java
@@ -25,8 +25,6 @@ package org.jboss.as.security;
 import java.io.IOException;
 import java.util.List;
 
-import org.jboss.as.security.Constants;
-import org.jboss.as.security.SecurityExtension;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -98,5 +96,9 @@ public class JSSEExpressionsUnitTestCase extends AbstractSubsystemBaseTest {
         for (Property prop : loginModule.get(Constants.MODULE_OPTIONS).asPropertyList()){
             Assert.assertEquals(ModelType.EXPRESSION, prop.getValue().getType());
         }
+
+
+        ModelNode domain = model.get("subsystem", "security", "security-domain", "jboss-empty-jsse", "jsse", "classic");
+        Assert.assertEquals(ModelType.OBJECT, domain.getType());
     }
 }

--- a/security/src/test/java/org/jboss/as/security/JSSEParsingUnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/JSSEParsingUnitTestCase.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.security;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.RunningMode;
+import org.jboss.as.controller.RunningModeControl;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.model.test.ModelTestParser;
+import org.jboss.as.model.test.ModelTestUtils;
+
+import org.jboss.as.subsystem.test.TestParser;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLMapper;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * TODO class javadoc.
+ *
+ * @author Brian Stansberry (c) 2011 Red Hat Inc.
+ */
+public class JSSEParsingUnitTestCase {
+
+    private static final ModelNode SUCCESS;
+
+    static {
+        SUCCESS = new ModelNode();
+        SUCCESS.get(ModelDescriptionConstants.OUTCOME).set(ModelDescriptionConstants.SUCCESS);
+        SUCCESS.get(ModelDescriptionConstants.RESULT);
+        SUCCESS.protect();
+    }
+
+    private ExtensionRegistry extensionParsingRegistry;
+    private ModelTestParser testParser;
+    private XMLMapper xmlMapper;
+
+    private final String TEST_NAMESPACE = "urn.org.jboss.test:1.0";
+
+    protected final String mainSubsystemName = SecurityExtension.SUBSYSTEM_NAME;
+    private final Extension mainExtension = new SecurityExtension();
+
+    @Before
+    public void initializeParser() throws Exception {
+        //Initialize the parser
+        xmlMapper = XMLMapper.Factory.create();
+        extensionParsingRegistry = new ExtensionRegistry(ProcessType.EMBEDDED_SERVER, new RunningModeControl(RunningMode.NORMAL), null, null);
+        testParser = new TestParser(mainSubsystemName, extensionParsingRegistry);
+        xmlMapper.registerRootElement(new QName(TEST_NAMESPACE, "test"), testParser);
+        mainExtension.initializeParsers(extensionParsingRegistry.getExtensionParsingContext("Test", xmlMapper));
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        xmlMapper = null;
+        extensionParsingRegistry = null;
+        testParser = null;
+    }
+
+    /**
+     * Parse the subsystem xml and create the operations that will be passed into the controller
+     *
+     * @param subsystemXml the subsystem xml to be parsed
+     * @return the created operations
+     * @throws XMLStreamException if there is a parsing problem
+     */
+    List<ModelNode> parse(String subsystemXml) throws XMLStreamException, IOException {
+        String xml = "<test xmlns=\"" + TEST_NAMESPACE + "\">"
+                + ModelTestUtils.readResource(getClass(), subsystemXml)
+                + "</test>";
+        final XMLStreamReader reader = XMLInputFactory.newInstance().createXMLStreamReader(new StringReader(xml));
+        final List<ModelNode> operationList = new ArrayList<ModelNode>();
+        xmlMapper.parseDocument(operationList, reader);
+        return operationList;
+    }
+
+    @Test
+    public void testParseMissingPasswordJSSE() throws Exception {
+        try {
+            parse("securityErrorMissingPassword.xml");
+            Assert.fail("There should have been an error.");
+        } catch (XMLStreamException ex) {
+            Assert.assertTrue(ex.getMessage(), ex.getMessage().contains("JBAS013319"));
+        }
+    }
+
+
+    @Test
+    public void testParseWrongJSSE() throws Exception {
+        try {
+            parse("securityParserError.xml");
+            Assert.fail("There should have been an error.");
+        } catch (XMLStreamException ex) {
+            Assert.assertTrue(ex.getMessage(), ex.getMessage().contains("JBAS013319"));
+        }
+    }
+
+    @Test
+    public void testParseValidJSSE() throws Exception {
+        parse("securityParserValidJSSE.xml");
+
+    }
+
+}

--- a/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
@@ -85,7 +85,7 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
 
         ModelNode writeOp = Util.createOperation("write-attribute", address);
         writeOp.get("name").set("login-modules");
-        for (int i = 1; i <= 5; i++) {
+        for (int i = 1; i <= 6; i++) {
             ModelNode module = writeOp.get("value").add();
             module.get("code").set("module-" + i);
             module.get("flag").set("optional");
@@ -97,8 +97,8 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         readOp.get("name").set("login-modules");
         ModelNode result = service.executeForResult(readOp);
         List<ModelNode> modules = result.asList();
-        Assert.assertEquals("There should be exactly 5 modules but there are not", 5, modules.size());
-        for (int i = 1; i <= 5; i++) {
+        Assert.assertEquals("There should be exactly 6 modules but there are not", 6, modules.size());
+        for (int i = 1; i <= 6; i++) {
             ModelNode module = modules.get(i - 1);
             Assert.assertEquals(module.get("code").asString(), "module-" + i);
         }

--- a/security/src/test/resources/org/jboss/as/security/securityErrorMissingPassword.xml
+++ b/security/src/test/resources/org/jboss/as/security/securityErrorMissingPassword.xml
@@ -30,8 +30,7 @@
                     <module-option name="env.option" value="${env.value:myvalue}"/>
                 </login-module>
             </authentication>
-            <jsse keystore-password="${keystore-password:changeit}"
-                  keystore-type="${keystore-type:JKS}"
+            <jsse keystore-type="${keystore-type:JKS}"
                   keystore-url="${keystore-url:../standalone/configuration/keystores/clientcert.jks}"
                   keystore-provider="${keystore-provider:com.misc.provider}"
                   keystore-provider-argument="${keystore-provider-argument:true}"
@@ -51,29 +50,6 @@
                   cipher-suites="${cipher-suites:cipher-suites}"
                   protocols="${protocols:protocols}"
                     />
-        </security-domain>
-        <security-domain name="other2" cache-type="default">
-            <authentication>
-                <login-module code="Remoting" flag="${prop.flag-optional:optional}">
-                    <module-option name="password-stacking" value="useFirstPass"/>
-                </login-module>
-                <login-module code="RealmDirect" flag="${prop.flag:required}">
-                    <module-option name="password-stacking" value="useFirstPass"/>
-                </login-module>
-            </authentication>
-        </security-domain>
-        <security-domain name="jboss-empty-jsse" >
-            <jsse />
-        </security-domain>
-        <security-domain name="jboss-web-policy" cache-type="default">
-            <authorization>
-                <policy-module code="Delegating" flag="${prop.flag:required}"/>
-            </authorization>
-        </security-domain>
-        <security-domain name="jboss-ejb-policy" cache-type="default">
-            <authorization>
-                <policy-module code="Delegating" flag="${prop.flag:required}"/>
-            </authorization>
         </security-domain>
     </security-domains>
 </subsystem>

--- a/security/src/test/resources/org/jboss/as/security/securityParserError.xml
+++ b/security/src/test/resources/org/jboss/as/security/securityParserError.xml
@@ -1,0 +1,39 @@
+<!--
+~ /*
+~ * JBoss, Home of Professional Open Source.
+~ * Copyright 2013, Red Hat, Inc., and individual contributors
+~ * as indicated by the @author tags. See the copyright.txt file in the
+~ * distribution for a full listing of individual contributors.
+~ *
+~ * This is free software; you can redistribute it and/or modify it
+~ * under the terms of the GNU Lesser General Public License as
+~ * published by the Free Software Foundation; either version 2.1 of
+~ * the License, or (at your option) any later version.
+~ *
+~ * This software is distributed in the hope that it will be useful,
+~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+~ * Lesser General Public License for more details.
+~ *
+~ * You should have received a copy of the GNU Lesser General Public
+~ * License along with this software; if not, write to the Free
+~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+~ */
+-->
+
+<subsystem xmlns="urn:jboss:domain:security:1.2">
+    <security-domains>
+        <security-domain name="other" cache-type="default">
+            <authentication>
+                <login-module code="UsersRoles" flag="${prop.flag:required}">
+                    <module-option name="env.option" value="${env.value:myvalue}"/>
+                </login-module>
+            </authentication>
+            <jsse server-alias="silent.planet" />
+        </security-domain>
+        <security-domain name="empty-jsse">
+            <jsse keystore-type="JKS" server-alias="silent.planet"/>
+        </security-domain>
+    </security-domains>
+</subsystem>

--- a/security/src/test/resources/org/jboss/as/security/securityParserValidJSSE.xml
+++ b/security/src/test/resources/org/jboss/as/security/securityParserValidJSSE.xml
@@ -30,12 +30,21 @@
                     <module-option name="env.option" value="${env.value:myvalue}"/>
                 </login-module>
             </authentication>
-            <jsse keystore-password="${keystore-password:changeit}"
-                  keystore-type="${keystore-type:JKS}"
-                  keystore-url="${keystore-url:../standalone/configuration/keystores/clientcert.jks}"
-                  keystore-provider="${keystore-provider:com.misc.provider}"
-                  keystore-provider-argument="${keystore-provider-argument:true}"
-                  key-manager-factory-algorithm="${keystore-manager-factory-algorithm:xyz}"
+            <jsse server-alias="silent.planet" />
+        </security-domain>
+        <security-domain name="jboss-empty-jsse" >
+            <jsse />
+        </security-domain>
+        <security-domain name="jboss-web-policy" cache-type="default">
+            <authorization>
+                <policy-module code="Delegating" flag="${prop.flag:required}"/>
+            </authorization>
+            <authentication>
+                <login-module code="UsersRoles" flag="${prop.flag:required}">
+                    <module-option name="env.option" value="${env.value:myvalue}"/>
+                </login-module>
+            </authentication>
+            <jsse key-manager-factory-algorithm="${keystore-manager-factory-algorithm:xyz}"
                   key-manager-factory-provider="${keystore-manager-factory-provider:xyz}"
                   truststore-password="${truststore-password:rmi+ssl}"
                   truststore-type="${truststore-type:JKS}"
@@ -49,26 +58,7 @@
                   service-auth-token="${service-auth-token:service-auth-token}"
                   client-auth="${client-auth:false}"
                   cipher-suites="${cipher-suites:cipher-suites}"
-                  protocols="${protocols:protocols}"
-                    />
-        </security-domain>
-        <security-domain name="other2" cache-type="default">
-            <authentication>
-                <login-module code="Remoting" flag="${prop.flag-optional:optional}">
-                    <module-option name="password-stacking" value="useFirstPass"/>
-                </login-module>
-                <login-module code="RealmDirect" flag="${prop.flag:required}">
-                    <module-option name="password-stacking" value="useFirstPass"/>
-                </login-module>
-            </authentication>
-        </security-domain>
-        <security-domain name="jboss-empty-jsse" >
-            <jsse />
-        </security-domain>
-        <security-domain name="jboss-web-policy" cache-type="default">
-            <authorization>
-                <policy-module code="Delegating" flag="${prop.flag:required}"/>
-            </authorization>
+                  protocols="${protocols:protocols}" />
         </security-domain>
         <security-domain name="jboss-ejb-policy" cache-type="default">
             <authorization>

--- a/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
@@ -100,6 +100,9 @@
                 <policy-module code="Delegating" flag="required"/>
             </authorization>
         </security-domain>
+        <security-domain name="jboss-empty-jsse" >
+            <jsse server-alias="silent.planet" />
+        </security-domain>
     </security-domains>
 	<vault code="somevault">
 	  <vault-option name="xyz" value="zxc"/>

--- a/security/src/test/resources/org/jboss/as/security/transformers.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers.xml
@@ -100,6 +100,9 @@
                 <policy-module code="Delegating" flag="required"/>
             </authorization>
         </security-domain>
+        <security-domain name="jboss-empty-jsse" >
+            <jsse server-alias="silent.planet" />
+        </security-domain>
     </security-domains>
     <vault code="${some.property:somevault}">
         <vault-option name="xyz" value="${some.property:default}"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/cli/JsseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/cli/JsseTestCase.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.cli;
+
+import java.io.IOException;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.junit.AfterClass;
+import static org.junit.Assert.*;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JsseTestCase extends AbstractCliTestBase {
+
+
+    @BeforeClass
+    public static void initSecurityDomains() throws Exception {
+        AbstractCliTestBase.initCLI();
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse:remove()", true);
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-valid:remove()", true);        
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-missing-pwd:remove()", true);
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse:add()");        
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-valid:add()");
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-missing-pwd:add()");
+    }
+
+    @AfterClass
+    public static void cleanSecurityDomains() throws Exception {
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse:remove()", true);
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-valid:remove()", true);
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-missing-pwd:remove()", true);
+        AbstractCliTestBase.closeCLI();
+    }
+
+
+    @Test
+    public void addMissingPassword() throws IOException {
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-missing-pwd/jsse=classic:add(server-alias=silent.planet,keystore={type=JKS})", true);
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getFromResponse(OUTCOME).toString(), is("failed"));
+    }
+
+    @Test
+    public void addValid() throws Exception {
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse-valid/jsse=classic:add(server-alias=silent.planet)");
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getFromResponse(OUTCOME).toString(), is("success"));
+    }
+
+    @Test
+    public void addEmpty() throws Exception {
+        cli.sendLine("/subsystem=security/security-domain=empty-jsse/jsse=classic:add()");
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertThat(result, is(notNullValue()));
+        assertThat(result.getFromResponse(OUTCOME).toString(), is("success"));
+    }
+}


### PR DESCRIPTION
Since all jsse attributes are optionnal, checking that we only look for a password if a trustore or a keystore is defined.
Checking also that adding a jsse element through the cli can't be empty.
https://issues.jboss.org/browse/WFLY-1575
