### PR TITLE
[WFLY-2071] Queue attributes must be read-only

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/QueueDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueDefinition.java
@@ -128,7 +128,7 @@ public class QueueDefinition extends SimpleResourceDefinition {
                             .build();
                     registry.registerReadOnlyAttribute(readOnlyRuntimeAttr, QueueReadAttributeHandler.RUNTIME_INSTANCE);
                 } else {
-                    registry.registerReadWriteAttribute(attr, null, QueueConfigurationWriteHandler.INSTANCE);
+                    registry.registerReadOnlyAttribute(attr, null);
                 }
             }
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueDefinition.java
@@ -124,7 +124,7 @@ public class JMSQueueDefinition extends SimpleResourceDefinition {
                 if (deployed) {
                     registry.registerReadOnlyAttribute(attr, JMSQueueConfigurationRuntimeHandler.INSTANCE);
                 } else {
-                    registry.registerReadWriteAttribute(attr, null, JMSQueueConfigurationWriteHandler.INSTANCE);
+                    registry.registerReadOnlyAttribute(attr, null);
                 }
             }
         }


### PR DESCRIPTION
Register the jms-queue and queue resource's attributes as read-only.
Once they are set when the queues are added, their value must not change
during the queue's lifetime
