### PR TITLE
[WFLY-280] Add operation to list log files that are in the jboss.server.log.dir. Add an operation to read these files.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -127,17 +127,19 @@ public class LoggingExtension implements Extension {
 
         final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, MANAGEMENT_API_MAJOR_VERSION,
                 MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);
-        final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(LoggingRootResource.INSTANCE);
-        registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, DESCRIBE_HANDLER);
+        final ManagementResourceRegistration registration;
 
         final ResolvePathHandler resolvePathHandler;
         if (context.getProcessType().isServer()) {
+            registration = subsystem.registerSubsystemModel(new LoggingRootResource(context.getPathManager()));
             resolvePathHandler = ResolvePathHandler.Builder.of(context.getPathManager())
                     .setParentAttribute(CommonAttributes.FILE)
                     .build();
         } else {
+            registration = subsystem.registerSubsystemModel(new LoggingRootResource(null));
             resolvePathHandler = null;
         }
+        registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, DESCRIBE_HANDLER);
         // Register root sub-models
         registerSubModels(registration, resolvePathHandler, true);
         // Register logging profile sub-models
@@ -192,7 +194,6 @@ public class LoggingExtension implements Extension {
         // Register the transformers
         TransformationDescription.Tools.register(subsystemBuilder.build(), subsystem, ModelVersion.create(1, 1, 0));
     }
