### PR TITLE
Upgrade Weld to 2.0.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -221,7 +221,7 @@
         <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
         <version.org.jboss.threads>2.1.1.Final</version.org.jboss.threads>
         <version.org.jboss.web.jasper-jdt>7.0.3.Final</version.org.jboss.web.jasper-jdt>
-        <version.org.jboss.weld.weld>2.0.3.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld>2.0.4.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.0.SP1</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.spi>2.2.0.Final</version.org.jboss.ws.spi>


### PR DESCRIPTION
- this address few serious memory leaks
