### PR TITLE
Subsystem and core model tests against eap

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractCoreModelTest.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractCoreModelTest.java
@@ -24,10 +24,12 @@ package org.jboss.as.core.model.test;
 import java.io.IOException;
 
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.model.test.EAPRepositoryReachableUtil;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 
 /**
@@ -89,5 +91,15 @@ public abstract class AbstractCoreModelTest {
      */
     protected static ModelNode checkOutcome(ModelNode result) {
         return ModelTestUtils.checkOutcome(result);
+    }
+
+    /**
+     * Uses {@link org.junit.Assume#assumeTrue(boolean)} to check that the EAP repository is reachable. If it is not reachable an {@linke org.junit.AssumptionViolatedException}
+     * is thrown causing the test to be conditionally ignored. The purpose of this method is to be called at the beginning of transformers tests against legacy EAP versions. If the
+     * internal EAP repository is not available to the caller, the test is conditionally @Ignored if running with the standard JUnit test runner. This means that no special setup
+     * is needed for being on the VPN or not.
+     */
+    protected void ignoreThisTestIfEAPRepositoryIsNotReachable() {
+        Assume.assumeTrue(EAPRepositoryReachableUtil.isReachable());
     }
 }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -558,7 +558,6 @@ public class CoreModelTestDelegate {
             return legacyKernelServicesInitializerImpl;
         }
 
