### PR TITLE
WFLY-2195 add defensive check if EntityManagerFactory was already closed

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/container/NonTxEmCloser.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/container/NonTxEmCloser.java
@@ -59,7 +59,9 @@ public class NonTxEmCloser {
         if (emStack != null) {
             for (EntityManager entityManager : emStack.values()) {
                 try {
-                    entityManager.close();
+                    if (entityManager.isOpen()) {
+                        entityManager.close();
+                    }
                 } catch (RuntimeException safeToIgnore) {
                     if (ROOT_LOGGER.isTraceEnabled()) {
                         ROOT_LOGGER.trace("Could not close (non-transactional) container managed entity manager." +

--- a/jpa/core/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
@@ -209,7 +209,9 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
                                 if (entityManagerFactory != null) {
                                     WritableServiceBasedNamingStore.pushOwner(deploymentUnitServiceName);
                                     try {
-                                        entityManagerFactory.close();
+                                        if (entityManagerFactory.isOpen()) {
+                                            entityManagerFactory.close();
+                                        }
                                     } catch (Throwable t) {
                                         JPA_LOGGER.failedToStopPUService(t, pu.getScopedPersistenceUnitName());
                                     } finally {


### PR DESCRIPTION
This (along with Hibernate changes) helps pass the entityManagerFactoryCloseExceptions tck test.
