### PR TITLE
resteasy upgrade and new modules

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -395,6 +395,24 @@
             <maven-resource group="com.fasterxml" artifact="classmate" />
         </module-def>
 
+        <module-def name="com.fasterxml.jackson.core.jackson-core">
+            <maven-resource group="com.fasterxml.jackson.core" artifact="jackson-core"/>
+        </module-def>
+
+        <module-def name="com.fasterxml.jackson.core.jackson-databind">
+            <maven-resource group="com.fasterxml.jackson.core" artifact="jackson-databind"/>
+        </module-def>
+
+        <module-def name="com.fasterxml.jackson.core.jackson-annotations">
+            <maven-resource group="com.fasterxml.jackson.core" artifact="jackson-annotations"/>
+        </module-def>
+
+        <module-def name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
+            <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-json-provider"/>
+            <maven-resource group="com.fasterxml.jackson.jaxrs" artifact="jackson-jaxrs-base"/>
+            <maven-resource group="com.fasterxml.jackson.module" artifact="jackson-module-jaxb-annotations" />
+        </module-def>
+
         <module-def name="com.github.relaxng">
             <maven-resource group="com.github.relaxng" artifact="relaxngDatatype" />
         </module-def>
@@ -1153,6 +1171,10 @@
             <maven-resource group="org.jboss.remotingjmx" artifact="remoting-jmx"/>
         </module-def>
 
+        <module-def name="org.jboss.resteasy.jose-jwt">
+            <maven-resource group="org.jboss.resteasy" artifact="jose-jwt"/>
+        </module-def>
+
         <module-def name="org.jboss.resteasy.resteasy-atom-provider">
             <maven-resource group="org.jboss.resteasy" artifact="resteasy-atom-provider"/>
         </module-def>
@@ -1167,6 +1189,10 @@
 
         <module-def name="org.jboss.resteasy.resteasy-jackson-provider">
             <maven-resource group="org.jboss.resteasy" artifact="resteasy-jackson-provider"/>
+        </module-def>
+
+        <module-def name="org.jboss.resteasy.resteasy-jackson2-provider">
+            <maven-resource group="org.jboss.resteasy" artifact="resteasy-jackson2-provider" jandex="true"/>
         </module-def>
 
         <module-def name="org.jboss.resteasy.resteasy-jaxb-provider">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -251,6 +251,31 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-core</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-json-provider</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                    <artifactId>jackson-jaxrs-base</artifactId>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.module</groupId>
+                    <artifactId>jackson-module-jaxb-annotations</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>com.h2database</groupId>
                     <artifactId>h2</artifactId>
                 </dependency>
@@ -1429,6 +1454,11 @@
 
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>jose-jwt</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-client</artifactId>
                 </dependency>
 
@@ -1460,6 +1490,11 @@
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-jackson-provider</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jackson2-provider</artifactId>
                 </dependency>
 
                 <dependency>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-annotations/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-annotations/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,27 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxrs">
-
-    <resources>
+<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.core.jackson-annotations">
+     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.activation.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.ws.rs.api"/>
-        <module name="org.apache.commons.io"/>
-        <module name="org.apache.commons.codec" />
-        <module name="org.apache.httpcomponents" export="true"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.hibernate.validator"/>
-        <module name="org.scannotation.scannotation" />
-        <module name="org.slf4j" />
-        <module name="javax.servlet.api"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-core/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,27 +21,12 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxrs">
-
-    <resources>
+<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.core.jackson-core">
+     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.activation.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.ws.rs.api"/>
-        <module name="org.apache.commons.io"/>
-        <module name="org.apache.commons.codec" />
-        <module name="org.apache.httpcomponents" export="true"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.hibernate.validator"/>
-        <module name="org.scannotation.scannotation" />
-        <module name="org.slf4j" />
-        <module name="javax.servlet.api"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-databind/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-databind/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,27 +21,14 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxrs">
-
-    <resources>
+<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.core.jackson-databind">
+     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.activation.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.ws.rs.api"/>
-        <module name="org.apache.commons.io"/>
-        <module name="org.apache.commons.codec" />
-        <module name="org.apache.httpcomponents" export="true"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.hibernate.validator"/>
-        <module name="org.scannotation.scannotation" />
-        <module name="org.slf4j" />
-        <module name="javax.servlet.api"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
+        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,27 +21,16 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxrs">
-
-    <resources>
+<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
+     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
         <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.activation.api"/>
-        <module name="javax.validation.api"/>
         <module name="javax.ws.rs.api"/>
-        <module name="org.apache.commons.io"/>
-        <module name="org.apache.commons.codec" />
-        <module name="org.apache.httpcomponents" export="true"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.hibernate.validator"/>
-        <module name="org.scannotation.scannotation" />
-        <module name="org.slf4j" />
-        <module name="javax.servlet.api"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
+        <module name="com.fasterxml.jackson.core.jackson-annotations"/>
+        <module name="com.fasterxml.jackson.core.jackson-core"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/jose-jwt/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/jose-jwt/main/module.xml
@@ -22,26 +22,22 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxrs">
-
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.jose-jwt">
     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
