### PR TITLE
Remove redundant TCCL reset

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowHandlersDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowHandlersDeploymentProcessor.java
@@ -1,3 +1,24 @@
+/**
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.wildfly.extension.undertow.deployment;
 
 import io.undertow.server.handlers.builder.PredicatedHandler;
@@ -38,30 +59,23 @@ public class UndertowHandlersDeploymentProcessor implements DeploymentUnitProces
             return;
         }
         final List<PredicatedHandler> handlerWrappers = new ArrayList<>();
-        ClassLoader oldCl = Thread.currentThread().getContextClassLoader();
+        ResourceRoot root = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
+        VirtualFile config = root.getRoot().getChild(WEB_INF);
         try {
-            ResourceRoot root = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
-            VirtualFile config = root.getRoot().getChild(WEB_INF);
-            try {
-                if (config.exists()) {
-                    handlerWrappers.addAll(PredicatedHandlersParser.parse(config.openStream(), module.getClassLoader()));
-                }
-                Enumeration<URL> paths = module.getClassLoader().getResources(META_INF);
-                while (paths.hasMoreElements()) {
-                    URL path = paths.nextElement();
-                    handlerWrappers.addAll(PredicatedHandlersParser.parse(path.openStream(), module.getClassLoader()));
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+            if (config.exists()) {
+                handlerWrappers.addAll(PredicatedHandlersParser.parse(config.openStream(), module.getClassLoader()));
             }
-            if(!handlerWrappers.isEmpty()) {
-                deploymentUnit.putAttachment(PREDICATED_HANDLERS, handlerWrappers);
+            Enumeration<URL> paths = module.getClassLoader().getResources(META_INF);
+            while (paths.hasMoreElements()) {
+                URL path = paths.nextElement();
+                handlerWrappers.addAll(PredicatedHandlersParser.parse(path.openStream(), module.getClassLoader()));
             }
-
-        } finally {
-            Thread.currentThread().setContextClassLoader(oldCl);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
-
+        if (!handlerWrappers.isEmpty()) {
+            deploymentUnit.putAttachment(PREDICATED_HANDLERS, handlerWrappers);
+        }
     }
 
     @Override


### PR DESCRIPTION
Hi @stuartwdouglas whenever you have a minute: just removing seemingly redundant ClassLoader oldCl = Thread.currentThread().getContextClassLoader(); and Thread.currentThread().setContextClassLoader(oldCl); probably a remnant after an API change?
