### PR TITLE
Fix for WFLY-1924 

### DIFF
--- a/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -22,10 +22,6 @@
 
 package org.jboss.as.remoting;
 
-import static org.jboss.as.remoting.RemotingMessages.MESSAGES;
-import static org.xnio.Options.SASL_POLICY_NOANONYMOUS;
-import static org.xnio.Options.SASL_POLICY_NOPLAINTEXT;
-
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
@@ -47,6 +43,10 @@ import org.xnio.IoFuture;
 import org.xnio.OptionMap;
 import org.xnio.Options;
 import org.xnio.Sequence;
+
+import static org.jboss.as.remoting.RemotingMessages.MESSAGES;
+import static org.xnio.Options.SASL_POLICY_NOANONYMOUS;
+import static org.xnio.Options.SASL_POLICY_NOPLAINTEXT;
 
 /**
  * A {@link RemoteOutboundConnectionService} manages a remoting connection created out of a remote:// URI scheme.
@@ -99,13 +99,16 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
             sslContext = realm.getSSLContext();
         }
 
-        OptionMap.Builder builder = OptionMap.builder();
-        builder.addAll(this.connectionCreationOptions);
+        final OptionMap.Builder builder = OptionMap.builder();
+        // first set the defaults
         builder.set(SASL_POLICY_NOANONYMOUS, Boolean.FALSE);
         builder.set(SASL_POLICY_NOPLAINTEXT, Boolean.FALSE);
         builder.set(Options.SASL_DISALLOWED_MECHANISMS, Sequence.of(JBOSS_LOCAL_USER));
         builder.set(Options.SSL_ENABLED, true);
         builder.set(Options.SSL_STARTTLS, true);
+        // now override with user specified options
+        builder.addAll(this.connectionCreationOptions);
+
 
         return endpoint.connect(uri, builder.getMap(), callbackHandler, sslContext);
     }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-1924 where the connection creation options overriding the defaults weren't taken into account while setting up the remote outbound connection.

I thought of writing up a test or adding it to existing testcase but to test this specific fix I'll end up spending way too much time on the test than what it's worth at this point. So am just sending out the PR with this fix and will ask the user who reported this, to test against his application.
