### PR TITLE
[WFLY-2069] Switch between alternatives in a batch

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -555,4 +555,15 @@ public interface MessagingMessages {
      */
     @Message(id = 11680, value = "It is not permitted to call this method on injected JMSContext (see JMS 2.0 spec, §12.4.5).")
     IllegalStateRuntimeException callNotPermittedOnInjectedJMSContext();
+
+    /**
+     * A message indicating the alternative attribute represented by the {@code name} parameter can not be undefined as the resource
+     * has not defined any other alternative .
+     *
+     * @param name the attribute name.
+     *
+     * @return the message.
+     */
+    @Message(id = 11681, value = "Attribute (%s) can not been undefined as the resource does not define any alternative to this attribute.")
+    String undefineAttributeWithoutAlternative(String name);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAttributes.java
@@ -153,6 +153,7 @@ public interface ConnectionFactoryAttributes {
                         }
                     }
                 })
+                .setRestartAllServices()
                 .build();
 
         AttributeDefinition CONSUMER_MAX_RATE = SimpleAttributeDefinitionBuilder.create("consumer-max-rate", INT)

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryWriteAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryWriteAttributeHandler.java
@@ -116,6 +116,11 @@ public class ConnectionFactoryWriteAttributeHandler extends AbstractWriteAttribu
     }
 
     private void applyOperationToHornetQService(final OperationContext context, String name, String attributeName, ModelNode value, ServiceController<?> hqService) {
+        if(attributeName.equals(Common.CONNECTOR.getName()) ||
+                attributeName.equals(Common.DISCOVERY_GROUP_NAME.getName())) {
+            return;
+        }
+
         HornetQServer server =  HornetQServer.class.cast(hqService.getValue());
         ConnectionFactoryControl control = ConnectionFactoryControl.class.cast(server.getManagementService().getResource(ResourceNames.JMS_CONNECTION_FACTORY + name));
         try {


### PR DESCRIPTION
- fix AlternativeAttributeCheckHandler as the check depends whether the
  operation is :write-attribute (and alternatives must not be defined) or
  :undefine-attribute (and an alternative _must_ be defined)
- flag discovery-group-name and connector attributes to restart all
  services
- skip runtime update on HornetQ control object for these 2 attributes
  (that are not part of HornetQ management API)

The fix can be checked manually using the _`standalone-full-ha.xml`_ configuration:

```
[standalone@localhost:9990 /] /subsystem=messaging/hornetq-server=default/connection-factory=RemoteConnectionFactory:read-resource
{
    "outcome" => "success",
    "result" => {
        ...
        "connector" => {"netty" => undefined},
        ...
    }
}
[standalone@localhost:9990 / #] batch
[standalone@localhost:9990 / #] /subsystem=messaging/hornetq-server=default/connection-factory=RemoteConnectionFactory:undefine-attribute(name=connector)
#1 /subsystem=messaging/hornetq-server=default/connection-factory=RemoteConnectionFactory:undefine-attribute(name=connector)
[standalone@localhost:9990 / #] /subsystem=messaging/hornetq-server=default/connection-factory=RemoteConnectionFactory:write-attribute(name=discovery-group-name, value=dg-group1)
#2 /subsystem=messaging/hornetq-server=default/connection-factory=RemoteConnectionFactory:write-attribute(name=discovery-group-name, value=dg-group1)
[standalone@localhost:9990 / #] run-batch
The batch executed successfully
[standalone@localhost:9990 /] /subsystem=messaging/hornetq-server=default/connection-factory=RemoteConnectionFactory:read-resource
{
    "outcome" => "success",
    "result" => {
        ...
        "connector" => undefined,
        ...
        "discovery-group-name" => "dg-group1",
        ...
    },
    "response-headers" => {
        "process-state" => "reload-required"
    }
}
[standalone@localhost:9990 /] /:reload
{
    "outcome" => "success",
    "result" => undefined
}
```
