### PR TITLE
[WFLY-490] use adjustable timeout for server startup in domain tests

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
@@ -27,6 +27,7 @@ import javax.security.auth.callback.CallbackHandler;
 import org.jboss.arquillian.container.spi.ConfigurationException;
 import org.jboss.arquillian.container.spi.client.deployment.Validate;
 import org.jboss.as.arquillian.container.CommonContainerConfiguration;
+import org.jboss.as.test.shared.TimeoutUtil;
 
 /**
  * JBossAsManagedConfiguration
@@ -72,7 +73,7 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
 
     private String javaVmArguments = "-Xmx512m -XX:MaxPermSize=128m";
 
-    private int startupTimeoutInSeconds = 120;
+    private int startupTimeoutInSeconds = TimeoutUtil.adjust(120);
 
     private boolean outputToConsole = true;
 


### PR DESCRIPTION
We (QA) are running the testsuite on a variety of different machines and some of them are pretty slow from time to time (especially Windows virtual machines). This change allows to adjust the timeout for server startup in domain tests using a system property, while keeping the timeout unchanged when the property is not defined. The motivation for this is RBAC test suite on Windows, though someone else might benefit from that too.
