### PR TITLE
[WFLY-2268] add generic JMS RA

### DIFF
--- a/build/build-configs.xml
+++ b/build/build-configs.xml
@@ -126,7 +126,10 @@
            paramTemplateFile="configuration/standalone/template.xml" 
            paramSubsystemsFile="configuration/examples/subsystems-rts.xml"
            paramOutputFile="${generated.configs.examples}/standalone-rts.xml"/>
-    		
+      <generate-server-config
+           paramTemplateFile="configuration/standalone/template.xml"
+           paramSubsystemsFile="configuration/examples/subsystems-genericjms.xml"
+           paramOutputFile="${generated.configs.examples}/standalone-genericjms.xml"/>
     </target>
 
 

--- a/build/build.xml
+++ b/build/build.xml
@@ -1118,6 +1118,10 @@
             <maven-resource group="org.jboss.ejb3" artifact="jboss-ejb3-ext-api"/>
         </module-def>
 
+        <module-def name="org.jboss.genericjms">
+          <maven-resource group="org.jboss.genericjms" artifact="generic-jms-ra-jar"/>
+        </module-def>
+
         <module-def name="org.jboss.integration.ext-content">
             <!-- Bundling external content into deployments -->
         </module-def>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1358,6 +1358,11 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>org.jboss.genericjms</groupId>
+                    <artifactId>generic-jms-ra-jar</artifactId>
+                </dependency>
+
+                <dependency>
                     <groupId>org.jboss.ironjacamar</groupId>
                     <artifactId>ironjacamar-core-api</artifactId>
                 </dependency>

--- a/build/src/main/resources/configuration/examples/subsystems-genericjms.xml
+++ b/build/src/main/resources/configuration/examples/subsystems-genericjms.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <subsystems>
+        <subsystem>configuration/subsystems/logging.xml</subsystem>
+        <subsystem>configuration/subsystems/batch.xml</subsystem>
+        <subsystem>configuration/subsystems/datasources.xml</subsystem>
+        <subsystem>configuration/subsystems/deployment-scanner.xml</subsystem>
+        <subsystem>configuration/subsystems/ee.xml</subsystem>
+        <subsystem supplement="full">configuration/subsystems/ejb3.xml</subsystem>
+        <subsystem>configuration/subsystems/io.xml</subsystem>
+        <subsystem>configuration/subsystems/infinispan.xml</subsystem>
+        <subsystem>configuration/subsystems/jacorb.xml</subsystem>
+        <subsystem>configuration/subsystems/jaxrs.xml</subsystem>
+        <subsystem>configuration/subsystems/jca.xml</subsystem>
+        <subsystem>configuration/subsystems/jdr.xml</subsystem>
+        <subsystem>configuration/subsystems/jmx.xml</subsystem>
+        <subsystem>configuration/subsystems/jpa.xml</subsystem>
+        <subsystem>configuration/subsystems/jsf.xml</subsystem>
+        <subsystem>configuration/subsystems/jsr77.xml</subsystem>
+        <subsystem>configuration/subsystems/mail.xml</subsystem>
+        <subsystem>configuration/subsystems/naming.xml</subsystem>
+        <subsystem>configuration/subsystems/pojo.xml</subsystem>
+        <subsystem>configuration/subsystems/remoting.xml</subsystem>
+        <subsystem>configuration/examples/subsystems/resource-adapters-genericjms.xml</subsystem>
+        <subsystem>configuration/subsystems/sar.xml</subsystem>
+        <subsystem include-if-set="security.manager">configuration/subsystems/security-manager.xml</subsystem>
+        <subsystem supplement="standalone">configuration/subsystems/security.xml</subsystem>
+        <subsystem>configuration/subsystems/threads.xml</subsystem>
+        <subsystem>configuration/subsystems/transactions.xml</subsystem>
+        <subsystem>configuration/subsystems/undertow.xml</subsystem>
+        <subsystem>configuration/subsystems/webservices.xml</subsystem>
+        <subsystem>configuration/subsystems/weld.xml</subsystem>
+    </subsystems>
+</config>
+
+
+

