### PR TITLE
[WFLY-490] Fix NPE when there is no resource

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -395,7 +395,7 @@ public class GlobalOperationHandlers {
             }
 
             if (aliasEntry == null) {
-                if (resource.hasChildren(childType)) {
+                if (resource != null && resource.hasChildren(childType)) {
                     set.addAll(resource.getChildrenNames(childType));
                 }
             } else {
@@ -403,7 +403,7 @@ public class GlobalOperationHandlers {
                 PathAddress target = aliasEntry.convertToTargetAddress(addr.append(element));
                 PathAddress targetParent = target.subAddress(0, target.size() - 1);
                 Resource parentResource = context.readResourceFromRoot(targetParent);
-                if (parentResource.hasChildren(target.getLastElement().getKey())) {
+                if (parentResource != null && parentResource.hasChildren(target.getLastElement().getKey())) {
                     set.add(element.getValue());
                 }
             }


### PR DESCRIPTION
Fixes an NPE when executing :read-resource-description(recursive=true,access-control=trim-descriptions,operations=true,inherited=false){roles=MAIN-MAINTAINER} where MAIN-MAINTAINER is a scoped role.

I found this when investigating https://issues.jboss.org/browse/WFLY-2088
