### PR TITLE
WFLY-1972 : CLI command should not allow same runtime-name to be used at another deploy

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deployment/StandaloneDeploymentUnicityTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deployment/StandaloneDeploymentUnicityTestCase.java
@@ -1,0 +1,84 @@
+/*
+* JBoss, Home of Professional Open Source.
+* Copyright 2012, Red Hat Middleware LLC, and individual contributors
+* as indicated by the @author tags. See the copyright.txt file in the
+* distribution for a full listing of individual contributors.
+*
+* This is free software; you can redistribute it and/or modify it
+* under the terms of the GNU Lesser General Public License as
+* published by the Free Software Foundation; either version 2.1 of
+* the License, or (at your option) any later version.
+*
+* This software is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this software; if not, write to the Free
+* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
+package org.jboss.as.core.model.test.deployment;
+
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLStreamException;
+import static org.hamcrest.CoreMatchers.containsString;
+import org.jboss.as.controller.ControllerMessages;
+import org.jboss.as.core.model.test.AbstractCoreModelTest;
+import org.jboss.as.core.model.test.KernelServices;
+import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class StandaloneDeploymentUnicityTestCase extends AbstractCoreModelTest {
+
+    @Test
+    public void testDeployments() throws Exception {
+        KernelServices kernelServices = createKernelServicesBuilder(TestModelType.STANDALONE)
+            .setXmlResource("standalone.xml")
+            .createContentRepositoryContent("12345678901234567890")
+            .build();
+        Assert.assertTrue(kernelServices.isSuccessfulBoot());
+
+        String marshalled = kernelServices.getPersistedSubsystemXml();
+        ModelTestUtils.compareXml(ModelTestUtils.readResource(this.getClass(), "standalone.xml"), marshalled);
+    }
+
+    @Test
+    public void testIncorrectDeployments() throws Exception {try { createKernelServicesBuilder(TestModelType.STANDALONE)
+            .setXmlResource("standalone_duplicate.xml")
+            .createContentRepositoryContent("12345678901234567890")
+            .build();
+        } catch (XMLStreamException ex) {
+            String expectedMessage = ControllerMessages.MESSAGES.duplicateNamedElement("abc.war", new Location() {
+                public int getLineNumber() {
+                    return 287;
+                }
+
+                public int getColumnNumber() {
+                    return 1;
+                }
+
+                public int getCharacterOffset() {
+                    return 1;
+                }
+
+                public String getPublicId() {
+                    return "";
+                }
+
+                public String getSystemId() {
+                    return "";
+                }
+            }).getMessage();
+            expectedMessage = expectedMessage.substring(expectedMessage.indexOf("JBAS014664:"));
+            Assert.assertThat(ex.getMessage(), containsString(expectedMessage));
+        }
+    }
+}

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<server xmlns="urn:jboss:domain:2.0">
+    <deployments>
+        <deployment name="myFirstApp" runtime-name="abc.war">
+            <content sha1="12345678901234567890"/>
+        </deployment>
+        <deployment name="mySecondApp" runtime-name="def.war">
+            <content sha1="12345678901234567890"/>
+        </deployment>
+    </deployments>
+</server>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone_duplicate.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone_duplicate.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<server xmlns="urn:jboss:domain:2.0">
+    <deployments>
+        <deployment name="myFirstApp" runtime-name="abc.war">
+            <content sha1="12345678901234567890"/>
+        </deployment>
+        <deployment name="mySecondApp" runtime-name="abc.war">
+            <content sha1="12345678901234567890"/>
+        </deployment>
+    </deployments>
+</server>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-deployments.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-deployments.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<domain xmlns="urn:jboss:domain:2.0">
+
+    <deployments>
+        <deployment name="test-deployment" runtime-name="foo.war">
+            <content sha1="09876543210987654321"/>
+        </deployment>
+        <deployment name="other-test-deployment" runtime-name="abc.war">
+            <content sha1="12345678901234567890"/>
+        </deployment>
+    </deployments>
+
+   <server-groups>
+        <server-group name="test" profile="test" management-subsystem-endpoint="true">
+
+            <jvm name="full" java-home="javaHome" type="SUN" env-classpath-ignored="true">
+                 <heap size="heapSize" max-size="maxHeapSize"/>
+                 <permgen size="permgenSize" max-size="maxPermGenSize"/>
+                 <stack size="stackSize"/>
+                 <agent-lib value="agentLib"/>
+                 <agent-path value="agentPath"/>
+                 <java-agent value="javaAgent"/>
+                 <jvm-options>
+                     <option value="option1"/>
+                     <option value="option2"/>
+                     <option value="option3"/>
+                 </jvm-options>
+                 <environment-variables>
+                     <variable name="name1" value="value1"/>
+                     <variable name="name2" value="value2"/>
+                 </environment-variables>
+            </jvm>
+
+            <socket-binding-group ref="test-sockets" port-offset="10"/>
+
+            <deployments>
+                <deployment name="test-deployment" runtime-name="foo.war" enabled="false" />
+                <deployment name="other-test-deployment" runtime-name="abc.war" enabled="false" />
+            </deployments>
+
+        </server-group>
+    </server-groups>
+</domain>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-duplicate-runtime-names.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-duplicate-runtime-names.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<domain xmlns="urn:jboss:domain:2.0">
+
+    <deployments>
+        <deployment name="test-deployment" runtime-name="foo.war">
+            <content sha1="09876543210987654321"/>
+        </deployment>
+        <deployment name="other-test-deployment" runtime-name="abc.war">
+            <content sha1="12345678901234567890"/>
+        </deployment>
+    </deployments>
+
+   <server-groups>
+        <server-group name="test" profile="test" management-subsystem-endpoint="true">
+
+            <jvm name="full" java-home="javaHome" type="SUN" env-classpath-ignored="true">
+                 <heap size="heapSize" max-size="maxHeapSize"/>
+                 <permgen size="permgenSize" max-size="maxPermGenSize"/>
+                 <stack size="stackSize"/>
+                 <agent-lib value="agentLib"/>
+                 <agent-path value="agentPath"/>
+                 <java-agent value="javaAgent"/>
+                 <jvm-options>
+                     <option value="option1"/>
+                     <option value="option2"/>
+                     <option value="option3"/>
+                 </jvm-options>
+                 <environment-variables>
+                     <variable name="name1" value="value1"/>
+                     <variable name="name2" value="value2"/>
+                 </environment-variables>
+            </jvm>
+
+            <socket-binding-group ref="test-sockets" port-offset="10"/>
+
+            <deployments>
+                <deployment name="test-deployment" runtime-name="foo.war" enabled="false" />
+                <deployment name="other-test-deployment" runtime-name="foo.war" enabled="false" />
+            </deployments>
+
+        </server-group>
+    </server-groups>
+</domain>

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainControllerMessages.java
@@ -578,4 +578,7 @@ public interface DomainControllerMessages {
     @Message(id = 10880, value = "No socket-binding-group named: %s")
     OperationFailedException noSocketBindingGroupCalled(String socketBindingGroup);
 
+    @Message(id = 10881, value = "There is already a deployment called %s with the same runtime name %s on server group %s")
+    OperationFailedException runtimeNameMustBeUnique(String existingDeployment, String runtimeName, String serverGroup);
+
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -19,7 +19,6 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.as.host.controller.parsing;
 
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
@@ -105,7 +104,7 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 /**
- * A mapper between an AS server's configuration model and XML representations, particularly  {@code domain.xml}.
+ * A mapper between an AS server's configuration model and XML representations, particularly {@code domain.xml}.
  *
  * @author Emanuel Muckenhuber
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
@@ -242,7 +241,6 @@ public class DomainXml extends CommonXml {
 
         // Content
         // Handle elements: sequence
-
         Element element = nextElement(reader, expectedNs);
         if (element == Element.EXTENSIONS) {
             extensionXml.parseExtensions(reader, address, expectedNs, list);
@@ -294,7 +292,6 @@ public class DomainXml extends CommonXml {
 
         // Content
         // Handle elements: sequence
-
         Element element = nextElement(reader, expectedNs);
         if (element == Element.EXTENSIONS) {
             extensionXml.parseExtensions(reader, address, expectedNs, list);
@@ -350,7 +347,6 @@ public class DomainXml extends CommonXml {
 
         // Content
         // Handle elements: sequence
-
         Element element = nextElement(reader, expectedNs);
         if (element == Element.EXTENSIONS) {
             extensionXml.parseExtensions(reader, address, expectedNs, list);
@@ -406,7 +402,6 @@ public class DomainXml extends CommonXml {
 
         // Content
         // Handle elements: sequence
-
         Element element = nextElement(reader, expectedNs);
         if (element == Element.EXTENSIONS) {
             extensionXml.parseExtensions(reader, address, expectedNs, list);
@@ -466,7 +461,6 @@ public class DomainXml extends CommonXml {
 
         // Content
         // Handle elements: sequence
-
         Element element = nextElement(reader, expectedNs);
         if (element == Element.EXTENSIONS) {
             extensionXml.parseExtensions(reader, address, expectedNs, list);
@@ -575,22 +569,22 @@ public class DomainXml extends CommonXml {
                 }
                 default:
                     switch (Attribute.forName(reader.getAttributeLocalName(i))) {
-                        case NAME:
-                            ModelNode op = new ModelNode();
-                            op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
-                            op.get(NAME).set(NAME);
-                            op.get(VALUE).set(ParseUtils.parsePossibleExpression(reader.getAttributeValue(i)));
-                            list.add(op);
-                            break;
-                        default:
-                            throw unexpectedAttribute(reader, i);
-                    }
+                    case NAME:
+                        ModelNode op = new ModelNode();
+                        op.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+                        op.get(NAME).set(NAME);
+                        op.get(VALUE).set(ParseUtils.parsePossibleExpression(reader.getAttributeValue(i)));
+                        list.add(op);
+                        break;
+                    default:
+                        throw unexpectedAttribute(reader, i);
+                }
             }
         }
     }
 
     void parseDomainSocketBindingGroups(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs,
-                                        final List<ModelNode> list, final Set<String> interfaces) throws XMLStreamException {
+            final List<ModelNode> list, final Set<String> interfaces) throws XMLStreamException {
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
             final Element element = Element.forName(reader.getLocalName());
@@ -616,7 +610,7 @@ public class DomainXml extends CommonXml {
     }
 
     void parseSocketBindingGroup_1_0(final XMLExtendedStreamReader reader, final Set<String> interfaces, final ModelNode address,
-                                     final Namespace expectedNs, final List<ModelNode> updates) throws XMLStreamException {
+            final Namespace expectedNs, final List<ModelNode> updates) throws XMLStreamException {
         final Set<String> includedGroups = new HashSet<String>();
         // unique socket-binding names
         final Set<String> uniqueBindingNames = new HashSet<String>();
@@ -653,12 +647,12 @@ public class DomainXml extends CommonXml {
                     HOST_CONTROLLER_LOGGER.warnIgnoringSocketBindingGroupInclude(reader.getLocation());
 
                     /* This will be reintroduced for 7.2.0, leave commented out
-                    final String includedGroup = readStringAttributeElement(reader, Attribute.SOCKET_BINDING_GROUP.getLocalName());
-                    if (!includedGroups.add(includedGroup)) {
-                        throw MESSAGES.alreadyDeclared(Attribute.SOCKET_BINDING_GROUP.getLocalName(), includedGroup, reader.getLocation());
-                    }
-                    SocketBindingGroupResourceDefinition.INCLUDES.parseAndAddParameterElement(includedGroup, bindingGroupUpdate, reader.getLocation());
-                    */
+                     final String includedGroup = readStringAttributeElement(reader, Attribute.SOCKET_BINDING_GROUP.getLocalName());
+                     if (!includedGroups.add(includedGroup)) {
+                     throw MESSAGES.alreadyDeclared(Attribute.SOCKET_BINDING_GROUP.getLocalName(), includedGroup, reader.getLocation());
+                     }
+                     SocketBindingGroupResourceDefinition.INCLUDES.parseAndAddParameterElement(includedGroup, bindingGroupUpdate, reader.getLocation());
+                     */
                     break;
                 }
                 case SOCKET_BINDING: {
@@ -676,7 +670,7 @@ public class DomainXml extends CommonXml {
     }
 
     void parseSocketBindingGroup_1_1(final XMLExtendedStreamReader reader, final Set<String> interfaces, final ModelNode address,
-                                     final Namespace expectedNs, final List<ModelNode> updates) throws XMLStreamException {
+            final Namespace expectedNs, final List<ModelNode> updates) throws XMLStreamException {
         final Set<String> includedGroups = new HashSet<String>();
         // both outbound-socket-bindings and socket-binding names
         final Set<String> uniqueBindingNames = new HashSet<String>();
@@ -701,9 +695,9 @@ public class DomainXml extends CommonXml {
         }
 
         /*This will be reintroduced for 7.2.0, leave commented out
-        final ModelNode includes = bindingGroupUpdate.get(INCLUDES);
-        includes.setEmptyList();
-        */
+         final ModelNode includes = bindingGroupUpdate.get(INCLUDES);
+         includes.setEmptyList();
+         */
         updates.add(bindingGroupUpdate);
 
         // Handle elements
@@ -712,15 +706,15 @@ public class DomainXml extends CommonXml {
             final Element element = Element.forName(reader.getLocalName());
             switch (element) {
                 /* This will be reintroduced for 7.2.0, leave commented out
-                case INCLUDE: {
-                    final String includedGroup = readStringAttributeElement(reader, Attribute.SOCKET_BINDING_GROUP.getLocalName());
-                    if (!includedGroups.add(includedGroup)) {
-                        throw MESSAGES.alreadyDeclared(Attribute.SOCKET_BINDING_GROUP.getLocalName(), includedGroup, reader.getLocation());
-                    }
-                    SocketBindingGroupResourceDefinition.INCLUDES.parseAndAddParameterElement(includedGroup, bindingGroupUpdate, reader.getLocation());
-                    break;
-                }
-                */
+                 case INCLUDE: {
+                 final String includedGroup = readStringAttributeElement(reader, Attribute.SOCKET_BINDING_GROUP.getLocalName());
+                 if (!includedGroups.add(includedGroup)) {
+                 throw MESSAGES.alreadyDeclared(Attribute.SOCKET_BINDING_GROUP.getLocalName(), includedGroup, reader.getLocation());
+                 }
+                 SocketBindingGroupResourceDefinition.INCLUDES.parseAndAddParameterElement(includedGroup, bindingGroupUpdate, reader.getLocation());
+                 break;
+                 }
+                 */
                 case SOCKET_BINDING: {
                     final String bindingName = parseSocketBinding(reader, interfaces, groupAddress, updates);
                     if (!uniqueBindingNames.add(bindingName)) {
@@ -804,8 +798,8 @@ public class DomainXml extends CommonXml {
             list.add(groupAddOp);
 
             // Handle elements
-
             boolean sawDeployments = false;
+
             while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
                 requireNamespace(reader, expectedNs);
                 final Element element = Element.forName(reader.getLocalName());
@@ -824,7 +818,10 @@ public class DomainXml extends CommonXml {
                             throw MESSAGES.alreadyDefined(element.getLocalName(), reader.getLocation());
                         }
                         sawDeployments = true;
-                        parseDeployments(reader, groupAddress, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED), Collections.<Element>emptySet());
+                        List<ModelNode> deployments = new ArrayList<ModelNode>();
+                        parseDeployments(reader, groupAddress, expectedNs, deployments, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED), Collections.<Element>emptySet());
+                        checkDeployments(deployments, reader);
+                        list.addAll(deployments);
                         break;
                     }
                     case DEPLOYMENT_OVERLAYS: {
@@ -840,6 +837,26 @@ public class DomainXml extends CommonXml {
                 }
             }
 
+        }
+    }
+
+    private void checkDeployments(List<ModelNode> deployments, final XMLExtendedStreamReader reader) throws XMLStreamException {
+        final Set<String> uniqueDeploymentNames = new HashSet<String>(deployments.size());
+        final Set<String> uniqueRuntimeNames = new HashSet<String>(deployments.size());
+        for (ModelNode deployment : deployments) {
+            String deploymentName = null;
+            for (Property property : deployment.get(ModelDescriptionConstants.ADDRESS).asPropertyList()) {
+                if (ModelDescriptionConstants.DEPLOYMENT.equals(property.getName())) {
+                    deploymentName = property.getValue().asString();
+                }
+            }
+            if (!uniqueDeploymentNames.add(deploymentName)) {
+                throw ParseUtils.duplicateNamedElement(reader, deploymentName);
+            }
+            String runtimeName = deployment.get(ModelDescriptionConstants.RUNTIME_NAME).asString();
+            if (!uniqueRuntimeNames.add(runtimeName)) {
+                throw ParseUtils.duplicateNamedElement(reader, runtimeName);
+            }
         }
     }
 
@@ -862,10 +879,8 @@ public class DomainXml extends CommonXml {
                 throw MESSAGES.duplicateDeclaration("profile", name, reader.getLocation());
             }
 
-
             //final Set<String> includes = new HashSet<String>();  // See commented out section below.
             //final ModelNode profileIncludes = new ModelNode();
-
             // Content
             // Sequence
             final Map<String, List<ModelNode>> profileOps = new LinkedHashMap<String, List<ModelNode>>();
@@ -906,16 +921,16 @@ public class DomainXml extends CommonXml {
                         }
                         throw unexpectedElement(reader);
                         /* This will be reintroduced for 7.2.0, leave commented out
-                        final String includedName = readStringAttributeElement(reader, Attribute.PROFILE.getLocalName());
-                        if (! names.contains(includedName)) {
-                            throw MESSAGES.profileNotFound(reader.getLocation());
-                        }
-                        if (! includes.add(includedName)) {
-                            throw MESSAGES.duplicateProfile(reader.getLocation());
-                        }
-                        profileIncludes.add(includedName);
-                        break;
-                        */
+                         final String includedName = readStringAttributeElement(reader, Attribute.PROFILE.getLocalName());
+                         if (! names.contains(includedName)) {
+                         throw MESSAGES.profileNotFound(reader.getLocation());
+                         }
+                         if (! includes.add(includedName)) {
+                         throw MESSAGES.duplicateProfile(reader.getLocation());
+                         }
+                         profileIncludes.add(includedName);
+                         break;
+                         */
                     }
                     default: {
                         throw unexpectedElement(reader);
@@ -933,8 +948,8 @@ public class DomainXml extends CommonXml {
             profile.get(OP).set(ADD);
             profile.get(OP_ADDR).set(address).add(ModelDescriptionConstants.PROFILE, name);
             /* This will be reintroduced for 7.2.0, leave commented out
-            profile.get(INCLUDES).set(profileIncludes);
-            */
+             profile.get(INCLUDES).set(profileIncludes);
+             */
             list.add(profile);
 
             // Process subsystems
@@ -1133,7 +1148,7 @@ public class DomainXml extends CommonXml {
 
         @Override
         public void parseAccessControl(final XMLExtendedStreamReader reader, final ModelNode address, final Namespace expectedNs,
-                                       final List<ModelNode> list) throws XMLStreamException {
+                final List<ModelNode> list) throws XMLStreamException {
             ModelNode accAuthzAddr = address.clone().add(ACCESS, AUTHORIZATION);
 
             final int count = reader.getAttributeCount();

--- a/server/src/main/java/org/jboss/as/server/ServerMessages.java
+++ b/server/src/main/java/org/jboss/as/server/ServerMessages.java
@@ -671,4 +671,7 @@ public interface ServerMessages {
     @Message(id = 18784, value = "Null '%s'")
     OperationFailedException nullParameter(String name);
 
+    @Message(id = 18785, value = "There is already a deployment called %s with the same runtime name %s")
+    OperationFailedException runtimeNameMustBeUnique(String existingDeployment, String runtimename);
+
 }

--- a/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/CommonXml.java
@@ -964,6 +964,7 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
         requireNoAttributes(reader);
 
         final Set<String> names = new HashSet<String>();
+        final Set<String> runtimeNames = new HashSet<String>();
 
         while (reader.nextTag() != END_ELEMENT) {
             requireNamespace(reader, expectedNs);
@@ -996,6 +997,9 @@ public abstract class CommonXml implements XMLElementReader<List<ModelNode>>, XM
                             break;
                         }
                         case RUNTIME_NAME: {
+                            if (!runtimeNames.add(value)) {
+                                throw duplicateNamedElement(reader, value);
+                            }
                             DeploymentAttributes.RUNTIME_NAME.parseAndSetParameter(value, deploymentAdd, reader);
                             break;
                         }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeployWithRuntimeNameTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeployWithRuntimeNameTestCase.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file
+ * in the distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.test.integration.domain.management.cli;
+
+import org.jboss.as.test.integration.management.util.SimpleHelloWorldServlet;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import org.jboss.as.domain.controller.DomainControllerMessages;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.suites.CLITestSuite;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertThat;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+public class DomainDeployWithRuntimeNameTestCase extends AbstractCliTestBase {
+
+    private File warFile;
+    private static String[] serverGroups;
+    public static final String RUNTIME_NAME = "SimpleServlet.war";
+    public static final String OTHER_RUNTIME_NAME = "OtherSimpleServlet.war";
+    private static final String APP_NAME = "simple1";
+    private static final String OTHER_APP_NAME = "simple2";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        serverGroups = CLITestSuite.serverGroups.keySet().toArray(new String[CLITestSuite.serverGroups.size()]);
+        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+    }
+
+   private File createWarFile(String content) throws IOException {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "HelloServlet.war");
+        war.addClass(SimpleHelloWorldServlet.class);
+        war.addAsWebInfResource(SimpleHelloWorldServlet.class.getPackage(), "web.xml", "web.xml");
+        war.addAsWebResource(new StringAsset(content), "page.html");
+        File tempFile = new File(System.getProperty("java.io.tmpdir"), "HelloServlet.war");
+        new ZipExporterImpl(war).exportTo(tempFile, true);
+        return tempFile;
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        AbstractCliTestBase.closeCLI();
+    }
+
+    @After
+    public void undeployAll() {
+        assertThat(warFile.delete(), is(true));
+        cli.sendLine("undeploy --all-relevant-server-groups " + APP_NAME, true);
+        cli.sendLine("undeploy --all-relevant-server-groups " + OTHER_APP_NAME, true);
+    }
+
+    @Test
+    public void testDeployWithSameRuntimeNameOnSameServerGroup() throws Exception {
+        // deploy to group servers
+        warFile = createWarFile("Version1");
+        cli.sendLine(buildDeployCommand(serverGroups[0], RUNTIME_NAME, APP_NAME));
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[0], false);
+        checkURL("/SimpleServlet/page.html", "Version1", serverGroups[0], false);
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[1], true);
+        warFile = createWarFile("Shouldn't be deployed, as runtime already exist");
+        cli.sendLine(buildDeployCommand(serverGroups[0], RUNTIME_NAME, OTHER_APP_NAME), true);
+        assertThat(cli.readOutput(), containsString(DomainControllerMessages.MESSAGES.runtimeNameMustBeUnique(APP_NAME, RUNTIME_NAME, serverGroups[0]).getMessage()));
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[0], false);
+        checkURL("/SimpleServlet/page.html", "Version1", serverGroups[0], false);
+    }
+
+    @Test
+    public void testDeployWithSameRuntimeNameOnDifferentServerGroup() throws Exception {
+        // deploy to group servers
+        warFile = createWarFile("Version1");
+        cli.sendLine(buildDeployCommand(serverGroups[0], RUNTIME_NAME, APP_NAME));
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[0], false);
+        checkURL("/SimpleServlet/page.html", "Version1", serverGroups[0], false);
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[1], true);
+        warFile = createWarFile("Version2");
+        cli.sendLine(buildDeployCommand(serverGroups[1], RUNTIME_NAME, OTHER_APP_NAME));
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[0], false);
+        checkURL("/SimpleServlet/page.html", "Version1", serverGroups[0], false);
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[1], false);
+        checkURL("/SimpleServlet/page.html", "Version2", serverGroups[1], false);
+    }
+
+    @Test
+    public void testDeployWithDifferentRuntimeNameOnDifferentServerGroup() throws Exception {
+        // deploy to group servers
+        warFile = createWarFile("Version1");
+        cli.sendLine(buildDeployCommand(serverGroups[0], RUNTIME_NAME, APP_NAME));
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[0], false);
+        checkURL("/SimpleServlet/page.html", "Version1", serverGroups[0], false);
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[1], true);
+        warFile = createWarFile("Version3");
+        cli.sendLine(buildDeployCommand(serverGroups[1], OTHER_RUNTIME_NAME, OTHER_APP_NAME));
+        checkURL("/SimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[0], false);
+        checkURL("/SimpleServlet/page.html", "Version1", serverGroups[0], false);
+        checkURL("/OtherSimpleServlet/hello", "SimpleHelloWorldServlet", serverGroups[1], false);
+        checkURL("/OtherSimpleServlet/page.html", "Version3", serverGroups[1], false);
+    }
+
+    private String buildDeployCommand(String serverGroup, String runtimeName, String  name) {
+        return "deploy --server-groups=" + serverGroup + " " + warFile.getAbsolutePath()  + " --runtime-name=" + runtimeName
+                + " --name=" + name;
+    }
+
+    private void checkURL(String path, String content, String serverGroup, boolean shouldFail) throws Exception {
+        List<String> groupServers = new ArrayList<String>();
+        for (String server : CLITestSuite.serverGroups.get(serverGroup)) {
+            groupServers.add(server);
+        }
+
+        for (String host : CLITestSuite.hostAddresses.keySet()) {
+            String address = CLITestSuite.hostAddresses.get(host);
+            for (String server : CLITestSuite.hostServers.get(host)) {
+                if (!groupServers.contains(server)) {
+                    continue;  // server not in the group
+                }
+                if (!CLITestSuite.serverStatus.get(server)) {
+                    continue; // server not started
+                }
+                int port = 8080 + CLITestSuite.portOffsets.get(server);
+
+                URL url = new URL("http", address, port, path);
+                boolean failed = false;
+                try {
+                    String response = HttpRequest.get(url.toString(), 10, TimeUnit.SECONDS);
+                    assertThat(response, containsString(content));
+                } catch (Exception e) {
+                    failed = true;
+                    if (!shouldFail) {
+                        throw new Exception("Http request failed.", e);
+                    }
+                }
+                if (shouldFail) {
+                    assertThat(url.toString(), failed, is(true));
+                }
+            }
+        }
+    }
+
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
@@ -31,6 +31,7 @@ import org.jboss.as.test.integration.domain.management.cli.BasicOpsTestCase;
 import org.jboss.as.test.integration.domain.management.cli.DataSourceTestCase;
 import org.jboss.as.test.integration.domain.management.cli.DeployAllServerGroupsTestCase;
 import org.jboss.as.test.integration.domain.management.cli.DeploySingleServerGroupTestCase;
