### PR TITLE
[WFLY-456][WFLY-2041] Fix tests when assertions are enabled

### DIFF
--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -48,7 +48,6 @@
                     <includes>
                         <include>**/*TestCase.java</include>
                     </includes>
-                    <enableAssertions>false</enableAssertions>
                     <systemPropertyVariables>
                         <org.jboss.model.test.cache.root>${org.jboss.model.test.cache.root}</org.jboss.model.test.cache.root>
                         <org.jboss.model.test.classpath.cache>${org.jboss.model.test.classpath.cache}</org.jboss.model.test.classpath.cache>

--- a/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/auditlog/JmxAuditLogHandlerTestCase.java
@@ -794,6 +794,7 @@ public class JmxAuditLogHandlerTestCase extends AbstractControllerTestBase {
 
 
         ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.STANDALONE_SERVER, new RunningModeControl(RunningMode.NORMAL), auditLogger, null);
+        extensionRegistry.setPathManager(pathManagerService);
         extensionRegistry.setWriterRegistry(new NullConfigurationPersister());
         extensionRegistry.setSubsystemParentResourceRegistrations(registration, null);
         JMXExtension extension = new JMXExtension();

--- a/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/rbac/JmxRbacTestCase.java
@@ -590,6 +590,7 @@ public abstract class JmxRbacTestCase extends AbstractControllerTestBase {
 
 
         ExtensionRegistry extensionRegistry = new ExtensionRegistry(ProcessType.STANDALONE_SERVER, new RunningModeControl(RunningMode.NORMAL), AuditLogger.NO_OP_LOGGER, getAuthorizer());
+        extensionRegistry.setPathManager(pathManagerService);
         extensionRegistry.setWriterRegistry(new NullConfigurationPersister());
         extensionRegistry.setSubsystemParentResourceRegistrations(registration, null);
         JMXExtension extension = new JMXExtension();


### PR DESCRIPTION
The problem was a null path manager failing the assertion in ExtensionRegistry
