### PR TITLE
[WFLY-2033] fix CMT NotSupported MDB

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/context/EJBContextImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/context/EJBContextImpl.java
@@ -100,6 +100,7 @@ public abstract class EJBContextImpl implements javax.ejb.EJBContext, Serializab
 
 
     public UserTransaction getUserTransaction() throws IllegalStateException {
+        AllowedMethodsInformation.checkAllowed(MethodType.GET_USER_TRANSACTION);
         return getComponent().getUserTransaction();
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/AbstractMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/AbstractMergingProcessor.java
@@ -104,9 +104,9 @@ public abstract class AbstractMergingProcessor<T extends EJBComponentDescription
     protected abstract void handleDeploymentDescriptor(final DeploymentUnit deploymentUnit, final DeploymentReflectionIndex deploymentReflectionIndex, final Class<?> componentClass, final T description) throws DeploymentUnitProcessingException;
 
 
-    protected MethodIntf getMethodIntf(MethodInterfaceType viewType) {
+    protected MethodIntf getMethodIntf(final MethodInterfaceType viewType, final MethodIntf defaultMethodIntf) {
         if (viewType == null) {
-            return MethodIntf.BEAN;
+            return defaultMethodIntf;
         }
         switch (viewType) {
             case Home:
@@ -124,7 +124,7 @@ public abstract class AbstractMergingProcessor<T extends EJBComponentDescription
             case MessageEndpoint:
                 return MethodIntf.MESSAGE_ENDPOINT;
         }
-        return MethodIntf.BEAN;
+        return defaultMethodIntf;
     }
 
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/MethodPermissionsMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/MethodPermissionsMergingProcessor.java
@@ -37,6 +37,7 @@ import org.jboss.as.ee.metadata.MethodAnnotationAggregator;
 import org.jboss.as.ee.metadata.RuntimeAnnotationInformation;
 import org.jboss.as.ejb3.component.EJBComponentDescription;
 import org.jboss.as.ejb3.component.MethodIntf;
+import org.jboss.as.ejb3.component.messagedriven.MessageDrivenComponentDescription;
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.ejb3.security.EJBMethodSecurityAttribute;
 import org.jboss.as.ejb3.security.EjbJaccConfigurator;
@@ -110,11 +111,11 @@ public class MethodPermissionsMergingProcessor extends AbstractMergingProcessor<
     }
 
     @Override
-    protected void handleDeploymentDescriptor(final DeploymentUnit deploymentUnit, final DeploymentReflectionIndex deploymentReflectionIndex, final Class<?> componentClass, final EJBComponentDescription componentConfiguration) throws DeploymentUnitProcessingException {
+    protected void handleDeploymentDescriptor(final DeploymentUnit deploymentUnit, final DeploymentReflectionIndex deploymentReflectionIndex, final Class<?> componentClass, final EJBComponentDescription componentDescription) throws DeploymentUnitProcessingException {
 
         //Add the configurator that calculates JACC permissions
         //TODO: should this be elsewhere?
-        componentConfiguration.getConfigurators().add(new EjbJaccConfigurator());
+        componentDescription.getConfigurators().add(new EjbJaccConfigurator());
 
         //DO NOT USE componentConfiguration.getDescriptorData()
         //It will return null if there is no <enterprise-beans/> declaration even if there is an assembly descriptor entry
@@ -126,29 +127,30 @@ public class MethodPermissionsMergingProcessor extends AbstractMergingProcessor<
 
                 //handle exclude-list
 
-                final ExcludeListMetaData excludeList = assemblyDescriptor.getExcludeListByEjbName(componentConfiguration.getEJBName());
+                final ExcludeListMetaData excludeList = assemblyDescriptor.getExcludeListByEjbName(componentDescription.getEJBName());
                 if (excludeList != null && excludeList.getMethods() != null) {
                     for (final MethodMetaData method : excludeList.getMethods()) {
                         final String methodName = method.getMethodName();
-                        final MethodIntf methodIntf = this.getMethodIntf(method.getMethodIntf());
+                        final MethodIntf defaultMethodIntf = (componentDescription instanceof MessageDrivenComponentDescription) ? MethodIntf.MESSAGE_ENDPOINT : MethodIntf.BEAN;
+                        final MethodIntf methodIntf = this.getMethodIntf(method.getMethodIntf(), defaultMethodIntf);
                         if (methodName.equals("*")) {
-                            componentConfiguration.getDescriptorMethodPermissions().setAttribute(methodIntf, null, EJBMethodSecurityAttribute.denyAll());
+                            componentDescription.getDescriptorMethodPermissions().setAttribute(methodIntf, null, EJBMethodSecurityAttribute.denyAll());
                         } else {
 
                             final MethodParametersMetaData methodParams = method.getMethodParams();
                             // update the session bean description with the tx attribute info
                             if (methodParams == null) {
-                                componentConfiguration.getDescriptorMethodPermissions().setAttribute(methodIntf, EJBMethodSecurityAttribute.denyAll(), methodName);
+                                componentDescription.getDescriptorMethodPermissions().setAttribute(methodIntf, EJBMethodSecurityAttribute.denyAll(), methodName);
                             } else {
 
-                                componentConfiguration.getDescriptorMethodPermissions().setAttribute(methodIntf, EJBMethodSecurityAttribute.denyAll(), null, methodName, this.getMethodParams(methodParams));
+                                componentDescription.getDescriptorMethodPermissions().setAttribute(methodIntf, EJBMethodSecurityAttribute.denyAll(), null, methodName, this.getMethodParams(methodParams));
                             }
                         }
                     }
                 }
 
                 //now handle method permissions
-                final MethodPermissionsMetaData methodPermissions = assemblyDescriptor.getMethodPermissionsByEjbName(componentConfiguration.getEJBName());
+                final MethodPermissionsMetaData methodPermissions = assemblyDescriptor.getMethodPermissionsByEjbName(componentDescription.getEJBName());
                 if (methodPermissions != null) {
                     for (final MethodPermissionMetaData methodPermissionMetaData : methodPermissions) {
 
@@ -162,24 +164,25 @@ public class MethodPermissionsMergingProcessor extends AbstractMergingProcessor<
                                 ejbMethodSecurityMetaData = EJBMethodSecurityAttribute.rolesAllowed(methodPermissionMetaData.getRoles());
                             }
                             final String methodName = method.getMethodName();
-                            final MethodIntf methodIntf = this.getMethodIntf(method.getMethodIntf());
+                            final MethodIntf defaultMethodIntf = (componentDescription instanceof MessageDrivenComponentDescription) ? MethodIntf.MESSAGE_ENDPOINT : MethodIntf.BEAN;
+                            final MethodIntf methodIntf = this.getMethodIntf(method.getMethodIntf(), defaultMethodIntf);
                             if (methodName.equals("*")) {
-                                final EJBMethodSecurityAttribute existingRoles = componentConfiguration.getDescriptorMethodPermissions().getAttributeStyle1(methodIntf, null);
+                                final EJBMethodSecurityAttribute existingRoles = componentDescription.getDescriptorMethodPermissions().getAttributeStyle1(methodIntf, null);
                                 ejbMethodSecurityMetaData = mergeExistingRoles(ejbMethodSecurityMetaData, existingRoles);
-                                componentConfiguration.getDescriptorMethodPermissions().setAttribute(methodIntf, null, ejbMethodSecurityMetaData);
+                                componentDescription.getDescriptorMethodPermissions().setAttribute(methodIntf, null, ejbMethodSecurityMetaData);
                             } else {
 
                                 final MethodParametersMetaData methodParams = method.getMethodParams();
                                 // update the session bean description with the tx attribute info
                                 if (methodParams == null) {
 
-                                    final EJBMethodSecurityAttribute existingRoles = componentConfiguration.getDescriptorMethodPermissions().getAttributeStyle2(methodIntf, methodName);
+                                    final EJBMethodSecurityAttribute existingRoles = componentDescription.getDescriptorMethodPermissions().getAttributeStyle2(methodIntf, methodName);
                                     ejbMethodSecurityMetaData = mergeExistingRoles(ejbMethodSecurityMetaData, existingRoles);
-                                    componentConfiguration.getDescriptorMethodPermissions().setAttribute(methodIntf, ejbMethodSecurityMetaData, methodName);
+                                    componentDescription.getDescriptorMethodPermissions().setAttribute(methodIntf, ejbMethodSecurityMetaData, methodName);
                                 } else {
-                                    final EJBMethodSecurityAttribute existingRoles = componentConfiguration.getDescriptorMethodPermissions().getAttributeStyle3(methodIntf, null, methodName, this.getMethodParams(methodParams));
+                                    final EJBMethodSecurityAttribute existingRoles = componentDescription.getDescriptorMethodPermissions().getAttributeStyle3(methodIntf, null, methodName, this.getMethodParams(methodParams));
                                     ejbMethodSecurityMetaData = mergeExistingRoles(ejbMethodSecurityMetaData, existingRoles);
-                                    componentConfiguration.getDescriptorMethodPermissions().setAttribute(methodIntf, ejbMethodSecurityMetaData, null, methodName, this.getMethodParams(methodParams));
+                                    componentDescription.getDescriptorMethodPermissions().setAttribute(methodIntf, ejbMethodSecurityMetaData, null, methodName, this.getMethodParams(methodParams));
                                 }
                             }
                         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/BaseMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/BaseMDB.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.cmt.notsupported;
+
+import static org.jboss.as.test.integration.ejb.mdb.cmt.notsupported.ContainerManagedTransactionNotSupportedTestCase.EXCEPTION_PROP_NAME;
+
+import javax.annotation.Resource;
+import javax.ejb.MessageDrivenContext;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public abstract class BaseMDB implements MessageListener {
+
+    private static final Logger logger = Logger.getLogger(BaseMDB.class);
+
+    @Resource(lookup="java:comp/DefaultJMSConnectionFactory")
+    private ConnectionFactory cf;
+
+    @Resource
+    protected MessageDrivenContext messageDrivenContext;
+
+    @Override
+    public void onMessage(Message message) {
+        logger.info("Received message: " + message);
+
+        boolean setRollbackOnlyThrowsIllegalStateException;
+
+        try {
+            // this method in a Container-managed MDB with transaction NOT_SUPPORTED must throw an exception
+            messageDrivenContext.setRollbackOnly();
+            setRollbackOnlyThrowsIllegalStateException = false;
+        } catch (IllegalStateException e) {
+            setRollbackOnlyThrowsIllegalStateException = true;
+        }
+
+        try {
+            final Destination replyTo = message.getJMSReplyTo();
+            if (replyTo != null) {
+                logger.info("Replying to " + replyTo);
+                try (
+                        JMSContext context = cf.createContext()
+                ) {
+                    context.createProducer()
+                            .setJMSCorrelationID(message.getJMSMessageID())
+                            .setProperty(EXCEPTION_PROP_NAME, setRollbackOnlyThrowsIllegalStateException)
+                            .send(replyTo, "");
+                }
+            }
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedMDBWithAnnotation.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedMDBWithAnnotation.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.cmt.notsupported;
+
+import static javax.ejb.TransactionAttributeType.NOT_SUPPORTED;
+import static javax.ejb.TransactionManagementType.CONTAINER;
+import static org.jboss.as.test.integration.ejb.mdb.cmt.notsupported.ContainerManagedTransactionNotSupportedTestCase.QUEUE_JNDI_NAME_FOR_ANNOTATION;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionManagement;
+import javax.jms.Message;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@TransactionManagement(CONTAINER)
+@MessageDriven(activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = QUEUE_JNDI_NAME_FOR_ANNOTATION)
+})
+public class ContainerManagedTransactionNotSupportedMDBWithAnnotation extends BaseMDB {
+
+    @TransactionAttribute(NOT_SUPPORTED)
+    @Override
+    public void onMessage(Message message) {
+        super.onMessage(message);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedMDBWithDD.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedMDBWithDD.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.cmt.notsupported;
+
+import javax.jms.Message;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class ContainerManagedTransactionNotSupportedMDBWithDD extends BaseMDB {
+
+    @Override
+    public void onMessage(Message message) {
+        super.onMessage(message);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ContainerManagedTransactionNotSupportedTestCase.java
@@ -1,0 +1,147 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.cmt.notsupported;
+
+import static org.jboss.as.test.shared.TimeoutUtil.adjust;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.UUID;
+
+import javax.annotation.Resource;
+import javax.jms.ConnectionFactory;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.TemporaryQueue;
+import javax.jms.TextMessage;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.common.jms.JMSOperations;
+import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ContainerManagedTransactionNotSupportedTestCase.JmsQueueSetup.class})
+public class ContainerManagedTransactionNotSupportedTestCase {
+
+    public static final String QUEUE_JNDI_NAME_FOR_ANNOTATION = "java:jboss/queue/cmt-not-supported-annotation";
+    public static final String QUEUE_JNDI_NAME_FOR_DD = "java:jboss/queue/cmt-not-supported-dd";
+
+    public static final String EXCEPTION_PROP_NAME = "setRollbackOnlyThrowsIllegalStateException";
+
+    static class JmsQueueSetup implements ServerSetupTask {
+
+        private JMSOperations jmsAdminOperations;
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            jmsAdminOperations = JMSOperationsProvider.getInstance(managementClient);
+            jmsAdminOperations.createJmsQueue("ContainerManagedTransactionNotSupportedTestCaseQueueWithAnnotation", QUEUE_JNDI_NAME_FOR_ANNOTATION);
+            jmsAdminOperations.createJmsQueue("ContainerManagedTransactionNotSupportedTestCaseQueueWithDD", QUEUE_JNDI_NAME_FOR_DD);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            if (jmsAdminOperations != null) {
+                jmsAdminOperations.removeJmsQueue("ContainerManagedTransactionNotSupportedTestCaseQueueWithAnnotation");
+                jmsAdminOperations.removeJmsQueue("ContainerManagedTransactionNotSupportedTestCaseQueueWithDD");
+                jmsAdminOperations.close();
+            }
+        }
+    }
+
+    @Resource(mappedName = QUEUE_JNDI_NAME_FOR_ANNOTATION)
+    private Queue queueForAnnotation;
+
+    @Resource(mappedName = QUEUE_JNDI_NAME_FOR_DD)
+    private Queue queueForDD;
+
+    @Resource(mappedName = "java:/ConnectionFactory")
+    private ConnectionFactory cf;
+
+    @Deployment
+    public static Archive createDeployment() {
+
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ContainerManagedTransactionNotSupportedTestCase.jar");
+        jar.addPackage(JMSOperations.class.getPackage());
+        jar.addClasses(TimeoutUtil.class);
+        jar.addPackage(BaseMDB.class.getPackage());
+        jar.addAsManifestResource(ContainerManagedTransactionNotSupportedMDBWithDD.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+
+        return jar;
+    }
+
+    /**
+     * Test that the {@link javax.ejb.MessageDrivenContext#setRollbackOnly()} throws an IllegalStateException
+     * when a CMT MDB with NOT_SUPPORTED transaction attribute is invoked.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testSetRollbackOnlyInContainerManagedTransactionNotSupportedMDBThrowsIllegalStateExceptionWithAnnotation() throws Exception {
+        doSetRollbackOnlyInContainerManagedTransactionNotSupportedMDBThrowsIllegalStateException(queueForAnnotation);
+    }
+
+    @Test
+    public void testSetRollbackOnlyInContainerManagedTransactionNotSupportedMDBThrowsIllegalStateExceptionWithDD() throws Exception {
+        doSetRollbackOnlyInContainerManagedTransactionNotSupportedMDBThrowsIllegalStateException(queueForDD);
+    }
+
+    private void doSetRollbackOnlyInContainerManagedTransactionNotSupportedMDBThrowsIllegalStateException(Destination destination) throws Exception {
+        try (
+                JMSContext context = cf.createContext()
+        ) {
+            TemporaryQueue replyTo = context.createTemporaryQueue();
+
+            String text = UUID.randomUUID().toString();
+
+            TextMessage message = context.createTextMessage(text);
+            message.setJMSReplyTo(replyTo);
+
+            context.createProducer()
+                    .send(destination, message);
+
+            Message reply = context.createConsumer(replyTo)
+                    .receive(adjust(2000));
+            assertNotNull(reply);
+            assertEquals(message.getJMSMessageID(), reply.getJMSCorrelationID());
+            assertTrue("messageDrivenContext.setRollbackOnly() did not throw the expected IllegalStateException",
+                    reply.getBooleanProperty(EXCEPTION_PROP_NAME));
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ejb-jar.xml
@@ -1,0 +1,58 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd"
+         version="3.2">
+    <enterprise-beans>
+        <message-driven>
+            <ejb-name>ContainerManagedTransactionNotSupportedMDBWithDD</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.ejb.mdb.cmt.notsupported.ContainerManagedTransactionNotSupportedMDBWithDD</ejb-class>
+            <messaging-type>javax.jms.MessageListener</messaging-type>
+            <transaction-type>Container</transaction-type>
+            <message-destination-type>javax.jms.Queue</message-destination-type>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destinationLookup</activation-config-property-name>
+                    <activation-config-property-value>java:jboss/queue/cmt-not-supported-dd</activation-config-property-value>
+                </activation-config-property>
+                <activation-config-property>
+                    <activation-config-property-name>destinationType</activation-config-property-name>
+                    <activation-config-property-value>javax.jms.Queue</activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+    </enterprise-beans>
+    <assembly-descriptor>
+        <container-transaction>
+            <method>
+                <ejb-name>ContainerManagedTransactionNotSupportedMDBWithDD</ejb-name>
+                <method-name>onMessage</method-name>
+                <method-params>
+                    <method-param>javax.jms.Message</method-param>
+                </method-params>
+            </method>
+            <trans-attribute>NotSupported</trans-attribute>
+        </container-transaction>
+    </assembly-descriptor>
+</ejb-jar>


### PR DESCRIPTION
- fix handling tx attributes of MDB
- check that EJBContext.getUserTransaction() is allowed before calling
  the component
- add test org.jboss.as.test.integration.ejb.mdb.cmt.notsupported.ContainerManagedTransactionNotSupportedTestCase

I've squashed @jaikiran commit that fixed the bug with the commit adding the tests.
