### PR TITLE
[WFLY-2218][WFLY-2242] Cleanup - Use DiscardAttributeValueChecker in Rem...

### DIFF
--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -26,7 +26,6 @@ package org.jboss.as.remoting;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.access.constraint.SensitivityClassification;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
@@ -35,7 +34,6 @@ import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.AttributeTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
@@ -158,13 +156,8 @@ public class RemotingExtension implements Extension {
     }
 
     private static AttributeTransformationDescriptionBuilder protocolTransform(AttributeTransformationDescriptionBuilder builder) {
-        builder.addRejectCheck(RejectAttributeChecker.DEFINED, RemoteOutboundConnectionResourceDefinition.PROTOCOL)
-                .setDiscard(new DiscardAttributeChecker.DefaultDiscardAttributeChecker() {
-                    @Override
-                    protected boolean isValueDiscardable(final PathAddress address, final String attributeName, final ModelNode attributeValue, final TransformationContext context) {
-                        return attributeValue.isDefined() && attributeValue.asString().equals(Protocol.REMOTE.toString());
-                    }
-                }, RemoteOutboundConnectionResourceDefinition.PROTOCOL);
+        builder.setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(Protocol.REMOTE.toString())), RemoteOutboundConnectionResourceDefinition.PROTOCOL)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, RemoteOutboundConnectionResourceDefinition.PROTOCOL);
         return builder;
     }
 


### PR DESCRIPTION
...oting transformer

This is just cleanup, something I noticed while writing documentation, and I had been using the previous version as a (bad) example.
