### PR TITLE
Mixed domain tests

### DIFF
--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -98,6 +98,34 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    public void testTransformerAS720() throws Exception {
+        ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.V7_2_0_FINAL;
+        //TODO Update to include the extra stuff needed for 1.2.0
+        String subsystemXml = "transform_1_1_0.xml";   //This has no expressions not understood by 1.1.0
+
+        ModelVersion modelVersion = ModelVersion.create(1, 2, 0); //The old model version
+        //Use the non-runtime version of the extension which will happen on the HC
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+                .setSubsystemXmlResource(subsystemXml);
+
+        // Add legacy subsystems
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
+                .addMavenResourceURL("org.jboss.as:jboss-as-ejb3:" + controllerVersion.getMavenGavVersion())
+                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + controllerVersion.getMavenGavVersion())
+                .skipReverseControllerCheck()
+                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName())))
+                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()), PathElement.pathElement("strict-max-bean-instance-pool")));
+
+        KernelServices mainServices = builder.build();
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertNotNull(mainServices);
+        Assert.assertNotNull(legacyServices);
+        generateLegacySubsystemResourceRegistrationDmr(mainServices, modelVersion);
+
+        checkSubsystemModelTransformation(mainServices, modelVersion, V_1_1_0_FIXER);
+    }
+
+    @Test
     public void testRejectExpressionsAS712() throws Exception {
         testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_2_FINAL);
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -100,6 +100,10 @@ public class DomainTransformers {
 
     private static void initializeDomainRegistry14(TransformerRegistry registry) {
         TransformersSubRegistration domain = registry.getDomainRegistration(VERSION_1_4);
+
+        //Discard the domain level core-service=management resource and its children
+        domain.registerSubResource(CoreManagementResourceDefinition.PATH_ELEMENT, true);
+
         //TODO not sure if these should be handled here for 1.4.0 or if it is better in the tests?
         //Add the domain interface name. This is currently from a read attribute handler but in < 1.4.0 it existed in the model
         domain.registerSubResource(PathElement.pathElement(INTERFACE), AddNameFromAddressResourceTransformer.INSTANCE);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -41,6 +41,7 @@ import org.jboss.as.controller.transform.ResourceTransformer;
 import org.jboss.as.controller.transform.TransformationTarget;
 import org.jboss.as.controller.transform.TransformerRegistry;
 import org.jboss.as.controller.transform.TransformersSubRegistration;
+import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 
 /**
  * Global transformation rules for the domain, host and server-config model.
@@ -78,6 +79,9 @@ public class DomainTransformers {
 
     private static void initializeDomainRegistryEAP60(TransformerRegistry registry, ModelVersion modelVersion) {
         TransformersSubRegistration domain = registry.getDomainRegistration(modelVersion);
+
+        //Discard the domain level core-service=management resource and its children
+        domain.registerSubResource(CoreManagementResourceDefinition.PATH_ELEMENT, true);
 
         // Discard all operations to the newly introduced jsf extension
         domain.registerSubResource(JSF_EXTENSION, IGNORED_EXTENSIONS);

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/transformers/DomainTransformers.java
@@ -80,6 +80,7 @@ public class DomainTransformers {
     private static void initializeDomainRegistryEAP60(TransformerRegistry registry, ModelVersion modelVersion) {
         TransformersSubRegistration domain = registry.getDomainRegistration(modelVersion);
 
+        //TODO see Brian's comments in https://github.com/wildfly/wildfly/pull/5160
         //Discard the domain level core-service=management resource and its children
         domain.registerSubResource(CoreManagementResourceDefinition.PATH_ELEMENT, true);
 
@@ -101,6 +102,7 @@ public class DomainTransformers {
     private static void initializeDomainRegistry14(TransformerRegistry registry) {
         TransformersSubRegistration domain = registry.getDomainRegistration(VERSION_1_4);
 
+        //TODO see Brian's comments in https://github.com/wildfly/wildfly/pull/5160
         //Discard the domain level core-service=management resource and its children
         domain.registerSubResource(CoreManagementResourceDefinition.PATH_ELEMENT, true);
 

--- a/pom.xml
+++ b/pom.xml
@@ -1236,6 +1236,12 @@
 
             <dependency>
                 <groupId>org.wildfly</groupId>
+                <artifactId>wildfly-subsystem-test-controller-7.2.0</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-subsystem-test-framework</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
+++ b/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
@@ -21,6 +21,7 @@
 */
 package org.jboss.as.remoting;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.IGNORED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
@@ -56,7 +57,6 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -182,6 +182,7 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBase
         checkRejectOutboundConnectionProperty(mainServices, version_1_1, CommonAttributes.REMOTE_OUTBOUND_CONNECTION, "remote-conn1");
         checkRejectOutboundConnectionProperty(mainServices, version_1_1, CommonAttributes.LOCAL_OUTBOUND_CONNECTION, "local-conn1");
         checkRejectOutboundConnectionProperty(mainServices, version_1_1, CommonAttributes.OUTBOUND_CONNECTION, "generic-conn1");
+        checkRejectHttpConnector(mainServices, version_1_1);
     }
 
     private void checkRejectOutboundConnectionProperty(KernelServices mainServices, ModelVersion version, String type, String name) throws OperationFailedException {
@@ -284,6 +285,18 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBase
         operation.get(OP_ADDR).set(address);
         operation.get(NAME).set("worker-read-threads");
         operation.get(VALUE).set("${worker.read.threads:5}");
+
+        checkReject(operation, mainServices, version);
+    }
+
+    private void checkRejectHttpConnector(KernelServices mainServices, ModelVersion version) throws OperationFailedException {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(ADD);
+        operation.get(CommonAttributes.CONNECTOR_REF).set("test");
+        ModelNode address = new ModelNode();
+        address.add(SUBSYSTEM, RemotingExtension.SUBSYSTEM_NAME);
+        address.add(HttpConnectorResource.PATH.getKey(), "test");
+        operation.get(OP_ADDR).set(address);
 
         checkReject(operation, mainServices, version);
     }

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -110,6 +110,7 @@ public class RemotingExtension implements Extension {
         if (context.isRegisterTransformers()) {
             registerTransformers_1_1(registration);
             registerTransformers_1_2(registration);
+            registerTransformers_1_3(registration);
         }
     }
 
@@ -118,6 +119,8 @@ public class RemotingExtension implements Extension {
         ResourceTransformationDescriptionBuilder builder = ResourceTransformationDescriptionBuilder.Factory.createSubsystemInstance();
         builder.getAttributeBuilder()
                 .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, RemotingSubsystemRootResource.ATTRIBUTES);
+
+        builder.rejectChildResource(HttpConnectorResource.PATH);
 
         ResourceTransformationDescriptionBuilder connector = builder.addChildResource(ConnectorResource.PATH);
         connector.addChildResource(PropertyResource.PATH).getAttributeBuilder().addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, PropertyResource.VALUE);

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
@@ -57,6 +57,7 @@ class KnownVersions {
         addSubsystemVersion(map, "jacorb", "1.1.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "datasources", "1.1.0", CORE_MODEL_7_1_2);
         addSubsystemVersion(map, "ejb3", "1.1.0", CORE_MODEL_7_1_2);
+        addSubsystemVersion(map, "ejb3", "1.2.0", CORE_MODEL_7_2_0);
         addSubsystemVersion(map, "infinispan", "1.3.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "infinispan", "1.4.0", CORE_MODEL_7_2_0);
         addSubsystemVersion(map, "jacorb", "1.1.0", CORE_MODEL_7_1_3);

--- a/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/ejb3-1.2.0.dmr
+++ b/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/ejb3-1.2.0.dmr
@@ -1,0 +1,584 @@
+{
+    "model-description" => {
+        "description" => "The configuration of the ejb3 subsystem.",
+        "attributes" => {
+            "default-security-domain" => {
+                "type" => STRING,
+                "description" => "The default security domain that will be used for EJBs if the bean doesn't explicitly specify one",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-mdb-instance-pool" => {
+                "type" => STRING,
+                "description" => "Name of the default MDB instance pool, which will be applicable to all MDBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-entity-bean-optimistic-locking" => {
+                "type" => BOOLEAN,
+                "description" => "If set to true entity beans will use optimistic locking by default",
+                "expressions-allowed" => true,
+                "nillable" => true
+            },
+            "in-vm-remote-interface-invocation-pass-by-value" => {
+                "type" => BOOLEAN,
+                "description" => "If set to false, the parameters to invocations on remote interface of an EJB, will be passed by reference. Else, the parameters will be passed by value.",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => true
+            },
+            "default-missing-method-permissions-deny-access" => {
+                "type" => BOOLEAN,
+                "description" => "If this is set to true then methods on an EJB with a security domain specified or with other methods with security metadata will have an implicit @DenyAll unless other security metadata is present",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => false
+            },
+            "default-clustered-sfsb-cache" => {
+                "type" => STRING,
+                "description" => "Name of the default stateful bean cache, which will be applicable to all clustered stateful EJBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-entity-bean-instance-pool" => {
+                "type" => STRING,
+                "description" => "Name of the default entity bean instance pool, which will be applicable to all entity beans, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-distinct-name" => {
+                "type" => STRING,
+                "description" => "The default distinct name that is applied to every EJB deployed on this server",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 0L,
+                "max-length" => 2147483647L
+            },
+            "default-singleton-bean-access-timeout" => {
+                "type" => LONG,
+                "description" => "The default access timeout for singleton beans",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => 5000,
+                "min" => 1L,
+                "max" => 2147483647L
+            },
+            "default-sfsb-cache" => {
+                "type" => STRING,
+                "description" => "Name of the default stateful bean cache, which will be applicable to all stateful EJBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-resource-adapter-name" => {
+                "type" => STRING,
+                "description" => "Name of the default resource adapter name that will be used by MDBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => "hornetq-ra",
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "enable-statistics" => {
+                "type" => BOOLEAN,
+                "description" => "If set to true, enable the collection of invocation statistics.",
+                "expressions-allowed" => true,
+                "nillable" => true
+            },
+            "default-stateful-bean-access-timeout" => {
+                "type" => LONG,
+                "description" => "The default access timeout for stateful beans",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => 5000,
+                "min" => 1L,
+                "max" => 2147483647L
+            },
+            "default-slsb-instance-pool" => {
+                "type" => STRING,
+                "description" => "Name of the default stateless bean instance pool, which will be applicable to all stateless EJBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }
+        },
+        "operations" => undefined,
+        "children" => {
+            "service" => {
+                "description" => "Centrally configurable services that are part of the EJB3 subsystem.",
+                "model-description" => undefined
+            },
+            "thread-pool" => {
+                "description" => "An EJB thread pool",
+                "model-description" => undefined
+            },
+            "file-passivation-store" => {
+                "description" => "A file system based passivation store",
+                "model-description" => undefined
+            },
+            "strict-max-bean-instance-pool" => {
+                "description" => "A bean instance pool with a strict upper limit",
+                "model-description" => undefined
+            },
+            "cache" => {
+                "description" => "A SFSB cache",
+                "model-description" => undefined
+            },
+            "cluster-passivation-store" => {
+                "description" => "A clustered passivation store",
+                "model-description" => undefined
+            }
+        }
+    },
+    "address" => [("subsystem" => "ejb3")],
+    "children" => [
+        {
+            "model-description" => {
+                "description" => "The EJB3 Asynchronous Invocation Service",
+                "attributes" => {"thread-pool-name" => {
+                    "type" => STRING,
+                    "description" => "The name of the thread pool which handles asynchronous invocations",
+                    "expressions-allowed" => true,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }},
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "async")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "The IIOP service",
+                "attributes" => {
+                    "enable-by-default" => {
+                        "type" => BOOLEAN,
+                        "description" => "If this is true EJB's will be exposed over IIOP by default, otherwise it needs to be explicitly enabled in the deployment descriptor",
+                        "expressions-allowed" => true,
+                        "nillable" => true
+                    },
+                    "use-qualified-name" => {
+                        "type" => BOOLEAN,
+                        "description" => "If true EJB names will be bound into the naming service with the application and module name prepended to the name (e.g. myapp/mymodule/MyEjb)",
+                        "expressions-allowed" => true,
+                        "nillable" => true
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "iiop")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A thread pool executor with an unbounded queue.  Such a thread pool has a core size and a queue with no upper bound.  When a task is submitted, if the number of running threads is less than the core size, a new thread is created.  Otherwise, the task is placed in queue.  If too many tasks are allowed to be submitted to this type of executor, an out of memory condition may occur.",
+                "attributes" => {
+                    "max-threads" => {
+                        "type" => INT,
+                        "description" => "The maximum thread pool size.",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "min" => 0L,
+                        "max" => 2147483647L
+                    },
+                    "thread-factory" => {
+                        "type" => STRING,
+                        "description" => "Specifies the name of a specific thread factory to use to create worker threads. If not defined an appropriate default thread factory will be used.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "keepalive-time" => {
+                        "type" => OBJECT,
+                        "description" => "Used to specify the amount of time that pool threads should be kept running when idle; if not specified, threads will run until the executor is shut down.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {
+                            "time" => {
+                                "type" => LONG,
+                                "description" => "The time",
+                                "expressions-allowed" => true,
+                                "nillable" => false
+                            },
+                            "unit" => {
+                                "type" => STRING,
+                                "description" => "The time unit",
+                                "expressions-allowed" => true,
+                                "nillable" => false
+                            }
+                        }
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The name of the thread pool.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("thread-pool" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A file system based passivation store",
+                "attributes" => {
+                    "idle-timeout" => {
+                        "type" => LONG,
+                        "description" => "The timeout in units specified by idle-timeout-unit, after which a bean will passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 300L,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "groups-path" => {
+                        "type" => STRING,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ejb3/groups",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "sessions-path" => {
+                        "type" => STRING,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ejb3/sessions",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "relative-to" => {
+                        "type" => STRING,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "jboss.server.data.dir",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "subdirectory-count" => {
+                        "type" => LONG,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 100,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "max-size" => {
+                        "type" => INT,
+                        "description" => "The maximum number of beans this cache should store before forcing old beans to passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 100000,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "idle-timeout-unit" => {
+                        "type" => STRING,
+                        "description" => "The unit of idle-timeout",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "SECONDS",
+                        "allowed" => [
+                            "NANOSECONDS",
+                            "MICROSECONDS",
+                            "MILLISECONDS",
+                            "SECONDS",
+                            "MINUTES",
+                            "HOURS",
+                            "DAYS"
+                        ]
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("file-passivation-store" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A bean instance pool with a strict upper limit",
+                "attributes" => {
+                    "timeout-unit" => {
+                        "type" => STRING,
+                        "description" => "The instance acquisition timeout unit",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "MINUTES",
+                        "allowed" => [
+                            "NANOSECONDS",
+                            "MICROSECONDS",
+                            "MILLISECONDS",
+                            "SECONDS",
+                            "MINUTES",
+                            "HOURS",
+                            "DAYS"
+                        ]
+                    },
+                    "max-pool-size" => {
+                        "type" => INT,
+                        "description" => "The maximum number of bean instances that the pool can hold at a given point in time",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 20,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "timeout" => {
+                        "type" => LONG,
+                        "description" => "The maximum amount of time to wait for a bean instance to be available from the pool",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 5L,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("strict-max-bean-instance-pool" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "The EJB3 Remote Service",
+                "attributes" => {
+                    "thread-pool-name" => {
+                        "type" => STRING,
+                        "description" => "The name of the thread pool that handles remote invocations",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "connector-ref" => {
+                        "type" => STRING,
+                        "description" => "The name of the connector on which the EJB3 remoting channel is registered",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {"channel-creation-options" => {
+                    "description" => "The options that will be used during the EJB remote channel creation",
+                    "model-description" => undefined
+                }}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "remote")
+            ],
+            "children" => [{
+                "model-description" => {
+                    "description" => "The options that will be used during the EJB remote channel creation",
+                    "attributes" => {
+                        "value" => {
+                            "type" => STRING,
+                            "description" => "The value for the EJB remote channel creation option",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "type" => {
+                            "type" => STRING,
+                            "description" => "The type of the channel creation option",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "allowed" => [
+                                "remoting",
+                                "xnio"
+                            ]
+                        }
+                    },
+                    "operations" => undefined,
+                    "children" => {}
+                },
+                "address" => [
+                    ("subsystem" => "ejb3"),
+                    ("service" => "remote"),
+                    ("channel-creation-options" => "*")
+                ]
+            }]
+        },
+        {
+            "model-description" => {
+                "description" => "A SFSB cache",
+                "attributes" => {
+                    "aliases" => {
+                        "type" => LIST,
+                        "description" => "The aliases by which this cache may also be referenced",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    },
+                    "passivation-store" => {
+                        "type" => STRING,
+                        "description" => "The passivation store used by this cache",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("cache" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "The EJB timer service",
+                "attributes" => {
+                    "path" => {
+                        "type" => STRING,
+                        "description" => "The directory to store persistent timer information in",
+                        "expressions-allowed" => true,
+                        "nillable" => true
+                    },
+                    "thread-pool-name" => {
+                        "type" => STRING,
+                        "description" => "The name of the thread pool used to run timer service invocations",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "relative-to" => {
+                        "type" => STRING,
+                        "description" => "The relative path that is used to resolve the timer data store location",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "timer-service")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A clustered passivation store",
+                "attributes" => {
+                    "idle-timeout" => {
+                        "type" => LONG,
+                        "description" => "The timeout in units specified by idle-timeout-unit, after which a bean will passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 300L,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "cache-container" => {
+                        "type" => STRING,
+                        "description" => "The name of the cache container used for the bean and client-mappings caches",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ejb",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "client-mappings-cache" => {
+                        "type" => STRING,
+                        "description" => "The name of the cache used to store client-mappings of the EJB remoting connector's socket-bindings",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "remote-connector-client-mappings",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "bean-cache" => {
+                        "type" => STRING,
+                        "description" => "The name of the cache used to store bean instances.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "passivate-events-on-replicate" => {
+                        "type" => BOOLEAN,
+                        "description" => "Indicates whether replication should trigger passivation events on the bean",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "max-size" => {
+                        "type" => INT,
+                        "description" => "The maximum number of beans this cache should store before forcing old beans to passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 10000,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "idle-timeout-unit" => {
+                        "type" => STRING,
+                        "description" => "The unit of idle-timeout",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "SECONDS",
+                        "allowed" => [
+                            "NANOSECONDS",
+                            "MICROSECONDS",
+                            "MILLISECONDS",
+                            "SECONDS",
+                            "MINUTES",
+                            "HOURS",
+                            "DAYS"
+                        ]
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("cluster-passivation-store" => "*")
+            ]
+        }
+    ]
+}

--- a/subsystem-test/test-controller-7.2.0/src/main/java/org/jboss/as/subsystem/test/AdditionalInitializationUtil.java
+++ b/subsystem-test/test-controller-7.2.0/src/main/java/org/jboss/as/subsystem/test/AdditionalInitializationUtil.java
@@ -44,4 +44,13 @@ public class AdditionalInitializationUtil {
     public static RunningMode getRunningMode(AdditionalInitialization additionalInit) {
         return additionalInit.getRunningMode();
     }
+
+
+    public static void doExtraInitialization(AdditionalInitialization additionalInit, ControllerInitializer controllerInitializer, ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        //TODO
+        //controllerInitializer.setTestModelControllerService(this);
+        controllerInitializer.initializeModel(rootResource, rootRegistration);
+        additionalInit.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration);
+    }
+
 }

--- a/subsystem-test/test-controller-7.2.0/src/main/java/org/jboss/as/subsystem/test/controller7_2_0/TestModelControllerService7_2_0.java
+++ b/subsystem-test/test-controller-7.2.0/src/main/java/org/jboss/as/subsystem/test/controller7_2_0/TestModelControllerService7_2_0.java
@@ -22,16 +22,31 @@
 
 package org.jboss.as.subsystem.test.controller7_2_0;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+
+import org.jboss.as.controller.BootContext;
 import org.jboss.as.controller.ControlledProcessState;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.RunningModeControl;
 import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.model.test.ModelTestModelControllerService;
 import org.jboss.as.model.test.ModelTestOperationValidatorFilter;
 import org.jboss.as.model.test.StringConfigurationPersister;
+import org.jboss.as.repository.ContentRepository;
+import org.jboss.as.server.controller.resources.ServerDeploymentResourceDefinition;
+import org.jboss.as.server.operations.RootResourceHack;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.AdditionalInitializationUtil;
 import org.jboss.as.subsystem.test.ControllerInitializer;
+import org.jboss.dmr.ModelNode;
+import org.jboss.vfs.VirtualFile;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -39,9 +54,77 @@ import org.jboss.as.subsystem.test.ControllerInitializer;
  */
 class TestModelControllerService7_2_0 extends ModelTestModelControllerService {
 
+    private final ExtensionRegistry extensionRegistry;
+    private final AdditionalInitialization additionalInit;
+    private final ControllerInitializer controllerInitializer;
+    private final Extension mainExtension;
+
     TestModelControllerService7_2_0(final Extension mainExtension, final ControllerInitializer controllerInitializer,
                                     final AdditionalInitialization additionalInit, final RunningModeControl runningModeControl, final ExtensionRegistry extensionRegistry,
                                     final StringConfigurationPersister persister, final ModelTestOperationValidatorFilter validateOpsFilter, final boolean registerTransformers) {
         super(AdditionalInitializationUtil.getProcessType(additionalInit), runningModeControl, extensionRegistry.getTransformerRegistry(), persister, validateOpsFilter, ModelTestModelControllerService.DESC_PROVIDER, new ControlledProcessState(true));
+        this.extensionRegistry = extensionRegistry;
+        this.additionalInit = additionalInit;
+        this.controllerInitializer = controllerInitializer;
+        this.mainExtension = mainExtension;
     }
+
+    @Override
+    protected void initExtraModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        rootResource.getModel().get(SUBSYSTEM);
+
+        ManagementResourceRegistration deployments = rootRegistration.registerSubModel(ServerDeploymentResourceDefinition.create(new ContentRepository() {
+
+            @Override
+            public boolean syncContent(byte[] hash) {
+                return false;
+            }
+
+            @Override
+            public void removeContent(byte[] hash, Object reference) {
+            }
+
+            @Override
+            public boolean hasContent(byte[] hash) {
+                return false;
+            }
+
+            @Override
+            public VirtualFile getContent(byte[] hash) {
+                return null;
+            }
+
+            @Override
+            public void addContentReference(byte[] hash, Object reference) {
+            }
+
+            @Override
+            public byte[] addContent(InputStream stream) throws IOException {
+                return null;
+            }
+        }, null));
+
+        //Hack to be able to access the registry for the jmx facade
+
+        rootRegistration.registerOperationHandler(RootResourceHack.DEFINITION, RootResourceHack.INSTANCE);
+
+        extensionRegistry.setSubsystemParentResourceRegistrations(rootRegistration, deployments);
+        AdditionalInitializationUtil.doExtraInitialization(additionalInit, controllerInitializer, extensionRegistry, rootResource, rootRegistration);
+    }
+
+
+    @Override
+    protected void boot(BootContext context) throws ConfigurationPersistenceException {
+        try {
+            super.boot(context);
+        } finally {
+            countdownDoneLatch();
+        }
+    }
+
+    @Override
+    protected void preBoot(List<ModelNode> bootOperations, boolean rollbackOnRuntimeFailure) {
+        mainExtension.initialize(extensionRegistry.getExtensionContext("Test", true));
+    }
+
 }

--- a/subsystem-test/test-controller-optional/pom.xml
+++ b/subsystem-test/test-controller-optional/pom.xml
@@ -49,6 +49,11 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-subsystem-test-controller-7.2.0</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
             <artifactId>wildfly-subsystem-test-framework</artifactId>
         </dependency>
     </dependencies>

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeploymentTest.java
@@ -21,7 +21,6 @@
 */
 package org.jboss.as.test.integration.domain.mixed;
 
-import static org.junit.Assert.assertTrue;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
@@ -40,6 +39,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STE
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TO_REPLACE;
 import static org.jboss.as.test.integration.domain.management.util.DomainTestSupport.validateResponse;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.xnio.IoUtils.safeClose;
 
@@ -82,8 +82,6 @@ public abstract class MixedDomainDeploymentTest {
     private static final ModelNode ROOT_REPLACEMENT_ADDRESS = new ModelNode();
     private static final ModelNode MAIN_SERVER_GROUP_ADDRESS = new ModelNode();
     private static final ModelNode MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS = new ModelNode();
-    private static final ModelNode OTHER_SERVER_GROUP_ADDRESS = new ModelNode();
-    private static final ModelNode OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS = new ModelNode();
 
     static {
         ROOT_ADDRESS.setEmptyList();
@@ -97,11 +95,6 @@ public abstract class MixedDomainDeploymentTest {
         MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS.add(SERVER_GROUP, "main-server-group");
         MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS.add(DEPLOYMENT, TEST);
         MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS.protect();
-        OTHER_SERVER_GROUP_ADDRESS.add(SERVER_GROUP, "other-server-group");
-        OTHER_SERVER_GROUP_ADDRESS.protect();
-        OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS.add(SERVER_GROUP, "other-server-group");
-        OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS.add(DEPLOYMENT, TEST);
-        OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS.protect();
     }
 
     private WebArchive webArchive;
@@ -109,6 +102,8 @@ public abstract class MixedDomainDeploymentTest {
     private WebArchive jsfTestArchive;
     private MixedDomainTestSupport testSupport;
     private File tmpDir;
+
+
 
     @Before
     public void setupDomain() throws Exception {
@@ -184,7 +179,7 @@ public abstract class MixedDomainDeploymentTest {
         String url = new File(tmpDir, "archives/" + TEST).toURI().toURL().toString();
         ModelNode content = new ModelNode();
         content.get("url").set(url);
-        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, getOtherServerGroupDeploymentAddress());
         System.out.println(composite);
         executeOnMaster(composite);
 
@@ -195,7 +190,7 @@ public abstract class MixedDomainDeploymentTest {
     public void testDeploymentViaStream() throws Exception {
         ModelNode content = new ModelNode();
         content.get(INPUT_STREAM_INDEX).set(0);
-        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, getOtherServerGroupDeploymentAddress());
         OperationBuilder builder = new OperationBuilder(composite, true);
         builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
 
@@ -210,7 +205,7 @@ public abstract class MixedDomainDeploymentTest {
         ModelNode content = new ModelNode();
         content.get("archive").set(true);
         content.get("path").set(new File(tmpDir, "archives/" + TEST).getAbsolutePath());
-        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, getOtherServerGroupDeploymentAddress());
         executeOnMaster(composite);
 
         performHttpCall(DomainTestSupport.slaveAddress, 8080);
@@ -221,7 +216,7 @@ public abstract class MixedDomainDeploymentTest {
         ModelNode content = new ModelNode();
         content.get("archive").set(false);
         content.get("path").set(new File(tmpDir, "exploded/" + TEST).getAbsolutePath());
-        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, getOtherServerGroupDeploymentAddress());
 
         executeOnMaster(composite);
 
@@ -283,7 +278,7 @@ public abstract class MixedDomainDeploymentTest {
 
         ModelNode content = new ModelNode();
         content.get(INPUT_STREAM_INDEX).set(0);
-        ModelNode op = createDeploymentReplaceOperation(content, MAIN_SERVER_GROUP_ADDRESS, OTHER_SERVER_GROUP_ADDRESS);
+        ModelNode op = createDeploymentReplaceOperation(content, MAIN_SERVER_GROUP_ADDRESS, getOtherServerGroupAddress());
         OperationBuilder builder = new OperationBuilder(op, true);
         builder.addInputStream(webArchive.as(ZipExporter.class).exportAsInputStream());
 
@@ -297,7 +292,7 @@ public abstract class MixedDomainDeploymentTest {
         ModelNode content = new ModelNode();
         content.get(INPUT_STREAM_INDEX).set(0);
         //Just be lazy here and deploy the jsf-test.war with the same name as the other deployments we tried
-        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+        ModelNode composite = createDeploymentOperation(content, MAIN_SERVER_GROUP_DEPLOYMENT_ADDRESS, getOtherServerGroupDeploymentAddress());
         OperationBuilder builder = new OperationBuilder(composite, true);
         builder.addInputStream(jsfTestArchive.as(ZipExporter.class).exportAsInputStream());
 
@@ -307,7 +302,7 @@ public abstract class MixedDomainDeploymentTest {
     }
 
     private void redeployTest() throws IOException {
-        ModelNode op = getEmptyOperation("redeploy", OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+        ModelNode op = getEmptyOperation("redeploy", getOtherServerGroupDeploymentAddress());
         executeOnMaster(op);
 
         performHttpCall(DomainTestSupport.slaveAddress, 8080);
@@ -315,7 +310,7 @@ public abstract class MixedDomainDeploymentTest {
 
 
     private void undeployTest() throws Exception {
-        ModelNode op = getEmptyOperation("undeploy", OTHER_SERVER_GROUP_DEPLOYMENT_ADDRESS);
+        ModelNode op = getEmptyOperation("undeploy", getOtherServerGroupDeploymentAddress());
         executeOnMaster(op);
 
         // Thread.sleep(1000);
@@ -338,9 +333,9 @@ public abstract class MixedDomainDeploymentTest {
         for (ModelNode deployment : deploymentList) {
             removeDeployment(deployment.asString(), MAIN_SERVER_GROUP_ADDRESS);
         }
-        deploymentList = getDeploymentList(OTHER_SERVER_GROUP_ADDRESS);
+        deploymentList = getDeploymentList(getOtherServerGroupAddress());
         for (ModelNode deployment : deploymentList) {
-            removeDeployment(deployment.asString(), OTHER_SERVER_GROUP_ADDRESS);
+            removeDeployment(deployment.asString(), getOtherServerGroupAddress());
         }
         deploymentList = getDeploymentList(ROOT_ADDRESS);
         for (ModelNode deployment : deploymentList) {
@@ -454,5 +449,19 @@ public abstract class MixedDomainDeploymentTest {
         }
         return op;
     }
+
+    private ModelNode getOtherServerGroupAddress() {
+        ModelNode addr = new ModelNode();
+        addr.add(SERVER_GROUP, getServerGroupName());
+        return addr;
+    }
+    private ModelNode getOtherServerGroupDeploymentAddress() {
+        ModelNode addr = new ModelNode();
+        addr.add(SERVER_GROUP, getServerGroupName());
+        addr.add(DEPLOYMENT, TEST);
+        return addr;
+    }
+
+    abstract String getServerGroupName();
 
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_2_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_2_Final_TestCase.java
@@ -28,7 +28,7 @@ import org.junit.BeforeClass;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@Version(AsVersion.V_7_1_2_Final)
+@Version(AsVersion.AS_7_1_2_FINAL)
 public class MixedDomainDeployment_7_1_2_Final_TestCase extends MixedDomainDeploymentTest {
     @BeforeClass
     public static void beforeClass() {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_2_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_2_Final_TestCase.java
@@ -32,6 +32,11 @@ import org.junit.BeforeClass;
 public class MixedDomainDeployment_7_1_2_Final_TestCase extends MixedDomainDeploymentTest {
     @BeforeClass
     public static void beforeClass() {
-        MixedDomainTestSuite.getSupport(MixedDomainDeployment_7_1_2_Final_TestCase.class);
+        MixedDomainTestSuite.getSupport(MixedDomain_7_1_2_Final_TestSuite.class);
+    }
+
+    @Override
+    String getServerGroupName() {
+        return "7.1.2-server-group";
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_3_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_3_Final_TestCase.java
@@ -32,6 +32,11 @@ import org.junit.BeforeClass;
 public class MixedDomainDeployment_7_1_3_Final_TestCase extends MixedDomainDeploymentTest {
     @BeforeClass
     public static void beforeClass() {
-        MixedDomainTestSuite.getSupport(MixedDomainDeployment_7_1_3_Final_TestCase.class);
+        MixedDomainTestSuite.getSupport(MixedDomain_7_1_3_Final_TestSuite.class);
+    }
+
+    @Override
+    String getServerGroupName() {
+        return "7.1.3-server-group";
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_3_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_1_3_Final_TestCase.java
@@ -28,7 +28,7 @@ import org.junit.BeforeClass;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@Version(AsVersion.V_7_1_3_Final)
+@Version(AsVersion.AS_7_1_3_FINAL)
 public class MixedDomainDeployment_7_1_3_Final_TestCase extends MixedDomainDeploymentTest {
     @BeforeClass
     public static void beforeClass() {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_2_0_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainDeployment_7_2_0_Final_TestCase.java
@@ -28,11 +28,15 @@ import org.junit.BeforeClass;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@Version(AsVersion.AS_7_1_3_FINAL)
-public class SimpleMixedDomain_7_1_3_Final_TestCase extends SimpleMixedDomainTest {
-
+@Version(AsVersion.AS_7_2_0_FINAL)
+public class MixedDomainDeployment_7_2_0_Final_TestCase extends MixedDomainDeploymentTest {
     @BeforeClass
     public static void beforeClass() {
-        MixedDomainTestSuite.getSupport(MixedDomain_7_1_3_Final_TestSuite.class);
+        MixedDomainTestSuite.getSupport(MixedDomain_7_2_0_Final_TestSuite.class);
+    }
+
+    @Override
+    String getServerGroupName() {
+        return "7.2.0-server-group";
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
@@ -57,7 +57,7 @@ public class MixedDomainTestSuite {
         Version.AsVersion version = getVersion(testClass);
         if (support == null) {
             try {
-                final MixedDomainTestSupport testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version.getVersion());
+                final MixedDomainTestSupport testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version);
                 // Start!
                 testSupport.start();
                 support = testSupport;

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomain_7_1_2_Final_TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomain_7_1_2_Final_TestSuite.java
@@ -33,7 +33,7 @@ import org.junit.runners.Suite.SuiteClasses;
  */
 @RunWith(Suite.class)
 @SuiteClasses(value= {SimpleMixedDomain_7_1_2_Final_TestCase.class, MixedDomainDeployment_7_1_2_Final_TestCase.class})
-@Version(AsVersion.V_7_1_2_Final)
+@Version(AsVersion.AS_7_1_2_FINAL)
 public class MixedDomain_7_1_2_Final_TestSuite extends MixedDomainTestSuite {
 
     @BeforeClass

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomain_7_1_3_Final_TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomain_7_1_3_Final_TestSuite.java
@@ -33,7 +33,7 @@ import org.junit.runners.Suite.SuiteClasses;
  */
 @RunWith(Suite.class)
 @SuiteClasses(value= {SimpleMixedDomain_7_1_3_Final_TestCase.class, MixedDomainDeployment_7_1_3_Final_TestCase.class})
-@Version(AsVersion.V_7_1_3_Final)
+@Version(AsVersion.AS_7_1_3_FINAL)
 public class MixedDomain_7_1_3_Final_TestSuite extends MixedDomainTestSuite {
 
     @BeforeClass

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomain_7_2_0_Final_TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomain_7_2_0_Final_TestSuite.java
@@ -23,16 +23,21 @@ package org.jboss.as.test.integration.domain.mixed;
 
 import org.jboss.as.test.integration.domain.mixed.Version.AsVersion;
 import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@Version(AsVersion.AS_7_1_3_FINAL)
-public class SimpleMixedDomain_7_1_3_Final_TestCase extends SimpleMixedDomainTest {
+@RunWith(Suite.class)
+@SuiteClasses(value= {SimpleMixedDomain_7_2_0_Final_TestCase.class, MixedDomainDeployment_7_2_0_Final_TestCase.class})
+@Version(AsVersion.AS_7_2_0_FINAL)
+public class MixedDomain_7_2_0_Final_TestSuite extends MixedDomainTestSuite {
 
     @BeforeClass
-    public static void beforeClass() {
-        MixedDomainTestSuite.getSupport(MixedDomain_7_1_3_Final_TestSuite.class);
+    public static void initializeDomain() {
+        getSupport(MixedDomain_7_2_0_Final_TestSuite.class);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -21,7 +21,7 @@
 */
 package org.jboss.as.test.integration.domain.mixed;
 
-import static org.junit.Assert.assertEquals;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
@@ -38,6 +38,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SCH
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+import static org.junit.Assert.assertEquals;
 
 import java.net.URL;
 import java.net.URLConnection;
@@ -154,6 +155,7 @@ public abstract class SimpleMixedDomainTest  {
         model.remove(SERVER_GROUP);
         model.remove(SOCKET_BINDING_GROUP);
         model.remove(SYSTEM_PROPERTY);
+        model.remove(CORE_SERVICE);
 
         return model;
     }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -107,11 +107,10 @@ public abstract class SimpleMixedDomainTest  {
     }
 
     private void cleanupKnownDifferencesInModelsForVersioningCheck(ModelNode masterModel, ModelNode slaveModel) {
+        //First get rid of any undefined crap
+        cleanUndefinedNodes(masterModel);
+        cleanUndefinedNodes(slaveModel);
         if (version == AsVersion.AS_7_1_2_FINAL || version == AsVersion.AS_7_1_3_FINAL) {
-            //First get rid of any undefined crap
-            cleanUndefinedNodes(masterModel);
-            cleanUndefinedNodes(slaveModel);
-
             if (masterModel.hasDefined(NAMESPACES) && masterModel.get(NAMESPACES).asList().isEmpty()) {
                 if (!slaveModel.hasDefined(NAMESPACES)) {
                     masterModel.remove(NAMESPACES);

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -107,7 +107,7 @@ public abstract class SimpleMixedDomainTest  {
     }
 
     private void cleanupKnownDifferencesInModelsForVersioningCheck(ModelNode masterModel, ModelNode slaveModel) {
-        if (version == AsVersion.V_7_1_2_Final || version == AsVersion.V_7_1_3_Final) {
+        if (version == AsVersion.AS_7_1_2_FINAL || version == AsVersion.AS_7_1_3_FINAL) {
             //First get rid of any undefined crap
             cleanUndefinedNodes(masterModel);
             cleanUndefinedNodes(slaveModel);

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_2_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_2_Final_TestCase.java
@@ -28,7 +28,7 @@ import org.junit.BeforeClass;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@Version(AsVersion.V_7_1_2_Final)
+@Version(AsVersion.AS_7_1_2_FINAL)
 public class SimpleMixedDomain_7_1_2_Final_TestCase extends SimpleMixedDomainTest {
 
     @BeforeClass

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_2_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_2_Final_TestCase.java
@@ -33,6 +33,6 @@ public class SimpleMixedDomain_7_1_2_Final_TestCase extends SimpleMixedDomainTes
 
     @BeforeClass
     public static void beforeClass() {
-        MixedDomainTestSuite.getSupport(SimpleMixedDomain_7_1_2_Final_TestCase.class);
+        MixedDomainTestSuite.getSupport(MixedDomain_7_1_2_Final_TestSuite.class);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_3_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_3_Final_TestCase.java
@@ -33,6 +33,6 @@ public class SimpleMixedDomain_7_1_3_Final_TestCase extends SimpleMixedDomainTes
 
     @BeforeClass
     public static void beforeClass() {
-        MixedDomainTestSuite.getSupport(SimpleMixedDomain_7_1_3_Final_TestCase.class);
+        MixedDomainTestSuite.getSupport(MixedDomain_7_1_3_Final_TestSuite.class);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_2_0_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_2_0_Final_TestCase.java
@@ -28,11 +28,11 @@ import org.junit.BeforeClass;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@Version(AsVersion.AS_7_1_3_FINAL)
-public class SimpleMixedDomain_7_1_3_Final_TestCase extends SimpleMixedDomainTest {
+@Version(AsVersion.AS_7_2_0_FINAL)
+public class SimpleMixedDomain_7_2_0_Final_TestCase extends SimpleMixedDomainTest {
 
     @BeforeClass
     public static void beforeClass() {
-        MixedDomainTestSuite.getSupport(MixedDomain_7_1_3_Final_TestSuite.class);
+        MixedDomainTestSuite.getSupport(MixedDomain_7_2_0_Final_TestSuite.class);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
@@ -36,19 +36,38 @@ public @interface Version {
 
     AsVersion value();
 
+    final String AS = "jboss-as-";
+    final String WILDFLY = "wildfly";
+    final String EAP = "jboss-eap-";
+
     enum AsVersion {
-        V_7_1_2_Final("7.1.2.Final"),
-        V_7_1_3_Final("7.1.3.Final");
+        V_7_1_2_Final(AS, "7.1.2.Final"),
+        V_7_1_3_Final(AS, "7.1.3.Final");
 
-        String version;
+        final String basename;
+        final String version;
 
-        AsVersion(String version){
+        AsVersion(String basename, String version){
+            this.basename = basename;
             this.version = version;
+        }
+
+        public String getBaseName() {
+            return basename;
         }
 
         public String getVersion() {
             return version;
         }
+
+        public String getExpandedDirectoryName() {
+            return basename + version;
+        }
+
+        public String getZipFileName() {
+            return getExpandedDirectoryName() + ".zip";
+        }
     }
+
 
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
@@ -41,8 +41,9 @@ public @interface Version {
     final String EAP = "jboss-eap-";
 
     enum AsVersion {
-        V_7_1_2_Final(AS, "7.1.2.Final"),
-        V_7_1_3_Final(AS, "7.1.3.Final");
+        AS_7_1_2_FINAL(AS, "7.1.2.Final"),
+        AS_7_1_3_FINAL(AS, "7.1.3.Final"),
+        AS_7_2_0_FINAL(AS, "7.2.0.Final");
 
         final String basename;
         final String version;

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/util/MixedDomainTestSupport.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/util/MixedDomainTestSupport.java
@@ -25,6 +25,8 @@ import java.io.File;
 
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.jboss.as.test.integration.domain.management.util.JBossAsManagedConfiguration;
+import org.jboss.as.test.integration.domain.mixed.Version;
+
 
 /**
  *
@@ -38,7 +40,7 @@ public class MixedDomainTestSupport extends DomainTestSupport {
     }
 
 
-    public static MixedDomainTestSupport create(String testClass, String version) throws Exception {
+    public static MixedDomainTestSupport create(String testClass, Version.AsVersion version) throws Exception {
         OldVersionCopier oldVersionCopier = OldVersionCopier.expandOldVersions();
         File dir = oldVersionCopier.getVersionDir(version);
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/util/OldVersionCopier.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/util/OldVersionCopier.java
@@ -40,6 +40,7 @@ import java.util.Enumeration;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import org.jboss.as.test.integration.domain.mixed.Version;
 import org.xnio.IoUtils;
 
 /**
@@ -64,8 +65,8 @@ public class OldVersionCopier {
         return copier;
     }
 
-    File getVersionDir(String version) {
-        File file = new File(targetOldVersions, "jboss-as-" + version);
+    File getVersionDir(Version.AsVersion version) {
+        File file = new File(targetOldVersions, version.getExpandedDirectoryName());
         if (!file.exists() || !file.isDirectory()) {
             throw new IllegalStateException("Could not find " + file.getAbsolutePath());
         }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/util/OldVersionCopier.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/util/OldVersionCopier.java
@@ -141,9 +141,6 @@ public class OldVersionCopier {
     private void patchModule(File moduleMainDir, URL patchedJar) throws Exception {
         assertTrue(moduleMainDir.exists());
         assertNotNull(patchedJar);
-        if (patchedJar == null) {
-            throw new RuntimeException("Null url");
-        }
         String oldJarName = null;
         for (String fileName : moduleMainDir.list()) {
             if (fileName.endsWith(".jar")) {

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -498,7 +498,8 @@
         
         <!-- 
             This is the standard full-ha profile from the original domain.xml with adjustments made to be able to start up
-            7.1.x slaves
+            7.1.x slaves.
+            The batch, io and undertow subsystems have been removed, and the web subsystem has been added.
         -->
         <profile name="full-ha-7.1.x">
             <subsystem xmlns="urn:jboss:domain:logging:2.0">
@@ -980,6 +981,441 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:weld:2.0"/>
         </profile>    
+        
+        
+        <!-- 
+            This is the standard full-ha profile from the original domain.xml with adjustments made to be able to start up
+            7.2.x slaves.
+            The batch, io and undertow subsystems have been removed, and the web subsystem has been added.            
+        -->                
+        <profile name="full-ha-7.2.x">
+            <subsystem xmlns="urn:jboss:domain:logging:2.0">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <named-formatter name="COLOR-PATTERN"/>
+                    </formatter>
+                </console-handler>
+                <periodic-rotating-file-handler name="FILE" autoflush="true">
+                    <formatter>
+                        <named-formatter name="PATTERN"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                    <append value="true"/>
+                </periodic-rotating-file-handler>
+                <logger category="com.arjuna">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="org.apache.tomcat.util.modeler">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="org.jboss.as.config">
+                    <level name="DEBUG"/>
+                </logger>
+                <logger category="sun.rmi">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="jacorb">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="jacorb.config">
+                    <level name="ERROR"/>
+                </logger>
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+                <formatter name="PATTERN">
+                    <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+                <formatter name="COLOR-PATTERN">
+                    <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+            </subsystem>
+
+            <subsystem xmlns="urn:jboss:domain:datasources:2.0">
+                <datasources>
+                    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <driver>h2</driver>
+                        <security>
+                            <user-name>sa</user-name>
+                            <password>sa</password>
+                        </security>
+                    </datasource>
+                    <drivers>
+                        <driver name="h2" module="com.h2database.h2">
+                            <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                        </driver>
+                    </drivers>
+                </datasources>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ee:2.0">
+                <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+                <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
+                <concurrent>
+                    <default-context-service/>
+                    <default-managed-thread-factory/>
+                    <default-managed-executor-service hung-task-threshold="60000" core-threads="5" max-threads="25" keepalive-time="5000"/>
+                    <default-managed-scheduled-executor-service hung-task-threshold="60000" core-threads="2" keepalive-time="3000"/>
+                </concurrent>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ejb3:2.0">
+                <session-bean>
+                    <stateless>
+                        <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                    </stateless>
+                    <!-- 
+                     passivation-disabled-cache-ref is not understood on 7.2.x
+                    <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered" passivation-disabled-cache-ref="simple"/>
+                     -->
+                    <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered"/>
+                    <singleton default-access-timeout="5000"/>
+                </session-bean>
+                <mdb>
+                    <resource-adapter-ref resource-adapter-name="hornetq-ra"/>
+                    <bean-instance-pool-ref pool-name="mdb-strict-max-pool"/>
+                </mdb>
+                <pools>
+                    <bean-instance-pools>
+                        <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                        <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    </bean-instance-pools>
+                </pools>
+                <caches>
+                    <cache name="simple" aliases="NoPassivationCache"/>
+                    <cache name="passivating" passivation-store-ref="file" aliases="SimpleStatefulCache"/>
+                    <cache name="clustered" passivation-store-ref="infinispan" aliases="StatefulTreeCache"/>
+                </caches>
+                <passivation-stores>
+                    <file-passivation-store name="file"/>
+                    <cluster-passivation-store name="infinispan" cache-container="ejb"/>
+                </passivation-stores>
+                <async thread-pool-name="default"/>
+                <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                    <data-stores>
+                        <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                    </data-stores>
+                </timer-service>
+                <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
+                <thread-pools>
+                    <thread-pool name="default">
+                        <max-threads count="10"/>
+                        <keepalive-time time="100" unit="milliseconds"/>
+                    </thread-pool>
+                </thread-pools>
+                <iiop enable-by-default="false" use-qualified-name="false"/>
+                <default-security-domain value="other"/>
+                <default-missing-method-permissions-deny-access value="true"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:infinispan:2.0">
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
+                    <transport lock-timeout="60000"/>
+                    <replicated-cache name="default" mode="SYNC" batching="true">
+                        <locking isolation="REPEATABLE_READ"/>
+                    </replicated-cache>
+                </cache-container>
+                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan">
+                    <transport lock-timeout="60000"/>
+                    <replicated-cache name="repl" mode="ASYNC" batching="true">
+                        <file-store/>
+                    </replicated-cache>
+                    <replicated-cache name="sso" mode="SYNC" batching="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
+                        <file-store/>
+                    </distributed-cache>
+                </cache-container>
+                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan">
+                    <transport lock-timeout="60000"/>
+                    <replicated-cache name="repl" mode="ASYNC" batching="true">
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <file-store/>
+                    </replicated-cache>
+                    <!--
+                      ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
+                      ~                 the socketbinding referenced by the EJB remoting connector 
+                      -->
+                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <file-store/>
+                    </distributed-cache>
+                </cache-container>
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
+                    <transport lock-timeout="60000"/>
+                    <local-cache name="local-query">
+                        <transaction mode="NONE"/>
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
+                    <invalidation-cache name="entity" mode="SYNC">
+                        <transaction mode="NON_XA"/>
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </invalidation-cache>
+                    <replicated-cache name="timestamps" mode="ASYNC">
+                        <transaction mode="NONE"/>
+                        <eviction strategy="NONE"/>
+                    </replicated-cache>
+                </cache-container>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+                <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
+                    <initializers transactions="spec" security="identity"/>
+                </orb>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jca:2.0">
+                <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+                <bean-validation enabled="true"/>
+                <default-workmanager>
+                    <short-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </short-running-threads>
+                    <long-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </long-running-threads>
+                </default-workmanager>
+                <cached-connection-manager/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jgroups:2.0" default-stack="udp">
+                <stack name="udp">
+                    <transport type="UDP" socket-binding="jgroups-udp"/>
+                    <protocol type="PING"/>
+                    <protocol type="MERGE3"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="UFC"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                    <protocol type="RSVP"/>
+                </stack>
+                <stack name="tcp">
+                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <protocol type="MPING" socket-binding="jgroups-mping"/>
+                    <protocol type="MERGE2"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+                    <protocol type="FD"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                    <protocol type="RSVP"/>
+                </stack>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+                <expose-resolved-model/>
+                <expose-expression-model/>
+                <!--<remoting-connector use-management-endpoint="false"/>-->
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+                <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jsr77:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:mail:1.1">
+                <mail-session jndi-name="java:jboss/mail/Default">
+                    <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+                </mail-session>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:messaging:1.4">
+                <hornetq-server>
+                    <cluster-password>${jboss.messaging.cluster.password:CHANGE ME!!}</cluster-password>
+                    <persistence-enabled>true</persistence-enabled>
+                    <journal-file-size>102400</journal-file-size>
+                    <journal-min-files>2</journal-min-files>
+                    <connectors>
+                        <netty-connector name="netty" socket-binding="messaging"/>
+                        <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                            <param key="batch-delay" value="50"/>
+                        </netty-connector>
+                        <servlet-connector name="servlet" socket-binding="http" host="default-host"/>
+                        <in-vm-connector name="in-vm" server-id="0"/>
+                    </connectors>
+                    <acceptors>
+                        <netty-acceptor name="netty" socket-binding="messaging"/>
+                        <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                            <param key="batch-delay" value="50"/>
+                            <param key="direct-deliver" value="false"/>
+                        </netty-acceptor>
+                        <in-vm-acceptor name="in-vm" server-id="0"/>
+                    </acceptors>
+                    <broadcast-groups>
+                        <broadcast-group name="bg-group1">
+                            <socket-binding>messaging-group</socket-binding>
+                            <broadcast-period>5000</broadcast-period>
+                            <connector-ref>netty</connector-ref>
+                        </broadcast-group>
+                    </broadcast-groups>
+                    <discovery-groups>
+                        <discovery-group name="dg-group1">
+                            <socket-binding>messaging-group</socket-binding>
+                            <refresh-timeout>10000</refresh-timeout>
+                        </discovery-group>
+                    </discovery-groups>
+                    <cluster-connections>
+                        <cluster-connection name="my-cluster">
+                            <address>jms</address>
+                            <connector-ref>netty</connector-ref>
+                            <discovery-group-ref discovery-group-name="dg-group1"/>
+                        </cluster-connection>
+                    </cluster-connections>
+                    <security-settings>
+                        <security-setting match="#">
+                            <permission type="send" roles="guest"/>
+                            <permission type="consume" roles="guest"/>
+                            <permission type="createNonDurableQueue" roles="guest"/>
+                            <permission type="deleteNonDurableQueue" roles="guest"/>
+                        </security-setting>
+                    </security-settings>
+                    <address-settings>
+                        <!--default for catch all-->
+                        <address-setting match="#">
+                            <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+                            <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+                            <redelivery-delay>0</redelivery-delay>
+                            <redistribution-delay>1000</redistribution-delay>
+                            <max-size-bytes>10485760</max-size-bytes>
+                            <address-full-policy>PAGE</address-full-policy>
+                            <page-size-bytes>2097152</page-size-bytes>
+                            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+                        </address-setting>
+                    </address-settings>
+                    <jms-connection-factories>
+                        <connection-factory name="InVmConnectionFactory">
+                            <connectors>
+                                <connector-ref connector-name="in-vm"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:/ConnectionFactory"/>
+                            </entries>
+                        </connection-factory>
+                        <connection-factory name="ServletConnectionFactory">
+                            <connectors>
+                                <connector-ref connector-name="servlet"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:jboss/exported/jms/ServletConnectionFactory"/>
+                            </entries>
+                        </connection-factory>
+                        <connection-factory name="RemoteConnectionFactory">
+                            <connectors>
+                                <connector-ref connector-name="netty"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:jboss/exported/jms/RemoteConnectionFactory"/>
+                            </entries>
+                            <ha>true</ha>
+                            <block-on-acknowledge>true</block-on-acknowledge>
+                            <retry-interval>1000</retry-interval>
+                            <retry-interval-multiplier>1.0</retry-interval-multiplier>
+                            <reconnect-attempts>-1</reconnect-attempts>
+                        </connection-factory>
+                        <pooled-connection-factory name="hornetq-ra">
+                            <transaction mode="xa"/>
+                            <connectors>
+                                <connector-ref connector-name="in-vm"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:/JmsXA"/>
+                                <!-- Global JNDI entry used to provide a default JMS Connection factory to EE application -->
+                                <entry name="java:jboss/DefaultJMSConnectionFactory"/>
+                            </entries>
+                        </pooled-connection-factory>
+                    </jms-connection-factories>
+                </hornetq-server>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:modcluster:1.2">
+                <mod-cluster-config advertise-socket="modcluster" connector="ajp">
+                    <dynamic-load-provider>
+                        <load-metric type="busyness"/>
+                    </dynamic-load-provider>
+                </mod-cluster-config>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:naming:2.0">
+                <remote-naming/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:remoting:2.0">
+                <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:resource-adapters:2.0"/>
+            <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:security:1.2">
+                <security-domains>
+                    <security-domain name="other" cache-type="default">
+                        <authentication>
+                            <login-module code="Remoting" flag="optional">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
+                    </security-domain>
+                    <security-domain name="jboss-web-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                    <security-domain name="jboss-ejb-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                </security-domains>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:transactions:2.0">
+                <core-environment>
+                    <process-id>
+                        <uuid/>
+                    </process-id>
+                </core-environment>
+                <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+                <coordinator-environment default-timeout="300"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+                <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+                <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
+                <virtual-server name="default-host" enable-welcome-root="true">
+                    <alias name="localhost"/>
+                    <alias name="example.com"/>
+                </virtual-server>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:webservices:1.2">
+                <modify-wsdl-address>true</modify-wsdl-address>
+                <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
+                <endpoint-config name="Standard-Endpoint-Config"/>
+                <endpoint-config name="Recording-Endpoint-Config">
+                    <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
+                        <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
+                    </pre-handler-chain>
+                </endpoint-config>
+                <client-config name="Standard-Client-Config"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:weld:2.0"/>
+        </profile>
+        
     </profiles>
     <!--
       ~ 
@@ -1104,6 +1540,12 @@
                 <heap size="64m" max-size="512m"/>
             </jvm>
             <socket-binding-group ref="full-ha-sockets-7.1.x"/>
+        </server-group>
+        <server-group name="7.2.0-server-group" profile="full-ha-7.2.x">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+            </jvm>
+            <socket-binding-group ref="full-ha-sockets"/>
         </server-group>
     </server-groups>
 </domain>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -4,13 +4,10 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
-        <extension module="org.jboss.as.cmp"/>
-        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -22,7 +19,6 @@
         <extension module="org.jboss.as.messaging"/>
         <extension module="org.jboss.as.modcluster"/>
         <extension module="org.jboss.as.naming"/>
-        <extension module="org.jboss.as.osgi"/>
         <extension module="org.jboss.as.pojo"/>
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
@@ -32,908 +28,38 @@
         <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
+        <extension module="org.wildfly.extension.batch"/>
+        <extension module="org.wildfly.extension.io"/>
+        <extension module="org.wildfly.extension.undertow"/>
     </extensions>
     <system-properties>
+        <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
+        <property name="java.net.preferIPv4Stack" value="true"/>
     </system-properties>
+    <management>
+        <access-control provider="simple">
+            <role-mapping>
+                <role name="SuperUser">
+                    <include>
+                        <user name="$local"/>
+                    </include>
+                </role>
+            </role-mapping>
+        </access-control>
+    </management>
+    <!-- This is the standard full-ha profile from the original domain.xml -->
     <profiles>
-        <profile name="default">
-            <subsystem xmlns="urn:jboss:domain:logging:1.2">
-                <console-handler name="CONSOLE">
-                    <level name="INFO"/>
-                    <formatter>
-                        <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
-                    </formatter>
-                </console-handler>
-                <periodic-rotating-file-handler name="FILE" autoflush="true">
-                    <formatter>
-                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
-                    </formatter>
-                    <file relative-to="jboss.server.log.dir" path="server.log"/>
-                    <suffix value=".yyyy-MM-dd"/>
-                    <append value="true"/>
-                </periodic-rotating-file-handler>
-                <logger category="com.arjuna">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.apache.tomcat.util.modeler">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.jboss.as.config">
-                    <level name="DEBUG"/>
-                </logger>
-                <logger category="sun.rmi">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="jacorb">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="jacorb.config">
-                    <level name="ERROR"/>
-                </logger>
-                <root-logger>
-                    <level name="INFO"/>
-                    <handlers>
-                        <handler name="CONSOLE"/>
-                        <handler name="FILE"/>
-                    </handlers>
-                </root-logger>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:1.1">
-                <datasources>
-                    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
-                        <driver>h2</driver>
-                        <security>
-                            <user-name>sa</user-name>
-                            <password>sa</password>
-                        </security>
-                    </datasource>
-                    <drivers>
-                        <driver name="h2" module="com.h2database.h2">
-                            <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
-                        </driver>
-                    </drivers>
-                </datasources>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ee:1.1">
-                <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
-                <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ejb3:1.4">
-                <session-bean>
-                    <stateless>
-                        <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
-                    </stateless>
-                    <stateful default-access-timeout="5000" cache-ref="simple"/>
-                    <singleton default-access-timeout="5000"/>
-                </session-bean>
-                <default-security-domain value="other"/>
-                <pools>
-                    <bean-instance-pools>
-                        <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
-                        <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
-                    </bean-instance-pools>
-                </pools>
-                <caches>
-                    <cache name="simple" aliases="NoPassivationCache"/>
-                    <cache name="passivating" passivation-store-ref="file" aliases="SimpleStatefulCache"/>
-                </caches>
-                <passivation-stores>
-                    <file-passivation-store name="file"/>
-                </passivation-stores>
-                <async thread-pool-name="default"/>
-                <timer-service thread-pool-name="default">
-                    <data-store path="timer-service-data" relative-to="jboss.server.data.dir"/>
-                </timer-service>
-                <remote connector-ref="remoting-connector" thread-pool-name="default"/>
-                <thread-pools>
-                    <thread-pool name="default">
-                        <max-threads count="10"/>
-                        <keepalive-time time="100" unit="milliseconds"/>
-                    </thread-pool>
-                </thread-pools>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:infinispan:1.4">
-                <cache-container name="web" aliases="standard-session-cache" default-cache="local-web" module="org.jboss.as.clustering.web.infinispan">
-                    <local-cache name="local-web" batching="true">
-                        <file-store passivation="false" purge="false"/>
-                    </local-cache>
-                </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.jboss.as.jpa.hibernate:4">
-                    <local-cache name="entity">
-                        <transaction mode="NON_XA"/>
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <expiration max-idle="100000"/>
-                    </local-cache>
-                    <local-cache name="local-query">
-                        <transaction mode="NONE"/>
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <expiration max-idle="100000"/>
-                    </local-cache>
-                    <local-cache name="timestamps">
-                        <transaction mode="NONE"/>
-                        <eviction strategy="NONE"/>
-                    </local-cache>
-                </cache-container>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jca:1.1">
-                <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
-                <bean-validation enabled="true"/>
-                <default-workmanager>
-                    <short-running-threads>
-                        <core-threads count="50"/>
-                        <queue-length count="50"/>
-                        <max-threads count="50"/>
-                        <keepalive-time time="10" unit="seconds"/>
-                    </short-running-threads>
-                    <long-running-threads>
-                        <core-threads count="50"/>
-                        <queue-length count="50"/>
-                        <max-threads count="50"/>
-                        <keepalive-time time="10" unit="seconds"/>
-                    </long-running-threads>
-                </default-workmanager>
-                <cached-connection-manager/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jmx:2.0">
-                <expose-resolved-model/>
-                <expose-expression-model/>
-                <!--<remoting-connector use-management-endpoint="false"/>-->
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jpa:1.1">
-                <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jsf:1.0" default-jsf-impl-slot="myslot"/>
-            <subsystem xmlns="urn:jboss:domain:mail:1.0">
-                <mail-session jndi-name="java:jboss/mail/Default">
-                    <smtp-server outbound-socket-binding-ref="mail-smtp"/>
-                </mail-session>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:naming:1.2">
-                <remote-naming/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
-                <properties>
-                    <property name="org.osgi.framework.startlevel.beginning">1</property>
-                </properties>
-                <capabilities>
-                    <capability name="javax.jws.api"/>
-                    <capability name="javax.persistence.api"/>
-                    <capability name="javax.servlet.api"/>
-                    <capability name="javax.transaction.api"/>
-                    <capability name="javax.ws.rs.api"/>
-                    <capability name="javax.xml.bind.api"/>
-                    <capability name="javax.xml.ws.api"/>
-                    <capability name="org.slf4j"/>
-                    <capability name="org.apache.felix.log" startlevel="1"/>
-                    <capability name="org.jboss.osgi.logging" startlevel="1"/>
-                    <capability name="org.apache.felix.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.http" startlevel="1"/>
-                </capabilities>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:remoting:1.1">
-                <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:resource-adapters:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:security:1.2">
-                <security-domains>
-                    <security-domain name="other" cache-type="default">
-                        <authentication>
-                            <login-module code="Remoting" flag="optional">
-                                <module-option name="password-stacking" value="useFirstPass"/>
-                            </login-module>
-                            <login-module code="RealmDirect" flag="required">
-                                <module-option name="password-stacking" value="useFirstPass"/>
-                            </login-module>
-                        </authentication>
-                    </security-domain>
-                    <security-domain name="jboss-web-policy" cache-type="default">
-                        <authorization>
-                            <policy-module code="Delegating" flag="required"/>
-                        </authorization>
-                    </security-domain>
-                    <security-domain name="jboss-ejb-policy" cache-type="default">
-                        <authorization>
-                            <policy-module code="Delegating" flag="required"/>
-                        </authorization>
-                    </security-domain>
-                </security-domains>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
-            <subsystem xmlns="urn:jboss:domain:transactions:1.2">
-                <core-environment>
-                    <process-id>
-                        <uuid/>
-                    </process-id>
-                </core-environment>
-                <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
-                <coordinator-environment default-timeout="300"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
-                <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
-                <virtual-server name="default-host" enable-welcome-root="true">
-                    <alias name="localhost"/>
-                    <alias name="example.com"/>
-                </virtual-server>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:webservices:1.2">
-                <modify-wsdl-address>true</modify-wsdl-address>
-                <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
-                <endpoint-config name="Standard-Endpoint-Config"/>
-                <endpoint-config name="Recording-Endpoint-Config">
-                    <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
-                        <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
-                    </pre-handler-chain>
-                </endpoint-config>
-                <client-config name="Standard-Client-Config"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:weld:1.0"/>
-        </profile>
-        <profile name="ha">
-            <subsystem xmlns="urn:jboss:domain:logging:1.2">
-                <console-handler name="CONSOLE">
-                    <level name="INFO"/>
-                    <formatter>
-                        <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
-                    </formatter>
-                </console-handler>
-                <periodic-rotating-file-handler name="FILE" autoflush="true">
-                    <formatter>
-                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
-                    </formatter>
-                    <file relative-to="jboss.server.log.dir" path="server.log"/>
-                    <suffix value=".yyyy-MM-dd"/>
-                    <append value="true"/>
-                </periodic-rotating-file-handler>
-                <logger category="com.arjuna">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.apache.tomcat.util.modeler">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.jboss.as.config">
-                    <level name="DEBUG"/>
-                </logger>
-                <logger category="sun.rmi">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="jacorb">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="jacorb.config">
-                    <level name="ERROR"/>
-                </logger>
-                <root-logger>
-                    <level name="INFO"/>
-                    <handlers>
-                        <handler name="CONSOLE"/>
-                        <handler name="FILE"/>
-                    </handlers>
-                </root-logger>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:1.1">
-                <datasources>
-                    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
-                        <driver>h2</driver>
-                        <security>
-                            <user-name>sa</user-name>
-                            <password>sa</password>
-                        </security>
-                    </datasource>
-                    <drivers>
-                        <driver name="h2" module="com.h2database.h2">
-                            <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
-                        </driver>
-                    </drivers>
-                </datasources>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ee:1.1">
-                <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
-                <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ejb3:1.4">
-                <session-bean>
-                    <stateless>
-                        <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
-                    </stateless>
-                    <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered"/>
-                    <singleton default-access-timeout="5000"/>
-                </session-bean>
-                <default-security-domain value="other"/>
-                <pools>
-                    <bean-instance-pools>
-                        <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
-                        <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
-                    </bean-instance-pools>
-                </pools>
-                <caches>
-                    <cache name="simple" aliases="NoPassivationCache"/>
-                    <cache name="passivating" passivation-store-ref="file" aliases="SimpleStatefulCache"/>
-                    <cache name="clustered" passivation-store-ref="infinispan" aliases="StatefulTreeCache"/>
-                </caches>
-                <passivation-stores>
-                    <file-passivation-store name="file"/>
-                    <cluster-passivation-store name="infinispan" cache-container="ejb"/>
-                </passivation-stores>
-                <async thread-pool-name="default"/>
-                <timer-service thread-pool-name="default">
-                    <data-store path="timer-service-data" relative-to="jboss.server.data.dir"/>
-                </timer-service>
-                <remote connector-ref="remoting-connector" thread-pool-name="default"/>
-                <thread-pools>
-                    <thread-pool name="default">
-                        <max-threads count="10"/>
-                        <keepalive-time time="100" unit="milliseconds"/>
-                    </thread-pool>
-                </thread-pools>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:infinispan:1.4">
-                <cache-container name="cluster" aliases="ha-partition" default-cache="default">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="default" mode="SYNC" batching="true">
-                        <locking isolation="REPEATABLE_READ"/>
-                    </replicated-cache>
-                </cache-container>
-                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.jboss.as.clustering.web.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true">
-                        <file-store/>
-                    </replicated-cache>
-                    <replicated-cache name="sso" mode="SYNC" batching="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
-                        <file-store/>
-                    </distributed-cache>
-                </cache-container>
-                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan">
-                    <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true">
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <file-store/>
-                    </replicated-cache>
-                    <!--
-                      ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
-                      ~                 the socketbinding referenced by the EJB remoting connector 
-                      -->
-                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <file-store/>
-                    </distributed-cache>
-                </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.jboss.as.jpa.hibernate:4">
-                    <transport lock-timeout="60000"/>
-                    <local-cache name="local-query">
-                        <transaction mode="NONE"/>
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <expiration max-idle="100000"/>
-                    </local-cache>
-                    <invalidation-cache name="entity" mode="SYNC">
-                        <transaction mode="NON_XA"/>
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <expiration max-idle="100000"/>
-                    </invalidation-cache>
-                    <replicated-cache name="timestamps" mode="ASYNC">
-                        <transaction mode="NONE"/>
-                        <eviction strategy="NONE"/>
-                    </replicated-cache>
-                </cache-container>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jca:1.1">
-                <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
-                <bean-validation enabled="true"/>
-                <default-workmanager>
-                    <short-running-threads>
-                        <core-threads count="50"/>
-                        <queue-length count="50"/>
-                        <max-threads count="50"/>
-                        <keepalive-time time="10" unit="seconds"/>
-                    </short-running-threads>
-                    <long-running-threads>
-                        <core-threads count="50"/>
-                        <queue-length count="50"/>
-                        <max-threads count="50"/>
-                        <keepalive-time time="10" unit="seconds"/>
-                    </long-running-threads>
-                </default-workmanager>
-                <cached-connection-manager/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="udp">
-                <stack name="udp">
-                    <transport type="UDP" socket-binding="jgroups-udp"/>
-                    <protocol type="PING"/>
-                    <!--  
-                        MERGE3 does not exist in 7.1.x, so use MERGE2 for these tests
-                        A server not starting is not a problem, it just means it needs to use another profile
-                    <protocol type="MERGE3"/>
-                     -->
-                    <protocol type="MERGE2"/>
-                    <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
-                    <protocol type="FD"/>
-                    <protocol type="VERIFY_SUSPECT"/>
-                    <!--  
-                        NAKACK does not exist in 7.1.x, so use NAKACK for these tests
-                        A server not starting is not a problem, it just means it needs to use another profile
-                    <protocol type="NAKACK2"/>
-                     -->
-                    <protocol type="pbcast.NAKACK"/>
-                    <protocol type="UNICAST2"/>
-                    <protocol type="pbcast.STABLE"/>
-                    <protocol type="pbcast.GMS"/>
-                    <protocol type="UFC"/>
-                    <protocol type="MFC"/>
-                    <protocol type="FRAG2"/>
-                    <protocol type="RSVP"/>
-                </stack>
-                <stack name="tcp">
-                    <transport type="TCP" socket-binding="jgroups-tcp"/>
-                    <protocol type="MPING" socket-binding="jgroups-mping"/>
-                    <protocol type="MERGE2"/>
-                    <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
-                    <protocol type="FD"/>
-                    <protocol type="VERIFY_SUSPECT"/>
-                    <!--  
-                        NAKACK does not exist in 7.1.x, so use NAKACK for these tests
-                        A server not starting is not a problem, it just means it needs to use another profile
-                    <protocol type="NAKACK2"/>
-                     -->
-                    <protocol type="pbcast.NAKACK"/>
-                    <protocol type="UNICAST2"/>
-                    <protocol type="pbcast.STABLE"/>
-                    <protocol type="pbcast.GMS"/>
-                    <protocol type="UFC"/>
-                    <protocol type="MFC"/>
-                    <protocol type="FRAG2"/>
-                    <protocol type="RSVP"/>
-                </stack>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jmx:2.0">
-                <expose-resolved-model/>
-                <expose-expression-model/>
-                <!--<remoting-connector use-management-endpoint="false"/>-->
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jpa:1.1">
-                <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:mail:1.0">
-                <mail-session jndi-name="java:jboss/mail/Default">
-                    <smtp-server outbound-socket-binding-ref="mail-smtp"/>
-                </mail-session>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:modcluster:1.1">
-                <mod-cluster-config advertise-socket="modcluster" connector="ajp">
-                    <dynamic-load-provider>
-                        <load-metric type="busyness"/>
-                    </dynamic-load-provider>
-                </mod-cluster-config>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:naming:1.2">
-                <remote-naming/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
-                <properties>
-                    <property name="org.osgi.framework.startlevel.beginning">1</property>
-                </properties>
-                <capabilities>
-                    <capability name="javax.jws.api"/>
-                    <capability name="javax.persistence.api"/>
-                    <capability name="javax.servlet.api"/>
-                    <capability name="javax.transaction.api"/>
-                    <capability name="javax.ws.rs.api"/>
-                    <capability name="javax.xml.bind.api"/>
-                    <capability name="javax.xml.ws.api"/>
-                    <capability name="org.slf4j"/>
-                    <capability name="org.apache.felix.log" startlevel="1"/>
-                    <capability name="org.jboss.osgi.logging" startlevel="1"/>
-                    <capability name="org.apache.felix.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.http" startlevel="1"/>
-                </capabilities>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:remoting:1.1">
-                <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:resource-adapters:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:security:1.2">
-                <security-domains>
-                    <security-domain name="other" cache-type="default">
-                        <authentication>
-                            <login-module code="Remoting" flag="optional">
-                                <module-option name="password-stacking" value="useFirstPass"/>
-                            </login-module>
-                            <login-module code="RealmDirect" flag="required">
-                                <module-option name="password-stacking" value="useFirstPass"/>
-                            </login-module>
-                        </authentication>
-                    </security-domain>
-                    <security-domain name="jboss-web-policy" cache-type="default">
-                        <authorization>
-                            <policy-module code="Delegating" flag="required"/>
-                        </authorization>
-                    </security-domain>
-                    <security-domain name="jboss-ejb-policy" cache-type="default">
-                        <authorization>
-                            <policy-module code="Delegating" flag="required"/>
-                        </authorization>
-                    </security-domain>
-                </security-domains>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
-            <subsystem xmlns="urn:jboss:domain:transactions:1.2">
-                <core-environment>
-                    <process-id>
-                        <uuid/>
-                    </process-id>
-                </core-environment>
-                <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
-                <coordinator-environment default-timeout="300"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
-                <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
-                <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
-                <virtual-server name="default-host" enable-welcome-root="true">
-                    <alias name="localhost"/>
-                    <alias name="example.com"/>
-                </virtual-server>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:webservices:1.2">
-                <modify-wsdl-address>true</modify-wsdl-address>
-                <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
-                <endpoint-config name="Standard-Endpoint-Config"/>
-                <endpoint-config name="Recording-Endpoint-Config">
-                    <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
-                        <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
-                    </pre-handler-chain>
-                </endpoint-config>
-                <client-config name="Standard-Client-Config"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:weld:1.0"/>
-        </profile>
-        <profile name="full">
-            <subsystem xmlns="urn:jboss:domain:logging:1.2">
-                <console-handler name="CONSOLE">
-                    <level name="INFO"/>
-                    <formatter>
-                        <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
-                    </formatter>
-                </console-handler>
-                <periodic-rotating-file-handler name="FILE" autoflush="true">
-                    <formatter>
-                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
-                    </formatter>
-                    <file relative-to="jboss.server.log.dir" path="server.log"/>
-                    <suffix value=".yyyy-MM-dd"/>
-                    <append value="true"/>
-                </periodic-rotating-file-handler>
-                <logger category="com.arjuna">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.apache.tomcat.util.modeler">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="org.jboss.as.config">
-                    <level name="DEBUG"/>
-                </logger>
-                <logger category="sun.rmi">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="jacorb">
-                    <level name="WARN"/>
-                </logger>
-                <logger category="jacorb.config">
-                    <level name="ERROR"/>
-                </logger>
-                <root-logger>
-                    <level name="INFO"/>
-                    <handlers>
-                        <handler name="CONSOLE"/>
-                        <handler name="FILE"/>
-                    </handlers>
-                </root-logger>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:1.1">
-                <datasources>
-                    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
-                        <driver>h2</driver>
-                        <security>
-                            <user-name>sa</user-name>
-                            <password>sa</password>
-                        </security>
-                    </datasource>
-                    <drivers>
-                        <driver name="h2" module="com.h2database.h2">
-                            <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
-                        </driver>
-                    </drivers>
-                </datasources>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ee:1.1">
-                <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
-                <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ejb3:1.4">
-                <session-bean>
-                    <stateless>
-                        <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
-                    </stateless>
-                    <stateful default-access-timeout="5000" cache-ref="simple"/>
-                    <singleton default-access-timeout="5000"/>
-                </session-bean>
-                <default-security-domain value="other"/>
-                <mdb>
-                    <resource-adapter-ref resource-adapter-name="hornetq-ra"/>
-                    <bean-instance-pool-ref pool-name="mdb-strict-max-pool"/>
-                </mdb>
-                <pools>
-                    <bean-instance-pools>
-                        <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
-                        <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
-                    </bean-instance-pools>
-                </pools>
-                <caches>
-                    <cache name="simple" aliases="NoPassivationCache"/>
-                    <cache name="passivating" passivation-store-ref="file" aliases="SimpleStatefulCache"/>
-                </caches>
-                <passivation-stores>
-                    <file-passivation-store name="file"/>
-                </passivation-stores>
-                <async thread-pool-name="default"/>
-                <timer-service thread-pool-name="default">
-                    <data-store path="timer-service-data" relative-to="jboss.server.data.dir"/>
-                </timer-service>
-                <remote connector-ref="remoting-connector" thread-pool-name="default"/>
-                <thread-pools>
-                    <thread-pool name="default">
-                        <max-threads count="10"/>
-                        <keepalive-time time="100" unit="milliseconds"/>
-                    </thread-pool>
-                </thread-pools>
-                <iiop enable-by-default="false" use-qualified-name="false"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:infinispan:1.4">
-                <cache-container name="web" aliases="standard-session-cache" default-cache="local-web" module="org.jboss.as.clustering.web.infinispan">
-                    <local-cache name="local-web" batching="true">
-                        <file-store passivation="false" purge="false"/>
-                    </local-cache>
-                </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.jboss.as.jpa.hibernate:4">
-                    <local-cache name="entity">
-                        <transaction mode="NON_XA"/>
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <expiration max-idle="100000"/>
-                    </local-cache>
-                    <local-cache name="local-query">
-                        <transaction mode="NONE"/>
-                        <eviction strategy="LRU" max-entries="10000"/>
-                        <expiration max-idle="100000"/>
-                    </local-cache>
-                    <local-cache name="timestamps">
-                        <transaction mode="NONE"/>
-                        <eviction strategy="NONE"/>
-                    </local-cache>
-                </cache-container>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
-                <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
-                    <initializers transactions="spec" security="on"/>
-                </orb>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
-                <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jca:1.1">
-                <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
-                <bean-validation enabled="true"/>
-                <default-workmanager>
-                    <short-running-threads>
-                        <core-threads count="50"/>
-                        <queue-length count="50"/>
-                        <max-threads count="50"/>
-                        <keepalive-time time="10" unit="seconds"/>
-                    </short-running-threads>
-                    <long-running-threads>
-                        <core-threads count="50"/>
-                        <queue-length count="50"/>
-                        <max-threads count="50"/>
-                        <keepalive-time time="10" unit="seconds"/>
-                    </long-running-threads>
-                </default-workmanager>
-                <cached-connection-manager/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jmx:2.0">
-                <expose-resolved-model/>
-                <expose-expression-model/>
-                <!--<remoting-connector use-management-endpoint="false"/>-->
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jpa:1.1">
-                <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jsr77:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:mail:1.0">
-                <mail-session jndi-name="java:jboss/mail/Default">
-                    <smtp-server outbound-socket-binding-ref="mail-smtp"/>
-                </mail-session>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:messaging:1.3">
-                <hornetq-server>
-                    <persistence-enabled>true</persistence-enabled>
-                    <journal-file-size>102400</journal-file-size>
-                    <journal-min-files>2</journal-min-files>
-                    <connectors>
-                        <netty-connector name="netty" socket-binding="messaging"/>
-                        <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
-                            <param key="batch-delay" value="50"/>
-                        </netty-connector>
-                        <in-vm-connector name="in-vm" server-id="0"/>
-                    </connectors>
-                    <acceptors>
-                        <netty-acceptor name="netty" socket-binding="messaging"/>
-                        <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
-                            <param key="batch-delay" value="50"/>
-                            <param key="direct-deliver" value="false"/>
-                        </netty-acceptor>
-                        <in-vm-acceptor name="in-vm" server-id="0"/>
-                    </acceptors>
-                    <security-settings>
-                        <security-setting match="#">
-                            <permission type="send" roles="guest"/>
-                            <permission type="consume" roles="guest"/>
-                            <permission type="createNonDurableQueue" roles="guest"/>
-                            <permission type="deleteNonDurableQueue" roles="guest"/>
-                        </security-setting>
-                    </security-settings>
-                    <address-settings>
-                        <!--default for catch all-->
-                        <address-setting match="#">
-                            <dead-letter-address>jms.queue.DLQ</dead-letter-address>
-                            <expiry-address>jms.queue.ExpiryQueue</expiry-address>
-                            <redelivery-delay>0</redelivery-delay>
-                            <max-size-bytes>10485760</max-size-bytes>
-                            <address-full-policy>BLOCK</address-full-policy>
-                            <message-counter-history-day-limit>10</message-counter-history-day-limit>
-                        </address-setting>
-                    </address-settings>
-                    <jms-connection-factories>
-                        <connection-factory name="InVmConnectionFactory">
-                            <connectors>
-                                <connector-ref connector-name="in-vm"/>
-                            </connectors>
-                            <entries>
-                                <entry name="java:/ConnectionFactory"/>
-                            </entries>
-                        </connection-factory>
-                        <connection-factory name="RemoteConnectionFactory">
-                            <connectors>
-                                <connector-ref connector-name="netty"/>
-                            </connectors>
-                            <entries>
-                                <entry name="java:jboss/exported/jms/RemoteConnectionFactory"/>
-                            </entries>
-                        </connection-factory>
-                        <pooled-connection-factory name="hornetq-ra">
-                            <transaction mode="xa"/>
-                            <connectors>
-                                <connector-ref connector-name="in-vm"/>
-                            </connectors>
-                            <entries>
-                                <entry name="java:/JmsXA"/>
-                            </entries>
-                        </pooled-connection-factory>
-                    </jms-connection-factories>
-                </hornetq-server>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:naming:1.2">
-                <remote-naming/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
-                <properties>
-                    <property name="org.osgi.framework.startlevel.beginning">1</property>
-                </properties>
-                <capabilities>
-                    <capability name="javax.jws.api"/>
-                    <capability name="javax.persistence.api"/>
-                    <capability name="javax.servlet.api"/>
-                    <capability name="javax.transaction.api"/>
-                    <capability name="javax.ws.rs.api"/>
-                    <capability name="javax.xml.bind.api"/>
-                    <capability name="javax.xml.ws.api"/>
-                    <capability name="org.slf4j"/>
-                    <capability name="org.apache.felix.log" startlevel="1"/>
-                    <capability name="org.jboss.osgi.logging" startlevel="1"/>
-                    <capability name="org.apache.felix.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.http" startlevel="1"/>
-                </capabilities>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:remoting:1.1">
-                <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:resource-adapters:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:security:1.2">
-                <security-domains>
-                    <security-domain name="other" cache-type="default">
-                        <authentication>
-                            <login-module code="Remoting" flag="optional">
-                                <module-option name="password-stacking" value="useFirstPass"/>
-                            </login-module>
-                            <login-module code="RealmDirect" flag="required">
-                                <module-option name="password-stacking" value="useFirstPass"/>
-                            </login-module>
-                        </authentication>
-                    </security-domain>
-                    <security-domain name="jboss-web-policy" cache-type="default">
-                        <authorization>
-                            <policy-module code="Delegating" flag="required"/>
-                        </authorization>
-                    </security-domain>
-                    <security-domain name="jboss-ejb-policy" cache-type="default">
-                        <authorization>
-                            <policy-module code="Delegating" flag="required"/>
-                        </authorization>
-                    </security-domain>
-                </security-domains>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
-            <subsystem xmlns="urn:jboss:domain:transactions:1.2">
-                <core-environment>
-                    <process-id>
-                        <uuid/>
-                    </process-id>
-                </core-environment>
-                <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
-                <coordinator-environment default-timeout="300"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
-                <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
-                <virtual-server name="default-host" enable-welcome-root="true">
-                    <alias name="localhost"/>
-                    <alias name="example.com"/>
-                </virtual-server>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:webservices:1.2">
-                <modify-wsdl-address>true</modify-wsdl-address>
-                <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
-                <endpoint-config name="Standard-Endpoint-Config"/>
-                <endpoint-config name="Recording-Endpoint-Config">
-                    <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
-                        <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
-                    </pre-handler-chain>
-                </endpoint-config>
-                <client-config name="Standard-Client-Config"/>
-            </subsystem>
-            <subsystem xmlns="urn:jboss:domain:weld:1.0"/>
-        </profile>
         <profile name="full-ha">
-            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+            <subsystem xmlns="urn:jboss:domain:logging:2.0">
                 <console-handler name="CONSOLE">
                     <level name="INFO"/>
                     <formatter>
-                        <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                        <named-formatter name="COLOR-PATTERN"/>
                     </formatter>
                 </console-handler>
                 <periodic-rotating-file-handler name="FILE" autoflush="true">
                     <formatter>
-                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                        <named-formatter name="PATTERN"/>
                     </formatter>
                     <file relative-to="jboss.server.log.dir" path="server.log"/>
                     <suffix value=".yyyy-MM-dd"/>
@@ -964,13 +90,26 @@
                         <handler name="FILE"/>
                     </handlers>
                 </root-logger>
+                <formatter name="PATTERN">
+                    <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+                <formatter name="COLOR-PATTERN">
+                    <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:datasources:1.1">
+            <subsystem xmlns="urn:jboss:domain:batch:1.0">
+                <job-repository>
+                    <in-memory/>
+                </job-repository>
+                <thread-pool>
+                    <max-threads count="10"/>
+                    <keepalive-time time="100" unit="milliseconds"/>
+                </thread-pool>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:datasources:2.0">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
-                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
                         <driver>h2</driver>
                         <security>
                             <user-name>sa</user-name>
@@ -984,19 +123,24 @@
                     </drivers>
                 </datasources>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ee:1.1">
+            <subsystem xmlns="urn:jboss:domain:ee:2.0">
                 <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
                 <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
+                <concurrent>
+                    <default-context-service/>
+                    <default-managed-thread-factory/>
+                    <default-managed-executor-service hung-task-threshold="60000" core-threads="5" max-threads="25" keepalive-time="5000"/>
+                    <default-managed-scheduled-executor-service hung-task-threshold="60000" core-threads="2" keepalive-time="3000"/>
+                </concurrent>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:ejb3:1.4">
+            <subsystem xmlns="urn:jboss:domain:ejb3:2.0">
                 <session-bean>
                     <stateless>
                         <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
                     </stateless>
-                    <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered"/>
+                    <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered" passivation-disabled-cache-ref="simple"/>
                     <singleton default-access-timeout="5000"/>
                 </session-bean>
-                <default-security-domain value="other"/>
                 <mdb>
                     <resource-adapter-ref resource-adapter-name="hornetq-ra"/>
                     <bean-instance-pool-ref pool-name="mdb-strict-max-pool"/>
@@ -1017,10 +161,12 @@
                     <cluster-passivation-store name="infinispan" cache-container="ejb"/>
                 </passivation-stores>
                 <async thread-pool-name="default"/>
-                <timer-service thread-pool-name="default">
-                    <data-store path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                    <data-stores>
+                        <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                    </data-stores>
                 </timer-service>
-                <remote connector-ref="remoting-connector" thread-pool-name="default"/>
+                <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
                 <thread-pools>
                     <thread-pool name="default">
                         <max-threads count="10"/>
@@ -1028,15 +174,21 @@
                     </thread-pool>
                 </thread-pools>
                 <iiop enable-by-default="false" use-qualified-name="false"/>
+                <default-security-domain value="other"/>
+                <default-missing-method-permissions-deny-access value="true"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:infinispan:1.4">
-                <cache-container name="cluster" aliases="ha-partition" default-cache="default">
+            <subsystem xmlns="urn:jboss:domain:io:1.0">
+                <worker name="default" io-threads="3"/>
+                <buffer-pool name="default" buffer-size="16384" buffers-per-slice="128"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:infinispan:2.0">
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
                     <transport lock-timeout="60000"/>
                     <replicated-cache name="default" mode="SYNC" batching="true">
                         <locking isolation="REPEATABLE_READ"/>
                     </replicated-cache>
                 </cache-container>
-                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.jboss.as.clustering.web.infinispan">
+                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan">
                     <transport lock-timeout="60000"/>
                     <replicated-cache name="repl" mode="ASYNC" batching="true">
                         <file-store/>
@@ -1062,7 +214,7 @@
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.jboss.as.jpa.hibernate:4">
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
                     <transport lock-timeout="60000"/>
                     <local-cache name="local-query">
                         <transaction mode="NONE"/>
@@ -1080,16 +232,13 @@
                     </replicated-cache>
                 </cache-container>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+            <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
                 <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
-                    <initializers transactions="spec" security="on"/>
+                    <initializers transactions="spec" security="identity"/>
                 </orb>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
-                <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-            </subsystem>
             <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jca:1.1">
+            <subsystem xmlns="urn:jboss:domain:jca:2.0">
                 <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
                 <bean-validation enabled="true"/>
                 <default-workmanager>
@@ -1109,26 +258,16 @@
                 <cached-connection-manager/>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="udp">
+            <subsystem xmlns="urn:jboss:domain:jgroups:2.0" default-stack="udp">
                 <stack name="udp">
                     <transport type="UDP" socket-binding="jgroups-udp"/>
                     <protocol type="PING"/>
-                    <!--  
-                        MERGE3 does not exist in 7.1.x, so use MERGE2 for these tests
-                        A server not starting is not a problem, it just means it needs to use another profile
                     <protocol type="MERGE3"/>
-                     -->
-                    <protocol type="MERGE2"/>
                     <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
-                    <protocol type="FD"/>
+                    <protocol type="FD_ALL"/>
                     <protocol type="VERIFY_SUSPECT"/>
-                    <!--  
-                        NAKACK does not exist in 7.1.x, so use NAKACK for these tests
-                        A server not starting is not a problem, it just means it needs to use another profile
-                    <protocol type="NAKACK2"/>
-                     -->
-                    <protocol type="pbcast.NAKACK"/>
-                    <protocol type="UNICAST2"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
                     <protocol type="pbcast.STABLE"/>
                     <protocol type="pbcast.GMS"/>
                     <protocol type="UFC"/>
@@ -1143,22 +282,16 @@
                     <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
                     <protocol type="FD"/>
                     <protocol type="VERIFY_SUSPECT"/>
-                    <!--  
-                        NAKACK does not exist in 7.1.x, so use NAKACK for these tests
-                        A server not starting is not a problem, it just means it needs to use another profile
-                    <protocol type="NAKACK2"/>
-                     -->
-                    <protocol type="pbcast.NAKACK"/>
-                    <protocol type="UNICAST2"/>
+                    <protocol type="pbcast.NAKACK2"/>
+                    <protocol type="UNICAST3"/>
                     <protocol type="pbcast.STABLE"/>
                     <protocol type="pbcast.GMS"/>
-                    <protocol type="UFC"/>
                     <protocol type="MFC"/>
                     <protocol type="FRAG2"/>
                     <protocol type="RSVP"/>
                 </stack>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:jmx:2.0">
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3">
                 <expose-resolved-model/>
                 <expose-expression-model/>
                 <!--<remoting-connector use-management-endpoint="false"/>-->
@@ -1168,12 +301,12 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
             <subsystem xmlns="urn:jboss:domain:jsr77:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:mail:1.0">
+            <subsystem xmlns="urn:jboss:domain:mail:1.1">
                 <mail-session jndi-name="java:jboss/mail/Default">
                     <smtp-server outbound-socket-binding-ref="mail-smtp"/>
                 </mail-session>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:messaging:1.3">
+            <subsystem xmlns="urn:jboss:domain:messaging:1.4">
                 <hornetq-server>
                     <cluster-password>${jboss.messaging.cluster.password:CHANGE ME!!}</cluster-password>
                     <persistence-enabled>true</persistence-enabled>
@@ -1184,6 +317,7 @@
                         <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                             <param key="batch-delay" value="50"/>
                         </netty-connector>
+                        <servlet-connector name="servlet" socket-binding="http" host="default-host"/>
                         <in-vm-connector name="in-vm" server-id="0"/>
                     </connectors>
                     <acceptors>
@@ -1230,7 +364,8 @@
                             <redelivery-delay>0</redelivery-delay>
                             <redistribution-delay>1000</redistribution-delay>
                             <max-size-bytes>10485760</max-size-bytes>
-                            <address-full-policy>BLOCK</address-full-policy>
+                            <address-full-policy>PAGE</address-full-policy>
+                            <page-size-bytes>2097152</page-size-bytes>
                             <message-counter-history-day-limit>10</message-counter-history-day-limit>
                         </address-setting>
                     </address-settings>
@@ -1243,6 +378,14 @@
                                 <entry name="java:/ConnectionFactory"/>
                             </entries>
                         </connection-factory>
+                        <connection-factory name="ServletConnectionFactory">
+                            <connectors>
+                                <connector-ref connector-name="servlet"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:jboss/exported/jms/ServletConnectionFactory"/>
+                            </entries>
+                        </connection-factory>
                         <connection-factory name="RemoteConnectionFactory">
                             <connectors>
                                 <connector-ref connector-name="netty"/>
@@ -1250,6 +393,11 @@
                             <entries>
                                 <entry name="java:jboss/exported/jms/RemoteConnectionFactory"/>
                             </entries>
+                            <ha>true</ha>
+                            <block-on-acknowledge>true</block-on-acknowledge>
+                            <retry-interval>1000</retry-interval>
+                            <retry-interval-multiplier>1.0</retry-interval-multiplier>
+                            <reconnect-attempts>-1</reconnect-attempts>
                         </connection-factory>
                         <pooled-connection-factory name="hornetq-ra">
                             <transaction mode="xa"/>
@@ -1258,46 +406,28 @@
                             </connectors>
                             <entries>
                                 <entry name="java:/JmsXA"/>
+                                <!-- Global JNDI entry used to provide a default JMS Connection factory to EE application -->
+                                <entry name="java:jboss/DefaultJMSConnectionFactory"/>
                             </entries>
                         </pooled-connection-factory>
                     </jms-connection-factories>
                 </hornetq-server>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:modcluster:1.1">
+            <subsystem xmlns="urn:jboss:domain:modcluster:1.2">
                 <mod-cluster-config advertise-socket="modcluster" connector="ajp">
                     <dynamic-load-provider>
                         <load-metric type="busyness"/>
                     </dynamic-load-provider>
                 </mod-cluster-config>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:naming:1.2">
+            <subsystem xmlns="urn:jboss:domain:naming:2.0">
                 <remote-naming/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
-                <properties>
-                    <property name="org.osgi.framework.startlevel.beginning">1</property>
-                </properties>
-                <capabilities>
-                    <capability name="javax.jws.api"/>
-                    <capability name="javax.persistence.api"/>
-                    <capability name="javax.servlet.api"/>
-                    <capability name="javax.transaction.api"/>
-                    <capability name="javax.ws.rs.api"/>
-                    <capability name="javax.xml.bind.api"/>
-                    <capability name="javax.xml.ws.api"/>
-                    <capability name="org.slf4j"/>
-                    <capability name="org.apache.felix.log" startlevel="1"/>
-                    <capability name="org.jboss.osgi.logging" startlevel="1"/>
-                    <capability name="org.apache.felix.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
-                    <capability name="org.jboss.as.osgi.http" startlevel="1"/>
-                </capabilities>
-            </subsystem>
             <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
-            <subsystem xmlns="urn:jboss:domain:remoting:1.1">
-                <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
+            <subsystem xmlns="urn:jboss:domain:remoting:2.0">
+                <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:resource-adapters:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:resource-adapters:2.0"/>
             <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
             <subsystem xmlns="urn:jboss:domain:security:1.2">
                 <security-domains>
@@ -1324,7 +454,501 @@
                 </security-domains>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
-            <subsystem xmlns="urn:jboss:domain:transactions:1.2">
+            <subsystem xmlns="urn:jboss:domain:transactions:2.0">
+                <core-environment>
+                    <process-id>
+                        <uuid/>
+                    </process-id>
+                </core-environment>
+                <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
+                <coordinator-environment default-timeout="300"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:undertow:1.0">
+                <buffer-caches>
+                    <buffer-cache name="default" buffer-size="1024" buffers-per-region="1024" max-regions="10"/>
+                </buffer-caches>
+                <server name="default-server">
+                    <http-listener name="default" socket-binding="http" max-post-size="10485760"/>
+                    <ajp-listener name="ajp" socket-binding="ajp" max-post-size="10485760"/>
+                    <host name="default-host" alias="localhost">
+                        <location name="/" handler="welcome-content"/>
+                    </host>
+                </server>
+                <servlet-container name="default" default-buffer-cache="default" stack-trace-on-error="local-only">
+                    <jsp-config/>
+                    <persistent-sessions path="persistent-web-sessions" relative-to="jboss.server.data.dir"/>
+                </servlet-container>
+                <handlers>
+                    <file name="welcome-content" path="${jboss.home.dir}/welcome-content" directory-listing="true"/>
+                </handlers>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:webservices:1.2">
+                <modify-wsdl-address>true</modify-wsdl-address>
+                <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
+                <endpoint-config name="Standard-Endpoint-Config"/>
+                <endpoint-config name="Recording-Endpoint-Config">
+                    <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">
+                        <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
+                    </pre-handler-chain>
+                </endpoint-config>
+                <client-config name="Standard-Client-Config"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:weld:2.0"/>
+        </profile>
+        
+        <!-- 
+            This is the standard full-ha profile from the original domain.xml with adjustments made to be able to start up
+            7.1.x slaves
+        -->
+        <profile name="full-ha-7.1.x">
+            <subsystem xmlns="urn:jboss:domain:logging:2.0">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <!--  
+                           This does not exist on 7.1.x, use pattern-formatter instead                        
+                        <named-formatter name="COLOR-PATTERN"/>
+                         -->
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+                <periodic-rotating-file-handler name="FILE" autoflush="true">
+                    <formatter>
+                        <!--  
+                           This does not exist on 7.1.x, use pattern-formatter instead                        
+                        <named-formatter name="PATTERN"/>
+                         -->
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                    <append value="true"/>
+                </periodic-rotating-file-handler>
+                <logger category="com.arjuna">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="org.apache.tomcat.util.modeler">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="org.jboss.as.config">
+                    <level name="DEBUG"/>
+                </logger>
+                <logger category="sun.rmi">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="jacorb">
+                    <level name="WARN"/>
+                </logger>
+                <logger category="jacorb.config">
+                    <level name="ERROR"/>
+                </logger>
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+                <!--
+                This does not exist on 7.1.x 
+                <formatter name="PATTERN">
+                    <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+                <formatter name="COLOR-PATTERN">
+                    <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+                 -->
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:datasources:2.0">
+                <datasources>
+                    <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
+                        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+                        <driver>h2</driver>
+                        <security>
+                            <user-name>sa</user-name>
+                            <password>sa</password>
+                        </security>
+                    </datasource>
+                    <drivers>
+                        <driver name="h2" module="com.h2database.h2">
+                            <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+                        </driver>
+                    </drivers>
+                </datasources>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ee:2.0">
+                <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
+                <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
+                <!-- 
+                  This does not exist on 7.1.x
+                <concurrent>
+                    <default-context-service/>
+                    <default-managed-thread-factory/>
+                    <default-managed-executor-service hung-task-threshold="60000" core-threads="5" max-threads="25" keepalive-time="5000"/>
+                    <default-managed-scheduled-executor-service hung-task-threshold="60000" core-threads="2" keepalive-time="3000"/>
+                </concurrent>
+                -->
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:ejb3:2.0">
+                <session-bean>
+                    <stateless>
+                        <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
+                    </stateless>
+                    <stateful default-access-timeout="5000" cache-ref="simple" clustered-cache-ref="clustered" passivation-disabled-cache-ref="simple"/>
+                    <singleton default-access-timeout="5000"/>
+                </session-bean>
+                <mdb>
+                    <resource-adapter-ref resource-adapter-name="hornetq-ra"/>
+                    <bean-instance-pool-ref pool-name="mdb-strict-max-pool"/>
+                </mdb>
+                <pools>
+                    <bean-instance-pools>
+                        <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                        <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
+                    </bean-instance-pools>
+                </pools>
+                <caches>
+                    <cache name="simple" aliases="NoPassivationCache"/>
+                    <cache name="passivating" passivation-store-ref="file" aliases="SimpleStatefulCache"/>
+                    <cache name="clustered" passivation-store-ref="infinispan" aliases="StatefulTreeCache"/>
+                </caches>
+                <passivation-stores>
+                    <file-passivation-store name="file"/>
+                    <cluster-passivation-store name="infinispan" cache-container="ejb"/>
+                </passivation-stores>
+                <async thread-pool-name="default"/>
+                <timer-service thread-pool-name="default" default-data-store="default-file-store">
+                    <data-stores>
+                        <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
+                    </data-stores>
+                </timer-service>
+                <!-- This does not exist on 7.1.x, use the standard remoting one instead 
+                <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
+                 -->
+                 <remote connector-ref="remoting-connector" thread-pool-name="default"/>
+                <thread-pools>
+                    <thread-pool name="default">
+                        <max-threads count="10"/>
+                        <keepalive-time time="100" unit="milliseconds"/>
+                    </thread-pool>
+                </thread-pools>
+                <iiop enable-by-default="false" use-qualified-name="false"/>
+                <default-security-domain value="other"/>
+                <default-missing-method-permissions-deny-access value="true"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:infinispan:2.0">
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server">
+                    <transport lock-timeout="60000"/>
+                    <replicated-cache name="default" mode="SYNC" batching="true">
+                        <locking isolation="REPEATABLE_READ"/>
+                    </replicated-cache>
+                </cache-container>
+                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan">
+                    <transport lock-timeout="60000"/>
+                    <replicated-cache name="repl" mode="ASYNC" batching="true">
+                        <file-store/>
+                    </replicated-cache>
+                    <replicated-cache name="sso" mode="SYNC" batching="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
+                        <file-store/>
+                    </distributed-cache>
+                </cache-container>
+                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan">
+                    <transport lock-timeout="60000"/>
+                    <replicated-cache name="repl" mode="ASYNC" batching="true">
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <file-store/>
+                    </replicated-cache>
+                    <!--
+                      ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
+                      ~                 the socketbinding referenced by the EJB remoting connector 
+                      -->
+                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <file-store/>
+                    </distributed-cache>
+                </cache-container>
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
+                    <transport lock-timeout="60000"/>
+                    <local-cache name="local-query">
+                        <transaction mode="NONE"/>
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </local-cache>
+                    <invalidation-cache name="entity" mode="SYNC">
+                        <transaction mode="NON_XA"/>
+                        <eviction strategy="LRU" max-entries="10000"/>
+                        <expiration max-idle="100000"/>
+                    </invalidation-cache>
+                    <replicated-cache name="timestamps" mode="ASYNC">
+                        <transaction mode="NONE"/>
+                        <eviction strategy="NONE"/>
+                    </replicated-cache>
+                </cache-container>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+                <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
+                    <initializers transactions="spec" security="identity"/>
+                </orb>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jca:2.0">
+                <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
+                <bean-validation enabled="true"/>
+                <default-workmanager>
+                    <short-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </short-running-threads>
+                    <long-running-threads>
+                        <core-threads count="50"/>
+                        <queue-length count="50"/>
+                        <max-threads count="50"/>
+                        <keepalive-time time="10" unit="seconds"/>
+                    </long-running-threads>
+                </default-workmanager>
+                <cached-connection-manager/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jdr:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jgroups:2.0" default-stack="udp">
+                <stack name="udp">
+                    <transport type="UDP" socket-binding="jgroups-udp"/>
+                    <protocol type="PING"/>
+                     <!-- 
+                        MERGE3 does not exist in 7.1.x, so use MERGE2 for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
+                     <protocol type="MERGE3"/>
+                     -->
+                    <protocol type="MERGE2"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
+                    <protocol type="FD_ALL"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <!--  
+                        NAKACK does not exist in 7.1.x, so use NAKACK for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
+                    <protocol type="NAKACK2"/>
+                     -->
+                    <protocol type="pbcast.NAKACK"/>
+                    <!--  
+                        UNICAST3 does not exist in 7.1.x, so use UNICAST2 for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
+                    <protocol type="UNICAST3"/>
+                     -->
+                    <protocol type="UNICAST2"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="UFC"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                    <protocol type="RSVP"/>
+                </stack>
+                <stack name="tcp">
+                    <transport type="TCP" socket-binding="jgroups-tcp"/>
+                    <protocol type="MPING" socket-binding="jgroups-mping"/>
+                     <!-- 
+                        MERGE3 does not exist in 7.1.x, so use MERGE2 for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
+                     <protocol type="MERGE3"/>
+                     -->
+                    <protocol type="MERGE2"/>
+                    <protocol type="FD_SOCK" socket-binding="jgroups-tcp-fd"/>
+                    <protocol type="FD"/>
+                    <protocol type="VERIFY_SUSPECT"/>
+                    <!--  
+                        NAKACK does not exist in 7.1.x, so use NAKACK for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
+                    <protocol type="NAKACK2"/>
+                     -->
+                    <protocol type="pbcast.NAKACK"/>
+                    <!--  
+                        UNICAST3 does not exist in 7.1.x, so use UNICAST2 for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
+                    <protocol type="UNICAST3"/>
+                     -->
+                    <protocol type="UNICAST2"/>
+                    <protocol type="pbcast.STABLE"/>
+                    <protocol type="pbcast.GMS"/>
+                    <protocol type="MFC"/>
+                    <protocol type="FRAG2"/>
+                    <protocol type="RSVP"/>
+                </stack>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jmx:1.3">
+                <expose-resolved-model/>
+                <expose-expression-model/>
+                <!--<remoting-connector use-management-endpoint="false"/>-->
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jpa:1.1">
+                <jpa default-datasource="" default-extended-persistence-inheritance="DEEP"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:jsf:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:jsr77:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:mail:1.1">
+                <mail-session jndi-name="java:jboss/mail/Default">
+                    <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+                </mail-session>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:messaging:1.4">
+                <hornetq-server>
+                    <cluster-password>${jboss.messaging.cluster.password:CHANGE ME!!}</cluster-password>
+                    <persistence-enabled>true</persistence-enabled>
+                    <journal-file-size>102400</journal-file-size>
+                    <journal-min-files>2</journal-min-files>
+                    <connectors>
+                        <netty-connector name="netty" socket-binding="messaging"/>
+                        <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                            <param key="batch-delay" value="50"/>
+                        </netty-connector>
+                        <!--
+                        This does not exist on 7.1.x 
+                        <servlet-connector name="servlet" socket-binding="http" host="default-host"/>
+                        -->
+                        <in-vm-connector name="in-vm" server-id="0"/>
+                    </connectors>
+                    <acceptors>
+                        <netty-acceptor name="netty" socket-binding="messaging"/>
+                        <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                            <param key="batch-delay" value="50"/>
+                            <param key="direct-deliver" value="false"/>
+                        </netty-acceptor>
+                        <in-vm-acceptor name="in-vm" server-id="0"/>
+                    </acceptors>
+                    <broadcast-groups>
+                        <broadcast-group name="bg-group1">
+                            <socket-binding>messaging-group</socket-binding>
+                            <broadcast-period>5000</broadcast-period>
+                            <connector-ref>netty</connector-ref>
+                        </broadcast-group>
+                    </broadcast-groups>
+                    <discovery-groups>
+                        <discovery-group name="dg-group1">
+                            <socket-binding>messaging-group</socket-binding>
+                            <refresh-timeout>10000</refresh-timeout>
+                        </discovery-group>
+                    </discovery-groups>
+                    <cluster-connections>
+                        <cluster-connection name="my-cluster">
+                            <address>jms</address>
+                            <connector-ref>netty</connector-ref>
+                            <discovery-group-ref discovery-group-name="dg-group1"/>
+                        </cluster-connection>
+                    </cluster-connections>
+                    <security-settings>
+                        <security-setting match="#">
+                            <permission type="send" roles="guest"/>
+                            <permission type="consume" roles="guest"/>
+                            <permission type="createNonDurableQueue" roles="guest"/>
+                            <permission type="deleteNonDurableQueue" roles="guest"/>
+                        </security-setting>
+                    </security-settings>
+                    <address-settings>
+                        <!--default for catch all-->
+                        <address-setting match="#">
+                            <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+                            <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+                            <redelivery-delay>0</redelivery-delay>
+                            <redistribution-delay>1000</redistribution-delay>
+                            <max-size-bytes>10485760</max-size-bytes>
+                            <address-full-policy>PAGE</address-full-policy>
+                            <page-size-bytes>2097152</page-size-bytes>
+                            <message-counter-history-day-limit>10</message-counter-history-day-limit>
+                        </address-setting>
+                    </address-settings>
+                    <jms-connection-factories>
+                        <connection-factory name="InVmConnectionFactory">
+                            <connectors>
+                                <connector-ref connector-name="in-vm"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:/ConnectionFactory"/>
+                            </entries>
+                        </connection-factory>
+                        <!--
+                        This does not exist on 7.1.x 
+                        <connection-factory name="ServletConnectionFactory">
+                            <connectors>
+                                <connector-ref connector-name="servlet"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:jboss/exported/jms/ServletConnectionFactory"/>
+                            </entries>
+                        </connection-factory>
+                         -->
+                        <connection-factory name="RemoteConnectionFactory">
+                            <connectors>
+                                <connector-ref connector-name="netty"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:jboss/exported/jms/RemoteConnectionFactory"/>
+                            </entries>
+                            <ha>true</ha>
+                            <block-on-acknowledge>true</block-on-acknowledge>
+                            <retry-interval>1000</retry-interval>
+                            <retry-interval-multiplier>1.0</retry-interval-multiplier>
+                            <reconnect-attempts>-1</reconnect-attempts>
+                        </connection-factory>
+                        <pooled-connection-factory name="hornetq-ra">
+                            <transaction mode="xa"/>
+                            <connectors>
+                                <connector-ref connector-name="in-vm"/>
+                            </connectors>
+                            <entries>
+                                <entry name="java:/JmsXA"/>
+                                <!-- Global JNDI entry used to provide a default JMS Connection factory to EE application -->
+                                <entry name="java:jboss/DefaultJMSConnectionFactory"/>
+                            </entries>
+                        </pooled-connection-factory>
+                    </jms-connection-factories>
+                </hornetq-server>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:modcluster:1.2">
+                <mod-cluster-config advertise-socket="modcluster" connector="ajp">
+                    <dynamic-load-provider>
+                        <load-metric type="busyness"/>
+                    </dynamic-load-provider>
+                </mod-cluster-config>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:naming:2.0">
+                <remote-naming/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:remoting:2.0">
+                <!-- This does not exist on 7.1.x, set up a standard connector instead 
+                <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+                 -->
+                 <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:resource-adapters:2.0"/>
+            <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:security:1.2">
+                <security-domains>
+                    <security-domain name="other" cache-type="default">
+                        <authentication>
+                            <login-module code="Remoting" flag="optional">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                            <login-module code="RealmDirect" flag="required">
+                                <module-option name="password-stacking" value="useFirstPass"/>
+                            </login-module>
+                        </authentication>
+                    </security-domain>
+                    <security-domain name="jboss-web-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                    <security-domain name="jboss-ejb-policy" cache-type="default">
+                        <authorization>
+                            <policy-module code="Delegating" flag="required"/>
+                        </authorization>
+                    </security-domain>
+                </security-domains>
+            </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:transactions:2.0">
                 <core-environment>
                     <process-id>
                         <uuid/>
@@ -1350,10 +974,12 @@
                         <handler name="RecordingHandler" class="org.jboss.ws.common.invocation.RecordingServerHandler"/>
                     </pre-handler-chain>
                 </endpoint-config>
+                <!-- This does not exist on 7.1.x 
                 <client-config name="Standard-Client-Config"/>
+                 -->
             </subsystem>
-            <subsystem xmlns="urn:jboss:domain:weld:1.0"/>
-        </profile>
+            <subsystem xmlns="urn:jboss:domain:weld:2.0"/>
+        </profile>    
     </profiles>
     <!--
       ~ 
@@ -1372,12 +998,9 @@
     <socket-binding-groups>
         <socket-binding-group name="standard-sockets" default-interface="public">
             <!-- Needed for server groups using the 'default' profile  -->
-            <socket-binding name="ajp" port="8009"/>
-            <socket-binding name="http" port="8080"/>
-            <socket-binding name="https" port="8443"/>
-            <!-- OSGi does not work in 7.1.x without this binding. See https://issues.jboss.org/browse/AS7-6202 -->
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
-            <socket-binding name="remoting" port="4447"/>
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
             <outbound-socket-binding name="mail-smtp">
@@ -1386,18 +1009,15 @@
         </socket-binding-group>
         <socket-binding-group name="ha-sockets" default-interface="public">
             <!-- Needed for server groups using the 'ha' profile  -->
-            <socket-binding name="ajp" port="8009"/>
-            <socket-binding name="http" port="8080"/>
-            <socket-binding name="https" port="8443"/>
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
             <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
-            <!-- OSGi does not work in 7.1.x without this binding. See https://issues.jboss.org/browse/AS7-6202 -->
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
-            <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
             <outbound-socket-binding name="mail-smtp">
@@ -1406,68 +1026,84 @@
         </socket-binding-group>
         <socket-binding-group name="full-sockets" default-interface="public">
             <!-- Needed for server groups using the 'full' profile  -->
-            <socket-binding name="ajp" port="8009"/>
-            <socket-binding name="http" port="8080"/>
-            <socket-binding name="https" port="8443"/>
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
             <socket-binding name="jacorb" interface="unsecure" port="3528"/>
             <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
             <socket-binding name="messaging" port="5445"/>
             <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
             <socket-binding name="messaging-throughput" port="5455"/>
-            <!-- OSGi does not work in 7.1.x without this binding. See https://issues.jboss.org/browse/AS7-6202 -->
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
-            <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
             <outbound-socket-binding name="mail-smtp">
                 <remote-destination host="localhost" port="25"/>
             </outbound-socket-binding>
         </socket-binding-group>
-        <!-- 
-            Use expressions in places they are allowed since expressions should be allowd on all versions.
-            The defaults will be used 
-        -->
-        <socket-binding-group name="full-ha-sockets" default-interface="${test.not.set.anywhere:public}">
+        <socket-binding-group name="full-ha-sockets" default-interface="public">
             <!-- Needed for server groups using the 'full-ha' profile  -->
-            <socket-binding name="ajp" port="8009"/>
-            <!--  use expressions here -->
-            <socket-binding name="http" port="${test.not.set.anywhere:8080}" fixed-port="${test.not.set.anywhere:false}"/>
-            <socket-binding name="https" port="8443"/>
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
             <socket-binding name="jacorb" interface="unsecure" port="3528"/>
             <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
-            <socket-binding name="jgroups-mping" port="${test.not.set.anywhere:0}" multicast-address="230.0.0.4" multicast-port="45700"/>
+            <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
             <socket-binding name="jgroups-tcp" port="7600"/>
             <socket-binding name="jgroups-tcp-fd" port="57600"/>
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="messaging" port="5445"/>
-            <!-- use expressions here -->
             <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
             <socket-binding name="messaging-throughput" port="5455"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
-            <!-- OSGi does not work in 7.1.x without this binding. See https://issues.jboss.org/browse/AS7-6202 -->
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+        </socket-binding-group>
+        <socket-binding-group name="full-ha-sockets-7.1.x" default-interface="public">
+            <!-- Needed for server groups using the 'full-ha-7.1.x' profile  -->
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
+            <socket-binding name="jacorb" interface="unsecure" port="3528"/>
+            <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
+            <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
+            <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
+            <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
+            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="messaging" port="5445"/>
+            <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
+            <socket-binding name="messaging-throughput" port="5455"/>
+            <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
             <outbound-socket-binding name="mail-smtp">
-                <!--  use expressions here -->
-                <remote-destination host="${test.not.set.anywhere:localhost}" port="${test.not.set.anywhere:25}"/>
+                <remote-destination host="localhost" port="25"/>
             </outbound-socket-binding>
-        </socket-binding-group>
+        </socket-binding-group>        
     </socket-binding-groups>
     <server-groups>
-        <server-group name="main-server-group" profile="full">
-            <jvm name="default">
-                <heap size="64m" max-size="512m"/>
-            </jvm>
-            <socket-binding-group ref="full-sockets"/>
-        </server-group>
-        <server-group name="other-server-group" profile="full-ha">
+        <server-group name="main-server-group" profile="full-ha">
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>
             </jvm>
             <socket-binding-group ref="full-ha-sockets"/>
+        </server-group>
+        <server-group name="7.1.2-server-group" profile="full-ha-7.1.x">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+            </jvm>
+            <socket-binding-group ref="full-ha-sockets-7.1.x"/>
+        </server-group>
+        <server-group name="7.1.3-server-group" profile="full-ha-7.1.x">
+            <jvm name="default">
+                <heap size="64m" max-size="512m"/>
+            </jvm>
+            <socket-binding-group ref="full-ha-sockets-7.1.x"/>
         </server-group>
     </server-groups>
 </domain>

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -993,12 +993,20 @@
                 <console-handler name="CONSOLE">
                     <level name="INFO"/>
                     <formatter>
+                        <!--  
+                           This does not exist on 7.2.x, use pattern-formatter instead                        
                         <named-formatter name="COLOR-PATTERN"/>
+                         -->
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                     </formatter>
                 </console-handler>
                 <periodic-rotating-file-handler name="FILE" autoflush="true">
                     <formatter>
+                        <!--  
+                           This does not exist on 7.2.x, use pattern-formatter instead                        
                         <named-formatter name="PATTERN"/>
+                         -->
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                     </formatter>
                     <file relative-to="jboss.server.log.dir" path="server.log"/>
                     <suffix value=".yyyy-MM-dd"/>
@@ -1029,12 +1037,14 @@
                         <handler name="FILE"/>
                     </handlers>
                 </root-logger>
+                <!--  This does not exist on 7.2.x
                 <formatter name="PATTERN">
                     <pattern-formatter pattern="%d{yyyy-MM-dd HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>
                 <formatter name="COLOR-PATTERN">
                     <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>
+                 -->
             </subsystem>
 
             <subsystem xmlns="urn:jboss:domain:datasources:2.0">
@@ -1057,12 +1067,15 @@
             <subsystem xmlns="urn:jboss:domain:ee:2.0">
                 <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
                 <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
+                <!-- 
+                  This does not exist on 7.2.x
                 <concurrent>
                     <default-context-service/>
                     <default-managed-thread-factory/>
                     <default-managed-executor-service hung-task-threshold="60000" core-threads="5" max-threads="25" keepalive-time="5000"/>
                     <default-managed-scheduled-executor-service hung-task-threshold="60000" core-threads="2" keepalive-time="3000"/>
                 </concurrent>
+                -->
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:ejb3:2.0">
                 <session-bean>
@@ -1101,7 +1114,10 @@
                         <file-data-store name="default-file-store" path="timer-service-data" relative-to="jboss.server.data.dir"/>
                     </data-stores>
                 </timer-service>
+                <!-- This does not exist on 7.1.x, use the standard remoting one instead 
                 <remote connector-ref="http-remoting-connector" thread-pool-name="default"/>
+                 -->
+                 <remote connector-ref="remoting-connector" thread-pool-name="default"/>
                 <thread-pools>
                     <thread-pool name="default">
                         <max-threads count="10"/>
@@ -1198,7 +1214,12 @@
                     <protocol type="FD_ALL"/>
                     <protocol type="VERIFY_SUSPECT"/>
                     <protocol type="pbcast.NAKACK2"/>
+                    <!--  
+                        UNICAST3 does not exist in 7.2.x, so use UNICAST2 for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
                     <protocol type="UNICAST3"/>
+                     -->
+                    <protocol type="UNICAST2"/>
                     <protocol type="pbcast.STABLE"/>
                     <protocol type="pbcast.GMS"/>
                     <protocol type="UFC"/>
@@ -1214,7 +1235,12 @@
                     <protocol type="FD"/>
                     <protocol type="VERIFY_SUSPECT"/>
                     <protocol type="pbcast.NAKACK2"/>
+                    <!--  
+                        UNICAST3 does not exist in 7.2.x, so use UNICAST2 for these tests
+                        A server not starting is not a problem, it just means it needs to use another profile
                     <protocol type="UNICAST3"/>
+                     -->
+                    <protocol type="UNICAST2"/>
                     <protocol type="pbcast.STABLE"/>
                     <protocol type="pbcast.GMS"/>
                     <protocol type="MFC"/>
@@ -1248,7 +1274,10 @@
                         <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                             <param key="batch-delay" value="50"/>
                         </netty-connector>
+                        <!--
+                        This does not exist on 7.2.x 
                         <servlet-connector name="servlet" socket-binding="http" host="default-host"/>
+                        -->
                         <in-vm-connector name="in-vm" server-id="0"/>
                     </connectors>
                     <acceptors>
@@ -1309,6 +1338,7 @@
                                 <entry name="java:/ConnectionFactory"/>
                             </entries>
                         </connection-factory>
+                        <!-- This does not exist on 7.2.x 
                         <connection-factory name="ServletConnectionFactory">
                             <connectors>
                                 <connector-ref connector-name="servlet"/>
@@ -1317,6 +1347,7 @@
                                 <entry name="java:jboss/exported/jms/ServletConnectionFactory"/>
                             </entries>
                         </connection-factory>
+                        -->
                         <connection-factory name="RemoteConnectionFactory">
                             <connectors>
                                 <connector-ref connector-name="netty"/>
@@ -1356,7 +1387,10 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
             <subsystem xmlns="urn:jboss:domain:remoting:2.0">
+                <!-- This does not exist on 7.1.x, set up a standard connector instead 
                 <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
+                 -->
+                 <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:resource-adapters:2.0"/>
             <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
@@ -1521,6 +1555,29 @@
                 <remote-destination host="localhost" port="25"/>
             </outbound-socket-binding>
         </socket-binding-group>        
+        <socket-binding-group name="full-ha-sockets-7.2.x" default-interface="public">
+            <!-- Needed for server groups using the 'full-ha-7.1.x' profile  -->
+            <socket-binding name="ajp" port="${jboss.ajp.port:8009}"/>
+            <socket-binding name="http" port="${jboss.http.port:8080}"/>
+            <socket-binding name="https" port="${jboss.https.port:8443}"/>
+            <socket-binding name="jacorb" interface="unsecure" port="3528"/>
+            <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
+            <socket-binding name="jgroups-mping" port="0" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45700"/>
+            <socket-binding name="jgroups-tcp" port="7600"/>
+            <socket-binding name="jgroups-tcp-fd" port="57600"/>
+            <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
+            <socket-binding name="jgroups-udp-fd" port="54200"/>
+            <socket-binding name="messaging" port="5445"/>
+            <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
+            <socket-binding name="messaging-throughput" port="5455"/>
+            <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
+            <socket-binding name="remoting" port="4447"/>
+            <socket-binding name="txn-recovery-environment" port="4712"/>
+            <socket-binding name="txn-status-manager" port="4713"/>
+            <outbound-socket-binding name="mail-smtp">
+                <remote-destination host="localhost" port="25"/>
+            </outbound-socket-binding>
+        </socket-binding-group>      
     </socket-binding-groups>
     <server-groups>
         <server-group name="main-server-group" profile="full-ha">
@@ -1545,7 +1602,7 @@
             <jvm name="default">
                 <heap size="64m" max-size="512m"/>
             </jvm>
-            <socket-binding-group ref="full-ha-sockets"/>
+            <socket-binding-group ref="full-ha-sockets-7.2.x"/>
         </server-group>
     </server-groups>
 </domain>

--- a/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.1.2.Final/domain/configuration/host-slave.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.1.2.Final/domain/configuration/host-slave.xml
@@ -33,7 +33,16 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/>
+       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm">
+            <ignored-resources type="extension">
+                <instance name="org.wildfly.extension.batch"/>
+                <instance name="org.wildfly.extension.io"/>
+                <instance name="org.wildfly.extension.undertow"/>
+            </ignored-resources>
+            <ignored-resources type="profile">
+                <instance name="full-ha"/>
+            </ignored-resources>
+       </remote>       
     </domain-controller>
 
     <interfaces>
@@ -61,6 +70,6 @@
    	</jvms>
 
     <servers>
-        <server name="server-one" group="other-server-group"/>
+        <server name="server-one" group="7.1.2-server-group"/>
     </servers>
 </host>

--- a/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.1.3.Final/domain/configuration/host-slave.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.1.3.Final/domain/configuration/host-slave.xml
@@ -41,6 +41,7 @@
             </ignored-resources>
             <ignored-resources type="profile">
                 <instance name="full-ha"/>
+                <instance name="full-ha-7.2.x"/>
             </ignored-resources>
        </remote>       
     </domain-controller>

--- a/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.1.3.Final/domain/configuration/host-slave.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.1.3.Final/domain/configuration/host-slave.xml
@@ -33,7 +33,16 @@
     </management>
 
     <domain-controller>
-       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/>
+       <remote host="${jboss.test.host.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm">
+            <ignored-resources type="extension">
+                <instance name="org.wildfly.extension.batch"/>
+                <instance name="org.wildfly.extension.io"/>
+                <instance name="org.wildfly.extension.undertow"/>
+            </ignored-resources>
+            <ignored-resources type="profile">
+                <instance name="full-ha"/>
+            </ignored-resources>
+       </remote>       
     </domain-controller>
 
     <interfaces>
@@ -60,7 +69,8 @@
          </jvm>
    	</jvms>
 
+
     <servers>
-        <server name="server-one" group="other-server-group"/>
+        <server name="server-one" group="7.1.3-server-group"/>
     </servers>
 </host>

--- a/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.2.0.Final/domain/configuration/host-slave.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-configs/jboss-as-7.2.0.Final/domain/configuration/host-slave.xml
@@ -41,14 +41,14 @@
             </ignored-resources>
             <ignored-resources type="profile">
                 <instance name="full-ha"/>
-                <instance name="full-ha-7.2.x"/>
+                <instance name="full-ha-7.1.x"/>
             </ignored-resources>
        </remote>       
     </domain-controller>
 
     <interfaces>
         <interface name="management">
-            <inet-address value="${jboss.test.host.slave.address}"/>
+           <inet-address value="${jboss.test.host.slave.address}"/>
         </interface>
         <interface name="public">
            <inet-address value="${jboss.test.host.slave.address}"/>
@@ -56,7 +56,7 @@
         <interface name="unsecure">
             <!-- Used for IIOP sockets in the standard configuration.
                  To secure JacORB you need to setup SSL -->
-           <inet-address value="${jboss.test.host.slave.address}"/>
+             <inet-address value="${jboss.test.host.slave.address}"/>
         </interface>
     </interfaces>
 
@@ -70,7 +70,8 @@
          </jvm>
    	</jvms>
 
+
     <servers>
-        <server name="server-one" group="7.1.2-server-group"/>
+        <server name="server-one" group="7.2.0-server-group"/>
     </servers>
 </host>

--- a/weld/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
+++ b/weld/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
@@ -64,10 +64,10 @@ public class WeldSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformers10(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
-    /*@Test //not ready yet in testing framework
+    @Test //not ready yet in testing framework
     public void testTransformersAS72() throws Exception {
         testTransformers10(ModelTestControllerVersion.V7_2_0_FINAL);
-    }*/
+    }
 
 
     private void testTransformers10(ModelTestControllerVersion controllerVersion) throws Exception {


### PR DESCRIPTION
1)Make it possible to test other distributions than jboss-as-xxx, e.g. wildfly-xxx and jboss-eap-xxx.

2)Get the mixed domain tests working for 7.1.x slaves, some updates to transformers to make that happen. 
a) The domain level core-service=management is discarded when pushing to old slaves, since this was introduced in 8.0.0. Rejecting that would effectively mean it is impossible to have a 8.0.0 DC using access control managing older slaves.
b) Remoting needs to reject the http connector

3)Simplified the mixed-domain test domain.xml, it now has a full-ha profile which is not used on the old slaves. The slaves belong to server groups referencing a profile based on full-ha, with necessary adjustments to be able to boot.

I have updated this with some commits to get the subsystem testing framework working for a 7.2.0 legacy controller, and mixed domain tests for a 7.2.0 slave.
