### PR TITLE
Fix potential memory leak when using Default datasource

### DIFF
--- a/build/src/main/resources/configuration/subsystems/datasources.xml
+++ b/build/src/main/resources/configuration/subsystems/datasources.xml
@@ -5,7 +5,7 @@
    <subsystem xmlns="urn:jboss:domain:datasources:2.0">
        <datasources>
            <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
-               <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
+               <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                <driver>h2</driver>
                <security>
                    <user-name>sa</user-name>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <version.com.fasterxml.jackson>2.2.3</version.com.fasterxml.jackson>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.google.guava>13.0.1</version.com.google.guava>
-        <version.com.h2database>1.3.168</version.com.h2database>
+        <version.com.h2database>1.3.173</version.com.h2database>
         <version.com.sun.codemodel>2.6</version.com.sun.codemodel>
         <version.com.sun.faces>2.2.2-jbossorg-1</version.com.sun.faces>
         <version.com.sun.istack>2.6.1</version.com.sun.istack>


### PR DESCRIPTION
This fix might look funny but is anything but.
setting DB_CLOSE_ON_EXIT=FALSE tells h2 not to crate DatabaseCloser Thread which if it is created holds reference to TCCL from requesting thread that originally started / requested database connection.
In most cases this is hibernate and this results hibernate deployment classes never get collected.
