### PR TITLE
JBEE-121 - Update to latest EE Spec API releases

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -490,7 +490,7 @@
         </module-def>
 
         <module-def name="javax.el.api">
-            <maven-resource group="org.jboss.spec.javax.el" artifact="jboss-el-api_2.2_spec"/>
+            <maven-resource group="org.jboss.spec.javax.el" artifact="jboss-el-api_3.0_spec"/>
         </module-def>
 
         <module-def name="javax.enterprise.api">
@@ -548,7 +548,7 @@
         </module-def>
 
         <module-def name="javax.security.jacc.api">
-            <maven-resource group="org.jboss.spec.javax.security.jacc" artifact="jboss-jacc-api_1.4_spec"/>
+            <maven-resource group="org.jboss.spec.javax.security.jacc" artifact="jboss-jacc-api_1.5_spec"/>
         </module-def>
 
         <module-def name="javax.servlet.api">
@@ -556,7 +556,7 @@
         </module-def>
 
         <module-def name="javax.servlet.jsp.api">
-            <maven-resource group="org.jboss.spec.javax.servlet.jsp" artifact="jboss-jsp-api_2.2_spec"/>
+            <maven-resource group="org.jboss.spec.javax.servlet.jsp" artifact="jboss-jsp-api_2.3_spec"/>
         </module-def>
 
         <module-def name="javax.servlet.jstl.api">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1649,7 +1649,7 @@
 
                 <dependency>
                     <groupId>org.jboss.spec.javax.el</groupId>
-                    <artifactId>jboss-el-api_2.2_spec</artifactId>
+                    <artifactId>jboss-el-api_3.0_spec</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1694,7 +1694,7 @@
 
                 <dependency>
                     <groupId>org.jboss.spec.javax.security.jacc</groupId>
-                    <artifactId>jboss-jacc-api_1.4_spec</artifactId>
+                    <artifactId>jboss-jacc-api_1.5_spec</artifactId>
                 </dependency>
 
                 <dependency>
@@ -1704,7 +1704,7 @@
 
                 <dependency>
                     <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
-                    <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+                    <artifactId>jboss-jsp-api_2.3_spec</artifactId>
                 </dependency>
 
                 <dependency>

--- a/jpa/core/pom.xml
+++ b/jpa/core/pom.xml
@@ -100,7 +100,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.el</groupId>
-            <artifactId>jboss-el-api_2.2_spec</artifactId>
+            <artifactId>jboss-el-api_3.0_spec</artifactId>
         </dependency>
         
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.5.0-b01</version.javax.mail>
         <version.javax.validation>1.1.0.Final</version.javax.validation>
-        <version.org.jboss.spec.javax.websockets>1.0.0.Beta1</version.org.jboss.spec.javax.websockets>
+        <version.org.jboss.spec.javax.websockets>1.0.0.Final</version.org.jboss.spec.javax.websockets>
         <version.jaxen>1.1.3</version.jaxen>
         <version.jboss.jaxbintros>1.0.2.GA</version.jboss.jaxbintros>
         <version.joda-time>1.6.2</version.joda-time>
@@ -203,27 +203,27 @@
         <version.org.jboss.slf4j.slf4j-jboss-logmanager>1.0.3.GA</version.org.jboss.slf4j.slf4j-jboss-logmanager>
         <version.org.jboss.logging.jul-to-slf4j-stub>1.0.1.Final</version.org.jboss.logging.jul-to-slf4j-stub>
         <!-- Include the artifactId for org.jboss.spec project versions because artifactId contains the API spec version -->
-        <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
-        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>1.0.0.Beta1</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
-        <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Alpha2</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
-        <version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>1.0.2.Final</version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec>
-        <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>1.0.0.CR1</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>
+        <version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.annotation.jboss-annotations-api_1.2_spec>
+        <version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.javax.batch.jboss-batch-api_1.0_spec>
+        <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
+        <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.0.Beta1</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
+        <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>
         <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>2.2.3</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>
