### PR TITLE
[WFLY-2342] Upgrade jboss-transaction-spi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
         <version.org.jboss.ironjacamar>1.1.0.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jandex>1.1.0.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.2.0.Final</version.org.jboss.jboss-dmr>
-        <version.org.jboss.jboss-transaction-spi>7.0.2.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jboss.jboss-transaction-spi>7.1.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.jboss-vfs>3.2.2.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.narayana>5.0.0.M4</version.org.jboss.narayana>
         <version.org.jboss.jsfunit>2.0.0.Beta1</version.org.jboss.jsfunit>


### PR DESCRIPTION
The upgrade contains two new marker interfaces for XA resources requested by the JCA team
