### PR TITLE
[WFLY-2065] Update jboss-transaction-spi

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
@@ -45,7 +45,6 @@ public class TransactionUtil {
 
     private static volatile TransactionSynchronizationRegistry transactionSynchronizationRegistry;
     private static volatile TransactionManager transactionManager;
-    private static final String ARJUNA_REAPER_THREAD_NAME = "Transaction Reaper Worker";
 
     public static void setTransactionManager(TransactionManager tm) {
         if (transactionManager == null) {
@@ -188,14 +187,11 @@ public class TransactionUtil {
          * @return
          */
         private boolean safeToClose(int status) {
-            boolean isItSafe = true;
             if (Status.STATUS_COMMITTED != status) {
-                String currentThreadName = currentThread();
-                boolean isBackgroundReaperThread = currentThreadName != null &&
-                        currentThreadName.startsWith(ARJUNA_REAPER_THREAD_NAME);
-                isItSafe = !isBackgroundReaperThread;
+                return !TxUtils.isTransactionManagerTimeoutThread();
             }
-            return isItSafe;
+
+            return true;
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
         <version.org.jboss.ironjacamar>1.1.0.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jandex>1.1.0.Alpha1</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.2.0.Final</version.org.jboss.jboss-dmr>
-        <version.org.jboss.jboss-transaction-spi>7.0.1.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jboss.jboss-transaction-spi>7.0.2.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.jboss-vfs>3.2.0.Beta1</version.org.jboss.jboss-vfs>
         <version.org.jboss.narayana>5.0.0.M4</version.org.jboss.narayana>
         <version.org.jboss.jsfunit>2.0.0.Beta1</version.org.jboss.jsfunit>


### PR DESCRIPTION
This PR means that the JPA subsystem will no longer need to hard code the transaction timeout reaper thread name.

The jboss-transactions-spi revision update (see https://github.com/jbosstm/jboss-transaction-spi for details) includes:
- [JBTM-1556] new method to determine TM reaper timeout threads
- [JBTM-1641] Don't dump exception when debug logging
