### PR TITLE
SRV.7.7.2 compliance and Weld-related serialization fix

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
@@ -39,5 +39,6 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.threads"/>
+        <module name="org.wildfly.security.manager"/>
     </dependencies>
 </module>

--- a/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/HashableMarshalledValueFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/HashableMarshalledValueFactory.java
@@ -27,6 +27,11 @@ package org.jboss.as.clustering.marshalling;
  * @author Paul Ferraro
  */
 public class HashableMarshalledValueFactory extends SimpleMarshalledValueFactory {
+
+    public HashableMarshalledValueFactory(MarshallingContextFactory factory, VersionedMarshallingConfiguration configuration, ClassLoader loader) {
+        super(factory, configuration, loader);
+    }
+
     public HashableMarshalledValueFactory(MarshallingContext context) {
         super(context);
     }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/MarshallingContext.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/MarshallingContext.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2013, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,46 +19,23 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-
 package org.jboss.as.clustering.marshalling;
 
 import java.io.IOException;
 
 import org.jboss.marshalling.Marshaller;
-import org.jboss.marshalling.MarshallerFactory;
-import org.jboss.marshalling.Marshalling;
-import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;
 
 /**
+ * A marshalling context for use with a {@link MarshalledValue}.
  * @author Paul Ferraro
  */
-public class MarshallingContext {
-    private final MarshallerFactory factory;
-    private final VersionedMarshallingConfiguration configuration;
+public interface MarshallingContext {
+    ClassLoader getClassLoader();
 
-    public MarshallingContext(VersionedMarshallingConfiguration configuration) {
-        this(Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader()), configuration);
-    }
+    int getCurrentVersion();
 
-    public MarshallingContext(MarshallerFactory factory, VersionedMarshallingConfiguration configuration) {
-        this.factory = factory;
-        this.configuration = configuration;
-    }
+    Unmarshaller createUnmarshaller(int version) throws IOException;
 
-    public int getCurrentVersion() {
-        return this.configuration.getCurrentMarshallingVersion();
-    }
-
-    public Unmarshaller createUnmarshaller(int version) throws IOException {
-        return this.factory.createUnmarshaller(this.getMarshallingConfiguration(version));
-    }
-
-    public Marshaller createMarshaller(int version) throws IOException {
-        return this.factory.createMarshaller(this.getMarshallingConfiguration(version));
-    }
-
-    private MarshallingConfiguration getMarshallingConfiguration(int version) {
-        return this.configuration.getMarshallingConfiguration(version);
-    }
+    Marshaller createMarshaller(int version) throws IOException;
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/MarshallingContextFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/MarshallingContextFactory.java
@@ -21,23 +21,10 @@
  */
 package org.jboss.as.clustering.marshalling;
 
-import org.jboss.marshalling.MarshallingConfiguration;
-import org.jboss.marshalling.ModularClassResolver;
-import org.jboss.modules.ModuleLoader;
-
 /**
- * Boilerplate code for marshalling configuration creation.
+ * Factory for creating a marshalling context.
  * @author Paul Ferraro
  */
-public class MarshallingConfigurationFactory {
-
-    public static MarshallingConfiguration createMarshallingConfiguration(ModuleLoader loader) {
-        MarshallingConfiguration config = new MarshallingConfiguration();
-        config.setClassResolver(ModularClassResolver.getInstance(loader));
-        return config;
-    }
-
-    private MarshallingConfigurationFactory() {
-        // Hide constructor
-    }
+public interface MarshallingContextFactory {
+    MarshallingContext createMarshallingContext(VersionedMarshallingConfiguration configuration, ClassLoader loader);
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/SimpleMarshalledValueFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/SimpleMarshalledValueFactory.java
@@ -26,7 +26,11 @@ package org.jboss.as.clustering.marshalling;
  * @author Paul Ferraro
  */
 public class SimpleMarshalledValueFactory implements MarshalledValueFactory<MarshallingContext> {
-    final MarshallingContext context;
+    protected final MarshallingContext context;
+
+    public SimpleMarshalledValueFactory(MarshallingContextFactory factory, VersionedMarshallingConfiguration configuration, ClassLoader loader) {
+        this(factory.createMarshallingContext(configuration, loader));
+    }
 
     public SimpleMarshalledValueFactory(MarshallingContext context) {
         this.context = context;

--- a/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/SimpleMarshallingContext.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/SimpleMarshallingContext.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.marshalling;
+
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+
+import org.jboss.marshalling.Marshaller;
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.Unmarshaller;
+
+/**
+ * @author Paul Ferraro
+ */
+public class SimpleMarshallingContext implements MarshallingContext {
+
+    private final MarshallerFactory factory;
+    private final VersionedMarshallingConfiguration configuration;
+    private final WeakReference<ClassLoader> loader;
+
+    public SimpleMarshallingContext(MarshallerFactory factory, VersionedMarshallingConfiguration configuration, ClassLoader loader) {
+        this.factory = factory;
+        this.configuration = configuration;
+        this.loader = new WeakReference<>(loader);
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return this.loader.get();
+    }
+
+    @Override
+    public int getCurrentVersion() {
+        return this.configuration.getCurrentMarshallingVersion();
+    }
+
+    @Override
+    public Unmarshaller createUnmarshaller(int version) throws IOException {
+        return this.factory.createUnmarshaller(this.getMarshallingConfiguration(version));
+    }
+
+    @Override
+    public Marshaller createMarshaller(int version) throws IOException {
+        return this.factory.createMarshaller(this.getMarshallingConfiguration(version));
+    }
+
+    private MarshallingConfiguration getMarshallingConfiguration(int version) {
+        return this.configuration.getMarshallingConfiguration(version);
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/SimpleMarshallingContextFactory.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/marshalling/SimpleMarshallingContextFactory.java
@@ -1,0 +1,25 @@
+package org.jboss.as.clustering.marshalling;
+
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.marshalling.Marshalling;
+
+/**
+ * Factory for creating a {@link SimpleMarshallingContext}.
+ * @author Paul Ferraro
+ */
+public class SimpleMarshallingContextFactory implements MarshallingContextFactory {
+    private final MarshallerFactory factory;
+
+    public SimpleMarshallingContextFactory() {
+        this(Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader()));
+    }
+
+    public SimpleMarshallingContextFactory(MarshallerFactory factory) {
+        this.factory = factory;
+    }
+
+    @Override
+    public SimpleMarshallingContext createMarshallingContext(VersionedMarshallingConfiguration configuration, ClassLoader loader) {
+        return new SimpleMarshallingContext(this.factory, configuration, loader);
+    }
+}

--- a/clustering/common/src/test/java/org/jboss/as/clustering/marshalling/SimpleMarshalledValueFactoryTestCase.java
+++ b/clustering/common/src/test/java/org/jboss/as/clustering/marshalling/SimpleMarshalledValueFactoryTestCase.java
@@ -60,7 +60,7 @@ public class SimpleMarshalledValueFactoryTestCase {
                 return new MarshallingConfiguration();
             }
         };
-        this.context = new MarshallingContext(Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader()), configuration);
+        this.context = new SimpleMarshallingContext(Marshalling.getMarshallerFactory("river", Marshalling.class.getClassLoader()), configuration, Thread.currentThread().getContextClassLoader());
         this.factory = this.createFactory(this.context);
     }
 
@@ -152,7 +152,7 @@ public class SimpleMarshalledValueFactoryTestCase {
         return (SimpleMarshalledValue<V>) unmarshall(marshall(mv));
     }
 
-    private byte[] marshall(Object mv) throws IOException {
+    private static byte[] marshall(Object mv) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(mv);
@@ -160,7 +160,7 @@ public class SimpleMarshalledValueFactoryTestCase {
         return baos.toByteArray();
     }
 
-    private Object unmarshall(byte[] bytes) throws IOException, ClassNotFoundException {
+    private static Object unmarshall(byte[] bytes) throws IOException, ClassNotFoundException {
         ByteArrayInputStream bais = new ByteArrayInputStream(bytes);
         ObjectInputStream ois = new ObjectInputStream(bais);
         try {

--- a/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanBackingCacheEntryStoreSource.java
+++ b/clustering/ejb3-infinispan/src/main/java/org/jboss/as/clustering/ejb3/cache/backing/infinispan/InfinispanBackingCacheEntryStoreSource.java
@@ -41,6 +41,7 @@ import org.jboss.as.clustering.marshalling.MarshalledValue;
 import org.jboss.as.clustering.marshalling.MarshalledValueFactory;
 import org.jboss.as.clustering.marshalling.MarshallingContext;
 import org.jboss.as.clustering.marshalling.SimpleMarshalledValueFactory;
+import org.jboss.as.clustering.marshalling.SimpleMarshallingContextFactory;
 import org.jboss.as.ejb3.cache.Cacheable;
 import org.jboss.as.ejb3.cache.IdentifierFactory;
 import org.jboss.as.ejb3.cache.PassivationManager;
@@ -114,7 +115,7 @@ public class InfinispanBackingCacheEntryStoreSource<K extends Serializable, V ex
     @Override
     public <E extends SerializationGroup<K, V, G>> BackingCacheEntryStore<G, Cacheable<G>, E> createGroupIntegratedObjectStore(IdentifierFactory<G> identifierFactory, PassivationManager<G, E> passivationManager, StatefulTimeoutInfo timeout) {
         Cache<G, MarshalledValue<E, MarshallingContext>> cache = this.groupCache.getValue();
-        MarshallingContext context = new MarshallingContext(passivationManager);
+        MarshallingContext context = new SimpleMarshallingContextFactory().createMarshallingContext(passivationManager, passivationManager.getClassLoader());
         MarshalledValueFactory<MarshallingContext> valueFactory = new SimpleMarshalledValueFactory(context);
         Registry<String, ?> registry = this.registry.getOptionalValue();
         NodeFactory<Address> nodeFactory = this.nodeFactory.getOptionalValue();
@@ -136,7 +137,7 @@ public class InfinispanBackingCacheEntryStoreSource<K extends Serializable, V ex
         }
         groupCache.getCacheManager().defineConfiguration(beanName, builder.build());
         Cache<K, MarshalledValue<E, MarshallingContext>> cache = container.<K, MarshalledValue<E, MarshallingContext>>getCache(beanName);
-        MarshallingContext context = new MarshallingContext(passivationManager);
+        MarshallingContext context = new SimpleMarshallingContextFactory().createMarshallingContext(passivationManager, passivationManager.getClassLoader());
         MarshalledValueFactory<MarshallingContext> valueFactory = new SimpleMarshalledValueFactory(context);
         NodeFactory<Address> nodeFactory = this.nodeFactory.getOptionalValue();
         Registry<String, ?> registry = this.registry.getOptionalValue();

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandDispatcherFactoryService.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandDispatcherFactoryService.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.jboss.as.clustering.marshalling.DynamicClassTable;
 import org.jboss.as.clustering.marshalling.MarshallingConfigurationFactory;
 import org.jboss.as.clustering.marshalling.MarshallingContext;
+import org.jboss.as.clustering.marshalling.SimpleMarshallingContextFactory;
 import org.jboss.as.clustering.marshalling.VersionedMarshallingConfiguration;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.Marshalling;
@@ -71,12 +72,12 @@ public class CommandDispatcherFactoryService implements CommandDispatcherFactory
     private static final short SCOPE_ID = 222;
     private static final int CURRENT_VERSION = 1;
 
-    final MarshallingContext marshallingContext = new MarshallingContext(this);
     final Map<Object, AtomicReference<Object>> contexts = new ConcurrentHashMap<>();
 
     private final Map<Integer, MarshallingConfiguration> configurations = new HashMap<>();
     private final CommandDispatcherFactoryConfiguration config;
 
+    volatile MarshallingContext marshallingContext;
     volatile NodeFactory<Address> factory = null;
 
     private volatile Group group = null;
@@ -98,6 +99,7 @@ public class CommandDispatcherFactoryService implements CommandDispatcherFactory
             Module module = loader.loadModule(this.config.getModuleIdentifier());
             config.setClassTable(new DynamicClassTable(module.getClassLoader()));
             this.configurations.put(CURRENT_VERSION, config);
+            this.marshallingContext = new SimpleMarshallingContextFactory().createMarshallingContext(this, module.getClassLoader());
         } catch (ModuleLoadException e) {
             throw new StartException(e);
         }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
@@ -31,6 +31,7 @@ import org.jboss.as.clustering.marshalling.MarshalledValue;
 import org.jboss.as.clustering.marshalling.MarshalledValueFactory;
 import org.jboss.as.clustering.marshalling.MarshallingContext;
 import org.jboss.as.clustering.marshalling.SimpleMarshalledValueFactory;
+import org.jboss.as.clustering.marshalling.SimpleMarshallingContextFactory;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.modules.Module;
 import org.jboss.msc.inject.Injector;
@@ -58,7 +59,7 @@ import org.wildfly.clustering.web.session.SessionManagerFactory;
  */
 @SuppressWarnings("rawtypes")
 public class InfinispanSessionManagerFactory extends AbstractService<SessionManagerFactory> implements SessionManagerFactory {
-    private final SessionAttributeMarshallingContext context;
+    private final Module module;
     private final JBossWebMetaData metaData;
     private final CacheInvoker invoker = new RetryingCacheInvoker(10, 100);
     private final Value<Cache> cache;
@@ -67,7 +68,7 @@ public class InfinispanSessionManagerFactory extends AbstractService<SessionMana
     private final InjectedValue<Registry> registry = new InjectedValue<>();
 
     public InfinispanSessionManagerFactory(Module module, JBossWebMetaData metaData, Value<Cache> cache, Value<KeyAffinityServiceFactory> affinityFactory) {
-        this.context = new SessionAttributeMarshallingContext(module);
+        this.module = module;
         this.cache = cache;
         this.affinityFactory = affinityFactory;
         this.metaData = metaData;
@@ -84,7 +85,7 @@ public class InfinispanSessionManagerFactory extends AbstractService<SessionMana
     }
 
     private <L> SessionFactory<?, L> getSessionFactory(SessionContext context, LocalContextFactory<L> localContextFactory) {
-        MarshallingContext marshallingContext = new MarshallingContext(this.context);
+        MarshallingContext marshallingContext = new SimpleMarshallingContextFactory().createMarshallingContext(new SessionAttributeMarshallingContext(this.module), this.module.getClassLoader());
         MarshalledValueFactory<MarshallingContext> factory = new SimpleMarshalledValueFactory(marshallingContext);
 
         switch (this.metaData.getReplicationConfig().getReplicationGranularity()) {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseImmutableSessionAttributes.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseImmutableSessionAttributes.java
@@ -24,6 +24,9 @@ package org.wildfly.clustering.web.infinispan.session.coarse;
 import java.util.Map;
 import java.util.Set;
 
+import org.jboss.as.clustering.marshalling.MarshalledValue;
+import org.jboss.as.clustering.marshalling.MarshallingContext;
+import org.wildfly.clustering.web.infinispan.session.SessionAttributeMarshaller;
 import org.wildfly.clustering.web.session.ImmutableSessionAttributes;
 
 /**
@@ -31,19 +34,25 @@ import org.wildfly.clustering.web.session.ImmutableSessionAttributes;
  * @author Paul Ferraro
  */
 public class CoarseImmutableSessionAttributes implements ImmutableSessionAttributes {
-    private final Map<String, Object> attributes;
+    private final MarshalledValue<Map<String, Object>, MarshallingContext> attributes;
+    private final SessionAttributeMarshaller<Map<String, Object>, MarshalledValue<Map<String, Object>, MarshallingContext>> marshaller;
 
-    public CoarseImmutableSessionAttributes(Map<String, Object> attributes) {
+    public CoarseImmutableSessionAttributes(MarshalledValue<Map<String, Object>, MarshallingContext> attributes, SessionAttributeMarshaller<Map<String, Object>, MarshalledValue<Map<String, Object>, MarshallingContext>> marshaller) {
         this.attributes = attributes;
+        this.marshaller = marshaller;
+    }
+
+    protected Map<String, Object> getAttributes() {
+        return this.marshaller.read(this.attributes);
     }
 
     @Override
     public Set<String> getAttributeNames() {
-        return this.attributes.keySet();
+        return this.getAttributes().keySet();
     }
 
     @Override
     public Object getAttribute(String name) {
-        return this.attributes.get(name);
+        return this.getAttributes().get(name);
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionAttributes.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionAttributes.java
@@ -23,8 +23,11 @@ package org.wildfly.clustering.web.infinispan.session.coarse;
 
 import java.util.Map;
 
+import org.jboss.as.clustering.marshalling.MarshalledValue;
+import org.jboss.as.clustering.marshalling.MarshallingContext;
 import org.wildfly.clustering.web.infinispan.CacheMutator;
 import org.wildfly.clustering.web.infinispan.Mutator;
+import org.wildfly.clustering.web.infinispan.session.SessionAttributeMarshaller;
 import org.wildfly.clustering.web.session.SessionAttributes;
 
 /**
@@ -32,25 +35,24 @@ import org.wildfly.clustering.web.session.SessionAttributes;
  * @author Paul Ferraro
  */
 public class CoarseSessionAttributes extends CoarseImmutableSessionAttributes implements SessionAttributes {
-    private final Map<String, Object> attributes;
     private final Mutator mutator;
 
-    public CoarseSessionAttributes(Map<String, Object> attributes, Mutator mutator) {
-        super(attributes);
-        this.attributes = attributes;
+    public CoarseSessionAttributes(MarshalledValue<Map<String, Object>, MarshallingContext> attributes, SessionAttributeMarshaller<Map<String, Object>, MarshalledValue<Map<String, Object>, MarshallingContext>> marshaller, Mutator mutator) {
+        super(attributes, marshaller);
         this.mutator = mutator;
     }
 
     @Override
     public Object removeAttribute(String name) {
-        Object value = this.attributes.remove(name);
+        Object value = this.getAttributes().remove(name);
         this.mutator.mutate();
         return value;
     }
 
     @Override
     public Object setAttribute(String name, Object value) {
-        Object old = (value != null) ? this.attributes.put(name, value) : this.attributes.remove(name);
+        Map<String, Object> attributes = this.getAttributes();
+        Object old = (value != null) ? attributes.put(name, value) : attributes.remove(name);
         this.mutator.mutate();
         return old;
     }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
@@ -74,9 +74,8 @@ public class CoarseSessionFactory<L> implements SessionFactory<CoarseSessionEntr
         CoarseSessionCacheEntry<L> cacheEntry = entry.getCacheEntry();
         SessionMetaData metaData = cacheEntry.getMetaData();
         MarshalledValue<Map<String, Object>, MarshallingContext> value = entry.getAttributes();
-        Map<String, Object> map = this.marshaller.read(value);
         Mutator attributesMutator = metaData.isNew() ? Mutator.PASSIVE : new CacheMutator<>(this.attributesCache, this.invoker, new SessionAttributesCacheKey(id), value, Flag.SKIP_LOCKING);
-        SessionAttributes attributes = new CoarseSessionAttributes(map, attributesMutator);
+        SessionAttributes attributes = new CoarseSessionAttributes(value, this.marshaller, attributesMutator);
         Mutator sessionMutator = metaData.isNew() ? Mutator.PASSIVE : new CacheMutator<>(this.sessionCache, this.invoker, id, cacheEntry);
         return new InfinispanSession<>(id, metaData, attributes, cacheEntry.getLocalContext(), this.localContextFactory, this.context, sessionMutator, this);
     }
@@ -86,8 +85,7 @@ public class CoarseSessionFactory<L> implements SessionFactory<CoarseSessionEntr
         CoarseSessionCacheEntry<L> cacheEntry = entry.getCacheEntry();
         ImmutableSessionMetaData metaData = cacheEntry.getMetaData();
         MarshalledValue<Map<String, Object>, MarshallingContext> value = entry.getAttributes();
-        Map<String, Object> map = this.marshaller.read(value);
-        ImmutableSessionAttributes attributes = new CoarseImmutableSessionAttributes(map);
+        ImmutableSessionAttributes attributes = new CoarseImmutableSessionAttributes(value, this.marshaller);
         return new InfinispanImmutableSession(id, metaData, attributes, this.context);
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/PassivationManager.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/PassivationManager.java
@@ -44,4 +44,6 @@ public interface PassivationManager<K, V extends Identifiable<K>> extends Versio
      *         assume it will be thrown.
      */
     void prePassivate(V obj);
+
+    ClassLoader getClassLoader();
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupContainer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupContainer.java
@@ -66,6 +66,11 @@ public class SerializationGroupContainer<K extends Serializable, V extends Cache
     }
 
     @Override
+    public ClassLoader getClassLoader() {
+        return this.passivationManager.getClassLoader();
+    }
+
+    @Override
     public int getCurrentMarshallingVersion() {
         return this.passivationManager.getCurrentMarshallingVersion();
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupMemberContainer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/impl/backing/SerializationGroupMemberContainer.java
@@ -99,6 +99,11 @@ public class SerializationGroupMemberContainer<K extends Serializable, V extends
     }
 
     @Override
+    public ClassLoader getClassLoader() {
+        return this.passivationManager.getClassLoader();
+    }
+
+    @Override
     public int getCurrentMarshallingVersion() {
         return this.passivationManager.getCurrentMarshallingVersion();
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
@@ -86,6 +86,7 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
     private final InterceptorFactory postActivate;
     private final Map<EJBBusinessMethod, AccessTimeoutDetails> methodAccessTimeouts;
     private final DefaultAccessTimeoutService defaultAccessTimeoutProvider;
+    private final ClassLoader loader;
     private final int currentMarshallingVersion;
     private final Map<Integer, MarshallingConfiguration> marshallingConfigurations;
 
@@ -119,6 +120,7 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
         this.methodAccessTimeouts = ejbComponentCreateService.getMethodApplicableAccessTimeouts();
         this.defaultAccessTimeoutProvider = ejbComponentCreateService.getDefaultAccessTimeoutService();
         this.ejb2XRemoveMethod = ejbComponentCreateService.getEjb2XRemoveMethod();
+        this.loader = ejbComponentCreateService.getClassLoader();
         this.currentMarshallingVersion = ejbComponentCreateService.getCurrentMarshallingVersion();
         this.marshallingConfigurations = ejbComponentCreateService.getMarshallingConfigurations();
         this.serialiableInterceptorContextKeys = ejbComponentCreateService.getSerializableInterceptorContextKeys();
@@ -158,6 +160,11 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
     @Override
     public void prePassivate(StatefulSessionComponentInstance instance) {
         instance.prePassivate();
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return this.loader;
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponentCreateService.java
@@ -40,8 +40,6 @@ import org.jboss.invocation.InterceptorFactory;
 import org.jboss.invocation.Interceptors;
 import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.ModularClassResolver;
-import org.jboss.marshalling.reflect.ReflectiveCreator;
-import org.jboss.marshalling.reflect.SunReflectiveCreator;
 import org.jboss.msc.inject.InjectionException;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.value.InjectedValue;
@@ -68,6 +66,7 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
     private final InterceptorFactory postActivate;
     private final StatefulTimeoutInfo statefulTimeout;
     private final CacheInfo cache;
+    private final ClassLoader loader;
     private final Map<Integer, MarshallingConfiguration> marshallingConfigurations;
     private final InjectedValue<DefaultAccessTimeoutService> defaultAccessTimeoutService = new InjectedValue<DefaultAccessTimeoutService>();
     private final InterceptorFactory ejb2XRemoveMethod;
@@ -101,9 +100,8 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
         //the interceptor chain for EJB e.x remove methods
         this.ejb2XRemoveMethod = Interceptors.getChainedInterceptorFactory(StatefulSessionSynchronizationInterceptor.factory(componentDescription.getTransactionManagementType()), new ImmediateInterceptorFactory(new StatefulRemoveInterceptor(false)), Interceptors.getTerminalInterceptorFactory());
         this.cache = componentDescription.getCache();
+        this.loader = componentConfiguration.getModuleClassLoader();
         MarshallingConfiguration marshallingConfiguration = new MarshallingConfiguration();
-        marshallingConfiguration.setSerializedCreator(new SunReflectiveCreator());
-        marshallingConfiguration.setExternalizerCreator(new ReflectiveCreator());
         marshallingConfiguration.setClassResolver(ModularClassResolver.getInstance(componentConfiguration.getModuleLoader()));
         marshallingConfiguration.setSerializabilityChecker(new StatefulSessionBeanSerializabilityChecker(componentConfiguration.getComponentClass()));
         marshallingConfiguration.setClassTable(new StatefulSessionBeanClassTable());
@@ -162,6 +160,10 @@ public class StatefulSessionComponentCreateService extends SessionBeanComponentC
 
     public CacheInfo getCache() {
         return this.cache;
+    }
+
+    public ClassLoader getClassLoader() {
+        return this.loader;
     }
 
     public int getCurrentMarshallingVersion() {


### PR DESCRIPTION
Send HttpSessionActivationListener events if session will be replicated or stored in write-through/back cache store.

Fix recurrence of "Singleton not set for ModuleClassLoader ... This means that you are trying to access a weld deployment with a Thread Context ClassLoader that is not associated with the deployment." errors.  Apparently Weld 2.0 still needs a specific TCCL set when serializing/deserializing state.
