### PR TITLE
*RBAC* [WFLY-2099] / [WFLY-490] Add a duplicate check with appropriate error message for duplicate include / exclude definitions.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -748,6 +748,9 @@ public interface DomainManagementMessages {
     @Message(id = 15286, value = "Invalid response. (Valid responses are A, a, B, b, C or c)")
     String invalidChoiceUpdateUserResponse();
 
+    @Message(id = 15287, value = "Role '%s' already contains an %s for type=%s, name=%s, realm=%s.")
+    OperationFailedException duplicateIncludeExclude(String roleName, String incExcl, String type, String name, String realm);
+
     /*
      * Logging IDs 15200 to 15299 are reserved for domain management, the file DomainManagementLogger also contains messages in
      * this range commencing 15200.
@@ -951,6 +954,8 @@ public interface DomainManagementMessages {
      */
     @Message(id = Message.NONE, value = "Using realm '%s' as discovered from the existing property files.")
     String discoveredRealm(final String realmName);
+
+
 
     //PUT YOUR NUMBERED MESSAGES ABOVE THE id=NONE ones!
 }


### PR DESCRIPTION
As the address of the include/exclude is not suitable to check for duplicates we need to also check the existing model.

Note: At the time the model is checked if there is a duplicate we will find the entry twice.
