### PR TITLE
[WFLY-2332] Don't leak the jboss-logmanager dependency.

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -119,7 +119,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -138,6 +137,11 @@
                   projects that depend on this project.-->
             <scope>provided</scope>
             <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
         </dependency>
 
         <dependency>
@@ -163,6 +167,11 @@
         <dependency>
             <groupId>org.jboss.sasl</groupId>
             <artifactId>jboss-sasl</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.stdio</groupId>
+            <artifactId>jboss-stdio</artifactId>
         </dependency>
 
         <dependency>

--- a/arquillian/container-embedded/pom.xml
+++ b/arquillian/container-embedded/pom.xml
@@ -75,6 +75,11 @@
 			<artifactId>arquillian-protocol-servlet</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
 
 	</dependencies>
 

--- a/clustering/infinispan/pom.xml
+++ b/clustering/infinispan/pom.xml
@@ -99,7 +99,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/clustering/server/pom.xml
+++ b/clustering/server/pom.xml
@@ -53,7 +53,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/configadmin/pom.xml
+++ b/configadmin/pom.xml
@@ -63,7 +63,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -120,7 +120,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/controller/pom.xml
+++ b/controller/pom.xml
@@ -94,7 +94,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/core-model-test/tests/pom.xml
+++ b/core-model-test/tests/pom.xml
@@ -74,6 +74,11 @@
            <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
            <groupId>junit</groupId>
            <artifactId>junit</artifactId>
            <scope>test</scope>

--- a/domain-http/interface/pom.xml
+++ b/domain-http/interface/pom.xml
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/domain-management/pom.xml
+++ b/domain-management/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>org.wildfly</groupId>
     <artifactId>wildfly-domain-management</artifactId>
-    
+
     <properties>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
     </properties>
@@ -52,10 +52,10 @@
                         <include>**/*TestSuite.java</include>
                     </includes>
                     <enableAssertions>false</enableAssertions>
-                    
+
                     <additionalClasspathElements>
                         <additionalClasspathElement>${project.basedir}/../src/test/resources</additionalClasspathElement>
-                    </additionalClasspathElements>                                        
+                    </additionalClasspathElements>
                 </configuration>
             </plugin>
         </plugins>
@@ -66,9 +66,9 @@
             <groupId>org.apache.directory.server</groupId>
             <artifactId>apacheds-all</artifactId>
             <version>${version.org.apache.ds}</version>
-            <scope>test</scope>                                            
-        </dependency>    
-    
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-common-core</artifactId>
@@ -98,6 +98,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>
@@ -122,6 +127,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-       
+
     </dependencies>
 </project>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -118,6 +118,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -71,7 +71,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -129,6 +129,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>

--- a/network/pom.xml
+++ b/network/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -97,7 +97,6 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -123,10 +123,10 @@
         <version.org.apache.ant>1.8.2</version.org.apache.ant>
         <version.org.apache.cxf>2.7.6</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>2.6.1</version.org.apache.cxf.xjcplugins>
-        <version.org.apache.ds>2.0.0-M7</version.org.apache.ds>               
+        <version.org.apache.ds>2.0.0-M7</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpclient>4.2.1</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.2.1</version.org.apache.httpcomponents.httpcore>
-        <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>        
+        <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
         <version.org.apache.maven>3.1.0</version.org.apache.maven>
         <version.org.apache.myfaces.core>2.1.8</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.0.2</version.org.apache.neethi>
@@ -794,6 +794,12 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-arquillian-container-domain-managed</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -933,6 +939,12 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-controller</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -975,6 +987,12 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-domain-management</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1063,6 +1081,16 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-host-controller</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.stdio</groupId>
+                        <artifactId>jboss-stdio</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1190,6 +1218,12 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-process-controller</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -1226,6 +1260,16 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-server</artifactId>
                 <version>${project.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.stdio</groupId>
+                        <artifactId>jboss-stdio</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>
@@ -3035,12 +3079,12 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            
+
             <dependency>
                 <groupId>org.apache.directory.server</groupId>
                 <artifactId>apacheds-all</artifactId>
                 <scope>test</scope>
-                <version>${version.org.apache.ds}</version>                                            
+                <version>${version.org.apache.ds}</version>
             </dependency>
 
             <dependency>
@@ -3685,6 +3729,12 @@
                <groupId>org.hornetq</groupId>
                <artifactId>hornetq-journal</artifactId>
                <version>${version.org.hornetq}</version>
+               <exclusions>
+                   <exclusion>
+                       <groupId>org.jboss.logmanager</groupId>
+                       <artifactId>jboss-logmanager</artifactId>
+                   </exclusion>
+               </exclusions>
             </dependency>
 
             <dependency>
@@ -4422,6 +4472,10 @@
                         <artifactId>byteman-submit</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.hornetq</groupId>
                         <artifactId>hornetq-core</artifactId>
                     </exclusion>
@@ -4830,6 +4884,10 @@
                     <exclusion>
                         <groupId>org.jboss.logging</groupId>
                         <artifactId>jboss-logging-processor</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -111,10 +111,6 @@
             <artifactId>jboss-logmanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
         </dependency>

--- a/version/pom.xml
+++ b/version/pom.xml
@@ -59,7 +59,15 @@
         <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging-annotations</artifactId>
+            <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+                  projects that depend on this project.-->
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Also a little clean-up for jboss-logging dependencies marked as provided.
