### PR TITLE
[WFLY-2083] Upgrade to HornetQ 2.4.0.Beta2

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -815,6 +815,14 @@
             <extract-native-jar group="org.hornetq" artifact="hornetq-native"/>
         </module-def>
 
+        <module-def name="org.hornetq.protocol.amqp">
+            <maven-resource group="org.hornetq" artifact="hornetq-amqp-protocol"/>
+        </module-def>
+
+        <module-def name="org.hornetq.protocol.stomp">
+            <maven-resource group="org.hornetq" artifact="hornetq-stomp-protocol"/>
+        </module-def>
+
         <module-def name="org.hornetq.ra">
             <maven-resource group="org.hornetq" artifact="hornetq-ra"/>
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -799,6 +799,11 @@
 
                 <dependency>
                     <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-amqp-protocol</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.hornetq</groupId>
                     <artifactId>hornetq-commons</artifactId>
                 </dependency>
 
@@ -835,6 +840,11 @@
                 <dependency>
                     <groupId>org.hornetq</groupId>
                     <artifactId>hornetq-server</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-stomp-protocol</artifactId>
                 </dependency>
 
                 <dependency>

--- a/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/amqp/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/amqp/main/module.xml
@@ -22,30 +22,14 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hornetq">
+<module xmlns="urn:jboss:module:1.1" name="org.hornetq.protocol.amqp">
     <resources>
-        <resource-root path="lib"/>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
-        <module name="javax.jms.api" />
-        <module name="org.jboss.jts"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.netty"/>
-        <module name="org.jgroups"/>
-        <module name="javax.resource.api"/>
-        <module name="org.jboss.jboss-transaction-spi"/>
-        <!--this reverse dependency is here so integration classes in the AS code base can be instantiated by HornetQ-->
-        <module name="org.jboss.as.messaging"/>
-        <!-- this optional dependency is required to be able to use this module from a jms-bridge to connect to a remote
-             AS7 server [AS7-6549] -->
-        <module name="org.jboss.remote-naming" optional="true"/>
-        <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
-        <module name="sun.jdk"/>
-        <!-- supported protocols (in addition to the CORE protocol) -->
-        <module name="org.hornetq.protocol.amqp" services="import" optional="true"/>
-        <module name="org.hornetq.protocol.stomp" services="import" optional="true"/>
+        <module name="org.apache.qpid.proton"/>
+        <!-- required to load HornetQ protocol SPI -->
+        <module name="org.hornetq"/>
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/stomp/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/stomp/main/module.xml
@@ -22,30 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hornetq">
+<module xmlns="urn:jboss:module:1.1" name="org.hornetq.protocol.stomp">
     <resources>
-        <resource-root path="lib"/>
         <!-- Insert resources here -->
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
-        <module name="javax.jms.api" />
-        <module name="org.jboss.jts"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.netty"/>
-        <module name="org.jgroups"/>
-        <module name="javax.resource.api"/>
-        <module name="org.jboss.jboss-transaction-spi"/>
-        <!--this reverse dependency is here so integration classes in the AS code base can be instantiated by HornetQ-->
-        <module name="org.jboss.as.messaging"/>
-        <!-- this optional dependency is required to be able to use this module from a jms-bridge to connect to a remote
-             AS7 server [AS7-6549] -->
-        <module name="org.jboss.remote-naming" optional="true"/>
-        <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
-        <module name="sun.jdk"/>
-        <!-- supported protocols (in addition to the CORE protocol) -->
-        <module name="org.hornetq.protocol.amqp" services="import" optional="true"/>
-        <module name="org.hornetq.protocol.stomp" services="import" optional="true"/>
+        <!-- required to load HornetQ protocol SPI -->
+        <module name="org.hornetq"/>
     </dependencies>
 </module>

--- a/messaging/src/test/java/org/jboss/as/messaging/jms/test/ConfigurationAttributesTestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/jms/test/ConfigurationAttributesTestCase.java
@@ -46,6 +46,8 @@ public class ConfigurationAttributesTestCase extends AttributesTestBase {
         UNSUPPORTED_HORNETQ_CONFIG_PROPERTIES.add("securityInvalidationInterval");
         UNSUPPORTED_HORNETQ_CONFIG_PROPERTIES.add("name");
         UNSUPPORTED_HORNETQ_CONFIG_PROPERTIES.add("maskPassword");
+        // messaging protocols are automatically resolved by HornetQ using a ServiceLoader
+        UNSUPPORTED_HORNETQ_CONFIG_PROPERTIES.add("resolveProtocols");
 
         //stuff we arent bothered about
         KNOWN_ATTRIBUTES = new TreeSet<String>();

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
         <version.org.hibernate.validator>5.0.1.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-        <version.org.hornetq>2.4.0.Beta1</version.org.hornetq>
+        <version.org.hornetq>2.4.0.Beta2</version.org.hornetq>
         <version.org.infinispan>6.0.0.Alpha4</version.org.infinispan>
         <version.org.infinispan.protostream>1.0.0.Alpha4</version.org.infinispan.protostream>
         <version.org.jacorb>2.3.2.jbossorg-4</version.org.jacorb>
@@ -3630,6 +3630,12 @@
 
             <dependency>
                 <groupId>org.hornetq</groupId>
+                <artifactId>hornetq-amqp-protocol</artifactId>
+                <version>${version.org.hornetq}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-server</artifactId>
                 <version>${version.org.hornetq}</version>
             </dependency>
@@ -3689,6 +3695,12 @@
             <dependency>
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-ra</artifactId>
+                <version>${version.org.hornetq}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hornetq</groupId>
+                <artifactId>hornetq-stomp-protocol</artifactId>
                 <version>${version.org.hornetq}</version>
             </dependency>
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/security/SecurityTestCase.java
@@ -108,8 +108,8 @@ public class SecurityTestCase {
             sf.createSession(HornetQDefaultConfiguration.getDefaultClusterUser(), HornetQDefaultConfiguration.getDefaultClusterPassword(), false, true, true, false, 1);
             fail("must not allow to create a session with the default cluster user credentials");
         } catch (HornetQException e) {
-            assertEquals(HornetQExceptionType.SECURITY_EXCEPTION, e.getType());
-            assertTrue(e.getMessage().startsWith("HQ119031"));
+            assertEquals(HornetQExceptionType.CLUSTER_SECURITY_EXCEPTION, e.getType());
+            assertTrue(e.getMessage().startsWith("HQ119099"));
         } finally {
             if (sf != null) {
                 sf.close();


### PR DESCRIPTION
With 2.4.0.Beta2, HornetQ loads its supported protocols (other than its
CORE protocol) using a ServiceLoader.
STOMP and AMQP protocols implementation have been moved to their own
artificats.

Add modules org.hornetq.protocol.stomp & org.hornet.protocol.amqp.
Import them by default in org.hornetq module dependencies.

To disable a protocol, remove it from the org.hornetq module
dependencies.
