### PR TITLE
[WFLY-1341] fixed the fix (just a typo)

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -81,8 +81,8 @@
                 <path name="sun/io"/>
                 <path name="sun/nio"/>
                 <path name="sun/nio/ch"/>
-                <path name="sun/nio/ext"/>
                 <path name="sun/nio/cs"/>
+                <path name="sun/nio/cs/ext"/>
                 <path name="sun/security"/>
                 <path name="sun/security/util"/>
                 <path name="sun/security/krb5"/>


### PR DESCRIPTION
Here's a fix for the original fix (just a typo). There's no such package as `sun.nio.ext`, it should have been `sun.nio.cs.ext` from the very beginning. The mistake is described in https://bugzilla.redhat.com/show_bug.cgi?id=959478 and if you look at the customer case linked from the BZ, you can see that the BZ was originally filed wrongly.
