### PR TITLE
WFLY-1786 Return the correct http and https ports taking into account the port-offset

### DIFF
--- a/network/src/main/java/org/jboss/as/network/SocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/SocketBinding.java
@@ -207,6 +207,14 @@ public final class SocketBinding {
         return registry.isRegistered(name);
     }
 
+    /**
+     * Returns the port configured for this socket binding.
+     * <p/>
+     * Note that this method does NOT take into account any port-offset that might have been configured. Use {@link #getAbsolutePort()}
+     * if the port-offset has to be considered.
+     *
+     * @return
+     */
     public int getPort() {
         return port;
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
@@ -22,11 +22,16 @@
 
 package org.wildfly.extension.undertow;
 
+import java.util.List;
+
 import io.undertow.server.ListenerRegistry;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.web.host.CommonWebServer;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
 /**
@@ -52,5 +57,23 @@ public class HttpListenerAdd extends AbstractListenerAdd {
     @Override
     void configureAdditionalDependencies(OperationContext context, ServiceBuilder<? extends AbstractListenerService> serviceBuilder, ModelNode model, AbstractListenerService service) throws OperationFailedException {
         serviceBuilder.addDependency(REGISTRY_SERVICE_NAME, ListenerRegistry.class, ((HttpListenerService)service).getHttpListenerRegistry());
+        // inject the CommonWebServer service
+        serviceBuilder.addDependency(CommonWebServer.SERVICE_NAME, WebServerService.class, ((HttpListenerService)service).getCommonWebServerInjector());
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        super.performRuntime(context, operation, model, verificationHandler, newControllers);
+
+        // install (if not already done by HttpsListenerAdd) CommonWebServer service
+        final ServiceController commonWebServerServiceController = context.getServiceRegistry(true).getService(CommonWebServer.SERVICE_NAME);
+        if (commonWebServerServiceController == null) {
+            final WebServerService webServerService = new WebServerService();
+            final ServiceController serviceController = context.getServiceTarget().addService(CommonWebServer.SERVICE_NAME, webServerService).install();
+            if (verificationHandler != null) {
+                serviceController.addListener(verificationHandler);
+            }
+            newControllers.add(serviceController);
+        }
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
@@ -22,13 +22,18 @@
 
 package org.wildfly.extension.undertow;
 
+import java.util.List;
+
 import io.undertow.server.ListenerRegistry;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.as.web.host.CommonWebServer;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 
 /**
@@ -58,5 +63,24 @@ public class HttpsListenerAdd extends AbstractListenerAdd {
         final String securityRealm = HttpsListenerResourceDefinition.SECURITY_REALM.resolveModelAttribute(context, model).asString();
 
         SecurityRealm.ServiceUtil.addDependency(serviceBuilder, ((HttpsListenerService) service).getSecurityRealm(), securityRealm, false);
+
+        // inject the CommonWebServer service
+        serviceBuilder.addDependency(CommonWebServer.SERVICE_NAME, WebServerService.class, ((HttpsListenerService)service).getCommonWebServerInjector());
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        super.performRuntime(context, operation, model, verificationHandler, newControllers);
+
+        // install (if not already done by HttpListenerAdd) CommonWebServer service
+        final ServiceController commonWebServerServiceController = context.getServiceRegistry(true).getService(CommonWebServer.SERVICE_NAME);
+        if (commonWebServerServiceController == null) {
+            final WebServerService webServerService = new WebServerService();
+            final ServiceController serviceController = context.getServiceTarget().addService(CommonWebServer.SERVICE_NAME, webServerService).install();
+            if (verificationHandler != null) {
+                serviceController.addListener(verificationHandler);
+            }
+            newControllers.add(serviceController);
+        }
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowMessages.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowMessages.java
@@ -22,6 +22,8 @@
 
 package org.wildfly.extension.undertow;
 
+import java.io.File;
+
 import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
@@ -38,8 +40,6 @@ import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 import org.jboss.vfs.VirtualFile;
-
-import java.io.File;
 
 /**
  * This module is using message IDs in the range 17300 - 17699.
@@ -168,4 +168,7 @@ public interface UndertowMessages {
 
     @Message(id = 17349, value = "Could not create log directory: %s")
     StartException couldNotCreateLogDirectory(File directory);
+
+    @Message(id = 17350, value = "Could not find the port number listening for protocol %s")
+    IllegalStateException noPortListeningForProtocol(final String protocol);
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemAdd.java
@@ -25,7 +25,6 @@ package org.wildfly.extension.undertow;
 import java.util.List;
 
 import io.undertow.Version;
-
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -35,6 +34,11 @@ import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.server.deployment.jbossallxml.JBossAllXmlParserRegisteringProcessor;
+import org.jboss.as.web.common.SharedTldsMetaDataBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.ImmediateValue;
 import org.wildfly.extension.undertow.deployment.ELExpressionFactoryProcessor;
 import org.wildfly.extension.undertow.deployment.EarContextRootProcessor;
 import org.wildfly.extension.undertow.deployment.JBossWebParsingDeploymentProcessor;
@@ -53,12 +57,6 @@ import org.wildfly.extension.undertow.deployment.WebJBossAllParser;
 import org.wildfly.extension.undertow.deployment.WebParsingDeploymentProcessor;
 import org.wildfly.extension.undertow.session.DistributableSessionManagerFactoryBuilder;
 import org.wildfly.extension.undertow.session.DistributableSessionManagerFactoryBuilderValue;
-import org.jboss.as.web.common.SharedTldsMetaDataBuilder;
-import org.jboss.as.web.host.CommonWebServer;
-import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 
 
 /**
@@ -109,8 +107,6 @@ class UndertowSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install());
 
-        newControllers.add(target.addService(CommonWebServer.SERVICE_NAME, new WebServerService())
-                .install());
 
 
         context.addStep(new AbstractDeploymentChainStep() {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/WebServerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/WebServerService.java
@@ -29,17 +29,29 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 
 /**
- *
- * TODO: this is a hack for now
  * @author Stuart Douglas
  */
-@Deprecated
-public class WebServerService implements CommonWebServer, Service<WebServerService> {
+class WebServerService implements CommonWebServer, Service<WebServerService> {
 
+
+    private volatile int httpPort = -1;
+    private volatile int httpsPort = -1;
 
     @Override
     public int getPort(final String protocol, final boolean secure) {
-        return secure ? 8443 : 8080;
+        // TODO: Is relying on "secure" enough of should the protocol be considered too? For example, how would this behave with AJP (or does it not matter)
+        if (secure) {
+            if (httpsPort == -1) {
+                // throw error
+                throw UndertowMessages.MESSAGES.noPortListeningForProtocol(protocol);
+            }
+            return httpsPort;
+        }
+        if (httpPort == -1) {
+            // throw error
+            throw UndertowMessages.MESSAGES.noPortListeningForProtocol(protocol);
+        }
+        return httpPort;
     }
 
     @Override
@@ -49,11 +61,21 @@ public class WebServerService implements CommonWebServer, Service<WebServerServi
 
     @Override
     public void stop(final StopContext context) {
-
+        httpPort = -1;
+        httpsPort = -1;
     }
 
     @Override
     public WebServerService getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
     }
+
+    void setHttpPort(final int port) {
+        this.httpPort = port;
+    }
+
+    void setHttpsPort(final int port) {
+        this.httpsPort = port;
+    }
+
 }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-1786 where the port-offset wasn't taken into account while handing out the port numbers to WebServices integration layer (in particular).

P.S:  My local testing, after this commit, involved fiddling with port-offset in arquillian.xml and running an existing testcase SimpleWebserviceEndpointTestCase which passed.
