### PR TITLE
[WFLY-125] Restart all services upon cluster-passivation-store model update.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ClusterPassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ClusterPassivationStoreResourceDefinition.java
@@ -45,27 +45,27 @@ public class ClusterPassivationStoreResourceDefinition extends PassivationStoreR
                     .setXmlName(EJB3SubsystemXMLAttribute.CACHE_CONTAINER.getLocalName())
                     .setDefaultValue(new ModelNode(ClusteredBackingCacheEntryStoreConfig.DEFAULT_CACHE_CONTAINER))
                     .setAllowExpression(true)
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     static final SimpleAttributeDefinition BEAN_CACHE =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.BEAN_CACHE, ModelType.STRING, true)
                     .setXmlName(EJB3SubsystemXMLAttribute.BEAN_CACHE.getLocalName())
                     .setAllowExpression(true)
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     static final SimpleAttributeDefinition CLIENT_MAPPINGS_CACHE =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CLIENT_MAPPINGS_CACHE, ModelType.STRING, true)
                     .setXmlName(EJB3SubsystemXMLAttribute.CLIENT_MAPPINGS_CACHE.getLocalName())
                     .setDefaultValue(new ModelNode(ClusteredBackingCacheEntryStoreConfig.DEFAULT_CLIENT_MAPPING_CACHE))
                     .setAllowExpression(true)
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     static final SimpleAttributeDefinition PASSIVATE_EVENTS_ON_REPLICATE =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.PASSIVATE_EVENTS_ON_REPLICATE, ModelType.BOOLEAN, true)
                     .setXmlName(EJB3SubsystemXMLAttribute.PASSIVATE_EVENTS_ON_REPLICATE.getLocalName())
                     .setDefaultValue(new ModelNode(ClusteredBackingCacheEntryStoreConfig.DEFAULT_PASSIVATE_EVENTS_ON_REPLICATE))
                     .setAllowExpression(true)
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     static final AttributeDefinition[] ATTRIBUTES = {IDLE_TIMEOUT, IDLE_TIMEOUT_UNIT, MAX_SIZE, CACHE_CONTAINER, BEAN_CACHE, CLIENT_MAPPINGS_CACHE, PASSIVATE_EVENTS_ON_REPLICATE };

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FilePassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/FilePassivationStoreResourceDefinition.java
@@ -44,21 +44,21 @@ public class FilePassivationStoreResourceDefinition extends PassivationStoreReso
                     .setXmlName(EJB3SubsystemXMLAttribute.RELATIVE_TO.getLocalName())
                     .setDefaultValue(new ModelNode().set(NonClusteredBackingCacheEntryStoreSource.DEFAULT_RELATIVE_TO))
                     .setAllowExpression(true)
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     public static final SimpleAttributeDefinition GROUPS_PATH =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.GROUPS_PATH, ModelType.STRING, true)
                     .setXmlName(EJB3SubsystemXMLAttribute.GROUPS_PATH.getLocalName())
                     .setDefaultValue(new ModelNode().set(NonClusteredBackingCacheEntryStoreSource.DEFAULT_GROUP_DIRECTORY_NAME))
                     .setAllowExpression(true)
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     public static final SimpleAttributeDefinition SESSIONS_PATH =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.SESSIONS_PATH, ModelType.STRING, true)
                     .setXmlName(EJB3SubsystemXMLAttribute.SESSIONS_PATH.getLocalName())
                     .setDefaultValue(new ModelNode().set(NonClusteredBackingCacheEntryStoreSource.DEFAULT_SESSION_DIRECTORY_NAME))
                     .setAllowExpression(true)
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     public static final SimpleAttributeDefinition SUBDIRECTORY_COUNT =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.SUBDIRECTORY_COUNT, ModelType.LONG, true)
@@ -66,7 +66,7 @@ public class FilePassivationStoreResourceDefinition extends PassivationStoreReso
                     .setDefaultValue(new ModelNode().set(NonClusteredBackingCacheEntryStoreSource.DEFAULT_SUBDIRECTORY_COUNT))
                     .setAllowExpression(true)
                     .setValidator(new IntRangeValidator(1, Integer.MAX_VALUE, true, true))
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
 
     private static final AttributeDefinition[] ATTRIBUTES = {IDLE_TIMEOUT, IDLE_TIMEOUT_UNIT, MAX_SIZE, RELATIVE_TO, GROUPS_PATH, SESSIONS_PATH, SUBDIRECTORY_COUNT};

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/PassivationStoreResourceDefinition.java
@@ -50,14 +50,14 @@ public abstract class PassivationStoreResourceDefinition extends SimpleResourceD
                     .setDefaultValue(new ModelNode().set(BackingCacheEntryStoreConfig.DEFAULT_IDLE_TIMEOUT))
                     .setAllowExpression(true)
                     .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, true, true))
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .build();
     static final SimpleAttributeDefinition IDLE_TIMEOUT_UNIT =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.IDLE_TIMEOUT_UNIT, ModelType.STRING, true)
                     .setXmlName(EJB3SubsystemXMLAttribute.IDLE_TIMEOUT_UNIT.getLocalName())
                     .setValidator(new TimeUnitValidator(true,true))
                     .setDefaultValue(new ModelNode().set(BackingCacheEntryStoreConfig.DEFAULT_IDLE_TIMEOUT_UNIT.name()))
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setAllowExpression(true)
                     .build();
     static final SimpleAttributeDefinitionBuilder MAX_SIZE_BUILDER =
@@ -66,7 +66,7 @@ public abstract class PassivationStoreResourceDefinition extends SimpleResourceD
                     .setDefaultValue(new ModelNode().set(BackingCacheEntryStoreConfig.DEFAULT_MAX_SIZE))
                     .setAllowExpression(true)
                     .setValidator(new LongRangeValidator(1, Integer.MAX_VALUE, true, true))
-                    .setFlags(AttributeAccess.Flag.RESTART_NONE)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     ;
 
     private final PassivationStoreWriteHandler<?> writeHandler;


### PR DESCRIPTION
This pull request changes the restart status for EJB3 passivation store attributes from RESTART_NONE to RESTART_ALL_SERVICES. This will ensure that changes to the model force the user to reload all services and thus ensure that the changes get picked up.
