### PR TITLE
[WFLY-2210] fix message endpoint isDeliveryTransacted()

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
@@ -52,9 +52,9 @@ import static java.security.AccessController.doPrivileged;
 import static java.util.Collections.emptyMap;
 import static javax.ejb.TransactionAttributeType.REQUIRED;
 import static org.jboss.as.ejb3.EjbLogger.ROOT_LOGGER;
-import static org.jboss.as.ejb3.component.MethodIntf.BEAN;
 
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
+import static org.jboss.as.ejb3.component.MethodIntf.MESSAGE_ENDPOINT;
 
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
@@ -124,7 +124,7 @@ public class MessageDrivenComponent extends EJBComponent implements PooledCompon
                 if(isBeanManagedTransaction())
                     return false;
                 // an MDB doesn't expose a real view
-                return getTransactionAttributeType(BEAN, method) == REQUIRED;
+                return getTransactionAttributeType(MESSAGE_ENDPOINT, method) == REQUIRED;
             }
 
             @Override


### PR DESCRIPTION
The
org.jboss.as.ejb3.inflow.MessageEndpointService#isDeliveryTransacted
method is checking the transaction attribute of the method using the
MethodIntf.BEAN while it should use the MethodIntf.MESSAGE_ENDPOINT
type.
