### PR TITLE
[WFLY-2345] Port Offset 0 does not work

### DIFF
--- a/network/src/main/java/org/jboss/as/network/SocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/SocketBinding.java
@@ -111,7 +111,7 @@ public final class SocketBinding {
 
     private int calculatePort() {
         int port = this.port;
-        if (port > 0 && isFixedPort == false) {
+        if (!isFixedPort) {
             port += socketBindings.getPortOffset();
         }
         return port;

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
@@ -35,6 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOC
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT_OFFSET;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -71,6 +72,7 @@ public class ControllerInitializer {
     public static final String INTERFACE_NAME = "test-interface";
     public static final String SOCKET_BINDING_GROUP_NAME = "test-socket-binding-group";
     protected volatile String bindAddress = "localhost";
+    protected volatile String portOffset;
     protected final Map<String, String> systemProperties = new HashMap<String, String>();
     protected final Map<String, Integer> socketBindings = new HashMap<String, Integer>();
     protected final Map<String, OutboundSocketBinding> outboundSocketBindings = new HashMap<String, OutboundSocketBinding>();
@@ -178,6 +180,15 @@ public class ControllerInitializer {
 
         PathInfo pathInfo = new PathInfo(name, path, relativeTo);
         paths.put(name, pathInfo);
+    }
+
+    /**
+     * Adds the port offset to the model (optional).
+     *
+     * @param portOffset the port offset ({@code null} means no offset will be added)
+     */
+    public void setPortOffset(String portOffset) {
+        this.portOffset = portOffset;
     }
 
     /**
@@ -307,6 +318,9 @@ public class ControllerInitializer {
         op.get(OP).set(ADD);
         op.get(OP_ADDR).set(PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, SOCKET_BINDING_GROUP_NAME)).toModelNode());
         op.get(DEFAULT_INTERFACE).set(INTERFACE_NAME);
+        if (portOffset != null) {
+            op.get(PORT_OFFSET).set(portOffset);
+        }
         ops.add(op);
 
 


### PR DESCRIPTION
When a port offset is specified in the socket binding group and the
socket binding has a port of 0, then the port offset is not used to
calculate the port instead port 0 is bound.

This pull request contains three changes:
- fix `SocketBinding` to also do offset calculation when the port is 0
- extend `ControllerInitializer` to allow specifing the port offset
- add a test in `OtherServicesSubsystemTestCase`

Issue: WFLY-2345
https://issues.jboss.org/browse/WFLY-2345
