### PR TITLE
Minor fix to the log message in naming subsystem

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
@@ -378,7 +378,7 @@ public interface NamingMessages {
     @Message(id = 11863, value = "Invalid name for context binding %s")
     DeploymentUnitProcessingException invalidNameForContextBinding(String name);
 
-    @Message(id = 11864, value = "Invaliding binding name %s, name must start with one of %s")
+    @Message(id = 11864, value = "Invalid binding name %s, name must start with one of %s")
     OperationFailedException invalidNamespaceForBinding(String name, String namespaces);
 
     /**


### PR DESCRIPTION
The commit here fixes a minor typo in the naming subsystems log message