+import org.jboss.as.test.integration.domain.management.cli.DomainDeployWithRuntimeNameTestCase;
 import org.jboss.as.test.integration.domain.management.cli.DomainDeploymentOverlayTestCase;
 import org.jboss.as.test.integration.domain.management.cli.JmsTestCase;
 import org.jboss.as.test.integration.domain.management.cli.RolloutPlanTestCase;
@@ -54,7 +55,8 @@ import org.junit.runners.Suite;
     UndeployWildcardDomainTestCase.class,
     JmsTestCase.class,
     DataSourceTestCase.class,
-    RolloutPlanTestCase.class
+    RolloutPlanTestCase.class,
+    DomainDeployWithRuntimeNameTestCase.class
 })
 public class CLITestSuite {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeployWithRuntimeNameTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/DeployWithRuntimeNameTestCase.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file
+ * in the distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.test.integration.management.cli;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.server.ServerMessages;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.CLITestUtil;
+import org.jboss.as.test.integration.management.util.SimpleHelloWorldServlet;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.impl.base.exporter.zip.ZipExporterImpl;
+import org.junit.After;
+import org.junit.AfterClass;
+import static org.junit.Assert.assertThat;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DeployWithRuntimeNameTestCase {
+
+    @ArquillianResource
+    URL url;
+
+
+    private CommandContext ctx;
+    private File warFile;
+    private String baseUrl;
+
+    public static final String RUNTIME_NAME = "SimpleServlet.war";
+    public static final String OTHER_RUNTIME_NAME = "OtherSimpleServlet.war";
+    private static final String APP_NAME = "simple1";
+    private static final String OTHER_APP_NAME = "simple2";
+
+     @Deployment
+    public static Archive<?> getDeployment() {
+        return ShrinkWrap.create(JavaArchive.class, "dummy.jar").addClass(DeployWithRuntimeNameTestCase.class);
+    }
+
+    @BeforeClass
+    public static void setupCli() throws Exception {
+        AbstractCliTestBase.initCLI();
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        ctx = CLITestUtil.getCommandContext();
+        ctx.connectController();
+        baseUrl = getBaseURL(url);
+    }
+
+    private File createWarFile(String content) throws IOException {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "HelloServlet.war");
+        war.addClass(SimpleHelloWorldServlet.class);
+        war.addAsWebInfResource(SimpleHelloWorldServlet.class.getPackage(), "web.xml", "web.xml");
+        war.addAsWebResource(new StringAsset(content), "page.html");
+        File tempFile = new File(System.getProperty("java.io.tmpdir"), "HelloServlet.war");
+        new ZipExporterImpl(war).exportTo(tempFile, true);
+        return tempFile;
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        AbstractCliTestBase.closeCLI();
+    }
+
+    @After
+    public void undeployAll() {
+        assertThat(warFile.delete(), is(true));
+        if(ctx != null) {
+            ctx.handleSafe("undeploy " + APP_NAME);
+            ctx.handleSafe("undeploy " +OTHER_APP_NAME);
+            ctx.terminateSession();
+        }
+    }
+
+    @Test
+    public void testDeployWithSameRuntimeName() throws Exception {
+        warFile = createWarFile("Version1");
+        ctx.handle(buildDeployCommand(RUNTIME_NAME, APP_NAME));
+        checkURL("SimpleServlet/page.html", "Version1",  false);
+        checkURL("SimpleServlet/hello", "SimpleHelloWorldServlet", false);
+        warFile = createWarFile("Shouldn't be deployed, as runtime already exist");
+        try {
+        ctx.handle(buildDeployCommand(RUNTIME_NAME, OTHER_APP_NAME));
+        } catch(CommandLineException ex) {
+            assertThat(ex.getMessage(), containsString(ServerMessages.MESSAGES.runtimeNameMustBeUnique(APP_NAME, RUNTIME_NAME).getMessage()));
+        }
+        checkURL("SimpleServlet/hello", "SimpleHelloWorldServlet",  false);
+        checkURL("SimpleServlet/page.html", "Version1",  false);
+    }
+
+    @Test
+    public void testDeployWithDifferentRuntimeName() throws Exception {
+        warFile = createWarFile("Version1");
+        ctx.handle(buildDeployCommand(RUNTIME_NAME, APP_NAME));
+        checkURL("SimpleServlet/hello", "SimpleHelloWorldServlet",  false);
+        checkURL("SimpleServlet/page.html", "Version1",  false);
+        warFile = createWarFile("Version2");
+        ctx.handle(buildDeployCommand(OTHER_RUNTIME_NAME, OTHER_APP_NAME));
+        checkURL("SimpleServlet/hello", "SimpleHelloWorldServlet",  false);
+        checkURL("SimpleServlet/page.html", "Version1", false);
+        checkURL("OtherSimpleServlet/hello", "SimpleHelloWorldServlet", false);
+        checkURL("OtherSimpleServlet/page.html", "Version2",false);
+    }
+
+    private String buildDeployCommand(String runtimeName, String name) {
+        return "deploy " + warFile.getAbsolutePath() + " --runtime-name=" + runtimeName + " --name=" + name;
+    }
+
+    private void checkURL(String path, String content, boolean shouldFail) throws Exception {
+        boolean failed = false;
+        try {
+            String response = HttpRequest.get(baseUrl + path, 10, TimeUnit.SECONDS);
+            assertThat(response, containsString(content));
+        } catch (Exception e) {
+            failed = true;
+            if (!shouldFail) {
+                throw new Exception("Http request failed.", e);
+            }
+        }
+        if (shouldFail) {
+            assertThat(baseUrl + path, failed, is(true));
+        }
+    }
+
+    private final String getBaseURL(URL url) throws MalformedURLException {
+        return new URL(url.getProtocol(), url.getHost(), url.getPort(), "/").toString();
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/SimpleHelloWorldServlet.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/SimpleHelloWorldServlet.java
@@ -1,0 +1,87 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jboss.as.test.integration.management.util;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+public class SimpleHelloWorldServlet extends HttpServlet {
+
+    /**
+     * Processes requests for both HTTP <code>GET</code> and <code>POST</code> methods.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    protected void processRequest(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        response.setContentType("text/html;charset=UTF-8");
+        PrintWriter out = response.getWriter();
+        try {
+            out.println("<!DOCTYPE html>");
+            out.println("<html>");
+            out.println("<head>");
+            out.println("<title>SimpleHelloWorldServlet</title>");
+            out.println("</head>");
+            out.println("<body>");
+            out.println("<h1>Servlet SimpleHelloWorldServlet at " + request.getContextPath() + "</h1>");
+            out.println("</body>");
+            out.println("</html>");
+        } finally {
+            out.close();
+        }
+    }
+
+    // <editor-fold defaultstate="collapsed" desc="HttpServlet methods. Click on the + sign on the left to edit the code.">
+    /**
+     * Handles the HTTP <code>GET</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Handles the HTTP <code>POST</code> method.
+     *
+     * @param request servlet request
+     * @param response servlet response
+     * @throws ServletException if a servlet-specific error occurs
+     * @throws IOException if an I/O error occurs
+     */
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        processRequest(request, response);
+    }
+
+    /**
+     * Returns a short description of the servlet.
+     *
+     * @return a String containing servlet description
+     */
+    @Override
+    public String getServletInfo() {
+        return "Short description";
+    }// </editor-fold>
+
+}

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/util/web.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/util/web.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<web-app version="3.0"
+         xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+    <servlet>
+        <servlet-name>HelloWorld</servlet-name>
+        <servlet-class>org.jboss.as.test.integration.management.util.SimpleHelloWorldServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>HelloWorld</servlet-name>
+        <url-pattern>/hello</url-pattern>
+    </servlet-mapping>
+</web-app>


### PR DESCRIPTION
- Checking runtime-name when dploying a new component so that the runtime-name is unique per servr instance in standalone or domain mode.
- Checking also unicity during XML parsing in domain.xml and standalone.xml.

https://issues.jboss.org/browse/WFLY-1972
https://bugzilla.redhat.com/show_bug.cgi?id=983980