-
 
 
     private void registerTransformers1_2_0(SubsystemRegistration subsystem) {

--- a/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.logging.Handler;
 
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.Messages;
 import org.jboss.logging.annotations.Cause;
@@ -690,4 +691,37 @@ public interface LoggingMessages {
             "The subsystem has not be initialized and cannot be used. To use JBoss Log Manager you must add the system " +
             "property \"java.util.logging.manager\" and set it to \"org.jboss.logmanager.LogManager\"")
     IllegalStateException extensionNotInitialized();
+
+    /**
+     * Creates an exception indicating a failure to read the log file
+     *
+     * @param cause the cause of the error
+     * @param name  the name of the file that was not found
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 11593, value = "Failed to read the log file '%s'")
+    OperationFailedException failedToReadLogFile(@Cause Throwable cause, String name);
+
+    /**
+     * Creates an exception indicating the file was found in the log directory.
+     *
+     * @param name              the name of the file that was not found
+     * @param directoryProperty the name of the property used to resolved the log directory
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 11594, value = "File '%s' was not found and cannot be found in the %s directory property.")
+    OperationFailedException logFileNotFound(String name, String directoryProperty);
+
+    /**
+     * Creates an exception indicating the user cannot read the file.
+     *
+     * @param name              the name of the file that was not allowed to be read
+     * @param directoryProperty the name of the property used to resolved the log directory
+     *
+     * @return an {@link OperationFailedException} for the error
+     */
+    @Message(id = 11595, value = "Permission was denied to read file '%s' in the %s directory property.")
+    OperationFailedException readPermissionDenied(String name, String directoryProperty);
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
@@ -24,21 +24,293 @@ package org.jboss.as.logging;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationContext.ResultHandler;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.StringLengthValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class LoggingRootResource extends SimpleResourceDefinition {
     static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, LoggingExtension.SUBSYSTEM_NAME);
-    static final LoggingRootResource INSTANCE = new LoggingRootResource();
 
-    private LoggingRootResource() {
+    static final SimpleAttributeDefinition NAME = SimpleAttributeDefinitionBuilder.create("name", ModelType.STRING, false)
+            .setAllowExpression(true)
+            .setValidator(new StringLengthValidator(1, false))
+            .build();
+
+    static final SimpleAttributeDefinition LINES = SimpleAttributeDefinitionBuilder.create("lines", ModelType.INT, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(10))
+            .setValidator(new IntRangeValidator(-1, true))
+            .build();
+
+    static final SimpleAttributeDefinition SKIP = SimpleAttributeDefinitionBuilder.create("skip", ModelType.INT, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(0))
+            .setValidator(new IntRangeValidator(0, true))
+            .build();
+
+    static final SimpleAttributeDefinition TAIL = SimpleAttributeDefinitionBuilder.create("tail", ModelType.BOOLEAN, true)
+            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(true))
+            .build();
+
+    static final SimpleAttributeDefinition FILE_NAME = SimpleAttributeDefinitionBuilder.create("file-name", ModelType.STRING, false)
+            .build();
+
+    static final SimpleAttributeDefinition FILE_SIZE = SimpleAttributeDefinitionBuilder.create("file-size", ModelType.LONG, false)
+            .build();
+
+    static final SimpleOperationDefinition READ_LOG_FILE = new SimpleOperationDefinitionBuilder("read-log-file", LoggingExtension.getResourceDescriptionResolver())
+            .setParameters(NAME, CommonAttributes.ENCODING, LINES, SKIP, TAIL)
+            .setReplyType(ModelType.LIST)
+            .setReplyValueType(ModelType.STRING)
+            .setReadOnly()
+            .setRuntimeOnly()
+            .build();
+
+    static final SimpleOperationDefinition LIST_LOG_FILES = new SimpleOperationDefinitionBuilder("list-log-files", LoggingExtension.getResourceDescriptionResolver())
+            .setReplyType(ModelType.LIST)
+            .setReplyParameters(FILE_NAME, FILE_SIZE)
+            .setReadOnly()
+            .setRuntimeOnly()
+            .build();
+
+    private final PathManager pathManager;
+
+    protected LoggingRootResource(final PathManager pathManager) {
         super(SUBSYSTEM_PATH,
                 LoggingExtension.getResourceDescriptionResolver(),
                 LoggingSubsystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
+        this.pathManager = pathManager;
+    }
+
+    @Override
+    public void registerOperations(final ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+        // Only register on server
+        if (pathManager != null) {
+            // TODO WFLY-1807 add 2.0.0 transformers for new operations
+            resourceRegistration.registerOperationHandler(LIST_LOG_FILES, new ListLogFilesOperation(pathManager));
+            resourceRegistration.registerOperationHandler(READ_LOG_FILE, new ReadLogFileOperation(pathManager));
+        }
+    }
+
+    private static class ListLogFilesOperation implements OperationStepHandler {
+
+        private final PathManager pathManager;
+
+        private ListLogFilesOperation(final PathManager pathManager) {
+            this.pathManager = pathManager;
+        }
+
+        @Override
+        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            final String logDir = pathManager.getPathEntry(ServerEnvironment.SERVER_LOG_DIR).resolvePath();
+            final File[] logFiles = new File(logDir).listFiles(new FileFilter() {
+                @Override
+                public boolean accept(final File pathname) {
+                    return pathname.isFile() && pathname.canRead();
+                }
+            });
+            final ModelNode result = context.getResult().setEmptyList();
+            for (File logFile : logFiles) {
+                final ModelNode fileInfo = new ModelNode();
+                fileInfo.get(FILE_NAME.getName()).set(logFile.getName());
+                fileInfo.get(FILE_SIZE.getName()).set(logFile.length());
+                result.add(fileInfo);
+            }
+            context.completeStep(ResultHandler.NOOP_RESULT_HANDLER);
+        }
+    }
+
+    private static class ReadLogFileOperation implements OperationStepHandler {
+
+        private final PathManager pathManager;
+
+        private ReadLogFileOperation(final PathManager pathManager) {
+            this.pathManager = pathManager;
+        }
+
+        @Override
+        public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+            // Validate the operation
+            for (AttributeDefinition attribute : READ_LOG_FILE.getParameters()) {
+                attribute.validateOperation(operation);
+            }
+
+            final String fileName = NAME.resolveModelAttribute(context, operation).asString();
+            final int numberOfLines = LINES.resolveModelAttribute(context, operation).asInt();
+            final int skip = SKIP.resolveModelAttribute(context, operation).asInt();
+            final boolean tail = TAIL.resolveModelAttribute(context, operation).asBoolean();
+            final ModelNode encodingModel = CommonAttributes.ENCODING.resolveModelAttribute(context, operation);
+            final String encoding = (encodingModel.isDefined() ? encodingModel.asString() : null);
+            final File path = new File(pathManager.resolveRelativePathEntry(fileName, ServerEnvironment.SERVER_LOG_DIR));
+
+            // The file must exist
+            if (!path.exists()) {
+                throw LoggingMessages.MESSAGES.logFileNotFound(fileName, ServerEnvironment.SERVER_LOG_DIR);
+            }
+            // User must have permissions to read the file
+            if (!path.canRead()) {
+                throw LoggingMessages.MESSAGES.readPermissionDenied(fileName, ServerEnvironment.SERVER_LOG_DIR);
+            }
+
+            // Read the contents of the log file
+            try {
+                final List<String> lines;
+                if (numberOfLines == 0) {
+                    lines = Collections.emptyList();
+                } else {
+                    lines = readLines(path, encoding, tail, skip, numberOfLines);
+                }
+                final ModelNode result = context.getResult().setEmptyList();
+                for (String line : lines) {
+                    result.add(line);
+                }
+            } catch (IOException e) {
+                throw LoggingMessages.MESSAGES.failedToReadLogFile(e, fileName);
+            }
+            context.completeStep(ResultHandler.NOOP_RESULT_HANDLER);
+        }
+
+        private List<String> readLines(final File file, final String encoding, final boolean tail, final int skip, final int numberOfLines) throws IOException {
+            final List<String> lines;
+            if (numberOfLines < 0) {
+                lines = new ArrayList<String>();
+            } else {
+                lines = new ArrayList<String>(numberOfLines);
+            }
+            final InputStream in;
+            BufferedReader reader = null;
+            try {
+                if (tail) {
+                    in = new LifoFileInputStream(file);
+                } else {
+                    in = new FileInputStream(file);
+                }
+                if (encoding == null) {
+                    reader = new BufferedReader(new InputStreamReader(in));
+                } else {
+                    reader = new BufferedReader(new InputStreamReader(in, encoding));
+                }
+                int lineCount = 0;
+                String line;
+                while ((line = reader.readLine()) != null) {
+                    if (++lineCount <= skip) continue;
+                    if (lines.size() == numberOfLines) break;
+                    lines.add(line);
+                }
+                if (tail) {
+                    Collections.reverse(lines);
+                }
+                return lines;
+            } finally {
+                safeClose(reader);
+            }
+        }
+    }
+
+    private static void safeClose(final Closeable closeable) {
+        if (closeable != null) try {
+            closeable.close();
+        } catch (Throwable t) {
+            LoggingLogger.ROOT_LOGGER.failedToCloseResource(t, closeable);
+        }
+    }
+
+    static final class LifoFileInputStream extends InputStream {
+        private final RandomAccessFile raf;
+        private final long len;
+        private long start;
+        private long end;
+        private long pos;
+
+        LifoFileInputStream(final File file) throws IOException {
+            raf = new RandomAccessFile(file, "r");
+            len = raf.length();
+            start = len;
+            end = len;
+            pos = end;
+        }
+
+        private void positionFile() throws IOException {
+            end = start;
+            // If we're at the beginning of the file, nothing more to read
+            if (end == 0) {
+                end = -1;
+                start = -1;
+                pos = -1;
+                return;
+            }
+
+            long filePointer = start - 1;
+            while (true) {
+                filePointer--;
+                // We're at the start of the file
+                if (filePointer < 0) {
+                    break;
+                }
+                // Position the file
+                raf.seek(filePointer);
+                final byte readByte = raf.readByte();
+                // If the byte is a line feed we've found the next line ignoring the last line feed in the file
+                if (readByte == '\n' && filePointer != (len - 1)) {
+                    break;
+                }
+            }
+            start = filePointer + 1;
+            pos = start;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (pos < end) {
+                raf.seek(pos++);
+                return raf.readByte();
+            } else if (pos < 0) {
+                return -1;
+            } else {
+                positionFile();
+                return read();
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            raf.close();
+        }
     }
 }

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -3,6 +3,17 @@ logging=The configuration of the logging subsystem.
 logging.add=Add the logging subsystem.
 logging.remove=Remove the logging subsystem.
 
