### PR TITLE
[WFLY-490][WFLY-2029] If an attribute has access-type=read-only/metric, ...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceDescriptionHandler.java
@@ -78,6 +78,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.registry.AliasEntry;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.AttributeAccess.AccessType;
 import org.jboss.as.controller.registry.AttributeAccess.Storage;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
@@ -400,7 +401,8 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
                     for (Property attrProp : nodeDescription.require(ATTRIBUTES).asPropertyList()) {
                         ModelNode attributeResult = new ModelNode();
                         Storage storage = Storage.valueOf(attrProp.getValue().get(STORAGE).asString().toUpperCase());
-                        addAttributeAuthorizationResults(attributeResult, attrProp.getName(), authResp, storage == Storage.RUNTIME);
+                        AccessType accessType = AccessType.forName(attrProp.getValue().get(ACCESS_TYPE).asString());
+                        addAttributeAuthorizationResults(attributeResult, attrProp.getName(), authResp, storage == Storage.RUNTIME, accessType);
                         attributes.get(attrProp.getName()).set(attributeResult);
                     }
                     result.get(ATTRIBUTES).set(attributes);
@@ -441,13 +443,23 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
             result.get(actionEffect == ActionEffect.READ_CONFIG || actionEffect == ActionEffect.READ_RUNTIME ? READ : WRITE).set(authResult.getDecision() == Decision.PERMIT);
         }
 
-        private void addAttributeAuthorizationResults(ModelNode result, String attributeName, ResourceAuthorization authResp, boolean runtime) {
+        private void addAttributeAuthorizationResults(ModelNode result, String attributeName, ResourceAuthorization authResp, boolean runtime, AccessType accessType) {
             if (runtime) {
                 addAttributeAuthorizationResult(result, attributeName, authResp, ActionEffect.READ_RUNTIME);
-                addAttributeAuthorizationResult(result, attributeName, authResp, ActionEffect.WRITE_RUNTIME);
+                if (accessType.isWritable()) {
+                    addAttributeAuthorizationResult(result, attributeName, authResp, ActionEffect.WRITE_RUNTIME);
+                } else {
+
+                }
             } else {
                 addAttributeAuthorizationResult(result, attributeName, authResp, ActionEffect.READ_CONFIG);
-                addAttributeAuthorizationResult(result, attributeName, authResp, ActionEffect.WRITE_CONFIG);
+                if (accessType.isWritable()) {
+                    addAttributeAuthorizationResult(result, attributeName, authResp, ActionEffect.WRITE_CONFIG);
+                }
+            }
+
+            if (!accessType.isWritable()) {
+                result.get(WRITE).set(false);
             }
         }
 
@@ -460,6 +472,7 @@ public class ReadResourceDescriptionHandler implements OperationStepHandler {
             AuthorizationResult authorizationResult = context.authorizeOperation(operation);
             result.get(EXECUTE).set(authorizationResult.getDecision() == Decision.PERMIT);
         }
+
     }
 
     /**

--- a/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/AttributeAccess.java
@@ -24,6 +24,8 @@ package org.jboss.as.controller.registry;
 import static org.jboss.as.controller.ControllerMessages.MESSAGES;
 
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -41,21 +43,46 @@ public final class AttributeAccess {
      */
     public static enum AccessType {
         /** A read-only attribute, which can be either {@code Storage.CONFIGURATION} or {@code Storage.RUNTIME} */
-        READ_ONLY("read-only"),
+        READ_ONLY("read-only", false),
         /** A read-write attribute, which can be either {@code Storage.CONFIGURATION} or {@code Storage.RUNTIME} */
-        READ_WRITE("read-write"),
+        READ_WRITE("read-write", true),
         /** A read-only {@code Storage.RUNTIME} attribute */
-        METRIC("metric");
+        METRIC("metric", false);
 
         private final String label;
+        private final boolean writable;
 
-        private AccessType(final String label) {
+        private AccessType(final String label, final boolean writable) {
             this.label = label;
+            this.writable = writable;
         }
 
         @Override
         public String toString() {
             return label;
+        }
+
+        private static final Map<String, AccessType> MAP;
+
+        static {
+            final Map<String, AccessType> map = new HashMap<String, AccessType>();
+            for (AccessType element : values()) {
+                final String name = element.getLocalName();
+                if (name != null) map.put(name, element);
+            }
+            MAP = map;
+        }
+
+        public static AccessType forName(String localName) {
+            return MAP.get(localName);
+        }
+
+        private String getLocalName() {
+            return label;
+        }
+
+        public boolean isWritable() {
+            return writable;
         }
     }
 


### PR DESCRIPTION
...make access-control list it with write=false

Previously https://gist.github.com/kabir/6511717#file-gistfile1-json-L29 would be 'true', but since it is read-only, it makes more sense to have write=false in the access-control section.