-
         @Override
         public KernelServicesBuilder setDontValidateOperations() {
             validateOperations = true;
@@ -567,7 +566,7 @@ public class CoreModelTestDelegate {
     }
 
     private class LegacyKernelServicesInitializerImpl implements LegacyKernelServicesInitializer {
-        private final ChildFirstClassLoaderBuilder classLoaderBuilder = new ChildFirstClassLoaderBuilder();
+        private final ChildFirstClassLoaderBuilder classLoaderBuilder;
         private final ModelVersion modelVersion;
         private final List<LegacyModelInitializerEntry> modelInitializerEntries = new ArrayList<LegacyModelInitializerEntry>();
         private final ModelTestControllerVersion testControllerVersion;
@@ -578,6 +577,7 @@ public class CoreModelTestDelegate {
         private ModelTestOperationValidatorFilter.Builder operationValidationExcludeFilterBuilder;
 
         LegacyKernelServicesInitializerImpl(ModelVersion modelVersion, ModelTestControllerVersion version) {
+            this.classLoaderBuilder = new ChildFirstClassLoaderBuilder(version.isEap());
             this.modelVersion = modelVersion;
             this.testControllerVersion = version;
         }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/CoreModelTestDelegate.java
@@ -593,6 +593,12 @@ public class CoreModelTestDelegate {
 
             classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.core.model.bridge.shared.*");
 
+            //These two is needed or the child first classloader never gets GC'ed which causes OOMEs for very big tests
+            //Here the Reference$ReaperThread hangs onto the classloader
+            classLoaderBuilder.addParentFirstClassPattern("org.jboss.modules.*");
+            //Here the NDC hangs onto the classloader
+            classLoaderBuilder.addParentFirstClassPattern("org.jboss.logmanager.*");
+
             classLoaderBuilder.addMavenResourceURL("org.wildfly:wildfly-core-model-test-framework:" + ModelTestControllerVersion.CurrentVersion.VERSION);
             classLoaderBuilder.addMavenResourceURL("org.wildfly:wildfly-model-test:" + ModelTestControllerVersion.CurrentVersion.VERSION);
 

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServicesBuilder.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/KernelServicesBuilder.java
@@ -21,9 +21,10 @@
 */
 package org.jboss.as.core.model.test;
 
-import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.model.test.ModelTestControllerVersion;
@@ -98,6 +99,7 @@ public interface KernelServicesBuilder {
     KernelServicesBuilder setModelInitializer(ModelInitializer modelInitializer, ModelWriteSanitizer modelWriteSanitizer);
 
     KernelServicesBuilder createContentRepositoryContent(String hash);
+
     /**
      * Creates a new legacy kernel services initializer used to configure a new controller containing an older version of the subsystem being tested.
      * When {@link #build()} is called any legacy controllers will be created as well.

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.model.test.EAPRepositoryReachableUtil;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 
 /**
@@ -55,10 +56,21 @@ public class TransformersTestParameters {
 
     public static List<Object[]> setupVersions(){
         List<Object[]> data = new ArrayList<Object[]>();
+        //AS releases
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.V7_1_2_FINAL)});
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.V7_1_3_FINAL)});
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.V7_2_0_FINAL)});
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(2, 0, 0), ModelTestControllerVersion.MASTER)});
+
+        //EAP releases
+        if (EAPRepositoryReachableUtil.isReachable()) {
+            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.EAP_6_0_0)});
+            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.EAP_6_0_1)});
+            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0)});
+            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1)});
+        }
+
+
         for (int i = 0 ; i < data.size() ; i++) {
             Object[] entry = data.get(i);
             System.out.println("Parameter " + i + ": " + entry[0]);

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameters.java
@@ -62,7 +62,7 @@ public class TransformersTestParameters {
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.V7_2_0_FINAL)});
         data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(2, 0, 0), ModelTestControllerVersion.MASTER)});
 
-        //EAP releases
+        //EAP releases - these will only get tested if the EAPRepositoryReachableUtil.TEST_TRANSFORMERS_EAP system property is set AND the EAP repostitory is available
         if (EAPRepositoryReachableUtil.isReachable()) {
             data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.EAP_6_0_0)});
             data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.EAP_6_0_1)});

--- a/model-test/src/main/java/org/jboss/as/model/test/ChildFirstClassLoaderBuilder.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ChildFirstClassLoaderBuilder.java
@@ -58,14 +58,15 @@ public class ChildFirstClassLoaderBuilder {
     /** A comma separated list of maven repository urls. If not set it will use http://repository.jboss.org/nexus/content/groups/developer/ */
     static final String MAVEN_REPOSITORY_URLS = "org.jboss.model.test.maven.repository.urls";
 
-
+    private final MavenUtil mavenUtil;
     private final File cache;
     private final List<URL> classloaderURLs = new ArrayList<URL>();
     private final List<Pattern> parentFirst = new ArrayList<Pattern>();
     private final List<Pattern> childFirst = new ArrayList<Pattern>();
     private ClassFilter parentExclusionFilter;
 
-    public ChildFirstClassLoaderBuilder() {
+    public ChildFirstClassLoaderBuilder(boolean useEapRepository) {
+        this.mavenUtil = MavenUtil.create(useEapRepository);
         final String root = System.getProperty(ROOT_PROPERTY);
         final String cacheFolderName = System.getProperty(CACHE_FOLDER_PROPERTY);
         if (root == null && cacheFolderName == null) {
@@ -187,7 +188,7 @@ public class ChildFirstClassLoaderBuilder {
             }
         } else {
             System.out.println("No cached maven url for " + artifactGav + " found. " + file.getAbsolutePath() + " does not exist.");
-            final URL url = MavenUtil.createMavenGavURL(artifactGav);
+            final URL url = mavenUtil.createMavenGavURL(artifactGav);
             classloaderURLs.add(url);
             final ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(file)));
             try {
@@ -219,7 +220,7 @@ public class ChildFirstClassLoaderBuilder {
             }
         } else {
             System.out.println("No cached recursive maven urls for " + artifactGav + " found. " + file.getAbsolutePath() + " does not exist.");
-            final List<URL> urls = MavenUtil.createMavenGavRecursiveURLs(artifactGav, excludes);
+            final List<URL> urls = mavenUtil.createMavenGavRecursiveURLs(artifactGav, excludes);
             classloaderURLs.addAll(urls);
             final ObjectOutputStream out = new ObjectOutputStream(new BufferedOutputStream(new FileOutputStream(file)));
             try {

--- a/model-test/src/main/java/org/jboss/as/model/test/EAPRepositoryReachableUtil.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/EAPRepositoryReachableUtil.java
@@ -31,16 +31,22 @@ import java.net.UnknownHostException;
  */
 public class EAPRepositoryReachableUtil {
 
+    //System property to turn on transformers tests for eap
+    private static String TEST_TRANSFORMERS_EAP = "jboss.test.transformers.eap";
     private static final String EAP_REPOSITORY_HOST = "download.lab.bos.redhat.com";
 
     static Boolean reachable;
 
     public static boolean isReachable() {
         if (reachable == null) {
-            try {
-                InetAddress.getByName(EAP_REPOSITORY_HOST);
-                reachable = true;
-            } catch (UnknownHostException e) {
+            if (System.getProperties().contains(TEST_TRANSFORMERS_EAP)) {
+                try {
+                    InetAddress.getByName(EAP_REPOSITORY_HOST);
+                    reachable = true;
+                } catch (UnknownHostException e) {
+                    reachable = false;
+                }
+            } else {
                 reachable = false;
             }
         }

--- a/model-test/src/main/java/org/jboss/as/model/test/EAPRepositoryReachableUtil.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/EAPRepositoryReachableUtil.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.model.test;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Utility to check if the EAP repository is available
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class EAPRepositoryReachableUtil {
+
+    private static final String EAP_REPOSITORY_HOST = "download.lab.bos.redhat.com";
+
+    static Boolean reachable;
+
+    public static boolean isReachable() {
+        if (reachable == null) {
+            try {
+                InetAddress.getByName(EAP_REPOSITORY_HOST);
+                reachable = true;
+            } catch (UnknownHostException e) {
+                reachable = false;
+            }
+        }
+        return reachable;
+    }
+}

--- a/model-test/src/main/java/org/jboss/as/model/test/FailedOperationTransformationConfig.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/FailedOperationTransformationConfig.java
@@ -366,7 +366,7 @@ public class FailedOperationTransformationConfig {
             ModelNode op = operation.clone();
             for (String attr : attributes) {
                 ModelNode value = op.get(attr);
-                if (value.isDefined()) {
+                if (value.isDefined() || correctUndefinedValue()) {
                     if (checkValue(attr, value, false)) {
                         AttributesPathAddressConfig<?> complexChildConfig = complexAttributes.get(attr);
                         if (complexChildConfig == null) {
@@ -380,6 +380,10 @@ public class FailedOperationTransformationConfig {
                 }
             }
             return operation;
+        }
+
+        protected boolean correctUndefinedValue() {
+            return false;
         }
 
         @Override

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -26,23 +26,25 @@ import java.util.Properties;
 
 public enum ModelTestControllerVersion {
     //AS releases
-    MASTER (CurrentVersion.VERSION, null),
-    V7_1_2_FINAL ("7.1.2.Final", "7.1.2"),
-    V7_1_3_FINAL ("7.1.3.Final", "7.1.2"),
-    V7_2_0_FINAL ("7.2.0.Final", "7.2.0"),
+    MASTER (CurrentVersion.VERSION, false, null),
+    V7_1_2_FINAL ("7.1.2.Final", false, "7.1.2"),
+    V7_1_3_FINAL ("7.1.3.Final", false, "7.1.2"),
+    V7_2_0_FINAL ("7.2.0.Final", false, "7.2.0"),
 
     //EAP releases
-    EAP_6_0_0 ("7.1.2.Final-redhat-1", "7.1.2"),
-    EAP_6_0_1 ("7.1.3.Final-redhat-4", "7.1.2"),
-    EAP_6_1_0 ("7.2.0.Final-redhat-8", "7.1.2"),
-    EAP_6_1_1 ("7.2.1.Final-redhat-10", "7.2.0")
+    EAP_6_0_0 ("7.1.2.Final-redhat-1", true, "7.1.2"),
+    EAP_6_0_1 ("7.1.3.Final-redhat-4", true, "7.1.2"),
+    EAP_6_1_0 ("7.2.0.Final-redhat-8", true, "7.2.0"),
+    EAP_6_1_1 ("7.2.1.Final-redhat-10", true, "7.2.0")
     ;
 
-    String mavenGavVersion;
-    String testControllerVersion;
-    private ModelTestControllerVersion(String mavenGavVersion, String testControllerVersion) {
+    private final String mavenGavVersion;
+    private final String testControllerVersion;
+    private final boolean eap;
+    private ModelTestControllerVersion(String mavenGavVersion, boolean eap, String testControllerVersion) {
         this.mavenGavVersion = mavenGavVersion;
         this.testControllerVersion = testControllerVersion;
+        this.eap = eap;
     }
 
     public String getMavenGavVersion() {
@@ -51,6 +53,10 @@ public enum ModelTestControllerVersion {
 
     public String getTestControllerVersion() {
         return testControllerVersion;
+    }
+
+    public boolean isEap() {
+        return eap;
     }
 
     public interface CurrentVersion {

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestControllerVersion.java
@@ -25,11 +25,17 @@ import java.util.Properties;
 
 
 public enum ModelTestControllerVersion {
+    //AS releases
     MASTER (CurrentVersion.VERSION, null),
     V7_1_2_FINAL ("7.1.2.Final", "7.1.2"),
     V7_1_3_FINAL ("7.1.3.Final", "7.1.2"),
     V7_2_0_FINAL ("7.2.0.Final", "7.2.0"),
-    V8_0_0_FINAL (VersionLocator.getCurrentVersion(), null)
+
+    //EAP releases
+    EAP_6_0_0 ("7.1.2.Final-redhat-1", "7.1.2"),
+    EAP_6_0_1 ("7.1.3.Final-redhat-4", "7.1.2"),
+    EAP_6_1_0 ("7.2.0.Final-redhat-8", "7.1.2"),
+    EAP_6_1_1 ("7.2.1.Final-redhat-10", "7.2.0")
     ;
 
     String mavenGavVersion;

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestKernelServicesImpl.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestKernelServicesImpl.java
@@ -302,6 +302,7 @@ public abstract class ModelTestKernelServicesImpl<T extends ModelTestKernelServi
                 for (T legacyService: legacyServices.values()) {
                     legacyService.shutdown();
                 }
+                legacyServices.clear();
             }
         }
     }

--- a/model-test/src/test/java/org/jboss/as/model/test/MavenUtilTestCase.java
+++ b/model-test/src/test/java/org/jboss/as/model/test/MavenUtilTestCase.java
@@ -2,10 +2,7 @@ package org.jboss.as.model.test;
 
 import org.apache.maven.repository.internal.MavenRepositorySystemUtils;
 import org.eclipse.aether.RepositorySystem;
-import org.eclipse.aether.impl.ArtifactDescriptorReader;
 import org.eclipse.aether.impl.DefaultServiceLocator;
-import org.eclipse.aether.impl.VersionRangeResolver;
-import org.eclipse.aether.impl.VersionResolver;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
@@ -1,10 +1,11 @@
 package org.jboss.as.subsystem.test;
 
-import javax.xml.stream.XMLStreamException;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
+
+import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ModelVersion;
@@ -12,12 +13,14 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.model.test.EAPRepositoryReachableUtil;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestKernelServices;
 import org.jboss.as.model.test.ModelTestModelControllerService;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 
 /**
@@ -349,5 +352,15 @@ public abstract class AbstractSubsystemTest {
      */
     protected void compareXml(String configId, final String original, final String marshalled, final boolean ignoreNamespace) throws Exception {
         ModelTestUtils.compareXml(original, marshalled, ignoreNamespace);
+    }
+
+    /**
+     * Uses {@link org.junit.Assume#assumeTrue(boolean)} to check that the EAP repository is reachable. If it is not reachable an {@linke org.junit.AssumptionViolatedException}
+     * is thrown causing the test to be conditionally ignored. The purpose of this method is to be called at the beginning of transformers tests against legacy EAP versions. If the
+     * internal EAP repository is not available to the caller, the test is conditionally @Ignored if running with the standard JUnit test runner. This means that no special setup
+     * is needed for being on the VPN or not.
+     */
+    protected void ignoreThisTestIfEAPRepositoryIsNotReachable() {
+        Assume.assumeTrue(EAPRepositoryReachableUtil.isReachable());
     }
 }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KernelServicesBuilder.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KernelServicesBuilder.java
@@ -87,6 +87,7 @@ public interface KernelServicesBuilder {
      */
      LegacyKernelServicesInitializer createLegacyKernelServicesBuilder(AdditionalInitialization additionalInit, ModelTestControllerVersion version, ModelVersion modelVersion);
 
+
     /**
      * Creates the controller and initializes it with the passed in configuration options.
      * If {@link #createLegacyKernelServicesBuilder(AdditionalInitialization, org.jboss.as.model.test.ModelTestControllerVersion, org.jboss.as.controller.ModelVersion)}

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -630,7 +630,7 @@ final class SubsystemTestDelegate {
         private final ModelTestControllerVersion testControllerVersion;
         private String extensionClassName;
         private ModelVersion modelVersion;
-        private ChildFirstClassLoaderBuilder classLoaderBuilder = new ChildFirstClassLoaderBuilder();
+        private ChildFirstClassLoaderBuilder classLoaderBuilder;
         private ModelTestOperationValidatorFilter.Builder operationValidationExcludeBuilder;
         private boolean persistXml = true;
         private boolean skipReverseCheck;
@@ -644,6 +644,7 @@ final class SubsystemTestDelegate {
         };
 
         public LegacyKernelServiceInitializerImpl(AdditionalInitialization additionalInit, ModelTestControllerVersion version, ModelVersion modelVersion) {
+            this.classLoaderBuilder = new ChildFirstClassLoaderBuilder(version.isEap());
             this.additionalInit = additionalInit == null ? AdditionalInitialization.MANAGEMENT : additionalInit;
             this.testControllerVersion = version;
             this.modelVersion = modelVersion;

--- a/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/TransformerSubsystemTestCase.java
+++ b/subsystem-test/tests/src/test/java/org/jboss/as/subsystem/test/transformers/TransformerSubsystemTestCase.java
@@ -73,6 +73,18 @@ public class TransformerSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testTransformers() throws Exception {
+        testTransformers(false);
+    }
+
+    @Test
+    public void testTransformersEAP() throws Exception {
+        testTransformers(true);
+    }
+
+    private void testTransformers(boolean eap) throws Exception {
+        if (eap) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         ModelVersion oldVersion = ModelVersion.create(1, 0, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(null)
                 .setSubsystemXml(getSubsystemXml());

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
@@ -29,7 +29,6 @@ import java.lang.reflect.Proxy;
 import java.security.SecureRandom;
 import java.util.Random;
 
-import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.controller.client.ModelControllerClient;
@@ -43,7 +42,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -216,7 +214,7 @@ public class ClientCompatibilityUnitTestCase {
 
     protected static ModelControllerClient createClient(final String artifact, final String version, final String host, final int port) throws Exception {
 
-        final ChildFirstClassLoaderBuilder classLoaderBuilder = new ChildFirstClassLoaderBuilder();
+        final ChildFirstClassLoaderBuilder classLoaderBuilder = new ChildFirstClassLoaderBuilder(false);
         classLoaderBuilder.addRecursiveMavenResourceURL(artifact + ":" + version, excludes);
         classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.controller.client.ModelControllerClientConfiguration");
         classLoaderBuilder.addParentFirstClassPattern("org.jboss.as.controller.client.ModelControllerClient");

--- a/weld/src/main/java/org/jboss/as/weld/WeldExtension.java
+++ b/weld/src/main/java/org/jboss/as/weld/WeldExtension.java
@@ -24,20 +24,25 @@ package org.jboss.as.weld;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import java.util.Map;
+
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Domain extension used to initialize the weld subsystem.
@@ -91,9 +96,24 @@ public class WeldExtension implements Extension {
 
     private void registerTransformers(SubsystemRegistration subsystem) {
         ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+        //These new attributes are assumed to be 'true' in the old version but default to false in the current version. So discard if 'true' and reject if 'undefined'.
         builder.getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.DEFINED, WeldResourceDefinition.NON_PORTABLE_MODE_ATTRIBUTE, WeldResourceDefinition.REQUIRE_BEAN_DESCRIPTOR_ATTRIBUTE)
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, WeldResourceDefinition.NON_PORTABLE_MODE_ATTRIBUTE, WeldResourceDefinition.REQUIRE_BEAN_DESCRIPTOR_ATTRIBUTE)
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, false, new ModelNode(true)),
+                        WeldResourceDefinition.NON_PORTABLE_MODE_ATTRIBUTE, WeldResourceDefinition.REQUIRE_BEAN_DESCRIPTOR_ATTRIBUTE)
+                .addRejectCheck(new RejectAttributeChecker.DefaultRejectAttributeChecker() {
+
+                    @Override
+                    public String getRejectionLogMessage(Map<String, ModelNode> attributes) {
+                        return WeldMessages.MESSAGES.rejectAttributesMustBeTrue(attributes.keySet());
+                    }
+
+                    @Override
+                    protected boolean rejectAttribute(PathAddress address, String attributeName, ModelNode attributeValue,
+                            TransformationContext context) {
+                        //This will not get called if it was discarded, so reject if it is undefined (default==false) or if defined and != 'true'
+                        return !attributeValue.isDefined() || !attributeValue.asString().equals("true");
+                    }
+                }, WeldResourceDefinition.NON_PORTABLE_MODE_ATTRIBUTE, WeldResourceDefinition.REQUIRE_BEAN_DESCRIPTOR_ATTRIBUTE)
                 .end();
         TransformationDescription.Tools.register(builder.build(), subsystem, ModelVersion.create(1, 0, 0));
     }

--- a/weld/src/main/java/org/jboss/as/weld/WeldMessages.java
+++ b/weld/src/main/java/org/jboss/as/weld/WeldMessages.java
@@ -144,4 +144,7 @@ public interface WeldMessages {
     @Message(id = 16079, value = "%s cannot be used at runtime")
     IllegalStateException cannotUseAtRuntime(String description);
 
+    @Message(id = 16080, value = "These attributes must be 'true' for use with CDI 1.0 '%s'")
+    String rejectAttributesMustBeTrue(Set<String> keySet);
+
 }

--- a/weld/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
+++ b/weld/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
@@ -58,21 +58,45 @@ public class WeldSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testTransformersAS712() throws Exception {
-        testTransformers10(ModelTestControllerVersion.V7_1_2_FINAL);
+        testTransformers10(ModelTestControllerVersion.V7_1_2_FINAL, false);
     }
 
     @Test
     public void testTransformersAS713() throws Exception {
-        testTransformers10(ModelTestControllerVersion.V7_1_3_FINAL);
+        testTransformers10(ModelTestControllerVersion.V7_1_3_FINAL, false);
     }
 
     @Test
     public void testTransformersAS72() throws Exception {
-        testTransformers10(ModelTestControllerVersion.V7_2_0_FINAL);
+        testTransformers10(ModelTestControllerVersion.V7_2_0_FINAL, false);
+    }
+
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        testTransformers10(ModelTestControllerVersion.EAP_6_0_0, true);
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformers10(ModelTestControllerVersion.EAP_6_0_1, true);
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers10(ModelTestControllerVersion.EAP_6_1_0, true);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testTransformers10(ModelTestControllerVersion.EAP_6_1_1, true);
     }
 
 
-    private void testTransformers10(ModelTestControllerVersion controllerVersion) throws Exception {
+    private void testTransformers10(ModelTestControllerVersion controllerVersion, boolean eap) throws Exception {
+        if (eap) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource("subsystem.xml");

--- a/weld/src/test/resources/org/jboss/as/weld/subsystem-reject.xml
+++ b/weld/src/test/resources/org/jboss/as/weld/subsystem-reject.xml
@@ -1,0 +1,1 @@
+<subsystem xmlns="urn:jboss:domain:weld:2.0" require-bean-descriptor="false"/>

--- a/weld/src/test/resources/org/jboss/as/weld/subsystem.xml
+++ b/weld/src/test/resources/org/jboss/as/weld/subsystem.xml
@@ -1,1 +1,1 @@
-<subsystem xmlns="urn:jboss:domain:weld:2.0" require-bean-descriptor="false" non-portable-mode="false" />
+<subsystem xmlns="urn:jboss:domain:weld:2.0" require-bean-descriptor="true" non-portable-mode="true" />


### PR DESCRIPTION
Core model tests are run already against all EAP releases. Although this will not show up on brontes since you need to use -Djboss.test.transformers.eap.

I've added EAP testing for the Weld transformers tests, although to see it in action, again you will need to use -Djboss.test.transformers.eap.
