### PR TITLE
WFLY-261

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-naming_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-naming_2_0.xsd
@@ -41,8 +41,9 @@
             </xs:documentation>
         </xs:annotation>
         <xs:all>
-            <xs:element name="bindings" type="bindingsType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="remote-naming" type="remote-namingType" minOccurs="0" maxOccurs="1" />
+        	<xs:element name="bindings" type="bindingsType" minOccurs="0" maxOccurs="1" />
+        	<xs:element name="remote-naming" type="remote-namingType" minOccurs="0" maxOccurs="1" />
+        	<xs:element name="parsing" type="parsingType" maxOccurs="1" minOccurs="0"></xs:element>
         </xs:all>
     </xs:complexType>
 
@@ -199,4 +200,16 @@
         </xs:attribute>
     </xs:complexType>
 
+
+    <xs:complexType name="parsingType">
+    	<xs:sequence maxOccurs="unbounded" minOccurs="1">
+    		<xs:element name="mapping" type="mappingType"></xs:element>
+    	</xs:sequence>
+    	<xs:attribute name="resolver-class" type="xs:string"></xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="mappingType">
+    	<xs:attribute name="value" type="xs:string"></xs:attribute>
+    	<xs:attribute name="class" type="xs:string"></xs:attribute>
+    </xs:complexType>
 </xs:schema>

--- a/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -50,6 +50,7 @@
                 <path name="com/sun/jndi/url/iiopname"/>
                 <path name="com/sun/jndi/url/ldap"/>
                 <path name="com/sun/jndi/url/ldaps"/>
+                <path name="com/sun/jndi/url/rmi"/>
                 <path name="com/sun/crypto/provider"/>
                 <path name="com/sun/org/apache/xml/internal/security/transforms/implementations"/>
                 <path name="com/sun/security/auth"/>

--- a/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
@@ -22,8 +22,11 @@
 
 package org.jboss.as.controller;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.xml.stream.Location;
