### PR TITLE
ClassCastException & NotSerializableException fixes for web session clustering

### DIFF
--- a/clustering/infinispan/src/main/resources/infinispan-defaults.xml
+++ b/clustering/infinispan/src/main/resources/infinispan-defaults.xml
@@ -26,7 +26,9 @@
     <global/>
     <default>
         <locking lockAcquisitionTimeout="15000" useLockStriping="false" concurrencyLevel="1000"/>
-        <transaction lockingMode="PESSIMISTIC"/>
+        <transaction lockingMode="PESSIMISTIC">
+            <recovery enabled="false"/>
+        </transaction>
         <storeAsBinary enabled="false"/>
         <clustering mode="local"></clustering>
         <eviction strategy="NONE"/>

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/LocalSessionContext.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/LocalSessionContext.java
@@ -21,16 +21,10 @@
  */
 package org.wildfly.clustering.web.undertow.session;
 
-import org.wildfly.clustering.web.session.RoutingSupport;
-import org.wildfly.clustering.web.session.SessionManager;
+import io.undertow.security.api.AuthenticatedSessionManager.AuthenticatedSession;
 
-import io.undertow.server.session.SessionListeners;
+public interface LocalSessionContext {
 
-/**
- * Exposes additional session manager aspects to a session.
- * @author Paul Ferraro
- */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager, RoutingSupport {
-    SessionListeners getSessionListeners();
-    SessionManager<LocalSessionContext> getSessionManager();
+    AuthenticatedSession getAuthenticatedSession();
+    void setAuthenticatedSession(AuthenticatedSession authenticatedSession);
 }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/LocalSessionContextFactory.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/LocalSessionContextFactory.java
@@ -21,16 +21,26 @@
  */
 package org.wildfly.clustering.web.undertow.session;
 
-import org.wildfly.clustering.web.session.RoutingSupport;
-import org.wildfly.clustering.web.session.SessionManager;
+import io.undertow.security.api.AuthenticatedSessionManager.AuthenticatedSession;
 
-import io.undertow.server.session.SessionListeners;
+import org.wildfly.clustering.web.LocalContextFactory;
 
-/**
- * Exposes additional session manager aspects to a session.
- * @author Paul Ferraro
- */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager, RoutingSupport {
-    SessionListeners getSessionListeners();
-    SessionManager<LocalSessionContext> getSessionManager();
+public class LocalSessionContextFactory implements LocalContextFactory<LocalSessionContext> {
+
+    @Override
+    public LocalSessionContext createLocalContext() {
+        return new LocalSessionContext() {
+            private volatile AuthenticatedSession authenticatedSession;
+
+            @Override
+            public AuthenticatedSession getAuthenticatedSession() {
+                return this.authenticatedSession;
+            }
+
+            @Override
+            public void setAuthenticatedSession(AuthenticatedSession authenticatedSession) {
+                this.authenticatedSession = authenticatedSession;
+            }
+        };
+    }
 }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapter.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapter.java
@@ -44,9 +44,9 @@ import org.wildfly.clustering.web.session.SessionManager;
  */
 public class SessionManagerAdapter implements UndertowSessionManager {
     private final SessionListeners sessionListeners = new SessionListeners();
-    private final SessionManager<Void> manager;
+    private final SessionManager<LocalSessionContext> manager;
 
-    public SessionManagerAdapter(SessionManager<Void> manager) {
+    public SessionManagerAdapter(SessionManager<LocalSessionContext> manager) {
         this.manager = manager;
     }
 
@@ -56,7 +56,7 @@ public class SessionManagerAdapter implements UndertowSessionManager {
     }
 
     @Override
-    public SessionManager<Void> getSessionManager() {
+    public SessionManager<LocalSessionContext> getSessionManager() {
         return this.manager;
     }
 
@@ -104,7 +104,7 @@ public class SessionManagerAdapter implements UndertowSessionManager {
         Batcher batcher = this.manager.getBatcher();
         boolean started = batcher.startBatch();
         try {
-            Session<Void> session = this.manager.createSession(id);
+            Session<LocalSessionContext> session = this.manager.createSession(id);
             io.undertow.server.session.Session adapter = this.getSession(session, exchange, config);
             this.sessionListeners.sessionCreated(adapter, exchange);
             return adapter;
@@ -123,7 +123,7 @@ public class SessionManagerAdapter implements UndertowSessionManager {
 
         Batcher batcher = this.manager.getBatcher();
         boolean started = batcher.startBatch();
-        Session<Void> session = null;
+        Session<LocalSessionContext> session = null;
         try {
             session = this.manager.findSession(id);
             return (session != null) ? this.getSession(session, exchange, config) : null;
@@ -145,7 +145,7 @@ public class SessionManagerAdapter implements UndertowSessionManager {
     /**
      * Appends routing information to session identifier.
      */
-    private io.undertow.server.session.Session getSession(Session<Void> session, HttpServerExchange exchange, SessionConfig config) {
+    private io.undertow.server.session.Session getSession(Session<LocalSessionContext> session, HttpServerExchange exchange, SessionConfig config) {
         SessionAdapter adapter = new SessionAdapter(this, session, config);
         if (config != null) {
             String id = session.getId();

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapterFactory.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapterFactory.java
@@ -45,7 +45,7 @@ public class SessionManagerAdapterFactory implements io.undertow.servlet.api.Ses
     public io.undertow.server.session.SessionManager createSessionManager(Deployment deployment) {
         SessionContext context = new SessionContextAdapter(deployment);
         SessionIdentifierFactory factory = new SessionIdentifierFactoryAdapter(new SecureRandomSessionIdGenerator());
-        SessionManager<Void> manager = this.factory.createSessionManager(context, factory, null);
+        SessionManager<LocalSessionContext> manager = this.factory.createSessionManager(context, factory, new LocalSessionContextFactory());
         return new SessionManagerAdapter(manager);
     }
 }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapterTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/SessionManagerAdapterTestCase.java
@@ -45,8 +45,8 @@ import org.wildfly.clustering.web.session.ImmutableSession;
 import org.wildfly.clustering.web.session.Session;
 import org.wildfly.clustering.web.session.SessionManager;
 
-public class SessionManagerFacadeTestCase {
-    private final SessionManager<Void> manager = mock(SessionManager.class);
+public class SessionManagerAdapterTestCase {
+    private final SessionManager<LocalSessionContext> manager = mock(SessionManager.class);
     private final SessionListener listener = mock(SessionListener.class);
 
     private SessionManagerAdapter adapter = new SessionManagerAdapter(this.manager);
@@ -104,7 +104,7 @@ public class SessionManagerFacadeTestCase {
         HttpServerExchange exchange = new HttpServerExchange(null);
         Batcher batcher = mock(Batcher.class);
         SessionConfig config = mock(SessionConfig.class);
-        Session<Void> session = mock(Session.class);
+        Session<LocalSessionContext> session = mock(Session.class);
         String sessionId = "session";
         String route = "route";
         String routingSessionId = "session.route";
@@ -136,7 +136,7 @@ public class SessionManagerFacadeTestCase {
         HttpServerExchange exchange = new HttpServerExchange(null);
         Batcher batcher = mock(Batcher.class);
         SessionConfig config = mock(SessionConfig.class);
-        Session<Void> session = mock(Session.class);
+        Session<LocalSessionContext> session = mock(Session.class);
         String requestedSessionId = "session.route1";
         String sessionId = "session";
         String route = "route";
@@ -188,7 +188,7 @@ public class SessionManagerFacadeTestCase {
         HttpServerExchange exchange = new HttpServerExchange(null);
         Batcher batcher = mock(Batcher.class);
         SessionConfig config = mock(SessionConfig.class);
-        Session<Void> session = mock(Session.class);
+        Session<LocalSessionContext> session = mock(Session.class);
         String requestedSessionId = "session.route1";
         String sessionId = "session";
         String route = "route2";


### PR DESCRIPTION
WFLY-1719 Infinispan 5.2.x enabled recovery by default.  Disable recovery in infinispan-defaults.xml to match default for Transaction resource.
WFLY-1910 NotSerializableException when Infinispan cache being committed Undertow stores the authenticated session in the HttpSession using a special attribute.  This attribute belongs in the local session context so that it is not replicated.
