### PR TITLE
WFLY-981 :  @RunAs/@RunAsPrincipal are ignored for @Startup/@Singleton bean

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -51,6 +51,7 @@ import org.jboss.as.ejb3.component.session.StatelessRemoteViewInstanceFactory;
 import org.jboss.as.ejb3.component.session.StatelessWriteReplaceInterceptor;
 import org.jboss.as.ejb3.concurrency.ContainerManagedConcurrencyInterceptorFactory;
 import org.jboss.as.ejb3.deployment.EjbJarDescription;
+import org.jboss.as.ejb3.security.SecurityContextInterceptorFactory;
 import org.jboss.as.ejb3.tx.EjbBMTInterceptor;
 import org.jboss.as.ejb3.tx.LifecycleCMTTxInterceptor;
 import org.jboss.as.ejb3.tx.TimerCMTTxInterceptor;
@@ -106,7 +107,12 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
         ComponentConfiguration singletonComponentConfiguration = new ComponentConfiguration(this, classIndex, moduleClassLoader, moduleLoader);
         // setup the component create service
         singletonComponentConfiguration.setComponentCreateServiceFactory(new SingletonComponentCreateServiceFactory(this.isInitOnStartup(), dependsOn));
-
+        getConfigurators().add(new ComponentConfigurator() {
+                @Override
+                public void configure(final DeploymentPhaseContext context, final ComponentDescription description, final ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
+                    configuration.addPostConstructInterceptor(new SecurityContextInterceptorFactory(isSecurityEnabled(), false), InterceptorOrder.View.SECURITY_CONTEXT);
+                }
+            });
         if (getTransactionManagementType().equals(TransactionManagementType.CONTAINER)) {
             //we need to add the transaction interceptor to the lifecycle methods
             getConfigurators().add(new ComponentConfigurator() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
@@ -31,6 +31,7 @@ import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentInterceptorFactory;
 import org.jboss.as.ejb3.component.EJBComponent;
+import org.jboss.as.security.service.SimpleSecurityManager;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorFactoryContext;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
@@ -43,9 +44,15 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
     private static final String DEFAULT_DOMAIN = "other";
 
     private final boolean securityRequired;
+    private final boolean propagateSecurity;
 
     public SecurityContextInterceptorFactory(final boolean securityRequired) {
+        this(securityRequired, true);
+    }
+
+    public SecurityContextInterceptorFactory(final boolean securityRequired, final boolean propagateSecurity) {
         this.securityRequired = securityRequired;
+        this.propagateSecurity = propagateSecurity;
     }
 
     @Override
@@ -54,7 +61,12 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
             throw MESSAGES.unexpectedComponent(component, EJBComponent.class);
         }
         final EJBComponent ejbComponent = (EJBComponent) component;
-        final ServerSecurityManager securityManager = ejbComponent.getSecurityManager();
+        final ServerSecurityManager securityManager;
+        if(propagateSecurity) {
+            securityManager = ejbComponent.getSecurityManager();
+        } else {
+            securityManager = new SimpleSecurityManager((SimpleSecurityManager) ejbComponent.getSecurityManager());
+        }
         final EJBSecurityMetaData securityMetaData = ejbComponent.getSecurityMetaData();
         String securityDomain =  securityMetaData.getSecurityDomain();
         if (securityDomain == null) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/SingletonBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/SingletonBean.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file
+ * in the distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.test.integration.ejb.security.runasprincipal;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.security.RolesAllowed;
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Remote;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import org.jboss.as.test.integration.ejb.security.runasprincipal.WhoAmI;
+import org.jboss.ejb3.annotation.RunAsPrincipal;
+import org.jboss.ejb3.annotation.SecurityDomain;
+import org.junit.Assert;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+@Singleton
+@Startup
+@Remote(WhoAmI.class)
+@RolesAllowed("Users")
+@RunAs("Admin")
+@RunAsPrincipal("Helloween")
+@SecurityDomain("other")
+public class SingletonBean implements WhoAmI {
+     @EJB(beanName = "StatelessBBean")
+    private WhoAmI beanB;
+
+    private String principal;
+
+    @PostConstruct
+    public void init() {
+        principal = beanB.getCallerPrincipal();
+        Assert.assertEquals("Helloween", principal);
+    }
+
+    public String getCallerPrincipal() {
+        return principal;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/transitive/SimpleSingletonBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/transitive/SimpleSingletonBean.java
@@ -18,15 +18,13 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
  * MA 02110-1301  USA
  */
-package org.jboss.as.test.integration.ejb.security.runasprincipal;
+package org.jboss.as.test.integration.ejb.security.runasprincipal.transitive;
 
-import javax.annotation.security.RolesAllowed;
-import javax.annotation.security.RunAs;
+import javax.annotation.PostConstruct;
 import javax.ejb.EJB;
 import javax.ejb.Remote;
 import javax.ejb.Singleton;
-import javax.ejb.Startup;
-import org.jboss.ejb3.annotation.RunAsPrincipal;
+import org.jboss.as.test.integration.ejb.security.runasprincipal.WhoAmI;
 import org.jboss.ejb3.annotation.SecurityDomain;
 
 /**
@@ -34,17 +32,22 @@ import org.jboss.ejb3.annotation.SecurityDomain;
  * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
  */
 @Singleton
-@Startup
 @Remote(WhoAmI.class)
-@RolesAllowed("Users")
-@RunAs("Admin")
-@RunAsPrincipal("Helloween")
 @SecurityDomain("other")
-public class SingletonCallerBean implements WhoAmI {
-     @EJB(beanName = "StatelessBBean")
+public class SimpleSingletonBean implements WhoAmI {
+
+    @EJB(beanName = "StatelessBBean")
     private WhoAmI beanB;
 
-    public String getCallerPrincipal() {
-        return beanB.getCallerPrincipal();
+    private String principal;
+
+    @PostConstruct
+    public void init() {
+        principal = beanB.getCallerPrincipal();
     }
+
+    public String getCallerPrincipal() {
+        return principal;
+    }
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/transitive/SingletonStartupBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/transitive/SingletonStartupBean.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file
+ * in the distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+package org.jboss.as.test.integration.ejb.security.runasprincipal.transitive;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.EJB;
+import javax.ejb.Remote;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import org.jboss.as.test.integration.ejb.security.runasprincipal.WhoAmI;
+import org.jboss.ejb3.annotation.SecurityDomain;
+import org.junit.Assert;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+@Singleton
+@Startup
+@Remote(WhoAmI.class)
+@SecurityDomain("other")
+public class SingletonStartupBean implements WhoAmI {
+
+    @EJB(beanName = "StatelessBBean")
+    private WhoAmI beanB;
+
+    private String principal;
+
+    @PostConstruct
+    public void init() {
+        principal = beanB.getCallerPrincipal();
+        Assert.fail("beanB requires role Admin");
+    }
+
+    public String getCallerPrincipal() {
+        return principal;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/transitive/StatelessSingletonUseBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runasprincipal/transitive/StatelessSingletonUseBean.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2013 Red Hat, inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+ * MA 02110-1301  USA
+ */
+
+package org.jboss.as.test.integration.ejb.security.runasprincipal.transitive;
+
+import javax.annotation.security.RunAs;
+import javax.ejb.EJB;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import org.jboss.as.test.integration.ejb.security.runasprincipal.WhoAmI;
+import org.jboss.ejb3.annotation.RunAsPrincipal;
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ *
+ * @author <a href="mailto:ehugonne@redhat.com">Emmanuel Hugonnet</a> (c) 2013 Red Hat, inc.
+ */
+
+@Stateless
+@Remote(WhoAmI.class)
+@RunAs("Admin")
+@RunAsPrincipal("IronMaiden")
+@SecurityDomain("other")
+public class StatelessSingletonUseBean implements WhoAmI {
+
+    @EJB(beanName = "SimpleSingletonBean")
+    private WhoAmI singleton;
+
+    public String getCallerPrincipal() {
+        return singleton.getCallerPrincipal();
+    }
+}


### PR DESCRIPTION
Adding a SecurityInterceptor for Singleton beans for postconstruct methods.
The security context on postcontruct methods in singleton is not propagating the security context.
JIRA : https://issues.jboss.org/browse/WFLY-981
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=921723
