### PR TITLE
[WFLY-2060] Add date in the server.log format in appclient and domain servers logging.properties as well

### DIFF
--- a/build/src/main/resources/appclient/configuration/logging.properties
+++ b/build/src/main/resources/appclient/configuration/logging.properties
@@ -62,4 +62,4 @@ formatter.CONSOLE.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
 formatter.FILE=org.jboss.logmanager.formatters.PatternFormatter
 formatter.FILE.properties=pattern
 formatter.FILE.constructorProperties=pattern
-formatter.FILE.pattern=%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.FILE.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n

--- a/build/src/main/resources/domain/configuration/default-server-logging.properties
+++ b/build/src/main/resources/domain/configuration/default-server-logging.properties
@@ -67,4 +67,4 @@ formatter.COLOR-PATTERN.pattern=%K{level}%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%
 
 formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
 formatter.PATTERN.properties=pattern
-formatter.PATTERN.pattern=%d{HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n
+formatter.PATTERN.pattern=%d{yyyy-MM-dd HH\:mm\:ss,SSS} %-5p [%c] (%t) %s%E%n


### PR DESCRIPTION
Fix appclient and domain servers logging.properties, see related PR #5081
