### PR TITLE
[WFLY-2077] Picketlink module org.picketlink is missing for 2.5.1

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1365,6 +1365,9 @@
             <maven-resource group="org.osgi" artifact="org.osgi.core"/>
         </module-def>
 
+        <module-def name="org.picketlink">
+        </module-def>
+
         <module-def name="org.picketlink.common">
             <maven-resource group="org.picketlink" artifact="picketlink-common"/>
         </module-def>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2077
