### PR TITLE
upgrade mod_cluster to the latest released version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,7 +187,7 @@
         <version.org.jboss.logmanager.log4j-jboss-logmanager>1.0.2.Final</version.org.jboss.logmanager.log4j-jboss-logmanager>
         <version.org.jboss.marshalling.jboss-marshalling>1.4.1.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.metadata>8.0.0.Beta2</version.org.jboss.metadata>
-        <version.org.jboss.mod_cluster>1.2.4.Final</version.org.jboss.mod_cluster>
+        <version.org.jboss.mod_cluster>1.3.0.Alpha1</version.org.jboss.mod_cluster>
         <version.org.jboss.modules.jboss-modules>1.3.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.0.Beta2</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.osgi.metadata>3.0.0.Final</version.org.jboss.osgi.metadata>


### PR DESCRIPTION
A 1.3.0.Alpha1 has been tagged it is better to use is one in WildFly8.
