### PR TITLE
[WFLY-1911] Check for username for scripted CLI to diable local auth.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -63,7 +63,7 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerProtocol, String controllerHost,
             int controllerPort, String username, char[] password,
             boolean initConsole, final int connectionTimeout) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, false, initConsole, connectionTimeout);
+        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, username != null, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }
@@ -72,7 +72,7 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerHost, int controllerPort,
             String username, char[] password,
             InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, false, consoleInput, consoleOutput);
+        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, username != null, consoleInput, consoleOutput);
         addShutdownHook(ctx);
         return ctx;
     }
@@ -81,7 +81,7 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     public CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
             String username, char[] password, boolean disableLocalAuth, boolean initConsole, int connectionTimeout)
             throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, disableLocalAuth, initConsole, connectionTimeout);
+        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, disableLocalAuth || username != null, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
@@ -50,10 +50,10 @@ public class CLITestUtil {
         return CommandContextFactory.getInstance().newCommandContext("http-remoting", serverAddr, serverPort, null, null);
     }
 
-    public static CommandContext getCommandContext(String address, int port, String user, char[] pwd, InputStream in, OutputStream out)
+    public static CommandContext getCommandContext(String address, int port, InputStream in, OutputStream out)
             throws CliInitializationException {
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext(address, port, user, pwd, in, out);
+        return CommandContextFactory.getInstance().newCommandContext(address, port, null, null, in, out);
     }
 
     public static CommandContext getCommandContext(OutputStream out) throws CliInitializationException {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
@@ -79,10 +79,9 @@ public class CLIWrapper {
     public CLIWrapper(boolean connect, String cliAddress) throws CliInitializationException {
 
         consoleOut = new ByteArrayOutputStream();
-        final char[] password = getPassword() == null ? null : getPassword().toCharArray();
         System.setProperty("aesh.terminal","org.jboss.aesh.terminal.TestTerminal");
         ctx = CLITestUtil.getCommandContext(
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), getUsername(), password,
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(),
                 createConsoleInput(), consoleOut);
 
         if (!connect) {


### PR DESCRIPTION
Additional checks on if a username has been specified in advance so when used in scripted mode local authentication will be automatically disabled if a username has been supplied.
