### PR TITLE
WFLY-2141, during vault.sh execution, catch InputMismatchException caused by non-integer input

### DIFF
--- a/security/src/main/java/org/jboss/as/security/vault/VaultTool.java
+++ b/security/src/main/java/org/jboss/as/security/vault/VaultTool.java
@@ -22,6 +22,7 @@
 package org.jboss.as.security.vault;
 
 import java.io.Console;
+import java.util.InputMismatchException;
 import java.util.Scanner;
 
 import org.apache.commons.cli.CommandLine;
@@ -102,25 +103,27 @@ public class VaultTool {
             Scanner in = new Scanner(System.in);
             while (true) {
                 System.out.println(VaultMessages.MESSAGES.interactiveCommandString());
-                int choice = in.nextInt();
-                switch (choice) {
-                    case 0:
-                        System.out.println(VaultMessages.MESSAGES.startingInteractiveSession());
-                        VaultInteractiveSession vsession = new VaultInteractiveSession();
-                        tool.setSession(vsession);
-                        vsession.start();
-                        break;
-                    case 1:
-                        System.out.println(VaultMessages.MESSAGES.removingInteractiveSession());
-                        tool.setSession(null);
-                        break;
-                    default:
-                        System.exit(0);
+                try {
+                    int choice = in.nextInt();
+                    switch (choice) {
+                        case 0:
+                            System.out.println(VaultMessages.MESSAGES.startingInteractiveSession());
+                            VaultInteractiveSession vsession = new VaultInteractiveSession();
+                            tool.setSession(vsession);
+                            vsession.start();
+                            break;
+                        case 1:
+                            System.out.println(VaultMessages.MESSAGES.removingInteractiveSession());
+                            tool.setSession(null);
+                            break;
+                        default:
+                            System.exit(0);
+                    }
+                } catch (InputMismatchException e) {
+                    System.exit(0);
                 }
             }
-
         }
-
     }
 
     public VaultTool(String[] args) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2141
Because VaultTool.main() only scans next token of the input as an int, a user non-integer input causes InputMismatchException, catch the exception and exit peacefully as default action.
