### PR TITLE
[WFLY-2047] org.jboss.as.connector module needs sun.jdk module dependenc...

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -32,6 +32,7 @@
     </resources>
 
     <dependencies>
+        <module name="sun.jdk"/>
         <module name="javax.api"/>
         <module name="javax.resource.api"/>
         <module name="javax.transaction.api"/>


### PR DESCRIPTION
"org.jboss.as.connector" module should include the dependency to "sun.jdk" module sothat it will have access to some of JDKs internal packages/classes as well. Like "com.sun.jndi.ldap.LdapCtx"
