### PR TITLE
WFLY-2056 component upgrade Hibernate ORM to 4.3.0.Beta4 and Hibernate commons.annotations to 4.0.4.Final 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,8 +146,8 @@
         <version.org.glassfish.javax.el>3.0-b07</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.0</version.org.glassfish.javax.json>
-        <version.org.hibernate>4.3.0.Beta3</version.org.hibernate>
-        <version.org.hibernate.commons.annotations>4.0.2.Final</version.org.hibernate.commons.annotations>
+        <version.org.hibernate>4.3.0.Beta4</version.org.hibernate>
+        <version.org.hibernate.commons.annotations>4.0.4.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
         <version.org.hibernate.validator>5.0.1.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
@@ -3450,6 +3450,10 @@
                         <groupId>org.jboss.spec.javax.transaction</groupId>
                         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-annotations</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -3469,6 +3473,10 @@
                     <exclusion>
                         <groupId>org.rhq.helpers</groupId>
                         <artifactId>rhq-pluginAnnotations</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -3514,6 +3522,10 @@
                         <groupId>org.slf4j</groupId>
                         <artifactId>slf4j-api</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.logging</groupId>
+                        <artifactId>jboss-logging-annotations</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -3521,6 +3533,12 @@
                <groupId>org.hibernate.common</groupId>
                <artifactId>hibernate-commons-annotations</artifactId>
                <version>${version.org.hibernate.commons.annotations}</version>
+	       <exclusions>
+	           <exclusion>
+                       <groupId>org.jboss.logging</groupId>
+                       <artifactId>jboss-logging-annotations</artifactId>
+                   </exclusion>
+               </exclusions>
             </dependency>
 
             <dependency>
@@ -3563,6 +3581,10 @@
                     <exclusion>
                         <groupId>org.jboss.spec.javax.transaction</groupId>
                         <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                       <groupId>org.jboss.logging</groupId>
+                       <artifactId>jboss-logging-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateSessionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateSessionFactory.java
@@ -65,7 +65,8 @@ public class SFSBHibernateSessionFactory {
                     "true");
             configuration.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
             configuration.setProperty(Environment.DATASOURCE, "java:jboss/datasources/ExampleDS");
-            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
+// Uncomment the following line when WFLY-2059 is fixed
+//            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
 
             // fetch the properties
             Properties properties = new Properties();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateTransaction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernateTransaction.java
@@ -66,7 +66,8 @@ public class SFSBHibernateTransaction {
             configuration.getProperties().put(AvailableSettings.JTA_PLATFORM, JBossAppServerJtaPlatform.class);
             configuration.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
             configuration.setProperty(Environment.DATASOURCE, "java:jboss/datasources/ExampleDS");
-            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
+// Uncomment the following line when WFLY-2059 is fixed
+//            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
 
             // fetch the properties
             Properties properties = new Properties();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernatewithCriteriaSession.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernatewithCriteriaSession.java
@@ -76,7 +76,8 @@ public class SFSBHibernatewithCriteriaSession {
             configuration.getProperties().put(AvailableSettings.JTA_PLATFORM, JBossAppServerJtaPlatform.class);
             configuration.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
             configuration.setProperty(Environment.DATASOURCE, "java:jboss/datasources/ExampleDS");
-            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
+// Uncomment the following line when WFLY-2059 is fixed
+//            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
 
             // fetch the properties
             Properties properties = new Properties();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernatewithMetaDataSession.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/hibernate/SFSBHibernatewithMetaDataSession.java
@@ -72,7 +72,8 @@ public class SFSBHibernatewithMetaDataSession {
                     "true");
             configuration.setProperty(Environment.HBM2DDL_AUTO, "create-drop");
             configuration.setProperty(Environment.DATASOURCE, "java:jboss/datasources/ExampleDS");
-            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
+// Uncomment the following line when WFLY-2059 is fixed
+//            configuration.setProperty("hibernate.listeners.envers.autoRegister", "false");
 
             // fetch the properties
             Properties properties = new Properties();


### PR DESCRIPTION
Also created WFLY-2059 to represent (minor) regression  HHH-8502.  When WFLY-2059/HHH-8502 envers can be disabled by applications that choose to do so with property hibernate.listeners.envers.autoRegister.  A few of our tests do this but don't need to. 
