### PR TITLE
WFLY-2032 component upgrade to jipijapa 1.0.0.Beta1 (byte validator and management console fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jgroups>3.3.4.Final</version.org.jgroups>
-        <version.org.jipijapa>1.0.0.Alpha5</version.org.jipijapa>
+        <version.org.jipijapa>1.0.0.Beta1</version.org.jipijapa>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.mockito>1.9.5</version.org.mockito>
         <version.org.opensaml.opensaml>2.5.3</version.org.opensaml.opensaml>


### PR DESCRIPTION
Helps with WFLY-1705 (JIPI-18 add withValidatorFactory to EntityManagerFactoryBuilder so that the BV can be passed in the second phase)
Addresses WFLY-2008 (JIPI-19 Cannot enabled metrics for JPA units) 
