### PR TITLE
Mark the ServerDeploymentRepository-temp-threads as daemon

### DIFF
--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentMountProvider.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentMountProvider.java
@@ -108,7 +108,7 @@ public interface DeploymentMountProvider {
             @Override
             public void start(StartContext context) throws StartException {
                 try {
-                    final JBossThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("ServerDeploymentRepository-temp-threads"), Boolean.FALSE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
+                    final JBossThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("ServerDeploymentRepository-temp-threads"), true, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
                     tempFileProvider = TempFileProvider.create("temp", Executors.newScheduledThreadPool(2, threadFactory), true);
                 } catch (IOException e) {
                     throw ServerMessages.MESSAGES.failedCreatingTempProvider();


### PR DESCRIPTION
The commit here marks the ServerDeploymentRepository-temp-threads as daemon threads to fix the issue reported here https://community.jboss.org/thread/232872
