### PR TITLE
try to guess JAVA_HOME if absent from environment in the a hopefully por...

### DIFF
--- a/build/src/main/resources/bin/jconsole.sh
+++ b/build/src/main/resources/bin/jconsole.sh
@@ -49,13 +49,21 @@ fi
 export JBOSS_HOME
 
 # Setup the JVM
-if [ "x$JAVA" = "x" ]; then
-    if [ "x$JAVA_HOME" != "x" ]; then
-        JAVA="$JAVA_HOME/bin/java"
-    else
+if [ "x$JAVA_HOME" = x ]; then
+   fail_java_home () {
         echo "JAVA_HOME is not set. Unable to locate the jars needed to run jconsole."
         exit 2
-    fi
+   }
+
+   JCONSOLE_PATH=`which jconsole` || fail_java_home
+   which readlink || fail_java_home # make sure readlink is present
+   JCONSOLE_TEST=`readlink "$JCONSOLE_PATH"`
+   while [ x"$JCONSOLE_TEST" != x ]; do
+      JCONSOLE_PATH="$JCONSOLE_TEST"
+      JCONSOLE_TEST=`readlink "$JCONSOLE_PATH"`
+   done
+   JAVA_HOME=`dirname "$JCONSOLE_PATH"`
+   JAVA_HOME=`dirname "$JAVA_HOME"`
 fi
 
 if [ "x$JBOSS_MODULEPATH" = "x" ]; then
@@ -85,4 +93,4 @@ done
 
 echo CLASSPATH $CLASSPATH
 
-$JAVA_HOME/bin/jconsole -J-Djava.class.path="$CLASSPATH" $@
+$JAVA_HOME/bin/jconsole -J-Djava.class.path="$CLASSPATH" "$@"


### PR DESCRIPTION
This is a fix for WFLY-1902

Remove useless $JAVA variable check and insert attempt to guess JAVA_HOME in case jconsole executable is in PATH.

Additionally I added quotes to call of jconsole to avoid parameter passing troubles when special characters are involved.

I've tested the script to work on fedora18, rhel5, aix6, hp-ux and solaris9.

On non-rpm platforms it is unlikely the change to have any effect because it is unlikely to have jconsole in PATH without JAVA_HOME. In such case error is printed to user as before. The readlink command is used in a portable way though so it may work if jconsole is present. Only aix seems to lack a readlink command but in such case error is also printed to user. jconsole.sh should also work on mac _no worse_ than without the modification. But I can't test that.

On fedora and RHEL the change helps user to have jconsole.sh working with default java installation where executables from the JDK are present but JAVA_HOME is not set.
