### PR TITLE
[WFLY-1971] Add rotate-on-boot attribute for the size-rotating-file-handler

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_3.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_3.xsd
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -23,11 +23,11 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-            targetNamespace="urn:jboss:domain:logging:2.0"
-            xmlns="urn:jboss:domain:logging:2.0"
-            elementFormDefault="qualified"
-            attributeFormDefault="unqualified"
-            version="2.0">
+           targetNamespace="urn:jboss:domain:logging:1.2"
+           xmlns="urn:jboss:domain:logging:1.2"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.2">
 
     <!-- The logging subsystem root element -->
     <xs:element name="subsystem" type="subsystem"/>
@@ -35,7 +35,7 @@
     <xs:complexType name="subsystem">
         <xs:annotation>
             <xs:documentation>
-            <![CDATA[
+                <![CDATA[
                 The configuration of the logging subsystem.
             ]]>
             </xs:documentation>
@@ -48,9 +48,8 @@
             <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
             <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
             <xs:element name="async-handler" type="asyncHandlerType"/>
-            <xs:element name="custom-handler" type="customHandlerType" />
+            <xs:element name="custom-handler" type="customHandlerType"/>
             <xs:element name="syslog-handler" type="syslogHandlerType"/>
-            <xs:element name="formatter" type="formatterType"/>
             <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
         </xs:choice>
     </xs:complexType>
@@ -82,7 +81,6 @@
             <xs:element name="async-handler" type="asyncHandlerType"/>
             <xs:element name="custom-handler" type="customHandlerType"/>
             <xs:element name="syslog-handler" type="syslogHandlerType"/>
-            <xs:element name="formatter" type="formatterType"/>
         </xs:choice>
         <xs:attribute name="name" type="xs:string" use="required"/>
     </xs:complexType>
@@ -161,7 +159,7 @@
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
             <xs:element name="filter" type="valueType" minOccurs="0"/>
-            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
             <xs:element name="target" minOccurs="0">
                 <xs:complexType>
                     <xs:attribute name="name" use="required">
@@ -190,7 +188,7 @@
             <xs:element name="level" type="refType" minOccurs="0"/>
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
-            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
             <xs:element name="file" type="pathType" minOccurs="1"/>
             <xs:element name="append" type="booleanValueType" minOccurs="0"/>
         </xs:all>
@@ -210,7 +208,7 @@
             <xs:element name="level" type="refType" minOccurs="0"/>
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
-            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
             <xs:element name="file" type="pathType"/>
             <xs:element name="suffix" type="valueType"/>
             <xs:element name="append" type="booleanValueType" minOccurs="0"/>
@@ -220,7 +218,7 @@
         <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
     </xs:complexType>
 
-        <xs:complexType name="sizeFileHandlerType">
+    <xs:complexType name="sizeFileHandlerType">
         <xs:annotation>
             <xs:documentation>
                 Defines a handler which writes to a file, rotating the log after a the size of the file grows beyond a
@@ -231,7 +229,7 @@
             <xs:element name="level" type="refType" minOccurs="0"/>
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
-            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
             <xs:element name="file" type="pathType"/>
             <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
             <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
@@ -246,7 +244,7 @@
     <xs:complexType name="asyncHandlerType">
         <xs:annotation>
             <xs:documentation>
-                Defines a handler which writes to the sub-handlers in an asynchronous thread.  Used for handlers which
+                Defines a handler which writes to the sub-handlers in an asynchronous thread. Used for handlers which
                 introduce a substantial amount of lag.
             </xs:documentation>
         </xs:annotation>
@@ -271,7 +269,7 @@
             <xs:element name="level" type="refType" minOccurs="0"/>
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
-            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="formatter" type="formatterType" minOccurs="0"/>
             <xs:element name="properties" type="propertiesType" minOccurs="0"/>
         </xs:all>
         <xs:attribute name="name" type="xs:string" use="required"/>
@@ -418,81 +416,23 @@
     <xs:complexType name="formatterType">
         <xs:annotation>
             <xs:documentation>
-                A formatter that can be assigned to a handler.
+                Defines a formatter.
             </xs:documentation>
         </xs:annotation>
         <xs:choice minOccurs="1" maxOccurs="1">
             <xs:element name="pattern-formatter" type="patternFormatterType" maxOccurs="1"/>
         </xs:choice>
-        <xs:attribute name="name" type="xs:string" use="required"/>
-    </xs:complexType>
-
-    <xs:complexType name="handlerFormatterType">
-        <xs:annotation>
-            <xs:documentation>
-                Defines a formatter.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:choice minOccurs="1" maxOccurs="1">
-            <xs:element name="pattern-formatter" type="handlerPatternFormatterType" maxOccurs="1"/>
-            <xs:element name="named-formatter" type="namedFormatterType" maxOccurs="1"/>
-        </xs:choice>
-    </xs:complexType>
-
-    <xs:complexType name="handlerPatternFormatterType">
-        <xs:annotation>
-            <xs:documentation>
-                Defines a pattern formatter.  See the documentation for org.jboss.logmanager.formatters.FormatStringParser
-                for more information about the format string.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="pattern" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="patternFormatterType">
         <xs:annotation>
             <xs:documentation>
-                Defines a pattern formatter.  See the documentation for org.jboss.logmanager.formatters.FormatStringParser
+                Defines a pattern formatter. See the documentation for
+                org.jboss.logmanager.formatters.FormatStringParser
                 for more information about the format string.
-
-                The color-map attribute allows for a comma delimited list of colors to be used for different levels. The
-                format is level-name:color-name.
-
-                Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
-
-                Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred, brightgreen,
-                brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="pattern" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation>
-                    The format pattern as defined in org.jboss.logmanager.formatters.FormatStringParser.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="color-map" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>
-                    The color-map attribute allows for a comma delimited list of colors to be used for different levels. The
-                    format is level-name:color-name.
-
-                    Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
-
-                    Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred, brightgreen,
-                    brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-    </xs:complexType>
-
-    <xs:complexType name="namedFormatterType">
-        <xs:annotation>
-            <xs:documentation>
-                The name of a defined formatter that will be used to format the log message.
-            </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:complexType name="syslogFormatterType">

--- a/logging/src/main/java/org/jboss/as/logging/Attribute.java
+++ b/logging/src/main/java/org/jboss/as/logging/Attribute.java
@@ -56,6 +56,7 @@ enum Attribute {
     RELATIVE_TO(PathResourceDefinition.RELATIVE_TO),
     REPLACEMENT(CommonAttributes.REPLACEMENT),
     REPLACE_ALL(CommonAttributes.REPLACE_ALL),
+    ROTATE_ON_BOOT(SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT),
     ROTATE_SIZE(SizeRotatingHandlerResourceDefinition.ROTATE_SIZE),
     SUFFIX(PeriodicHandlerResourceDefinition.SUFFIX),
     SYSLOG_TYPE("syslog-type"),

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -46,10 +46,13 @@ import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.controller.services.path.ResolvePathHandler;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker.DiscardAttributeValueChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
 import org.jboss.as.logging.stdio.LogContextStdioContextSelector;
+import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.ClassLoaderLogContextSelector;
 import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.ThreadLocalLogContextSelector;
@@ -207,6 +210,10 @@ public class LoggingExtension implements Extension {
     private static TransformationDescription get1_2_0_1_3_0Description() {
         final ResourceTransformationDescriptionBuilder subsystemBuilder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         // TODO WFLY-1807 add 2.0.0 stuff
+        subsystemBuilder.getAttributeBuilder()
+                .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT)
+                .end();
         return subsystemBuilder.build();
     }
 
@@ -257,6 +264,7 @@ public class LoggingExtension implements Extension {
             COMMON_ATTRIBUTE_NAMES.put(AsyncHandlerResourceDefinition.QUEUE_LENGTH.getName(), "logging.async-handler");
             COMMON_ATTRIBUTE_NAMES.put(PathResourceDefinition.RELATIVE_TO.getName(), null);
             COMMON_ATTRIBUTE_NAMES.put(SizeRotatingHandlerResourceDefinition.ROTATE_SIZE.getName(), "logging.size-rotating-file-handler");
+            COMMON_ATTRIBUTE_NAMES.put(SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT.getName(), "logging.size-rotating-file-handler");
             COMMON_ATTRIBUTE_NAMES.put(AsyncHandlerResourceDefinition.SUBHANDLERS.getName(), "logging.async-handler");
             COMMON_ATTRIBUTE_NAMES.put(PeriodicHandlerResourceDefinition.SUFFIX.getName(), "logging.periodic-rotating-file-handler");
             COMMON_ATTRIBUTE_NAMES.put(ConsoleHandlerResourceDefinition.TARGET.getName(), "logging.console-handler");

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -1199,7 +1199,8 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                     break;
                 }
                 case FORMATTER:
-                    if (namespace == Namespace.LOGGING_1_2)
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1 ||
+                            namespace == Namespace.LOGGING_1_2 || namespace == Namespace.LOGGING_1_3)
                         throw unexpectedElement(reader);
                     parseFormatter(reader, profileAddress, formatterOperations, formatterNames);
                     break;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -72,6 +72,7 @@ import static org.jboss.as.logging.PeriodicHandlerResourceDefinition.SUFFIX;
 import static org.jboss.as.logging.RootLoggerResourceDefinition.ROOT_LOGGER_ATTRIBUTE_NAME;
 import static org.jboss.as.logging.RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME;
 import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.MAX_BACKUP_INDEX;
+import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT;
 import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.ROTATE_SIZE;
 import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_FILE_HANDLER;
 import static org.jboss.as.logging.SyslogHandlerResourceDefinition.APP_NAME;
@@ -752,6 +753,12 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                         throw unexpectedAttribute(reader, i);
                     }
                     ENABLED.parseAndSetParameter(value, operation, reader);
+                    break;
+                case ROTATE_ON_BOOT:
+                    if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1 || namespace == Namespace.LOGGING_1_2) {
+                        throw unexpectedAttribute(reader, i);
+                    }
+                    ROTATE_ON_BOOT.parseAndSetParameter(value, operation, reader);
                     break;
                 default:
                     throw unexpectedAttribute(reader, i);

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
@@ -56,6 +56,7 @@ import static org.jboss.as.logging.PeriodicHandlerResourceDefinition.SUFFIX;
 import static org.jboss.as.logging.RootLoggerResourceDefinition.ROOT_LOGGER_ATTRIBUTE_NAME;
 import static org.jboss.as.logging.RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME;
 import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.MAX_BACKUP_INDEX;
