### PR TITLE
[WFLY-1973] Reload error on pooled-connection-factory

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/BinderServiceUtil.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/BinderServiceUtil.java
@@ -77,11 +77,11 @@ public class BinderServiceUtil {
                     public void transition(ServiceController<? extends ManagedReferenceFactory> controller, ServiceController.Transition transition) {
                         switch (transition) {
                             case STARTING_to_UP: {
-                                ROOT_LOGGER.boundJndiName("ALIAS " + alias);
+                                ROOT_LOGGER.boundJndiName(alias);
                                 break;
                             }
-                            case START_REQUESTED_to_DOWN: {
-                                ROOT_LOGGER.unboundJndiName("ALIAS " + alias);
+                            case STOPPING_to_DOWN: {
+                                ROOT_LOGGER.unboundJndiName(alias);
                                 break;
                             }
                             case REMOVING_to_REMOVED: {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
@@ -434,9 +434,12 @@ public class PooledConnectionFactoryService implements Service<Void> {
 
     private void createJNDIAliases(final BindInfo bindInfo, List<String> aliases, ServiceController<ResourceAdapterDeployment> controller) {
         for (final String alias : aliases) {
-            installAliasBinderService(controller.getServiceContainer(),
-                    bindInfo,
-                    alias);
+            // do not install the alias' binder service if it is already registered
+            if (controller.getServiceContainer().getService(ContextNames.bindInfoFor(alias).getBinderServiceName()) == null) {
+                installAliasBinderService(controller.getServiceContainer(),
+                        bindInfo,
+                        alias);
+            }
         }
     }
 


### PR DESCRIPTION
- do not install the pooled-connection-factory aliases' binder services
  if they are already registered (as it the case when performing a
  :reload)
- in PooledConnectionFactoryRemove, remove the JNDI aliases' binder
  service when the pooled cf service is removed.
- fix logging of alias unbinding in BinderServiceUtil to have the
  message appearing when a pooled-cf is stopped/removed
