### PR TITLE
[WFLY-2167] Set resolve-path operation to be a READ_ONLY and RUNTIME_ONLY operation

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/services/path/ResolvePathHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/services/path/ResolvePathHandler.java
@@ -81,6 +81,8 @@ public class ResolvePathHandler implements OperationStepHandler {
     private static final SimpleOperationDefinition DEFAULT_OPERATION_DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, new ResolvePathResourceDescriptionResolver(OPERATION_NAME))
             .addParameter(RELATIVE_TO_ONLY)
             .setReplyType(ModelType.STRING)
+            .setReadOnly()
+            .setRuntimeOnly()
             .build();
 
 


### PR DESCRIPTION
Adds the `READ_ONLY` and `RUNTIME_ONLY` flags on the `resolve-path` operation. This is needed in domain mode for the describe operation to work correct. Also CLI tab complete.