+import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT;
 import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.ROTATE_SIZE;
 import static org.jboss.as.logging.SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_FILE_HANDLER;
 import static org.jboss.as.logging.SyslogHandlerResourceDefinition.APP_NAME;
@@ -271,6 +272,7 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
         writer.writeAttribute(HANDLER_NAME.getXmlName(), name);
         AUTOFLUSH.marshallAsAttribute(model, writer);
         ENABLED.marshallAsAttribute(model, false, writer);
+        ROTATE_ON_BOOT.marshallAsAttribute(model, false, writer);
         writeCommonHandler(writer, model);
         FILE.marshallAsElement(model, writer);
         ROTATE_SIZE.marshallAsElement(model, writer);

--- a/logging/src/main/java/org/jboss/as/logging/Namespace.java
+++ b/logging/src/main/java/org/jboss/as/logging/Namespace.java
@@ -41,6 +41,8 @@ public enum Namespace {
 
     LOGGING_1_2("urn:jboss:domain:logging:1.2"),
 
+    LOGGING_1_3("urn:jboss:domain:logging:1.3"),
+
     LOGGING_2_0("urn:jboss:domain:logging:2.0");
 
     /**

--- a/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.services.path.ResolvePathHandler;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker.DiscardAttributeValueChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.logging.resolvers.SizeResolver;
@@ -55,6 +56,12 @@ class SizeRotatingHandlerResourceDefinition extends AbstractFileHandlerDefinitio
             .setValidator(new IntRangeValidator(1, true))
             .build();
 
+    public static final PropertyAttributeDefinition ROTATE_ON_BOOT = PropertyAttributeDefinition.Builder.of("rotate-on-boot", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(false))
+            .setPropertyName("rotateOnBoot")
+            .build();
+
     public static final PropertyAttributeDefinition ROTATE_SIZE = PropertyAttributeDefinition.Builder.of("rotate-size", ModelType.STRING)
             .setAllowExpression(true)
             .setAttributeMarshaller(ElementAttributeMarshaller.VALUE_ATTRIBUTE_MARSHALLER)
@@ -64,7 +71,7 @@ class SizeRotatingHandlerResourceDefinition extends AbstractFileHandlerDefinitio
             .setValidator(new SizeValidator())
             .build();
 
-    static final AttributeDefinition[] ATTRIBUTES = Logging.join(DEFAULT_ATTRIBUTES, AUTOFLUSH, APPEND, FILE, MAX_BACKUP_INDEX, ROTATE_SIZE, NAMED_FORMATTER);
+    static final AttributeDefinition[] ATTRIBUTES = Logging.join(DEFAULT_ATTRIBUTES, AUTOFLUSH, APPEND, FILE, MAX_BACKUP_INDEX, ROTATE_SIZE, NAMED_FORMATTER, ROTATE_ON_BOOT);
 
     public SizeRotatingHandlerResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean includeLegacyAttributes) {
         super(SIZE_ROTATING_HANDLER_PATH, SizeRotatingFileHandler.class, resolvePathHandler,
@@ -84,6 +91,8 @@ class SizeRotatingHandlerResourceDefinition extends AbstractFileHandlerDefinitio
         // Register the logger resource
         final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(SIZE_ROTATING_HANDLER_PATH)
                 .getAttributeBuilder()
+                .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE, MAX_BACKUP_INDEX, ROTATE_SIZE)
                 .end();
 

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -103,6 +103,7 @@ logging.periodic-rotating-file-handler.add=Add a new periodic rotating file hand
 logging.size-rotating-file-handler=Defines a handler which writes to a file, rotating the log after a the size of the file grows beyond a certain point and keeping a fixed number of backups.
 logging.size-rotating-file-handler.max-backup-index=The maximum number of backups to keep.
 logging.size-rotating-file-handler.rotate-size=The size at which to rotate the log file.
+logging.size-rotating-file-handler.rotate-on-boot=Indicates the file should be rotated each time the file attribute is changed. This always happens when at initialization time.
 logging.size-rotating-file-handler.add=Add a new size rotating file handler.
 
 # Custom handler definitions

--- a/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
@@ -77,7 +77,7 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
         testPeriodicRotatingFileHandler(kernelServices, PROFILE);
 
         testSizeRotatingFileHandler(kernelServices, null);
-        testPeriodicRotatingFileHandler(kernelServices, PROFILE);
+        testSizeRotatingFileHandler(kernelServices, PROFILE);
     }
 
     @Test
@@ -430,12 +430,14 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
 
         testWrite(kernelServices, address, SizeRotatingHandlerResourceDefinition.MAX_BACKUP_INDEX, 20);
         testWrite(kernelServices, address, SizeRotatingHandlerResourceDefinition.ROTATE_SIZE, "50m");
+        testWrite(kernelServices, address, SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT, true);
 
         // Undefine attributes
         testUndefineCommonAttributes(kernelServices, address);
         testUndefine(kernelServices, address, CommonAttributes.APPEND);
         testUndefine(kernelServices, address, CommonAttributes.AUTOFLUSH);
         testUndefine(kernelServices, address, SizeRotatingHandlerResourceDefinition.MAX_BACKUP_INDEX);
+        testUndefine(kernelServices, address, SizeRotatingHandlerResourceDefinition.ROTATE_ON_BOOT);
 
         // Clean-up
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(address));

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
-import org.jboss.as.controller.transform.description.RejectAttributeChecker.DefaultRejectAttributeChecker;
 import org.jboss.as.logging.logmanager.ConfigurationPersistence;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.RejectExpressionsConfig;

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -84,7 +84,7 @@
         <suffix value=".yyyy-MM-dd"/>
     </periodic-rotating-file-handler>
 
-    <size-rotating-file-handler name="sizeLogger">
+    <size-rotating-file-handler name="sizeLogger" rotate-on-boot="true">
         <level name="DEBUG"/>
         <encoding value="UTF-8"/>
         <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>


### PR DESCRIPTION
Added 1.3 version of the logging schema for backwards compatibility as this will go into EAP as well.
