### PR TITLE
jgroups gossip discovery example configuration files

### DIFF
--- a/build/build-configs.xml
+++ b/build/build-configs.xml
@@ -88,6 +88,28 @@
                 paramSubsystemsFile="examples/standalone/subsystems-ec2-ha.xml"
                 paramOutputFile="${generated.configs.examples}/standalone-ec2-ha.xml"/>
       </sequential>
+      <sequential>
+          <xslt
+                in="${generated.configs.src.dir}/configuration/standalone/subsystems-full-ha.xml" 
+                out="${project.build.directory}/generated-subsystems/examples/standalone/subsystems-gossip-full-ha.xml"
+                style="${generated.configs.src.dir}/configuration/examples/xslt/supplement-gossip-discovery.xsl"/>
+          <generate-server-config
+                paramTemplateFile="configuration/standalone/template.xml"
+                paramSubsystemsFileBaseDir="${project.build.directory}/generated-subsystems/"
+                paramSubsystemsFile="examples/standalone/subsystems-gossip-full-ha.xml"
+                paramOutputFile="${generated.configs.examples}/standalone-gossip-full-ha.xml"/>
+      </sequential>
+      <sequential>
+          <xslt
+                in="${generated.configs.src.dir}/configuration/standalone/subsystems-ha.xml"
+                out="${project.build.directory}/generated-subsystems/examples/standalone/subsystems-gossip-ha.xml"
+                style="${generated.configs.src.dir}/configuration/examples/xslt/supplement-gossip-discovery.xsl"/>
+          <generate-server-config
+                paramTemplateFile="configuration/standalone/template.xml"
+                paramSubsystemsFileBaseDir="${project.build.directory}/generated-subsystems/"
+                paramSubsystemsFile="examples/standalone/subsystems-gossip-ha.xml"
+                paramOutputFile="${generated.configs.examples}/standalone-gossip-ha.xml"/>
+      </sequential>
       <generate-server-config 
            paramTemplateFile="configuration/standalone/template.xml" 
            paramSubsystemsFile="configuration/examples/subsystems-hornetq-colocated.xml"

--- a/build/src/main/resources/configuration/examples/xslt/supplement-gossip-discovery.xsl
+++ b/build/src/main/resources/configuration/examples/xslt/supplement-gossip-discovery.xsl
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0">
+
+   <!-- xsl:output method="xml" indent="yes"/ -->
+
+   <xsl:template match="@*|node()">
+      <xsl:copy>
+         <xsl:apply-templates select="@*|node()" />
+      </xsl:copy>
+   </xsl:template>
+
+   <xsl:template match="*[local-name() = 'subsystem' and contains(concat(text(), '&#xA;'), '/jgroups.xml&#xA;')]">
+      <xsl:copy>
+         <xsl:attribute name="supplement">
+            <xsl:value-of select="'gossip'"/>
+         </xsl:attribute>
+         <xsl:apply-templates select="@*|node()" />
+      </xsl:copy>
+   </xsl:template>
+
+</xsl:stylesheet>

--- a/build/src/main/resources/configuration/subsystems/jgroups.xml
+++ b/build/src/main/resources/configuration/subsystems/jgroups.xml
@@ -84,7 +84,22 @@
            </protocol>
        </replacement>
    </supplement>
+   <supplement name="gossip-discovery">
+       <replacement placeholder="TCP-DISCOVERY">
+           <protocol type="TCPGOSSIP">
+               <property name="initial_hosts">${jboss.jgroups.gossip.initial_hosts}</property>
+               <property name="num_initial_members">${jboss.jgroups.gossip.num_initial_members}</property>
+           </protocol>
+       </replacement>
+       <replacement placeholder="UDP-DISCOVERY">
+           <protocol type="TCPGOSSIP">
+               <property name="initial_hosts">${jboss.jgroups.gossip.initial_hosts}</property>
+               <property name="num_initial_members">${jboss.jgroups.gossip.num_initial_members}</property>
+           </protocol>
+       </replacement>
+   </supplement>
    <supplement name="ec2" includes="no-multicast s3-ping"/>
+   <supplement name="gossip" includes="no-multicast gossip-discovery"/>
    <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
    <socket-binding name="jgroups-tcp" port="7600"/>
    <socket-binding name="jgroups-tcp-fd" port="57600"/>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -236,6 +236,7 @@
                                          <include>standalone-xts.xml</include>
                                          <include>standalone-rts.xml</include>
                                          <include>standalone-ec2-*.xml</include>
+                                         <include>standalone-gossip-*.xml</include>
                                     </includes>
                                 </resource>
                             </resources>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -121,6 +121,16 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
     @Test
     public void testStandaloneEC2FullHA() throws Exception {
         parseXml("docs/examples/configs/standalone-ec2-full-ha.xml");
+
+    }
+    @Test
+    public void testStandaloneGossipHA() throws Exception {
+        parseXml("docs/examples/configs/standalone-gossip-ha.xml");
+    }
+
+    @Test
+    public void testStandaloneGossipFullHA() throws Exception {
+        parseXml("docs/examples/configs/standalone-gossip-full-ha.xml");
     }
 
     @Test


### PR DESCRIPTION
Hello, I've added gossip discovery example configuration files similarly to the EC2 configuration files in https://github.com/wildfly/wildfly/pull/4886

The reason to have this alternative method is that it would allow for running in any environment, even without internet access. As well it's very convenient for testing purposes.

issue tracker: https://issues.jboss.org/browse/WFLY-2015

FYI I'm not yet preparing mod_cluster configuration files because it seems it's not prepared to work with undertow yet.
