### PR TITLE
According to openJDK sources (both 6 & 7):

### DIFF
--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
@@ -369,7 +369,7 @@ public class PlatformMBeanResourceUnitTestCase {
         Assert.assertEquals(mbean.isThreadCpuTimeSupported(), threadCPUSupported);
         boolean currentThreadPUSupported = describedResource.resource.get(PlatformMBeanConstants.CURRENT_THREAD_CPU_TIME_SUPPORTED).asBoolean();
         Assert.assertEquals(mbean.isCurrentThreadCpuTimeSupported(), currentThreadPUSupported);
-        boolean threadCPUEnabled = describedResource.resource.get(PlatformMBeanConstants.THREAD_CPU_TIME_ENABLED).asBoolean();
+        boolean threadCPUEnabled = false;
         if (threadCPUSupported || currentThreadPUSupported) {
             threadCPUEnabled = describedResource.resource.get(PlatformMBeanConstants.THREAD_CPU_TIME_ENABLED).asBoolean();
             Assert.assertEquals(mbean.isThreadCpuTimeSupported(), threadCPUEnabled);

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
@@ -614,9 +614,6 @@ public class PlatformMBeanResourceUnitTestCase {
             if (attrVal.isDefined()) {
                 Assert.assertEquals(prop.getName() + " has incorrect ModelType", desc.get(TYPE).asType(), attrVal.getType());
             } else {
-                System.out.println(prop.getName());
-                System.out.println(prop.getValue());
-                System.out.println(desc.get(NILLABLE));
                 /*
                     In case of three special properties no assert possible on some platforms
                  */

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanResourceUnitTestCase.java
@@ -367,10 +367,13 @@ public class PlatformMBeanResourceUnitTestCase {
         Assert.assertEquals(mbean.isThreadContentionMonitoringEnabled(), threadContentionEnabled);
         boolean threadCPUSupported = describedResource.resource.get(PlatformMBeanConstants.THREAD_CPU_TIME_SUPPORTED).asBoolean();
         Assert.assertEquals(mbean.isThreadCpuTimeSupported(), threadCPUSupported);
-        boolean threadCPUEnabled = describedResource.resource.get(PlatformMBeanConstants.THREAD_CPU_TIME_ENABLED).asBoolean();
-        Assert.assertEquals(mbean.isThreadCpuTimeSupported(), threadCPUEnabled);
         boolean currentThreadPUSupported = describedResource.resource.get(PlatformMBeanConstants.CURRENT_THREAD_CPU_TIME_SUPPORTED).asBoolean();
         Assert.assertEquals(mbean.isCurrentThreadCpuTimeSupported(), currentThreadPUSupported);
+        boolean threadCPUEnabled = describedResource.resource.get(PlatformMBeanConstants.THREAD_CPU_TIME_ENABLED).asBoolean();
+        if (threadCPUSupported || currentThreadPUSupported) {
+            threadCPUEnabled = describedResource.resource.get(PlatformMBeanConstants.THREAD_CPU_TIME_ENABLED).asBoolean();
+            Assert.assertEquals(mbean.isThreadCpuTimeSupported(), threadCPUEnabled);
+        }
 
         ModelNode op = getOperation("reset-peak-thread-count", "threading", null);
         Assert.assertFalse(executeOp(op, false).isDefined());


### PR DESCRIPTION
http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/6-b14/sun/management/ThreadImpl.java#ThreadImpl.isThreadCpuTimeEnabled()

method (isThreadCpuTimeEnabled) mustn't called if both of isThreadCpuTimeSupported isCurrentThreadCpuTimeSupported returned false.

This commit makes this test safe on platforms which not supported Thread time feature.

This should close this issue:
https://issues.jboss.org/browse/WFLY-349
