### PR TITLE
WFLY-1547 Use the new TempFileProvider#create() VFS API which allows cleaning existing content

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/DeployHandler.java
@@ -489,7 +489,7 @@ public class DeployHandler extends DeploymentHandler {
             TempFileProvider tempFileProvider;
             MountHandle root;
             try {
-                tempFileProvider = TempFileProvider.create("cli", Executors.newSingleThreadScheduledExecutor());
+                tempFileProvider = TempFileProvider.create("cli", Executors.newSingleThreadScheduledExecutor(), true);
                 root = extractArchive(f, tempFileProvider);
             } catch (IOException e) {
                 throw new OperationFormatException("Unable to extract archive '" + f.getAbsolutePath() + "' to temporary location");

--- a/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/UndeployHandler.java
@@ -281,7 +281,7 @@ public class UndeployHandler extends DeploymentHandler {
             TempFileProvider tempFileProvider;
             MountHandle root;
             try {
-                tempFileProvider = TempFileProvider.create("cli", Executors.newSingleThreadScheduledExecutor());
+                tempFileProvider = TempFileProvider.create("cli", Executors.newSingleThreadScheduledExecutor(), true);
                 root = extractArchive(f, tempFileProvider);
             } catch (IOException e) {
                 throw new OperationFormatException("Unable to extract archive '" + f.getAbsolutePath() + "' to temporary location");

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <version.org.jboss.jandex>1.1.0.Alpha1</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.2.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-transaction-spi>7.0.1.Final</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.jboss-vfs>3.2.0.Beta1</version.org.jboss.jboss-vfs>
+        <version.org.jboss.jboss-vfs>3.2.1.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.narayana>5.0.0.M4</version.org.jboss.narayana>
         <version.org.jboss.jsfunit>2.0.0.Beta1</version.org.jboss.jsfunit>
         <version.org.jboss.logging.jboss-logging>3.1.3.GA</version.org.jboss.logging.jboss-logging>

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentMountProvider.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentMountProvider.java
@@ -109,7 +109,7 @@ public interface DeploymentMountProvider {
             public void start(StartContext context) throws StartException {
                 try {
                     final JBossThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("ServerDeploymentRepository-temp-threads"), Boolean.FALSE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
-                    tempFileProvider = TempFileProvider.create("temp", Executors.newScheduledThreadPool(2, threadFactory));
+                    tempFileProvider = TempFileProvider.create("temp", Executors.newScheduledThreadPool(2, threadFactory), true);
                 } catch (IOException e) {
                     throw ServerMessages.MESSAGES.failedCreatingTempProvider();
                 }

--- a/server/src/main/java/org/jboss/as/server/deployment/module/TempFileProviderService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/module/TempFileProviderService.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.server.deployment.module;
 
+import java.io.IOException;
+import java.util.concurrent.Executors;
+
 import org.jboss.as.server.ServerMessages;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -30,9 +33,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.vfs.TempFileProvider;
 import org.jboss.vfs.VFSUtils;
-
-import java.io.IOException;
-import java.util.concurrent.Executors;
 
 /**
  * Service responsible for managing the life-cycle of a TempFileProvider.
@@ -45,7 +45,7 @@ public class TempFileProviderService implements Service<TempFileProvider> {
     private static final TempFileProvider PROVIDER;
     static {
        try {
-          PROVIDER = TempFileProvider.create("deployment", Executors.newScheduledThreadPool(2));
+          PROVIDER = TempFileProvider.create("deployment", Executors.newScheduledThreadPool(2), true);
        }
        catch (final IOException ioe) {
           throw ServerMessages.MESSAGES.failedToCreateTempFileProvider(ioe);


### PR DESCRIPTION
The commit here upgrade VFS to 3.2.1.Final and uses the newly exposed API which allows cleaning existing content from the temp dir. This is required to fix https://issues.jboss.org/browse/WFLY-1547

P.S: Brian, the current code which was creating a TempFileProvider was already dealing with IOException by rethrowing it as a failure. So I decided to let it stay this way instead of the other option of just logging it and moving forward, which we had discussed the other day.
