### PR TITLE
[WFLY-2248] / [WFLY-1592] Regression regarding older clients connecting to native management interface.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <version.org.jboss.remoting>4.0.0.Beta1</version.org.jboss.remoting>
         <version.org.jboss.remotingjmx.remoting-jmx>2.0.0.CR3</version.org.jboss.remotingjmx.remoting-jmx>
         <version.org.jboss.resteasy>3.0.4.Final</version.org.jboss.resteasy>
-        <version.org.jboss.sasl>1.0.3.Final</version.org.jboss.sasl>
+        <version.org.jboss.sasl>1.0.4.CR1</version.org.jboss.sasl>
         <version.org.jboss.seam.int>6.0.0.GA</version.org.jboss.seam.int>
         <version.org.jboss.security.jboss-negotiation>2.2.3.Final</version.org.jboss.security.jboss-negotiation>
         <version.org.jboss.security.jbossxacml>2.0.8.Final</version.org.jboss.security.jbossxacml>

--- a/remoting/src/main/java/org/jboss/as/remoting/RealmSecurityProvider.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RealmSecurityProvider.java
@@ -84,6 +84,7 @@ import org.xnio.ssl.XnioSsl;
 class RealmSecurityProvider implements RemotingSecurityProvider {
 
     static final String SASL_OPT_REALM_PROPERTY = "com.sun.security.sasl.digest.realm";
+    static final String SASL_OPT_ALT_PROTO_PROPERTY = "org.jboss.sasl.digest.alternative_protocols";
     static final String SASL_OPT_PRE_DIGESTED_PROPERTY = "org.jboss.sasl.digest.pre_digested";
     static final String SASL_OPT_LOCAL_DEFAULT_USER = "jboss.sasl.local-user.default-user";
     static final String SASL_OPT_LOCAL_USER_CHALLENGE_PATH = "jboss.sasl.local-user.challenge-path";
@@ -134,6 +135,7 @@ class RealmSecurityProvider implements RemotingSecurityProvider {
             if (authMechs.contains(AuthMechanism.DIGEST)) {
                 mechanisms.add(DIGEST_MD5);
                 properties.add(Property.of(SASL_OPT_REALM_PROPERTY, realm.getName()));
+                properties.add(Property.of(SASL_OPT_ALT_PROTO_PROPERTY, "remote")); // Older clients were hard coded to use 'remote' as the protocol.
                 Map<String, String> mechConfig = realm.getMechanismConfig(AuthMechanism.DIGEST);
                 boolean plainTextDigest = true;
                 if (mechConfig.containsKey(DIGEST_PLAIN_TEXT)) {

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementAddHandler.java
@@ -84,8 +84,6 @@ public class NativeManagementAddHandler extends AbstractAddStepHandler {
         final String hostName = WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.NODE_NAME, null);
         NativeManagementServices.installRemotingServicesIfNotInstalled(serviceTarget, hostName, verificationHandler, newControllers, context.getServiceRegistry(false));
         installNativeManagementConnector(context, model, endpointName, serviceTarget, verificationHandler, newControllers);
-
-
     }
 
     // TODO move this kind of logic into AttributeDefinition itself


### PR DESCRIPTION
The 'protocol' used within the SASL negotiation phase was changed from 'remote' to 'remoting', this is required for future GSSAPI/Kerberos work - this pull requests allows newer servers to still communicate with older clients that still use 'remote'.
