### PR TITLE
WFLY-2028 : An exploded war inside an archived ear returns 404

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/structure/EarStructureProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EarStructureProcessor.java
@@ -25,6 +25,7 @@ package org.jboss.as.ee.structure;
 import static org.jboss.as.ee.EeMessages.MESSAGES;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -257,7 +258,7 @@ public class EarStructureProcessor implements DeploymentUnitProcessor {
      */
     private ResourceRoot createResourceRoot(final DeploymentUnit deploymentUnit, final VirtualFile file, final boolean markAsSubDeployment, final boolean explodeDuringMount) throws IOException {
         final boolean war = file.getName().toLowerCase(Locale.ENGLISH).endsWith(WAR_EXTENSION);
-        final Closeable closable = file.isFile() ? mount(file, explodeDuringMount) : null;
+        final Closeable closable = file.isFile() ? mount(file, explodeDuringMount) : exportExplodedWar(war, file, deploymentUnit);
         final MountHandle mountHandle = new MountHandle(closable);
         final ResourceRoot resourceRoot = new ResourceRoot(file, mountHandle);
         deploymentUnit.addToAttachmentList(Attachments.RESOURCE_ROOTS, resourceRoot);
@@ -269,6 +270,20 @@ public class EarStructureProcessor implements DeploymentUnitProcessor {
         }
         return resourceRoot;
     }
+
+    private Closeable exportExplodedWar(final boolean war, final VirtualFile file, final DeploymentUnit deploymentUnit) throws IOException {
+        if (isExplodedWarInArchiveEar(war, file, deploymentUnit)) {
+            File warContent = file.getPhysicalFile();
+            VFSUtils.recursiveCopy(file, warContent.getParentFile());
+            return VFS.mountReal(warContent, file);
+        }
+        return null;
+    }
+
+    private boolean isExplodedWarInArchiveEar(final boolean war, final VirtualFile file, final DeploymentUnit deploymentUnit) {
+        return war && !file.isFile() && deploymentUnit.hasAttachment(Attachments.DEPLOYMENT_CONTENTS) && deploymentUnit.getAttachment(Attachments.DEPLOYMENT_CONTENTS).isFile();
+    }
+
 
     public void undeploy(DeploymentUnit context) {
         final List<ResourceRoot> children = context.removeAttachment(Attachments.RESOURCE_ROOTS);


### PR DESCRIPTION
- Fixing bug by extracting exploded WAR in zipped EAR.
- Updating deployment test to check that this works.

https://issues.jboss.org/browse/WFLY-2028
