### PR TITLE
WFLY-1791 : Parsing escaped characters in quotes

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/parsing/QuotesState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/QuotesState.java
@@ -31,18 +31,23 @@ public class QuotesState extends DefaultParsingState {
 
     public static final QuotesState QUOTES_EXCLUDED = new QuotesState(false);
     public static final QuotesState QUOTES_INCLUDED = new QuotesState(true);
+    public static final QuotesState QUOTES_INCLUDED_KEEP_ESCAPES = new QuotesState(true, EscapeCharacterState.KEEP_ESCAPE);
 
     public QuotesState(boolean quotesInContent) {
         this(quotesInContent, true);
     }
 
     public QuotesState(boolean quotesInContent, boolean escapeEnabled) {
+        this(quotesInContent, escapeEnabled ? EscapeCharacterState.INSTANCE : null);
+    }
+
+    public QuotesState(boolean quotesInContent, EscapeCharacterState escape) {
         super(ID, quotesInContent);
 
         this.setEndContentHandler(new ErrorCharacterHandler("The closing '\"' is missing."));
         this.putHandler('"', GlobalCharacterHandlers.LEAVE_STATE_HANDLER);
-        if(escapeEnabled) {
-            this.enterState('\\', EscapeCharacterState.INSTANCE);
+        if(escape != null) {
+            this.enterState('\\', escape);
         }
         this.setDefaultHandler(GlobalCharacterHandlers.CONTENT_CHARACTER_HANDLER);
     }

--- a/cli/src/main/java/org/jboss/as/cli/parsing/operation/PropertyValueState.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/operation/PropertyValueState.java
@@ -54,7 +54,7 @@ public class PropertyValueState extends DefaultParsingState {
         for(int i = 0; i < listEnd.length; ++i) {
             putHandler(listEnd[i], GlobalCharacterHandlers.LEAVE_STATE_HANDLER);
         }
-        enterState('"', QuotesState.QUOTES_INCLUDED);
+        enterState('"', QuotesState.QUOTES_INCLUDED_KEEP_ESCAPES);
         enterState('[', new DefaultStateWithEndCharacter("BRACKETS", ']', true, true, enterStateHandlers));
         enterState('(', new DefaultStateWithEndCharacter("PARENTHESIS", ')', true, true, enterStateHandlers));
         enterState('{', new DefaultStateWithEndCharacter("BRACES", '}', true, true, enterStateHandlers));

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueParsingTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/ArgumentValueParsingTestCase.java
@@ -318,6 +318,14 @@ public class ArgumentValueParsingTestCase {
     }
 
     @Test
+    public void testEscapedQuotes() throws Exception {
+        ModelNode value = parse("\"substituteAll(\\\"JBAS\\\",\\\"DUMMY\\\")\"");
+        assertNotNull(value);
+        assertEquals(ModelType.STRING, value.getType());
+        assertEquals("substituteAll(\"JBAS\",\"DUMMY\")", value.asString());
+    }
+
+    @Test
     public void testLoginModules() throws Exception {
         ModelNode value = parse("[{code=Database, flag=required, module-options=[unauthenticatedIdentity=guest," +
                 "dsJndiName=java:jboss/jdbc/ApplicationDS," +

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/OperationParsingTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/OperationParsingTestCase.java
@@ -260,6 +260,45 @@ public class OperationParsingTestCase {
         assertEquals("\"   \"", handler.getPropertyValue("another"));
     }
 
+    @Test
+    public void testOperationEscapedQuotesInArgumentValues() throws Exception {
+        DefaultCallbackHandler handler = new DefaultCallbackHandler();
+
+        parse("/subsystem=logging/console-handler=CONSOLE:write-attribute(name=filter-spec, value=\"substituteAll(\\\"JBAS\\\",\\\"DUMMY\\\")\")", handler);
+
+        assertTrue(handler.hasAddress());
+        assertTrue(handler.hasOperationName());
+        assertTrue(handler.hasProperties());
+        assertFalse(handler.endsOnAddressOperationNameSeparator());
+        assertFalse(handler.endsOnPropertyListStart());
+        assertFalse(handler.endsOnPropertySeparator());
+        assertFalse(handler.endsOnPropertyValueSeparator());
+        assertFalse(handler.endsOnNodeSeparator());
+        assertFalse(handler.endsOnNodeTypeNameSeparator());
+        assertFalse(handler.isRequestComplete());
+
+        assertEquals("write-attribute", handler.getOperationName());
+
+        OperationRequestAddress address = handler.getAddress();
+        Iterator<Node> i = address.iterator();
+        assertTrue(i.hasNext());
+        Node node = i.next();
+        assertEquals("subsystem", node.getType());
+        assertEquals("logging", node.getName());
+        assertTrue(i.hasNext());
+        node = i.next();
+        assertEquals("console-handler", node.getType());
+        assertEquals("CONSOLE", node.getName());
+        assertFalse(i.hasNext());
+
+        Set<String> args = handler.getPropertyNames();
+        assertEquals(2, args.size());
+        assertTrue(args.contains("name"));
+        assertEquals("filter-spec", handler.getPropertyValue("name"));
+        assertTrue(args.contains("value"));
+        assertEquals("\"substituteAll(\\\"JBAS\\\",\\\"DUMMY\\\")\"", handler.getPropertyValue("value"));
+    }
+
     protected void parse(String opReq, DefaultCallbackHandler handler) throws CommandFormatException {
         parser.parse(opReq, handler);
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/GlobalOpsTestCase.java
@@ -22,12 +22,12 @@
 package org.jboss.as.test.integration.management.cli;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
-import static org.junit.Assert.assertTrue;
 
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import static org.hamcrest.CoreMatchers.is;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -39,6 +39,8 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.AfterClass;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -253,5 +255,21 @@ public class GlobalOpsTestCase extends AbstractCliTestBase {
 
         assertTrue(((Map)((Map)map.get("step-1")).get("result")).containsKey("management-major-version"));
 
+    }
+
+    @Test
+    public void testStringValueParsing() throws Exception {
+        cli.sendLine("/subsystem=logging/console-handler=TEST-FILTER:add");
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        cli.sendLine("/subsystem=logging/console-handler=TEST-FILTER:write-attribute(name=filter-spec, value=\"substituteAll(\\\"JBAS\\\",\\\"DUMMY\\\")\")");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        cli.sendLine("/subsystem=logging/console-handler=TEST-FILTER:read-resource(recursive=true)");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        Map<String, Object> resource = result.getResultAsMap();
+        assertTrue(resource.containsKey("filter-spec"));
+        assertThat((String) resource.get("filter-spec"), is("substituteAll(\"JBAS\",\"DUMMY\")"));
     }
 }


### PR DESCRIPTION
Keeping escaped chars as escaped chars during property value parsing.

Jira : https://issues.jboss.org/browse/WFLY-1791
BZ : https://bugzilla.redhat.com/show_bug.cgi?id=982303

Alexey needs to check before merging can occur
