### PR TITLE
[WFLY-490] / [WFLY-2271] Use the attribute defintion to resolve the value required for rollback should rollback be required.

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractWriteAttributeHandler.java
@@ -79,12 +79,15 @@ public abstract class AbstractWriteAttributeHandler<T> implements OperationStepH
         final ModelNode currentValue = submodel.get(attributeName).clone();
 
         final AttributeDefinition attributeDefinition = getAttributeDefinition(attributeName);
+        final ModelNode defaultValue;
         if (attributeDefinition != null) {
+            defaultValue = attributeDefinition.getDefaultValue();
             final ModelNode syntheticOp = new ModelNode();
             syntheticOp.get(attributeName).set(newValue);
             attributeDefinition.validateAndSet(syntheticOp, submodel);
             newValue = submodel.get(attributeName);
         } else {
+            defaultValue = null;
             submodel.get(attributeName).set(newValue);
         }
 
@@ -107,6 +110,9 @@ public abstract class AbstractWriteAttributeHandler<T> implements OperationStepH
                         @Override
                         public void handleRollback(OperationContext context, ModelNode operation) {
                             ModelNode valueToRestore = currentValue.resolve();
+                            if (valueToRestore.isDefined() == false && defaultValue != null) {
+                                valueToRestore = defaultValue;
+                            }
                             try {
                                 revertUpdateToRuntime(context, operation, attributeName, valueToRestore, resolvedValue, handback.handback);
                             } catch (Exception e) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleIncludeAllWriteAttributeHander.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/access/RoleIncludeAllWriteAttributeHander.java
@@ -37,6 +37,7 @@ public class RoleIncludeAllWriteAttributeHander extends AbstractWriteAttributeHa
     private final WritableAuthorizerConfiguration authorizerConfiguration;
 
     RoleIncludeAllWriteAttributeHander(final WritableAuthorizerConfiguration authorizerConfiguration) {
+        super(RoleMappingResourceDefinition.INCLUDE_ALL);
         this.authorizerConfiguration = authorizerConfiguration;
     }
 


### PR DESCRIPTION
This one requires some feedback to check why this was not already done this way.  

As not all attributes are mandatory it seems the attribute definition should be used to resolve the original value to take into account that we may have been relying on the default value.

Alternatively I could write a fix purely in terms of the write attribute handler I am currently trying to fix but I suspect our testing of rollbacks is pretty light especially as most operations are expected to work, I wonder how many other write attribute handlers assume that the value to restore successfully resolved.
