### PR TITLE
Upgrade jboss-threads to 2.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,7 +219,7 @@
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Beta2</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
         <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
-        <version.org.jboss.threads>2.1.0.Final</version.org.jboss.threads>
+        <version.org.jboss.threads>2.1.1.Final</version.org.jboss.threads>
         <version.org.jboss.web.jasper-jdt>7.0.3.Final</version.org.jboss.web.jasper-jdt>
         <version.org.jboss.weld.weld>2.0.3.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.0.SP1</version.org.jboss.weld.weld-api>


### PR DESCRIPTION
WFLY: https://issues.jboss.org/browse/WFLY-1987 

EAP6.2 needs upgrade jboss-threads to 2.1.1.Final (https://bugzilla.redhat.com/show_bug.cgi?id=994281) which contains fix of https://bugzilla.redhat.com/show_bug.cgi?id=985204 
upgrade in upstream.
