### PR TITLE
WFLY-2221: binder service release() may be invoked after unsuccessful se...

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/service/BinderService.java
+++ b/naming/src/main/java/org/jboss/as/naming/service/BinderService.java
@@ -96,8 +96,9 @@ public class BinderService implements Service<ManagedReferenceFactory> {
     }
 
     public void release() {
-        if (refcnt.decrementAndGet() <= 0)
+        if (refcnt.decrementAndGet() <= 0 && controller != null) {
             controller.setMode(ServiceController.Mode.REMOVE);
+        }
     }
 
     /**


### PR DESCRIPTION
...rvice install, in such scenario the controller field is null
