### PR TITLE
fix JMSDestinationDefinition creation

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
@@ -45,8 +45,7 @@ import javax.jms.TopicConnectionFactory;
  */
 @JMSDestinationDefinition(
         name="java:comp/env/myQueue4",
-        interfaceName="javax.jms.Queue",
-        destinationName="myQueue4"
+        interfaceName="javax.jms.Queue"
 )
 @JMSDestinationDefinitions(
         value =  {


### PR DESCRIPTION
- fix typo in startQueue/startTopic to use the correct queueName/topicName
  to create the destination path (instead of destinationName that can be
  null)
- fix check in uniqueName(): destination will be set to "" if it's not
  present in the destination definition.