@@ -89,6 +92,18 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
                                      final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
         super(name, xmlName, null, ModelType.OBJECT, allowNull, allowExpression, null, corrector, new MapValidator(elementValidator, allowNull, minSize, maxSize), false,
                 alternatives, requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+        this.elementValidator = elementValidator;
+    }
+
+    protected MapAttributeDefinition(final String name, final String xmlName, final ModelNode defaultValue,
+            final boolean allowNull, boolean allowExpression, final int minSize, final int maxSize,
+            final ParameterCorrector corrector, final ParameterValidator elementValidator, final String[] alternatives,
+            final String[] requires, final AttributeMarshaller attributeMarshaller, final boolean resourceOnly,
+            final DeprecationData deprecated, final AccessConstraintDefinition[] accessConstraints,
+            final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+        super(name, xmlName, defaultValue, ModelType.OBJECT, allowNull, allowExpression, null, corrector, new MapValidator(
+                elementValidator, allowNull, minSize, maxSize), false, alternatives, requires, attributeMarshaller,
+                resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
         this.elementValidator = elementValidator;
     }
 
@@ -246,6 +261,39 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
      */
     protected ModelNode convertParameterElementExpressions(ModelNode parameterElementValue) {
         return isAllowExpression() ? convertStringExpression(parameterElementValue) : parameterElementValue;
+    }
+
+    protected static ModelNode convertToModel(Map<String, ? extends Object> convertMe) {
+        if (convertMe == null || convertMe.size() == 0) {
+            return null;
+        }
+        final ModelNode model = new ModelNode();
+
+        for (String key : convertMe.keySet()) {
+            final Object value = convertMe.get(key);
+            if (value instanceof Long) {
+                model.add(key, (Long) value);
+            } else if (value instanceof Double) {
+                model.add(key, (Double) value);
+            } else if (value instanceof String) {
+                model.add(key, (String) value);
+            } else if (value instanceof Integer) {
+                model.add(key, (Integer) value);
+            } else if (value instanceof Boolean) {
+                model.add(key, (Boolean) value);
+            } else if (value instanceof ModelNode) {
+                model.add(key, (ModelNode) value);
+            } else if (value instanceof BigInteger) {
+                model.add(key, (BigInteger) value);
+            } else if (value instanceof BigDecimal) {
+                model.add(key, (BigDecimal) value);
+            } else if (value instanceof byte[]) {
+                model.add(key, (byte[]) value);
+            } else {
+                throw new IllegalArgumentException();
+            }
+        }
+        return model;
     }
 
     public static final ParameterCorrector LIST_TO_MAP_CORRECTOR = new ParameterCorrector() {

--- a/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
@@ -30,6 +30,7 @@ import java.util.ResourceBundle;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.jboss.as.controller.PropertiesAttributeDefinition.Builder;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -49,12 +50,12 @@ import org.jboss.dmr.Property;
 //todo maybe replace with SimpleMapAttributeDefinition?
 public final class PropertiesAttributeDefinition extends MapAttributeDefinition {
 
-    private PropertiesAttributeDefinition(final String name, final String xmlName, final boolean allowNull, boolean allowExpression,
+    private PropertiesAttributeDefinition(final String name, final String xmlName, final ModelNode defaultValue, final boolean allowNull, boolean allowExpression,
                                           final int minSize, final int maxSize, final ParameterCorrector corrector, final ParameterValidator elementValidator,
                                           final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller, final boolean resourceOnly,
                                           final DeprecationData deprecated, final AccessConstraintDefinition[] accessConstraints,
                                           final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
-        super(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, elementValidator, alternatives, requires, attributeMarshaller,
+        super(name, xmlName, defaultValue,allowNull, allowExpression, minSize, maxSize, corrector, elementValidator, alternatives, requires, attributeMarshaller,
                 resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
     }
 
@@ -149,6 +150,16 @@ public final class PropertiesAttributeDefinition extends MapAttributeDefinition 
             return this;
         }
 
+        public Builder setDefaultValue(Map<String, ? extends Object> defaultValue) {
+            if(defaultValue == null || defaultValue.size() ==0){
+                super.defaultValue = null;
+                return this;
+            } else {
+                super.defaultValue = convertToModel(defaultValue);
+                return this;
+            }
+        }
+
         @Override
         public PropertiesAttributeDefinition build() {
             if (validator == null) {
@@ -157,7 +168,7 @@ public final class PropertiesAttributeDefinition extends MapAttributeDefinition 
             if (attributeMarshaller == null) {
                 attributeMarshaller = new PropertiesAttributeMarshaller(wrapXmlElement, wrapperElement);
             }
-            return new PropertiesAttributeDefinition(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, validator, alternatives,
+            return new PropertiesAttributeDefinition(name, xmlName, defaultValue, allowNull, allowExpression, minSize, maxSize, corrector, validator, alternatives,
                     requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
         }
     }

--- a/controller/src/main/java/org/jboss/as/controller/SimpleMapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleMapAttributeDefinition.java
@@ -28,11 +28,13 @@ import static org.jboss.as.controller.parsing.Attribute.NAME;
 import static org.jboss.as.controller.parsing.Element.PROPERTY;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.jboss.as.controller.PropertiesAttributeDefinition.Builder;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
@@ -51,12 +53,12 @@ import org.jboss.dmr.Property;
  */
 public class SimpleMapAttributeDefinition extends MapAttributeDefinition {
 
-    private SimpleMapAttributeDefinition(final String name, final String xmlName, final boolean allowNull, boolean allowExpression,
+    private SimpleMapAttributeDefinition(final String name, final String xmlName, final ModelNode defaultValue,final boolean allowNull, boolean allowExpression,
                                          final int minSize, final int maxSize, final ParameterCorrector corrector, final ParameterValidator elementValidator,
                                          final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller,final boolean resourceOnly,
                                          final DeprecationData deprecated, final AccessConstraintDefinition[] accessConstraints,
                                          final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
-        super(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, elementValidator, alternatives,
+        super(name, xmlName, defaultValue,allowNull, allowExpression, minSize, maxSize, corrector, elementValidator, alternatives,
                 requires, attributeMarshaller, resourceOnly,deprecated, accessConstraints, nullSignificant, flags);
     }
 
@@ -116,6 +118,16 @@ public class SimpleMapAttributeDefinition extends MapAttributeDefinition {
             super(basis);
         }
 
+        public Builder setDefaultValue(Map<String, ? extends Object> defaultValue) {
+            if(defaultValue == null || defaultValue.size() ==0){
+                super.defaultValue = null;
+                return this;
+            } else {
+                super.defaultValue = convertToModel(defaultValue);
+                return this;
+            }
+        }
+
         @Override
         public SimpleMapAttributeDefinition build() {
             if (validator == null) {
@@ -124,7 +136,7 @@ public class SimpleMapAttributeDefinition extends MapAttributeDefinition {
             if (attributeMarshaller == null) {
                 attributeMarshaller = new MapAttributeMarshaller();
             }
-            return new SimpleMapAttributeDefinition(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, validator, alternatives, requires,
+            return new SimpleMapAttributeDefinition(name, xmlName, defaultValue, allowNull, allowExpression, minSize, maxSize, corrector, validator, alternatives, requires,
                     attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
         }
     }

--- a/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
+++ b/jmx/src/main/java/org/jboss/as/jmx/model/MBeanInfoFactory.java
@@ -72,6 +72,7 @@ import javax.management.openmbean.OpenMBeanParameterInfo;
 import javax.management.openmbean.OpenMBeanParameterInfoSupport;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularType;
 
 import org.jboss.as.controller.CompositeOperationHandler;
 import org.jboss.as.controller.PathAddress;
@@ -269,9 +270,13 @@ public class MBeanInfoFactory {
             boolean expressionsAllowed = prop.getValue().hasDefined(EXPRESSIONS_ALLOWED) && prop.getValue().get(EXPRESSIONS_ALLOWED).asBoolean();
             descriptions.put(DESC_EXPRESSIONS_ALLOWED, String.valueOf(expressionsAllowed));
 
+            final OpenType<?> openType = converters.convertToMBeanType(value);
             if (!expressionsAllowed) {
                 Object defaultValue = getIfExists(value, DEFAULT);
-                descriptions.put(DEFAULT_VALUE_FIELD, defaultValue);
+
+                if(!(openType.isArray() || openType instanceof TabularType)){
+                    descriptions.put(DEFAULT_VALUE_FIELD, defaultValue);
+                }
                 if (value.has(ALLOWED)) {
                     if (value.get(TYPE).asType()!=ModelType.LIST){
                         List<ModelNode> allowed = value.get(ALLOWED).asList();

--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -44,7 +44,7 @@ import org.jboss.as.naming.context.NamespaceContextSelector;
  */
 public class InitialContext extends NamingContext {
 
-
+    private static final NamingMessages NAMING_MESSAGES = NamingMessages.MESSAGES;
     /**
      * Map of any additional naming schemes
      */
@@ -110,6 +110,8 @@ public class InitialContext extends NamingContext {
                         Context ctx = NamingManager.getURLContext(scheme, getEnvironment());
                         if(ctx!=null){
                             return ctx.lookup(name);
+                        } else {
+                            throw NAMING_MESSAGES.noURLContextFactory(name.toString());
                         }
                     }
                 }

--- a/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
@@ -483,4 +483,62 @@ public interface NamingMessages {
      */
     @Message(id = 11876, value = "Binding type %s requires attributed named %s defined")
     OperationFailedException bindingTypeRequiresAttributeDefined(BindingType bindingType, String attributeName);
+
+    /**
+     * Creates an exception indicating the url context could not be found.
+     *
+     * @param referenceName the reference name.
+     *
+     * @return a {@link NamingException} for the error.
+     */
+    @Message(id = 11877, value = "The url '%s' could not be resolved. The Context.URL_PKG_PREFIXES is not specified, empty or factory cannot be loaded.")
+    NameNotFoundException noURLContextFactory(String url);
+
+    /**
+     * Creates exception indicating that parameter must be defined.
+     *
+     * @param attributeName attribute name.
+     *
+     * @return a {@link OperationFailedException} for the error.
+     */
+    @Message(id = 11878, value = "Attribute '%s' must be defined.")
+    OperationFailedException attributeMustBeDefined(String attributeName);
+
+    /**
+     * Creates exception indicating that certain class must implement interface.
+     *
+     * @param className - name of the class.
+     * @param interfaceName - name of the interface.
+     * @return a {@link OperationFailedException} for the error.
+     */
+    @Message(id = 11879, value = "Class '%s' does not implement interface '%s'.")
+    OperationFailedException requireSpecificInterface(String className, String interfaceName);
+
+    /**
+     * Creates exception indicating that certain class must have no-arg constructor.
+     *
+     * @param className - name of the class.
+     * @return a {@link OperationFailedException} for the error.
+     */
+    @Message(id = 11880, value = "Class '%s' does not have no argument constructor.")
+    OperationFailedException requireNoArgConstructor(String className);
+
+    /**
+     * Creates exception indicating AS could not load certain class.
+     *
+     * @param className - name of the class.
+     * @param error - reason of failure.
+     * @return a {@link OperationFailedException} for the error.
+     */
+    @Message(id = 11881, value = "Can not load class '%s'.")
+    OperationFailedException cannottLoadClass(String className, @Cause Throwable cause);
+
+    /**
+     * Creates exception indicating that attribute entry is a duplicate.
+     *
+     * @param entry - name of entry.
+     * @return a {@link OperationFailedException} for the error.
+     */
+    @Message(id = 11882, value = "Entry '%s' is a duplicate.")
+    OperationFailedException duplicateEntry(String entry);
 }

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingExtension.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingExtension.java
@@ -25,6 +25,8 @@ package org.jboss.as.naming.subsystem;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.BINDING_TYPE;
 import static org.jboss.as.naming.subsystem.NamingSubsystemModel.ENVIRONMENT;
+import static org.jboss.as.naming.subsystem.NamingSubsystemModel.RESOLVER_CLASS;
+import static org.jboss.as.naming.subsystem.NamingSubsystemModel.RESOLVER_MAPPING;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
@@ -118,6 +120,13 @@ public class NamingExtension implements Extension {
                     .setDiscard(DiscardAttributeChecker.UNDEFINED, ENVIRONMENT)
                     .addRejectCheck(new BindingType11RejectChecker(), BINDING_TYPE)
                     .end();
+
+            builder.getAttributeBuilder()
+                    .addRejectCheck(RejectAttributeChecker.DEFINED , RESOLVER_MAPPING)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED , RESOLVER_CLASS)
+                    .setDiscard(DiscardAttributeChecker.UNDEFINED, RESOLVER_MAPPING)
+                    .setDiscard(DiscardAttributeChecker.UNDEFINED, RESOLVER_CLASS);
+
             TransformationDescription.Tools.register(builder.build(), subsystem, VERSION_1_1_0);
 
             // register 1.2.0 and 1.3.0 transformer
@@ -126,6 +135,13 @@ public class NamingExtension implements Extension {
                     .getAttributeBuilder()
                     .addRejectCheck(new BindingType11RejectChecker(), BINDING_TYPE)
                     .end();
+
+            builder.getAttributeBuilder()
+            .addRejectCheck(RejectAttributeChecker.DEFINED , RESOLVER_MAPPING)
+            .addRejectCheck(RejectAttributeChecker.DEFINED , RESOLVER_CLASS)
+            .setDiscard(DiscardAttributeChecker.UNDEFINED, RESOLVER_MAPPING)
+            .setDiscard(DiscardAttributeChecker.UNDEFINED, RESOLVER_CLASS);
+
             TransformationDescription.Tools.register(builder.build(), subsystem, VERSION_1_2_0);
             TransformationDescription.Tools.register(builder.build(), subsystem, VERSION_1_3_0);
         }

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemModel.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemModel.java
@@ -29,6 +29,9 @@ import org.jboss.as.controller.PathElement;
  */
 public interface NamingSubsystemModel {
 
+    String RESOLVER_CLASS = "resolver-class";
+    String RESOLVER_MAPPING = "resolver-mapping";
+
     String BINDING = "binding";
     String BINDING_TYPE = "binding-type";
 
@@ -55,6 +58,5 @@ public interface NamingSubsystemModel {
 
     PathElement BINDING_PATH = PathElement.pathElement(BINDING);
     PathElement REMOTE_NAMING_PATH = PathElement.pathElement(SERVICE, REMOTE_NAMING);
-
 
 }

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemRootResourceDefinition.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemRootResourceDefinition.java
@@ -22,13 +22,38 @@
 
 package org.jboss.as.naming.subsystem;
 
+import static org.jboss.as.naming.NamingMessages.MESSAGES;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.naming.NameParser;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.DefaultAttributeMarshaller;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleMapAttributeDefinition;
 import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.AttributeAccess.Flag;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.naming.management.JndiViewOperation;
+import org.jboss.as.naming.util.DefaultNameParserResolver;
+import org.jboss.as.naming.util.NameParserResolver;
+import org.jboss.as.naming.util.RmiNameParser;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for the Naming subsystem's root management resource.
@@ -37,18 +62,103 @@ import org.jboss.as.naming.management.JndiViewOperation;
  */
 public class NamingSubsystemRootResourceDefinition extends SimpleResourceDefinition {
 
+    static final SimpleOperationDefinition JNDI_VIEW = new SimpleOperationDefinitionBuilder(JndiViewOperation.OPERATION_NAME, NamingExtension.getResourceDescriptionResolver(NamingExtension.SUBSYSTEM_NAME))
+    .addAccessConstraint(NamingExtension.JNDI_VIEW_CONSTRAINT)
+    .withFlag(OperationEntry.Flag.RUNTIME_ONLY)
+    .build();
+
+    static final SimpleAttributeDefinition RESOLVER_CLASS = new SimpleAttributeDefinitionBuilder(
+            NamingSubsystemModel.RESOLVER_CLASS, ModelType.STRING)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setAllowNull(true)
+            .setAllowExpression(false)
+            .setValidator(new ClassValidator(NameParserResolver.class))
+            .setDefaultValue(new ModelNode().set(DefaultNameParserResolver.class.getName())).build();
+
+    static final SimpleMapAttributeDefinition RESOLVER_MAPPING;
+    static {
+
+        Map<String,String> resolverMappingDefaultValue = new HashMap<String, String>();
+        resolverMappingDefaultValue.put(NameParserResolver.KEY_DEFAULT,org.jboss.as.naming.util.NameParser.class.getName());
+        resolverMappingDefaultValue.put(NameParserResolver.KEY_RMI,RmiNameParser.class.getName());
+        RESOLVER_MAPPING = new SimpleMapAttributeDefinition.Builder(NamingSubsystemModel.RESOLVER_MAPPING, true)
+                .setFlags(Flag.RESTART_RESOURCE_SERVICES)
+                .setAllowNull(true)
+                .setAllowExpression(false)
+                .setValidator(new ClassValidator(NameParser.class))
+                .setDefaultValue(resolverMappingDefaultValue)
+                .setAttributeMarshaller(new DefaultAttributeMarshaller() {
+                    @Override
+                    public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel,
+                            boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
+                        resourceModel = resourceModel.get(attribute.getName());
+                        if (resourceModel.isDefined()) {
+                            writer.writeStartElement(attribute.getName());
+                            for (ModelNode property : resourceModel.asList()) {
+                                writer.writeEmptyElement("mapping");
+                                writer.writeAttribute("value", property.asProperty().getName());
+                                writer.writeAttribute("class", property.asProperty().getValue().asString());
+                            }
+                            writer.writeEndElement();
+                        }
+                    }
+                }).build();
+    }
+    //this must be last, so other statics are initialized before constructor is called
     public static final NamingSubsystemRootResourceDefinition INSTANCE = new NamingSubsystemRootResourceDefinition();
 
-    static final SimpleOperationDefinition JNDI_VIEW = new SimpleOperationDefinitionBuilder(JndiViewOperation.OPERATION_NAME, NamingExtension.getResourceDescriptionResolver(NamingExtension.SUBSYSTEM_NAME))
-            .addAccessConstraint(NamingExtension.JNDI_VIEW_CONSTRAINT)
-            .withFlag(OperationEntry.Flag.RUNTIME_ONLY)
-            .build();
-
     private NamingSubsystemRootResourceDefinition() {
-        super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, NamingExtension.SUBSYSTEM_NAME),
-                NamingExtension.getResourceDescriptionResolver(NamingExtension.SUBSYSTEM_NAME),
-                NamingSubsystemAdd.INSTANCE, NamingSubsystemRemove.INSTANCE);
+        super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, NamingExtension.SUBSYSTEM_NAME), NamingExtension
+                .getResourceDescriptionResolver(NamingExtension.SUBSYSTEM_NAME), NamingSubsystemAdd.INSTANCE,
+                NamingSubsystemRemove.INSTANCE);
     }
 
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        super.registerAttributes(resourceRegistration);
+        resourceRegistration.registerReadWriteAttribute(RESOLVER_CLASS, null, new ReloadRequiredWriteAttributeHandler(RESOLVER_CLASS));
+        resourceRegistration.registerReadWriteAttribute(RESOLVER_MAPPING, null, new ReloadRequiredWriteAttributeHandler(RESOLVER_MAPPING));
+    }
 
+    @SuppressWarnings("all")
+    private static class ClassValidator implements ParameterValidator {
+
+        private Class requiredInterface;
+
+        public ClassValidator(Class requiredInterface) {
+            super();
+            this.requiredInterface = requiredInterface;
+        }
+        @Override
+        public void validateResolvedParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            if(value.isDefined()){
+                    validateClass(value.asString());
+            } else {
+                throw MESSAGES.attributeMustBeDefined(parameterName);
+            }
+        }
+        @Override
+        public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+            this.validateResolvedParameter(parameterName, value.resolve());
+        }
+
+        protected void validateClass(final String className) throws OperationFailedException {
+            Class clazz = null;
+            try {
+                clazz = Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                throw MESSAGES.cannottLoadClass(className,e);
+            }
+            if (!requiredInterface.isAssignableFrom(clazz)) {
+                throw MESSAGES.requireSpecificInterface(className, requiredInterface.getName());
+            }
+            try {
+                clazz.getConstructor(null);
+            } catch (NoSuchMethodException nsme) {
+                throw MESSAGES.requireNoArgConstructor(className);
+            } catch (SecurityException se) {
+                throw MESSAGES.requireNoArgConstructor(className);
+            }
+        }
+    }
 }

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemXMLAttribute.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemXMLAttribute.java
@@ -36,7 +36,8 @@ public enum NamingSubsystemXMLAttribute {
     MODULE("module"),
     NAME("name"),
     TYPE("type"),
-    VALUE("value"),;
+    VALUE("value"),
+    RESOLVER_CLASS("resolver-class"),;
 
     private final String name;
 

--- a/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemXMLElement.java
+++ b/naming/src/main/java/org/jboss/as/naming/subsystem/NamingSubsystemXMLElement.java
@@ -45,6 +45,9 @@ public enum NamingSubsystemXMLElement {
     ENVIRONMENT_PROPERTY("property"),
 
     EXTERNAL_CONTEXT("external-context"),
+
+    PARSING("parsing"),
+    MAPPING("mapping")
     ;
 
     private final String name;

--- a/naming/src/main/java/org/jboss/as/naming/util/DefaultNameParserResolver.java
+++ b/naming/src/main/java/org/jboss/as/naming/util/DefaultNameParserResolver.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.naming.util;
+
+import java.util.Map;
+
+import javax.naming.Name;
+
+/**
+ * Default implementation of {@link NameParserResolver}. It expects keys to be equal to URL scheme.
+ *
+ * @author baranowb
+ *
+ */
+public class DefaultNameParserResolver implements NameParserResolver {
+
+    @Override
+    public javax.naming.NameParser findNameParser(final String name, final Map<String, javax.naming.NameParser> parserMap,
+            final javax.naming.NameParser defaultNameParser) {
+        String key = getURLScheme(name);
+        if (key == null) {
+            key = KEY_DEFAULT;
+        }
+        return getParser(key, parserMap, defaultNameParser);
+    }
+
+    @Override
+    public javax.naming.NameParser findNameParser(final Name name, final Map<String, javax.naming.NameParser> parserMap,
+            final javax.naming.NameParser defaultNameParser) {
+        String key = getURLScheme(name.get(0));
+        if (key == null) {
+            key = KEY_DEFAULT;
+        }
+        return getParser(key, parserMap, defaultNameParser);
+    }
+
+    private javax.naming.NameParser getParser(final String key, final Map<String, javax.naming.NameParser> parserMap,
+            final javax.naming.NameParser defaultNameParser) {
+        if (parserMap == null || parserMap.size() == 0) {
+            return defaultNameParser;
+        }
+        if (parserMap.containsKey(key)) {
+            return parserMap.get(key);
+        } else {
+            return defaultNameParser;
+        }
+    }
+
+    private static String getURLScheme(String name) {
+        int colon_posn = name.indexOf(':');
+        int slash_posn = name.indexOf('/');
+
+        if (colon_posn > 0 && ((slash_posn-1)==colon_posn))
+            return name.substring(0, colon_posn);
+
+        return null;
+    }
+}

--- a/naming/src/main/java/org/jboss/as/naming/util/NameParserResolver.java
+++ b/naming/src/main/java/org/jboss/as/naming/util/NameParserResolver.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.naming.util;
+
+import java.util.Map;
+
+import javax.naming.Name;
+
+/**
+ * Interface which defines contract for object capable of matching name to proper name parser.
+ * Note that, NameParser instance must return implementation of CompositeName. However how CompositeName parts are
+ * determined, remains a mystery shrouded by NameParser interface.
+ * Implementation must have no-arg constructor.
+ * @author baranowb
+ */
+public interface NameParserResolver {
+
+    /**
+     * Key for default parser.
+     */
+    String KEY_DEFAULT="default";
+    String KEY_RMI="rmi";
+    /**
+     *
+     * @param name - name which is supposed to be parsed by object instance returned by this method.
+     * @param parserMap - map of prefixes/keys to instances of {@link javax.naming.NameParser}. Key values depend on implementation of this interface.
+     * @param defaultNameParser - this parser will be used in case - matcher did not find and NameParser and there is no entry under {@link #KEY_DEFAULT}.
+     * @return
+     */
+    javax.naming.NameParser findNameParser(String name, Map<String, javax.naming.NameParser> parserMap, javax.naming.NameParser defaultNameParser);
+    /**
+    *
+    * @param name - name which is supposed to be parsed by object instance returned by this method.
+    * @param parserMap - map of prefixes/keys to instances of {@link javax.naming.NameParser}. Key values depend on implementation of this interface.
+    * @param defaultNameParser - this parser will be used in case - matcher did not find and NameParser and there is no entry under {@link #KEY_DEFAULT}.
+    * @return
+    */
+    javax.naming.NameParser findNameParser(Name name, Map<String, javax.naming.NameParser> parserMap, javax.naming.NameParser defaultNameParser);
+}

--- a/naming/src/main/java/org/jboss/as/naming/util/RmiNameParser.java
+++ b/naming/src/main/java/org/jboss/as/naming/util/RmiNameParser.java
@@ -22,27 +22,45 @@
 
 package org.jboss.as.naming.util;
 
+import java.util.Enumeration;
+import java.util.Properties;
+
 import javax.naming.CompositeName;
+import javax.naming.CompoundName;
 import javax.naming.Name;
+import javax.naming.NameParser;
 import javax.naming.NamingException;
 
 /**
- * Name parser used by the NamingContext instances.  Relies on composite name instances.
+ * @author baranowb
  *
- * @author John E. Bailey
  */
-public class NameParser implements javax.naming.NameParser {
+public class RmiNameParser implements NameParser {
 
-    public static final NameParser INSTANCE = new NameParser();
+    private static final String REPLACE_TO = "//";
+    private static final String REPLACE_WITH = "\\\\/\\\\/";
+    private static final Properties SYNTAX;
+    static {
+        SYNTAX = new Properties();
+        SYNTAX.put("jndi.syntax.direction", "left_to_right");
+        SYNTAX.put("jndi.syntax.ignorecase", "false");
+        SYNTAX.put("jndi.syntax.separator", "/");
+        SYNTAX.put("jndi.syntax.escape", "\\");
+    }
 
-    /**
-     * Parse the string name into a {@code javax.naming.Name} instance.
-     *
-     * @param name The name to parse
-     * @return The parsed name.
-     * @throws NamingException
-     */
+    @Override
     public Name parse(String name) throws NamingException {
-        return new CompositeName(name);
+        name = name.replaceFirst(REPLACE_TO, REPLACE_WITH);
+        CompoundName tempName = new CompoundName(name, SYNTAX);
+        return new FlyName(tempName.getAll());
+    }
+
+    private class FlyName extends CompositeName {
+
+        private static final long serialVersionUID = -1460841804550306348L;
+
+        public FlyName(Enumeration<String> comps) {
+            super(comps);
+        }
     }
 }

--- a/naming/src/main/resources/org/jboss/as/naming/subsystem/LocalDescriptions.properties
+++ b/naming/src/main/resources/org/jboss/as/naming/subsystem/LocalDescriptions.properties
@@ -3,6 +3,8 @@ naming.add=Adds the naming subsystem.
 naming.remove=Removes the naming subsystem.
 naming.jndi-view=Dump the local JNDI tree
 
+naming.resolver-mapping=Contains mapping of prefix/key to NameParser class name. The key value is used by parser resolver to determine proper NameParser class.
+naming.resolver-class=Class name of Name Parser Resolver. Instance of this class is used to resolve JNDI lookup name to proper NameParser.
 
 binding=JNDI bindings for primitive types
 binding.add=Adds a JNDI binding

--- a/naming/src/test/resources/org/jboss/as/naming/subsystem/subsystem.xml
+++ b/naming/src/test/resources/org/jboss/as/naming/subsystem/subsystem.xml
@@ -37,4 +37,7 @@
         </external-context>
     </bindings>
     <remote-naming/>
+    <parsing resolver-class="org.jboss.as.naming.util.DefaultNameParserResolver">
+    	<mapping value="default" class="org.jboss.as.naming.util.NameParser"/>
+    </parsing>
 </subsystem>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/ConnectedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/connector/ConnectedBean.java
@@ -52,7 +52,7 @@ public class ConnectedBean implements ConnectedBeanInterface {
             connection = connector.getMBeanServerConnection();
         } finally {
             if (connector != null) {
-                IoUtils.safeClose(connector);
+                connector.close();
             }
         }
     }


### PR DESCRIPTION
- add exception in NamingContext in case of no URL factory can be found, to avoid misleading "NameNotFound" from WFLY services registry
- fix testcase for above( export in jdk module + source fix )
- add configurable NameParser resolver to allow proper parsing of different types of names