--- a/build/src/main/resources/configuration/examples/subsystems/resource-adapters-genericjms.xml
+++ b/build/src/main/resources/configuration/examples/subsystems/resource-adapters-genericjms.xml
@@ -1,0 +1,23 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <extension-module>org.jboss.as.connector</extension-module>
+
+    <subsystem xmlns="urn:jboss:domain:resource-adapters:1.1">
+        <resource-adapters>
+            <resource-adapter id="generic-jms-ra.rar">
+                <module slot="main" id="org.jboss.genericjms"/>
+                <transaction-support>NoTransaction</transaction-support>
+                <connection-definitions>
+                    <connection-definition class-name="org.jboss.resource.adapter.jms.JmsManagedConnectionFactory" jndi-name="${genericjms.cf.jndi-name}" pool-name="${genericjms.cf.pool-name}">
+                        <config-property name="JndiParameters">java.naming.factory.initial=${genericjms.cf.jndi.contextfactory};java.naming.provider.url=${genericjms.cf.jndi.url}</config-property>
+                        <config-property name="ConnectionFactory">${genericjms.cf.jndi.lookup}</config-property>
+                        <security>
+                            <application/>
+                        </security>
+                    </connection-definition>
+                </connection-definitions>
+            </resource-adapter>
+        </resource-adapters>
+    </subsystem>
+</config>

--- a/build/src/main/resources/configuration/subsystems/ejb3.xml
+++ b/build/src/main/resources/configuration/subsystems/ejb3.xml
@@ -54,7 +54,7 @@
       </replacement>
       <replacement placeholder="MDB">
 	       <mdb>
-	           <resource-adapter-ref resource-adapter-name="hornetq-ra"/>
+	           <resource-adapter-ref resource-adapter-name="${ejb.resource-adapter-name:hornetq-ra}"/>
 	           <bean-instance-pool-ref pool-name="mdb-strict-max-pool"/>
 	       </mdb>
       </replacement>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/META-INF/ra.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/META-INF/ra.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://java.sun.com/xml/ns/j2ee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee
+           http://java.sun.com/xml/ns/j2ee/connector_1_5.xsd"
+           version="1.5">
+
+    <description>JBoss Generic JMS JCA Resource Adapter</description>
+    <display-name>Generic JMS Adapter</display-name>
+
+    <vendor-name>Red Hat Middleware LLC</vendor-name>
+    <eis-type>JMS 1.1 Server</eis-type>
+    <resourceadapter-version>5.0</resourceadapter-version>
+
+    <license>
+        <description>
+            JBoss, Home of Professional Open Source.
+            Copyright 2006, Red Hat Middleware LLC, and individual contributors
+            as indicated by the @author tags. See the copyright.txt file in the
+            distribution for a full listing of individual contributors.
+
+            This is free software; you can redistribute it and/or modify it
+            under the terms of the GNU Lesser General Public License as
+            published by the Free Software Foundation; either version 2.1 of
+            the License, or (at your option) any later version.
+
+            This software is distributed in the hope that it will be useful,
+            but WITHOUT ANY WARRANTY; without even the implied warranty of
+            MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+            Lesser General Public License for more details.
+
+            You should have received a copy of the GNU Lesser General Public
+            License along with this software; if not, write to the Free
+            Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+            02110-1301 USA, or see the FSF site: http://www.fsf.org.
+        </description>
+        <license-required>true</license-required>
+    </license>
+
+    <resourceadapter>
+        <resourceadapter-class>org.jboss.resource.adapter.jms.JmsResourceAdapter</resourceadapter-class>
+
+        <outbound-resourceadapter>
+            <connection-definition>
+                <managedconnectionfactory-class>org.jboss.resource.adapter.jms.JmsManagedConnectionFactory
+                </managedconnectionfactory-class>
+                <config-property>
+                    <description>The jndi name of the connection factory</description>
+                    <config-property-name>ConnectionFactory</config-property-name>
+                    <config-property-type>java.lang.String</config-property-type>
+                    <config-property-value>XAConnectionFactory</config-property-value>
+                </config-property>
+                <config-property>
+                    <description>A comma-separated list of JNDI parameters</description>
+                    <config-property-name>JndiParameters</config-property-name>
+                    <config-property-type>java.lang.String</config-property-type>
+                    <config-property-value></config-property-value>
+                </config-property>
+                <config-property>
+                    <description>The default session type</description>
+                    <config-property-name>SessionDefaultType</config-property-name>
+                    <config-property-type>java.lang.String</config-property-type>
+                    <config-property-value>agnostic</config-property-value>
+                </config-property>
+                <config-property>
+                    <description>The user name used to login to the jms server</description>
+                    <config-property-name>UserName</config-property-name>
+                    <config-property-type>java.lang.String</config-property-type>
+                    <config-property-value></config-property-value>
+                </config-property>
+                <config-property>
+                    <description>The password used to login to the jms server</description>
+                    <config-property-name>Password</config-property-name>
+                    <config-property-type>java.lang.String</config-property-type>
+                    <config-property-value></config-property-value>
+                </config-property>
+                <config-property>
+                    <description>The client id for this connection factory</description>
+                    <config-property-name>ClientID</config-property-name>
+                    <config-property-type>java.lang.String</config-property-type>
+                    <config-property-value></config-property-value>
+                </config-property>
+                <config-property>
+                    <config-property-name>Strict</config-property-name>
+                    <config-property-type>java.lang.Boolean</config-property-type>
+                    <config-property-value>true</config-property-value>
+                </config-property>
+                <config-property>
+                    <description>Maximum wait for a lock</description>
+                    <config-property-name>UseTryLock</config-property-name>
+                    <config-property-type>java.lang.Integer</config-property-type>
+                    <config-property-value>60</config-property-value>
+                </config-property>
+                <connectionfactory-interface>org.jboss.resource.adapter.jms.JmsConnectionFactory
+                </connectionfactory-interface>
+                <connectionfactory-impl-class>org.jboss.resource.adapter.jms.JmsConnectionFactoryImpl
+                </connectionfactory-impl-class>
+                <connection-interface>javax.jms.Session</connection-interface>
+                <connection-impl-class>org.jboss.resource.adapter.jms.JmsSession</connection-impl-class>
+            </connection-definition>
+            <transaction-support>XATransaction</transaction-support>
+            <authentication-mechanism>
+                <authentication-mechanism-type>BasicPassword</authentication-mechanism-type>
+                <credential-interface>javax.resource.spi.security.PasswordCredential</credential-interface>
+            </authentication-mechanism>
+            <reauthentication-support>false</reauthentication-support>
+        </outbound-resourceadapter>
+
+        <inbound-resourceadapter>
+            <messageadapter>
+                <messagelistener>
+                    <messagelistener-type>javax.jms.MessageListener</messagelistener-type>
+                    <activationspec>
+                        <activationspec-class>org.jboss.resource.adapter.jms.inflow.JmsActivationSpec
+                        </activationspec-class>
+                        <required-config-property>
+                            <config-property-name>destination</config-property-name>
+                        </required-config-property>
+                        <required-config-property>
+                            <config-property-name>connectionFactory</config-property-name>
+                        </required-config-property>
+                    </activationspec>
+                </messagelistener>
+            </messageadapter>
+        </inbound-resourceadapter>
+
+    </resourceadapter>
+</connector>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
@@ -1,0 +1,42 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.genericjms">
+    <resources>
+       <resource-root path="."/>
+        <!-- Insert resources here -->
+    </resources>
+    <dependencies>
+        <module name="org.jboss.common-core" slot="main"/>
+        <module name="javax.api" slot="main"/>
+        <module name="javax.jms.api" slot="main"/>
+        <module name="javax.resource.api" slot="main"/>
+        <module name="org.jboss.logging" slot="main"/>
+
+        <!--
+             This module is used to provide the provider-specific classes
+             containing the JMS implementation (and any of their dependencies)
+             used by the generic JMS resource adapter
+        -->
+        <module name="org.jboss.genericjms.provider" slot="main"/>
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,7 @@
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
         <version.org.jboss.ejb-client>2.0.0.Beta3</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.1.0</version.org.jboss.ejb3.ext-api>