-        <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Alpha3</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
-        <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
+        <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
+        <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>
-        <version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>1.0.0.Beta1</version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>
+        <version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>1.0.0.Final</version.org.jboss.spec.javax.resource.jboss-connector-api_1.7_spec>
         <version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>1.0.4.Final</version.org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec>
         <version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>1.0.0.Alpha1</version.org.jboss.spec.javax.security.auth.message.jboss-jaspi-api_1.1_spec>
-        <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>1.0.2.Final</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec>
-        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Beta1</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
-        <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>1.0.1.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec>
-        <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.0.3.Final</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
-        <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.0.0.Beta1</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
+        <version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>1.0.0.Beta1</version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec>
+        <version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>1.0.0.Final</version.org.jboss.spec.javax.servlet.jboss-servlet-api_3.1_spec>
+        <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.0.Beta1</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
+        <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.0.4.Beta1</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
+        <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
-        <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.3.Beta1</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
-        <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Beta2</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
+        <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.3.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
+        <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
         <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
         <version.org.jboss.threads>2.1.1.Final</version.org.jboss.threads>
@@ -4717,6 +4717,10 @@
                         <groupId>io.undertow</groupId>
                         <artifactId>undertow-build-config</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
+                        <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 
@@ -5216,8 +5220,8 @@
 
             <dependency>
                 <groupId>org.jboss.spec.javax.el</groupId>
-                <artifactId>jboss-el-api_2.2_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.el.jboss-el-api_2.2_spec}</version>
+                <artifactId>jboss-el-api_3.0_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec}</version>
             </dependency>
 
             <dependency>
@@ -5270,8 +5274,8 @@
 
             <dependency>
                 <groupId>org.jboss.spec.javax.security.jacc</groupId>
-                <artifactId>jboss-jacc-api_1.4_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.4_spec}</version>
+                <artifactId>jboss-jacc-api_1.5_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.security.jacc.jboss-jacc-api_1.5_spec}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.servlet</groupId>
@@ -5288,8 +5292,8 @@
 
             <dependency>
                 <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
-                <artifactId>jboss-jsp-api_2.2_spec</artifactId>
-                <version>${version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.2_spec}</version>
+                <artifactId>jboss-jsp-api_2.3_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec}</version>
                 <exclusions>
                     <exclusion>
                         <groupId>org.jboss.spec.javax.servlet</groupId>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -158,7 +158,7 @@
 
         <dependency>
         	<groupId>org.jboss.spec.javax.security.jacc</groupId>
-        	<artifactId>jboss-jacc-api_1.4_spec</artifactId>
+        	<artifactId>jboss-jacc-api_1.5_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -42,8 +42,16 @@
     <!-- Export out the EE Specs and demos -->
 
     <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>jaxrs-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.batch</groupId>
+      <artifactId>jboss-batch-api_1.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ejb</groupId>
@@ -51,7 +59,11 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.el</groupId>
-      <artifactId>jboss-el-api_2.2_spec</artifactId>
+      <artifactId>jboss-el-api_3.0_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.enterprise.concurrent</groupId>
+      <artifactId>jboss-concurrency-api_1.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.faces</groupId>
@@ -75,7 +87,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.security.jacc</groupId>
-      <artifactId>jboss-jacc-api_1.4_spec</artifactId>
+      <artifactId>jboss-jacc-api_1.5_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet</groupId>
@@ -83,7 +95,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
-      <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+      <artifactId>jboss-jsp-api_2.3_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.servlet.jstl</groupId>
@@ -92,6 +104,10 @@
     <dependency>
       <groupId>org.jboss.spec.javax.transaction</groupId>
       <artifactId>jboss-transaction-api_1.2_spec</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.spec.javax.websocket</groupId>
+      <artifactId>jboss-websocket-api_1.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.xml.bind</groupId>

--- a/spec-api/test/src/test/java/org/jboss/as/spec/api/test/SpecApiDependencyCheck.java
+++ b/spec-api/test/src/test/java/org/jboss/as/spec/api/test/SpecApiDependencyCheck.java
@@ -19,11 +19,20 @@ package org.jboss.as.spec.api.test;
 import javax.annotation.*;
 import javax.annotation.security.*;
 import javax.annotation.sql.*;