+        <module name="org.codehaus.jackson.jackson-core-asl"/>
+        <module name="org.codehaus.jackson.jackson-jaxrs"/>
+        <module name="org.codehaus.jackson.jackson-mapper-asl"/>
+        <module name="org.codehaus.jackson.jackson-xc"/>
+        <module name="javax.xml.bind.api"/>
         <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.activation.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.ws.rs.api"/>
-        <module name="org.apache.commons.io"/>
-        <module name="org.apache.commons.codec" />
-        <module name="org.apache.httpcomponents" export="true"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.hibernate.validator"/>
-        <module name="org.scannotation.scannotation" />
-        <module name="org.slf4j" />
+        <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
+        <module name="javax.ws.rs.api"/>
+        <module name="org.jboss.resteasy.resteasy-jackson-provider" services="import"/>
+        <module name="org.jboss.resteasy.resteasy-jaxrs" services="import"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
@@ -22,26 +22,21 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxrs">
-
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jackson2-provider">
     <resources>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
+        <module name="com.fasterxml.jackson.core.jackson-annotations" export="true"/>
+        <module name="com.fasterxml.jackson.core.jackson-core" export="true"/>
+        <module name="com.fasterxml.jackson.core.jackson-databind" export="true"/>
+        <module name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider"/>
+        <module name="javax.xml.bind.api"/>
         <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.activation.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.ws.rs.api"/>
-        <module name="org.apache.commons.io"/>
-        <module name="org.apache.commons.codec" />
-        <module name="org.apache.httpcomponents" export="true"/>
-        <module name="org.apache.log4j"/>
-        <module name="org.hibernate.validator"/>
-        <module name="org.scannotation.scannotation" />
-        <module name="org.slf4j" />
+        <module name="javax.enterprise.api"/>
         <module name="javax.servlet.api"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
+        <module name="javax.ws.rs.api"/>
+        <module name="org.jboss.resteasy.resteasy-jaxrs"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,7 @@
         <version.asm>3.3.1</version.asm>
         <version.ch.qos.cal10n>0.7.3</version.ch.qos.cal10n>
         <version.com.fasterxml.classmate>0.8.0</version.com.fasterxml.classmate>
+        <version.com.fasterxml.jackson>2.2.3</version.com.fasterxml.jackson>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.google.guava>13.0.1</version.com.google.guava>
         <version.com.h2database>1.3.168</version.com.h2database>
@@ -187,7 +188,7 @@
         <version.org.jboss.remote-naming>2.0.0.Beta2</version.org.jboss.remote-naming>
         <version.org.jboss.remoting>4.0.0.Beta1</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.0.CR1</version.org.jboss.remotingjmx.remoting-jmx>
-        <version.org.jboss.resteasy>3.0.2.Final</version.org.jboss.resteasy>
+        <version.org.jboss.resteasy>3.0.4.Final</version.org.jboss.resteasy>
         <version.org.jboss.sasl>1.0.3.Final</version.org.jboss.sasl>
         <version.org.jboss.seam.int>6.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>2.2.3.Final</version.org.jboss.security.jboss-negotiation>
@@ -1358,6 +1359,38 @@
                 <groupId>com.fasterxml</groupId>
                 <artifactId>classmate</artifactId>
                 <version>${version.com.fasterxml.classmate}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-json-provider</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                <artifactId>jackson-jaxrs-base</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
+            </dependency>
+            <!-- also need JAXB annotation support -->
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-jaxb-annotations</artifactId>
+                <version>${version.com.fasterxml.jackson}</version>
             </dependency>
 
             <dependency>
@@ -4675,6 +4708,12 @@
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
+                <artifactId>jose-jwt</artifactId>
+                <version>${version.org.jboss.resteasy}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-client</artifactId>
                 <version>${version.org.jboss.resteasy}</version>
             </dependency>
@@ -4715,6 +4754,10 @@
                     <exclusion>
                         <groupId>net.jcip</groupId>
                         <artifactId>jcip-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.annotation</groupId>
+                        <artifactId>jboss-annotations-api_1.1_spec</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>javax.annotation</groupId>
@@ -4815,6 +4858,30 @@
                     <exclusion>
                         <groupId>org.codehaus.jackson</groupId>
                         <artifactId>jackson-xc</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-jackson2-provider</artifactId>
+                <version>${version.org.jboss.resteasy}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-databind</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.core</groupId>
+                        <artifactId>jackson-annotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.fasterxml.jackson.jaxrs</groupId>
+                        <artifactId>jackson-jaxrs-json-provider</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
- Update to Resteasy 3.0.4
- Add Jackson2 modules
- Add Resteasy jose-jwt module
- Add Resteasy-jackson2-provider optional module