+# read-log-file operation
+logging.read-log-file=Reads the contents of a log file.
+logging.read-log-file.name=The name of the log file to read. This file must exist in the jboss.server.log.dir.
+logging.read-log-file.lines=The number of lines to read from the file. A value of -1 will read all log lines.
+logging.read-log-file.skip=The number of lines to skip before reading.
+logging.read-log-file.tail=Reads from the end of the file.
+
+logging.list-log-files=Lists the log files in the jboss.server.log.dir directory.
+logging.list-log-files.file-name=The name of the file.
+logging.list-log-files.file-size=The size of the log file in bytes.
+
 # Logging profiles
 logging.logging-profile=A profile that can be assigned to a deployment for it's logging configuration.
 logging.logging-profile.add=Adds a logging profile.

--- a/logging/src/test/java/org/jboss/as/logging/RootSubsystemOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/RootSubsystemOperationsTestCase.java
@@ -1,0 +1,223 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.SubsystemOperations;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.Logger;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class RootSubsystemOperationsTestCase extends AbstractOperationsTestCase {
+    private final String msg = "Test message ";
+
+    @Before
+    public void clearLogDir() {
+        final File dir = LoggingTestEnvironment.get().getLogDir();
+        deleteRecursively(dir);
+    }
+
+    @Override
+    protected void standardSubsystemTest(final String configId) throws Exception {
+        // do nothing as this is not a subsystem parsing test
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return LoggingTestEnvironment.getManagementInstance();
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("/simple-subsystem.xml");
+    }
+
+    @Test
+    public void testListLogFiles() throws Exception {
+        final KernelServices kernelServices = boot();
+
+        // Subsystem address
+        final ModelNode address = SUBSYSTEM_ADDRESS.toModelNode();
+        final ModelNode op = SubsystemOperations.createOperation("list-log-files", address);
+        ModelNode result = executeOperation(kernelServices, op);
+        List<ModelNode> logFiles = SubsystemOperations.readResult(result).asList();
+
+        // Should only be one file
+        // TODO (jrp) can be tested when LOGMGR-83 is committed and the logmanager is updated
+        // assertEquals("Found: " + logFiles, 1, logFiles.size());
+
+        // Should only be a simple.log file
+        boolean found = false;
+        for (ModelNode fileInfo : logFiles) {
+            if ("simple.log".equals(fileInfo.get("file-name").asString())) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue("simple.log file was not found", found);
+
+        // Change the permissions on the file so read is not allowed
+        final File file = new File(LoggingTestEnvironment.get().getLogDir(), "simple.log");
+        // The file should exist
+        assertTrue("File does not exist", file.exists());
+
+        // Only test if successfully set
+        if (file.setReadable(false)) {
+            result = executeOperation(kernelServices, op);
+            logFiles = SubsystemOperations.readResult(result).asList();
+            assertTrue("Read permission was found to be true on the file.", logFiles.isEmpty());
+            // Reset the file permissions
+            assertTrue("Could not reset file permissions", file.setReadable(true));
+        }
+    }
+
+    @Test
+    public void testReadLogFile() throws Exception {
+        final KernelServices kernelServices = boot();
+
+        // Log 50 records
+        final Logger logger = getLogger();
+        for (int i = 0; i < 50; i++) {
+            logger.info(msg + i);
+        }
+
+        // Subsystem address
+        final ModelNode address = SUBSYSTEM_ADDRESS.toModelNode();
+        final ModelNode op = SubsystemOperations.createOperation("read-log-file", address);
+        op.get("name").set("simple.log");
+        ModelNode result = executeOperation(kernelServices, op);
+        List<String> logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(10, logLines.size());
+        checkLogLines(logLines, 40);
+
+        // Read from top
+        op.get("tail").set(false);
+        result = executeOperation(kernelServices, op);
+        logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(10, logLines.size());
+        checkLogLines(logLines, 0);
+
+        // Read more lines from top
+        op.get("lines").set(20);
+        result = executeOperation(kernelServices, op);
+        logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(20, logLines.size());
+        checkLogLines(logLines, 0);
+
+        // Read from bottom
+        op.get("tail").set(true);
+        result = executeOperation(kernelServices, op);
+        logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(20, logLines.size());
+        checkLogLines(logLines, 30);
+
+        // Skip lines from bottom
+        op.get("tail").set(true);
+        op.get("skip").set(5);
+        result = executeOperation(kernelServices, op);
+        logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(20, logLines.size());
+        checkLogLines(logLines, 25);
+
+        // Skip lines from top
+        op.get("tail").set(false);
+        op.get("skip").set(5);
+        result = executeOperation(kernelServices, op);
+        logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(20, logLines.size());
+        checkLogLines(logLines, 5);
+
+        // Read all lines
+        op.get("tail").set(false);
+        op.get("lines").set(-1);
+        op.remove("skip");
+        result = executeOperation(kernelServices, op);
+        logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(50, logLines.size());
+        checkLogLines(logLines, 0);
+
+        // Read all lines, but 5 lines
+        op.get("tail").set(false);
+        op.get("lines").set(-1);
+        op.get("skip").set(5);
+        result = executeOperation(kernelServices, op);
+        logLines = SubsystemOperations.readResultAsList(result);
+        assertEquals(45, logLines.size());
+        checkLogLines(logLines, 5);
+
+        // Change the permissions on the file so read is not allowed
+        final File file = new File(LoggingTestEnvironment.get().getLogDir(), op.get("name").asString());
+        // The file should exist
+        assertTrue("File does not exist", file.exists());
+
+        // Only test if successfully set
+        if (file.setReadable(false)) {
+            result = kernelServices.executeOperation(op);
+            assertFalse("Should have failed due to denial of read permissions on the file.", SubsystemOperations.isSuccessfulOutcome(result));
+            // Reset the file permissions
+            assertTrue("Could not reset file permissions", file.setReadable(true));
+        }
+
+        // Test an invalid file
+        op.get("name").set("invalid");
+        result = kernelServices.executeOperation(op);
+        assertFalse("Should have failed due to invalid file.", SubsystemOperations.isSuccessfulOutcome(result));
+    }
+
+    private void checkLogLines(final List<String> logLines, final int start) {
+        int index = start;
+        for (String line : logLines) {
+            final String lineMsg = msg + index;
+            assertTrue(String.format("Expected line containing '%s', found '%s", lineMsg, line), line.contains(msg + index));
+            index++;
+        }
+    }
+
+    private Logger getLogger() {
+        return LogContext.getSystemLogContext().getLogger("org.jboss.as.logging.test");
+    }
+
+    static void deleteRecursively(final File dir) {
+        if (dir.isDirectory()) {
+            final File[] files = dir.listFiles();
+            for (File file : files) {
+                if (file.isDirectory()) {
+                    deleteRecursively(file);
+                }
+                file.delete();
+            }
+        }
+    }
+}

--- a/logging/src/test/resources/simple-subsystem.xml
+++ b/logging/src/test/resources/simple-subsystem.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:logging:2.0">
+
+    <file-handler name="FILE" autoflush="true">
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="simple.log"/>
+    </file-handler>
+
+    <logger category="org.jboss.as.logging.test" use-parent-handlers="false">
+        <level name="INFO"/>
+        <handlers>
+            <handler name="FILE"/>
+        </handlers>
+    </logger>
+
+    <root-logger>
+        <level name="INFO"/>
+    </root-logger>
+
+    <formatter name="PATTERN">
+        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+    </formatter>
+</subsystem>


### PR DESCRIPTION
Adds two new operations; `list-log-files` and `read-log-file`.

The `list-log-files` lists all files in the `jboss.server.log.dir`. This does use the `File.canRead()` as partial way to secure files that should not be exposed via read. I did open a discussion on the ML about this and didn't hear much concern except for my initial concern about list files.

The `read-log-file` does just as it says and reads a log file. There are 5 options for this option;
- `name` (required): the name of the log file to read
- `encoding`: the encoding for the log file
- `lines`: the number of lines to read, defaults to 10
- `skip`: the number of lines to skip before adding the results
- `tail`: true to read from the bottom up, default is true