+import javax.batch.api.*;
+import javax.batch.api.chunk.*;
+import javax.batch.api.chunk.listener.*;
+import javax.batch.api.listener.*;
+import javax.batch.api.partition.*;
+import javax.batch.operations.*;
+import javax.batch.runtime.*;
+import javax.batch.runtime.context.*;
 import javax.decorator.*;
 import javax.ejb.*;
 import javax.ejb.embeddable.*;
 import javax.ejb.spi.*;
 import javax.el.*;
+import javax.enterprise.concurrent.*;
 import javax.enterprise.context.*;
 import javax.enterprise.context.spi.*;
 import javax.enterprise.event.*;
@@ -41,15 +50,20 @@ import javax.faces.context.*;
 import javax.faces.convert.*;
 import javax.faces.el.*;
 import javax.faces.event.*;
+import javax.faces.flow.*;
 import javax.faces.lifecycle.*;
 import javax.faces.model.*;
 import javax.faces.render.*;
 import javax.faces.validator.*;
 import javax.faces.view.*;
+import javax.faces.view.facelets.*;
 import javax.faces.webapp.*;
 import javax.inject.*;
 import javax.interceptor.*;
 import javax.jms.*;
+import javax.json.*;
+import javax.json.spi.*;
+import javax.json.stream.*;
 import javax.jws.*;
 import javax.jws.soap.*;
 import javax.mail.*;
@@ -90,10 +104,16 @@ import javax.transaction.xa.*;
 import javax.validation.*;
 import javax.validation.bootstrap.*;
 import javax.validation.constraints.*;
+import javax.validation.constraintvalidation.*;
+import javax.validation.executable.*;
 import javax.validation.groups.*;
 import javax.validation.metadata.*;
 import javax.validation.spi.*;
+import javax.websocket.*;
+import javax.websocket.server.*;
 import javax.ws.rs.*;
+import javax.ws.rs.client.*;
+import javax.ws.rs.container.*;
 import javax.ws.rs.core.*;
 import javax.ws.rs.ext.*;
 import javax.xml.bind.*;
@@ -109,6 +129,7 @@ import javax.xml.rpc.handler.soap.*;
 import javax.xml.rpc.holders.*;
 import javax.xml.rpc.server.*;
 import javax.xml.rpc.soap.*;
+import javax.xml.soap.*;
 import javax.xml.ws.*;
 import javax.xml.ws.handler.*;
 import javax.xml.ws.handler.soap.*;
@@ -121,12 +142,12 @@ import javax.xml.ws.wsaddressing.*;
 /**
  * This class checks the dependencies as exported by the
  * "spec-api" module to ensure that compilation of all Java EE
- * 6 Specification Platform APIs are reachable.  As such, no runtime
+ * 7 Specification Platform APIs are reachable.  As such, no runtime
  * assertions are required here, only references.  If this class compiles, 
  * all noted references are reachable within the spec-api dependency chain. 
  * 
  * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
- * @see http://download.oracle.com/javaee/6/api/
+ * @see http://docs.oracle.com/javaee/7/api/
  */
 @SuppressWarnings("unused")
 public class SpecApiDependencyCheck {

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -88,7 +88,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
-            <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+            <artifactId>jboss-jsp-api_2.3_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -181,7 +181,7 @@
 
         <dependency>
             <groupId>org.jboss.spec.javax.el</groupId>
-            <artifactId>jboss-el-api_2.2_spec</artifactId>
+            <artifactId>jboss-el-api_3.0_spec</artifactId>
         </dependency>
 
         <dependency>
@@ -191,7 +191,7 @@
 
         <dependency>
            <groupId>org.jboss.spec.javax.servlet.jsp</groupId>
-           <artifactId>jboss-jsp-api_2.2_spec</artifactId>
+           <artifactId>jboss-jsp-api_2.3_spec</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
These changes include updates to the EE Spec APIs.  Final versions provided where possible.   Note this pull request also includes an update to the org.jboss.spec EL 3.0 project replacing org.jboss.spec EL 2.2.  While the EL implementation is currently provided by org.glassfish:javax.el we still need our version of the APIs to satisfy the dependency on org.jboss.el.cache.FactoryFinderCache.  See also:  WFLY-519.  Signature tests passing with these changes.
