### PR TITLE
WFLY-1906 AS7-4547 Remove the -XX:+TieredCompilation JVM option from the standalone.bat

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -145,16 +145,6 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
   )
 )
 
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
-  rem Add tiered compilation, if supported (64 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I "\-XX:\-TieredCompilation \-client" > nul
-  if errorlevel == 1 (
-    "%JAVA%" -XX:+TieredCompilation -version > nul 2>&1
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-XX:+TieredCompilation %JAVA_OPTS%"
-    )
-  )
-)
 
 rem Find jboss-modules.jar, or we can't continue
 if exist "%UNQUOTED_JBOSS_HOME%\jboss-modules.jar" (


### PR DESCRIPTION
JIRA https://issues.jboss.org/browse/WFLY-1906

The commit here fixes the issue where the -XX:+TieredCompilation option wasn't removed from the standalone.bat but was only removed from standalone.sh when a fix was done for https://issues.jboss.org/browse/AS7-4547
