### PR TITLE
Added basic integration tests for Picketlink SAML2 authentication

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/PicketLinkTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/PicketLinkTestBase.java
@@ -1,0 +1,252 @@
+package org.jboss.as.test.integration.security.picketlink;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.text.StrSubstitutor;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.params.ClientPNames;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpParams;
+import org.apache.http.util.EntityUtils;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.network.NetworkUtils;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
+import org.jboss.as.test.integration.security.common.config.SecurityDomain;
+import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.logging.Logger;
+
+/**
+ * Base class with common utilities for PicketLink integration tests
+ * 
+ * @author Filip Bogyai
+ */
+public class PicketLinkTestBase {
+
+	public static final String ANIL = "anil";
+	public static final String MARCUS = "marcus";
+
+	public static final String USERS = ANIL + "=" + ANIL + "\n" + MARCUS + "=" + MARCUS;
+	public static final String ROLES = ANIL + "=" + "gooduser" + "\n" + MARCUS	+ "=baduser";
+	
+	private static final Logger LOGGER = Logger.getLogger(PicketLinkTestBase.class);
+	
+	/**
+	 * Requests given URL and checks if the returned HTTP status code is the
+	 * expected one. Returns HTTP response body
+	 * 
+	 * @param URL url to which the request should be made
+	 * @param DefaultHttpClient httpClient to test multiple access            
+	 * @param expectedStatusCode expected status code returned from the requested server
+	 * @return HTTP response body
+	 * @throws ClientProtocolException
+	 * @throws IOException
+	 * @throws URISyntaxException
+	 */
+	public static String makeCall(URL url, DefaultHttpClient httpClient, int expectedStatusCode) 
+			throws ClientProtocolException,	IOException, URISyntaxException {
+
+		String httpResponseBody = null;
+		HttpGet httpGet = new HttpGet(url.toURI());
+		HttpResponse response = httpClient.execute(httpGet);
+		int statusCode = response.getStatusLine().getStatusCode();
+		LOGGER.info("Request to: " + url + " responds: " + statusCode);
+
+		assertEquals("Unexpected status code", expectedStatusCode, statusCode);
+
+		HttpEntity entity = response.getEntity();
+		if (entity != null) {
+			httpResponseBody = EntityUtils.toString(response.getEntity());
+			EntityUtils.consume(entity);
+		}
+		return httpResponseBody;
+	}
+
+	
+	/**
+	 * Requests given URL and returns redirect location URL from response header.
+	 * If response is not redirected then returns the same URL which was
+	 * requested
+	 * 
+	 * @param URL url to which the request should be made
+	 * @param DefaultHttpClient httpClient to test multiple access
+	 * @return URL redirect location
+	 * @throws ClientProtocolException
+	 * @throws IOException
+	 * @throws URISyntaxException
+	 */
+	public static URL makeCallWithoutRedirect(URL url, DefaultHttpClient httpClient)
+			throws ClientProtocolException, IOException, URISyntaxException {
+
+		HttpParams params = new BasicHttpParams();
+		params.setParameter(ClientPNames.HANDLE_REDIRECTS, false);
+		String redirectLocation = url.toExternalForm();
+
+		HttpGet httpGet = new HttpGet(url.toURI());
+		httpGet.setParams(params);
+		HttpResponse response = httpClient.execute(httpGet);
+		int statusCode = response.getStatusLine().getStatusCode();
+		LOGGER.info("Request to: " + url + " responds: " + statusCode);
+
+		Header locationHeader = response.getFirstHeader("location");
+		if (locationHeader != null) {
+			redirectLocation = locationHeader.getValue();
+		}
+
+		HttpEntity entity = response.getEntity();
+		if (entity != null) {
+			EntityUtils.consume(entity);
+		}
+		return new URL(redirectLocation);
+	}
+	
+	/**
+	 * Requests given SP and post SAMLRequest to IdP, then post back SAMLResponse. 
+	 * Returns HTTP response body
+	 * 
+	 * @param URL spURL of requested Service Provider
+	 * @param URL idpURL of Identity Provider
+	 * @param DefaultHttpClient httpClient to test multiple access  
+	 * @return HTTP response body
+	 * @throws ClientProtocolException
+	 * @throws IOException
+	 * @throws URISyntaxException
+	 */
+	public static String postSAML2Assertions(URL spURL, URL idpURL, DefaultHttpClient httpClient)
+			throws ClientProtocolException, IOException, URISyntaxException{
+		
+		String httpResponseBody = makeCall(spURL, httpClient, 200);
+		
+		//parse SAMLRequest and post it to IdP
+		String[] splitted = httpResponseBody.split("NAME=\"SAMLRequest\" VALUE=\"");
+		String samlRequest = splitted[1].substring(0,	splitted[1].indexOf("\""));
+		List<NameValuePair> pairs = new ArrayList<NameValuePair>();
+		pairs.add(new BasicNameValuePair("SAMLRequest", samlRequest));
+
+		HttpPost httpPost = new HttpPost(idpURL.toURI());
+		httpPost.setEntity(new UrlEncodedFormEntity(pairs));
+		HttpResponse httpResponse = httpClient.execute(httpPost);
+
+		HttpEntity entity = httpResponse.getEntity();
+		if (entity != null) {
+			httpResponseBody = EntityUtils.toString(httpResponse.getEntity());
+			EntityUtils.consume(entity);
+		}
+		
+		//parse SAMLResponse and post it back to SP
+		splitted = httpResponseBody.split("NAME=\"SAMLResponse\" VALUE=\"");
+		String samlResponse = splitted[1].substring(0, splitted[1].indexOf("\""));
+		pairs = new ArrayList<NameValuePair>();
+		pairs.add(new BasicNameValuePair("SAMLResponse", samlResponse));
+
+		httpPost = new HttpPost(spURL.toURI());
+		httpPost.setEntity(new UrlEncodedFormEntity(pairs));			
+		httpResponse = httpClient.execute(httpPost);
+
+		entity = httpResponse.getEntity();
+		if (entity != null) {
+			httpResponseBody = EntityUtils.toString(httpResponse.getEntity());
+			EntityUtils.consume(entity);
+		}
+		
+		return httpResponseBody;
+	}
+
+	
+	/**
+	 * Replace variables in PicketLink configurations files with given values
+	 * and set ${hostname} variable from system property: node0
+	 * 
+	 * @param String resourceFile 
+	 * @param String deploymentName 
+	 * @param String bindingType 
+	 * @return String content
+	 */
+	public static String propertiesReplacer(String resourceFile, String deploymentName ,String bindingType) {
+
+		String hostname = System.getProperty("node0");		
+		
+		//expand possible IPv6 address
+		try{
+			hostname = NetworkUtils.formatPossibleIpv6Address(InetAddress.getByName(hostname).getHostAddress());
+		}catch(UnknownHostException ex){
+			String message = "Cannot resolve host address: "+ hostname + " , error : " + ex.getMessage();
+			LOGGER.error(message);
+			throw new RuntimeException(ex);			
+		}		
+		
+		final Map<String, String> map = new HashMap<String, String>();
+		String content = "";
+		map.put("hostname", hostname);
+		map.put("deployment", deploymentName);
+		map.put("bindingType", bindingType);
+		
+		try {
+			content = StrSubstitutor.replace(IOUtils.toString(SAML2BasicAuthenticationTestCase.class.getResourceAsStream(resourceFile), "UTF-8"), map);
+		} catch (IOException ex) {
+			String message = "Cannot find or modify configuration file "+ resourceFile + " , error : " + ex.getMessage();
+			LOGGER.error(message);
+			throw new RuntimeException(ex);
+		}
+		return content;
+	}
+
+	/**
+	 * A {@link ServerSetupTask} instance which creates security domains for Identity Provider(IdP)
+	 * and Service Provider(SP)
+	 * 
+	 * @author Filip Bogyai
+	 */
+	static class SecurityDomainsSetup extends
+			AbstractSecurityDomainsServerSetupTask {
+
+		/**
+		 * Returns SecurityDomains configuration for this testcase.
+		 * 
+		 * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask#getSecurityDomains()
+		 */
+		@Override
+		protected SecurityDomain[] getSecurityDomains() {
+
+			final SecurityDomain idp = new SecurityDomain.Builder()
+					.name("idp")
+					.cacheType("default")
+					.loginModules(
+							new SecurityModule.Builder()
+									.name("UsersRoles")
+									.flag("required")
+									.putOption("usersProperties","users.properties")
+									.putOption("rolesProperties","roles.properties").build()) //
+					.build();
+			final SecurityDomain sp = new SecurityDomain.Builder()
+					.name("sp")
+					.cacheType("default")
+					.loginModules(
+							new SecurityModule.Builder()
+									.name("org.picketlink.identity.federation.bindings.jboss.auth.SAML2LoginModule")
+									.flag("required").build()) //
+					.build();
+			return new SecurityDomain[] { idp, sp };
+		}
+	}
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/SAML2BasicAuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/SAML2BasicAuthenticationTestCase.java
@@ -1,0 +1,214 @@
+package org.jboss.as.test.integration.security.picketlink;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for Picketlink SAML2 authentication between Identity Provider(IdP) and
+ * Service Providers(SP) SP-1 has POST binding, SP-2 has REDIRECT binding
+ * 
+ * @author Filip Bogyai
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ PicketLinkTestBase.SecurityDomainsSetup.class })
+@RunAsClient
+@Ignore("PLINK2-119")
+public class SAML2BasicAuthenticationTestCase {
+
+	private static Logger LOGGER = Logger.getLogger(SAML2BasicAuthenticationTestCase.class);
+
+	private static final String IDP = "idp";
+	private static final String SP1 = "sp1";
+	private static final String SP2 = "sp2";
+
+	@ArquillianResource
+	@OperateOnDeployment(IDP)
+	private URL idpUrl;
+
+	@ArquillianResource
+	@OperateOnDeployment(SP1)
+	private URL sp1Url;
+
+	@ArquillianResource
+	@OperateOnDeployment(SP2)
+	private URL sp2Url;
+
+	@Deployment(name = IDP)
+	public static WebArchive deploymentIdP() {
+		LOGGER.info("Start deployment " + IDP);
+		final WebArchive war = ShrinkWrap.create(WebArchive.class, IDP + ".war");
+		war.addAsResource(new StringAsset(PicketLinkTestBase.USERS), "users.properties");
+		war.addAsResource(new StringAsset(PicketLinkTestBase.ROLES), "roles.properties");
+		war.addAsWebInfResource(SAML2BasicAuthenticationTestCase.class.getPackage(),"web.xml", "web.xml");		
+		war.addAsWebInfResource(Utils.getJBossWebXmlAsset("idp", "org.picketlink.identity.federation.bindings.tomcat.idp.IDPWebBrowserSSOValve"),
+				"jboss-web.xml");		
+		war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.picketlink"),"jboss-deployment-structure.xml");
+		war.addAsWebInfResource(new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-idp.xml",IDP,"")), "picketlink.xml");
+		war.add(new StringAsset("Welcome to IdP"), "index.jsp");
+		war.add(new StringAsset("Welcome to IdP hosted"), "hosted/index.jsp");
+
+		return war;
+	}
+
+	@Deployment(name = SP1)
+	public static WebArchive deploymentSP1() {
+		LOGGER.info("Start deployment " + SP1);
+		final WebArchive war = ShrinkWrap.create(WebArchive.class, SP1 + ".war");
+		war.addAsWebInfResource(SAML2BasicAuthenticationTestCase.class.getPackage(),"web.xml", "web.xml");		
+		war.addAsWebInfResource( Utils.getJBossWebXmlAsset("sp", "org.picketlink.identity.federation.bindings.tomcat.sp.ServiceProviderAuthenticator"),
+				"jboss-web.xml");		
+		war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.picketlink"), "jboss-deployment-structure.xml");
+		war.addAsWebInfResource(new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-sp.xml",SP1,"POST")), "picketlink.xml");
+		war.add(new StringAsset("Welcome to SP1"), "index.jsp");
+
+		return war;
+	}
+
+	@Deployment(name = SP2)
+	public static WebArchive deploymentSP2() {
+		LOGGER.info("Start deployment " + SP2);
+		final WebArchive war = ShrinkWrap.create(WebArchive.class, SP2 + ".war");
+		war.addAsWebInfResource(SAML2BasicAuthenticationTestCase.class.getPackage(),"web.xml", "web.xml");		
+		war.addAsWebInfResource( Utils.getJBossWebXmlAsset("sp", "org.picketlink.identity.federation.bindings.tomcat.sp.ServiceProviderAuthenticator"),
+				"jboss-web.xml");		
+		war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.picketlink"),"jboss-deployment-structure.xml");
+		war.addAsWebInfResource(new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-sp.xml",SP2,"REDIRECT")), "picketlink.xml");
+		war.add(new StringAsset("Welcome to SP2"), "index.jsp");
+
+		return war;
+	}
+
+	/**
+	 * Tests access to protected service provider with manual handling of
+	 * redirections
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testRedirectSP() throws Exception {
+
+		final DefaultHttpClient httpClient = new DefaultHttpClient();
+		
+		try {
+
+			final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(PicketLinkTestBase.ANIL, PicketLinkTestBase.ANIL);
+			httpClient.getCredentialsProvider().setCredentials(new AuthScope(idpUrl.getHost(), idpUrl.getPort()),credentials);
+
+			// login to IdP
+			String response = PicketLinkTestBase.makeCall(idpUrl, httpClient, 200);
+			assertTrue("IdP index page was not reached",response.contains("Welcome to IdP"));
+
+			// request SP2
+			URL redirectLocation = PicketLinkTestBase.makeCallWithoutRedirect(sp2Url, httpClient);
+
+			// redirected to IdP
+			redirectLocation = PicketLinkTestBase.makeCallWithoutRedirect(redirectLocation,httpClient);
+
+			// redirected back to SP2
+			redirectLocation = PicketLinkTestBase.makeCallWithoutRedirect(redirectLocation,httpClient);
+
+			// successfully authorized in SP2
+			response = PicketLinkTestBase.makeCall(redirectLocation, httpClient, 200);
+			assertTrue("SP2 index page was not reached", response.contains("Welcome to SP2"));
+
+		} finally {
+			httpClient.getConnectionManager().shutdown();
+		}
+	}
+
+	/**
+	 * Tests access to protected service provider with automatic handling of
+	 * redirections
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testAutoRedirectSP() throws Exception {
+
+		final DefaultHttpClient httpClient = new DefaultHttpClient();
+		httpClient.setRedirectStrategy(Utils.REDIRECT_STRATEGY);
+		try {
+
+			final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(PicketLinkTestBase.ANIL, PicketLinkTestBase.ANIL);
+			httpClient.getCredentialsProvider().setCredentials(new AuthScope(idpUrl.getHost(), idpUrl.getPort()),credentials);
+
+			String response = PicketLinkTestBase.makeCall(sp2Url, httpClient, 200);
+			assertTrue("SP2 index page was not reached",response.contains("Welcome to SP2"));
+			
+		} finally {
+			httpClient.getConnectionManager().shutdown();
+		}
+	}
+	
+	/**
+	 * Tests access to protected service provider with post binding
+	 * 
+	 * @throws Exception
+	 */
+
+	@Test
+	public void testPostSP() throws Exception {
+
+		final DefaultHttpClient httpClient = new DefaultHttpClient();
+		httpClient.setRedirectStrategy(Utils.REDIRECT_STRATEGY);
+		
+		try {
+
+			final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(PicketLinkTestBase.ANIL, PicketLinkTestBase.ANIL);
+			httpClient.getCredentialsProvider().setCredentials(new AuthScope(idpUrl.getHost(), idpUrl.getPort()),credentials);
+
+			String response = PicketLinkTestBase.makeCall(idpUrl, httpClient, 200);
+			assertTrue("IdP index page was not reached",response.contains("Welcome to IdP"));
+			
+			response = PicketLinkTestBase.postSAML2Assertions(sp1Url, idpUrl , httpClient);
+			assertTrue("SP1 index page was not reached",response.contains("Welcome to SP1"));
+		} finally {
+			httpClient.getConnectionManager().shutdown();
+		}
+	}
+	
+	/**
+	 * Tests access to protected service provider without credentials or with bad credentials
+	 * which must be denied
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testUnauthorizedAccess() throws Exception {
+
+		final DefaultHttpClient httpClient = new DefaultHttpClient();
+		httpClient.setRedirectStrategy(Utils.REDIRECT_STRATEGY);
+		try {
+		    
+			PicketLinkTestBase.makeCall(sp2Url, httpClient, 401);
+			
+			final UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(PicketLinkTestBase.MARCUS, PicketLinkTestBase.MARCUS);
+			httpClient.getCredentialsProvider().setCredentials(new AuthScope(idpUrl.getHost(), idpUrl.getPort()),credentials);
+
+			PicketLinkTestBase.makeCall(sp2Url, httpClient, 403);
+			
+		} finally {
+			httpClient.getConnectionManager().shutdown();
+		}
+	}
+	
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/SAML2GlobalSSOandLogoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/SAML2GlobalSSOandLogoutTestCase.java
@@ -1,0 +1,141 @@
+package org.jboss.as.test.integration.security.picketlink;
+
+import static org.junit.Assert.assertTrue;
+
+import java.net.URL;
+
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests for SSO and Global Logout using Picketlink SAML2 authentication between Identity Provider(IdP) and
+ * two Service Providers(SP) 
+ * 
+ * @author Filip Bogyai
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ PicketLinkTestBase.SecurityDomainsSetup.class })
+@RunAsClient
+@Ignore("PLINK2-119")
+public class SAML2GlobalSSOandLogoutTestCase {
+
+	private static Logger LOGGER = Logger.getLogger(SAML2GlobalSSOandLogoutTestCase.class);
+
+	private static final String IDP = "idp";
+	private static final String SP1 = "sp1";
+	private static final String SP2 = "sp2";
+	private static final String LOGOUT_PARAMETER = "?GLO=true";
+
+	@ArquillianResource
+	@OperateOnDeployment(IDP)
+	private URL idpUrl;
+
+	@ArquillianResource
+	@OperateOnDeployment(SP1)
+	private URL sp1Url;
+
+	@ArquillianResource
+	@OperateOnDeployment(SP2)
+	private URL sp2Url;
+
+	@Deployment(name = IDP)
+	public static WebArchive deploymentIdP() {
+		LOGGER.info("Start deployment " + IDP);
+		final WebArchive war = ShrinkWrap.create(WebArchive.class, IDP + ".war");
+		war.addAsResource(new StringAsset(PicketLinkTestBase.USERS), "users.properties");
+		war.addAsResource(new StringAsset(PicketLinkTestBase.ROLES), "roles.properties");
+		war.addAsWebInfResource(SAML2GlobalSSOandLogoutTestCase.class.getPackage(),"web.xml", "web.xml");		
+		war.addAsWebInfResource(Utils.getJBossWebXmlAsset("idp", "org.picketlink.identity.federation.bindings.tomcat.idp.IDPWebBrowserSSOValve"),
+				"jboss-web.xml");		
+		war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.picketlink"),"jboss-deployment-structure.xml");
+		war.addAsWebInfResource(new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-idp.xml",IDP,"")), "picketlink.xml");
+		war.add(new StringAsset("Welcome to IdP"), "index.jsp");
+		war.add(new StringAsset("Welcome to IdP hosted"), "hosted/index.jsp");
+
+		return war;
+	}
+
+	@Deployment(name = SP1)
+	public static WebArchive deploymentSP1() {
+		LOGGER.info("Start deployment " + SP1);
+		final WebArchive war = ShrinkWrap.create(WebArchive.class, SP1 + ".war");
+		war.addAsWebInfResource(SAML2GlobalSSOandLogoutTestCase.class.getPackage(),"web.xml", "web.xml");		
+		war.addAsWebInfResource( Utils.getJBossWebXmlAsset("sp", "org.picketlink.identity.federation.bindings.tomcat.sp.ServiceProviderAuthenticator"),
+				"jboss-web.xml");		
+		war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.picketlink"), "jboss-deployment-structure.xml");
+		war.addAsWebInfResource(new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-sp.xml",SP1,"REDIRECT")), "picketlink.xml");
+		war.add(new StringAsset("Welcome to SP1"), "index.jsp");
+		war.add(new StringAsset("Logout in progress"), "logout.jsp");
+
+		return war;
+	}
+
+	@Deployment(name = SP2)
+	public static WebArchive deploymentSP2() {
+		LOGGER.info("Start deployment " + SP2);
+		final WebArchive war = ShrinkWrap.create(WebArchive.class, SP2 + ".war");
+		war.addAsWebInfResource(SAML2GlobalSSOandLogoutTestCase.class.getPackage(),"web.xml", "web.xml");		
+		war.addAsWebInfResource( Utils.getJBossWebXmlAsset("sp", "org.picketlink.identity.federation.bindings.tomcat.sp.ServiceProviderAuthenticator"),
+				"jboss-web.xml");		
+		war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.picketlink"),"jboss-deployment-structure.xml");
+		war.addAsWebInfResource(new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-sp.xml",SP2,"REDIRECT")), "picketlink.xml");
+		war.add(new StringAsset("Welcome to SP2"), "index.jsp");
+		war.add(new StringAsset("Logout in progress"), "logout.jsp");
+
+		return war;
+	}
+	
+	/**
+	 * Tests PicketLink IdP to handle Single Sing On and Global Logout
+	 * 
+	 * @throws Exception
+	 */
+	@Test
+	public void testSSOandGLO() throws Exception {
+
+		final DefaultHttpClient httpClient = new DefaultHttpClient();
+		httpClient.setRedirectStrategy(Utils.REDIRECT_STRATEGY);
+		try {
+
+			UsernamePasswordCredentials credentials = new UsernamePasswordCredentials(PicketLinkTestBase.ANIL, PicketLinkTestBase.ANIL);
+			httpClient.getCredentialsProvider().setCredentials(new AuthScope(idpUrl.getHost(), idpUrl.getPort()),credentials);
+			
+			String response = PicketLinkTestBase.makeCall(sp1Url, httpClient, 200);
+			assertTrue("SP1 index page was not reached",response.contains("Welcome to SP1"));
+			
+			//now we change credentials so when they are requested again we get 403 - Forbidden
+			credentials = new UsernamePasswordCredentials(PicketLinkTestBase.MARCUS, PicketLinkTestBase.MARCUS);
+			httpClient.getCredentialsProvider().setCredentials(new AuthScope(idpUrl.getHost(), idpUrl.getPort()),credentials);
+			
+			response = PicketLinkTestBase.makeCall(sp2Url, httpClient, 200);
+			assertTrue("SP2 index page was not reached",response.contains("Welcome to SP2"));
+			
+			URL logoutUrl = new URL(sp1Url.toExternalForm()+LOGOUT_PARAMETER);
+			response = PicketLinkTestBase.makeCall(logoutUrl , httpClient, 200);			
+			assertTrue("Logout page was not reached", response.contains("Logout"));
+			
+			PicketLinkTestBase.makeCall(sp1Url, httpClient, 403);
+			PicketLinkTestBase.makeCall(sp2Url, httpClient, 403);
+			
+									
+		} finally {
+			httpClient.getConnectionManager().shutdown();
+		}
+	}
+	
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-idp.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-idp.xml
@@ -1,0 +1,35 @@
+<PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
+	<PicketLinkIDP xmlns="urn:picketlink:identity-federation:config:2.1" StrictPostBinding="false">
+		<IdentityURL>http://${hostname}:8080/${deployment}/</IdentityURL>
+		<Trust>
+			<Domains>${hostname}</Domains>
+		</Trust>		
+	</PicketLinkIDP>
+	<Handlers xmlns="urn:picketlink:identity-federation:handler:config:2.1">
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2IssuerTrustHandler" />
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2LogOutHandler" />
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2AuthenticationHandler" />
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.RolesGenerationHandler" />
+	</Handlers>
+	<!-- 
+		The configuration bellow defines a token timeout and a clock skew. Both configurations will be used during the SAML Assertion creation.
+		This configuration is optional. It is defined only to show you how to set the token timeout and clock skew configuration. 
+	 -->
+	<PicketLinkSTS xmlns="urn:picketlink:identity-federation:config:2.1" TokenTimeout="300000" ClockSkew="0">
+		<TokenProviders>
+			<TokenProvider
+				ProviderClass="org.picketlink.identity.federation.core.saml.v1.providers.SAML11AssertionTokenProvider"
+				TokenType="urn:oasis:names:tc:SAML:1.0:assertion"
+				TokenElement="Assertion" TokenElementNS="urn:oasis:names:tc:SAML:1.0:assertion" />
+			<TokenProvider
+				ProviderClass="org.picketlink.identity.federation.core.saml.v2.providers.SAML20AssertionTokenProvider"
+				TokenType="urn:oasis:names:tc:SAML:2.0:assertion"
+				TokenElement="Assertion" TokenElementNS="urn:oasis:names:tc:SAML:2.0:assertion" />
+		</TokenProviders>
+	</PicketLinkSTS>
+
+</PicketLink>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-sp.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-sp.xml
@@ -1,0 +1,19 @@
+<PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
+	<PicketLinkSP xmlns="urn:picketlink:identity-federation:config:2.1"
+		ServerEnvironment="tomcat" BindingType="${bindingType}">
+		<IdentityURL>http://${hostname}:8080/idp/</IdentityURL>
+		<ServiceURL>http://${hostname}:8080/${deployment}/</ServiceURL>
+	</PicketLinkSP>
+	<Handlers xmlns="urn:picketlink:identity-federation:handler:config:2.1">
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2LogOutHandler" />
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2AuthenticationHandler">
+			
+			<Option Key="ASSERTION_SESSION_ATTRIBUTE_NAME" Value="org.picketlink.sp.assertion"/>
+			
+		</Handler>
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.RolesGenerationHandler" />
+	</Handlers>
+</PicketLink>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/web.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+	version="2.5">
+
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured area</web-resource-name>
+			<url-pattern>/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>gooduser</role-name>			
+		</auth-constraint>
+	</security-constraint>
+
+	<login-config>
+	    <auth-method>BASIC</auth-method>
+	    <realm-name>Test realm</realm-name>
+    </login-config>
+	
+	<security-role>
+		<role-name>gooduser</role-name>
+	</security-role>	
+</web-app>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -91,7 +91,7 @@ public class Utils {
     private static final Logger LOGGER = Logger.getLogger(Utils.class);
 
     /** The REDIRECT_STRATEGY for Apache HTTP Client */
-    private static final RedirectStrategy REDIRECT_STRATEGY = new DefaultRedirectStrategy() {
+    public static final RedirectStrategy REDIRECT_STRATEGY = new DefaultRedirectStrategy() {
         @Override
         public boolean isRedirected(HttpRequest request, HttpResponse response, HttpContext context) {
             boolean isRedirect = false;


### PR DESCRIPTION
It would be beneficial to add PicketLink integration tests into WildFly testsuite for better coverage.
https://issues.jboss.org/browse/JBQA-8263

Test are now ignored because of: https://issues.jboss.org/browse/PLINK2-119