+        <version.org.jboss.genericjms>1.0.0.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.0.Beta4</version.org.jboss.invocation>
         <version.org.jboss.ironjacamar>1.1.0.Final</version.org.jboss.ironjacamar>
@@ -4102,6 +4103,12 @@
                         <artifactId>jboss-ejb-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.genericjms</groupId>
+                <artifactId>generic-jms-ra-jar</artifactId>
+                <version>${version.org.jboss.genericjms}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -259,6 +259,11 @@ public class ParseAndMarshalModelsTestCase {
     }
 
     @Test
+    public void testStandaloneGenericJMSXml() throws Exception {
+        standaloneXmlTest(getGeneratedExampleConfigFile("standalone-genericjms.xml"));
+    }
+
+    @Test
     public void test710StandaloneXml() throws Exception {
         standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-0.xml"));
     }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -158,6 +158,11 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         parseXml("docs/examples/configs/standalone-rts.xml");
     }
 
+    @Test
+    public void testStandaloneGenericJMS() throws Exception {
+        parseXml("docs/examples/configs/standalone-genericjms.xml");
+    }
+
     private void parseXml(String xmlName) throws ParserConfigurationException, SAXException, IOException {
         SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         schemaFactory.setErrorHandler(new ErrorHandlerImpl());


### PR DESCRIPTION
Add module for the generic JMS RA (org.jboss.genericjms).
Depends on its 1.0.0.Final release

The generic JMS RA module is not working out of the box.
It depends on a org.jboss.genericjms.provider module that does not
exist and must be created and configured with the JMS implementation
used by the generic RA.

The resource-adapter subsystem must also be configured with a new
resource-adapter containing all the informations to look up the JMS
managed resources from the broker (among other information)
A standalone-genericjms.xml will be created to use the generic JMS
RA. It depends on expressions that must be passed to the server to
properly setup the JMS resources
