### PR TITLE
[WFLY-2051], fix write-attribute for STRING value using expression without double quotes.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
+++ b/cli/src/main/java/org/jboss/as/cli/ArgumentValueConverter.java
@@ -30,6 +30,7 @@ import org.jboss.as.cli.parsing.arguments.ArgumentValueInitialState;
 import org.jboss.as.cli.parsing.arguments.ArgumentValueState;
 import org.jboss.as.cli.parsing.arguments.ListState;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ValueExpression;
 
 
 /**
@@ -68,7 +69,11 @@ public interface ArgumentValueConverter {
             }
             ModelNode toSet = null;
             try {
-                toSet = ModelNode.fromString(value);
+                if (value.contains("${") && !(value.startsWith("\"") && value.endsWith("\""))) {
+                    ValueExpression valueExpression = new ValueExpression(value);
+                    toSet = new ModelNode().set(valueExpression);
+                } else
+                    toSet = ModelNode.fromString(value);
             } catch (Exception e) {
                 final ArgumentValueCallbackHandler handler = new ArgumentValueCallbackHandler();
                 StateParser.parse(value, handler, ArgumentValueInitialState.INSTANCE);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2051

If write STRING type attribute using expression, add double quotes to store as String like other expression usage of non-STRING type.
