### PR TITLE
[WFLY-2350] Async stop of services that need to deregister with the RecoveryManager 

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/datasource/DirectDataSourceInjectionSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/datasource/DirectDataSourceInjectionSource.java
@@ -40,6 +40,7 @@ import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.security.service.SubjectFactoryService;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
@@ -232,8 +233,10 @@ public class DirectDataSourceInjectionSource extends InjectionSource {
 
 
         final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append("DataSourceDefinition", moduleDescription.getApplicationName(), moduleDescription.getModuleName(), jndiName);
-        final ServiceBuilder<?> dataSourceServiceBuilder = serviceTarget
-                .addService(dataSourceServiceName, dataSourceService)
+        final ServiceBuilder<?> dataSourceServiceBuilder =
+                Services.addServerExecutorDependency(
+                    serviceTarget.addService(dataSourceServiceName, dataSourceService),
+                        dataSourceService.getExecutorServiceInjector(), false)
                 .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
                         dataSourceService.getTransactionIntegrationInjector())
                 .addDependency(ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE, ManagementRepository.class,

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
@@ -57,6 +57,7 @@ import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.security.service.SubjectFactoryService;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.DeploymentModelUtils;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -274,8 +275,10 @@ public class DsXmlDeploymentInstallProcessor implements DeploymentUnitProcessor 
 
 
         final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
-        final ServiceBuilder<?> dataSourceServiceBuilder = serviceTarget
-                .addService(dataSourceServiceName, dataSourceService)
+        final ServiceBuilder<?> dataSourceServiceBuilder =
+                Services.addServerExecutorDependency(
+                        serviceTarget.addService(dataSourceServiceName, dataSourceService),
+                        dataSourceService.getExecutorServiceInjector(), false)
                 .addDependency(ConnectorServices.TRANSACTION_INTEGRATION_SERVICE, TransactionIntegration.class,
                         dataSourceService.getTransactionIntegrationInjector())
                 .addDependency(ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE, ManagementRepository.class,

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/ParsedRaDeploymentProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/ParsedRaDeploymentProcessor.java
@@ -47,6 +47,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.security.service.SubjectFactoryService;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentModelUtils;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -213,7 +214,10 @@ public class ParsedRaDeploymentProcessor implements DeploymentUnitProcessor {
 
 
             // Create the service
-            ServiceBuilder builder = serviceTarget.addService(deployerServiceName, raDeploymentService)
+            ServiceBuilder builder =
+                    Services.addServerExecutorDependency(
+                        serviceTarget.addService(deployerServiceName, raDeploymentService),
+                        raDeploymentService.getExecutorServiceInjector(), false)
                     .addDependency(ConnectorServices.IRONJACAMAR_MDR, AS7MetadataRepository.class, raDeploymentService.getMdrInjector())
                     .addDependency(ConnectorServices.RA_REPOSITORY_SERVICE, ResourceAdapterRepository.class, raDeploymentService.getRaRepositoryInjector())
                     .addDependency(ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE, ManagementRepository.class, raDeploymentService.getManagementRepositoryInjector())

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterDeploymentService.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.connector.metadata.deployment.ResourceAdapterDeployment;
 import org.jboss.as.connector.metadata.xmldescriptors.ConnectorXmlDescriptor;
@@ -112,8 +113,10 @@ public final class ResourceAdapterDeploymentService extends AbstractResourceAdap
             raDeployment = raDeployer.doDeploy();
             deploymentName = raDeployment.getDeploymentName();
         } catch (Throwable t) {
-            unregisterAll(deploymentName);
-            throw MESSAGES.failedToStartRaDeployment(t, deploymentName);
+            // To clean up we need to invoke blocking behavior, so do that in another thread
+            // and let this MSC thread return
+            cleanupStartAsync(context, deploymentName, t, duServiceName, classLoader);
+            return;
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(old);
             WritableServiceBasedNamingStore.popOwner();
@@ -138,17 +141,41 @@ public final class ResourceAdapterDeploymentService extends AbstractResourceAdap
         }
     }
 
+    // TODO this could be replaced by the superclass method if there is no need for the TCCL change and push/pop owner
+    // The stop() call doesn't do that so it's probably not needed
+    private void cleanupStartAsync(final StartContext context, final String deploymentName,
+                                     final Throwable cause, final ServiceName duServiceName, final ClassLoader toUse) {
+        ExecutorService executorService = getLifecycleExecutorService();
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                ClassLoader old = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+                try {
+                    WritableServiceBasedNamingStore.pushOwner(duServiceName);
+                    WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(toUse);
+                    unregisterAll(deploymentName);
+                } finally {
+                    try {
+                        context.failed(MESSAGES.failedToStartRaDeployment(cause, deploymentName));
+                    } finally {
+                        WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(old);
+                        WritableServiceBasedNamingStore.popOwner();
+                    }
+                }
+            }
+        };
+        context.asynchronous();
+        executorService.execute(r);
+
+    }
+
 
     /**
      * Stop
      */
     @Override
     public void stop(StopContext context) {
-        DEPLOYMENT_CONNECTOR_LOGGER.debugf("Stopping sevice %s",
-                deploymentServiceName);
-        unregisterAll(deploymentName);
-
-    }
+        stopAsync(context, deploymentName, deploymentServiceName);    }
 
     @Override
     public void unregisterAll(String deploymentName) {

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.connector.services.resourceadapters.deployment;
 
-import static org.jboss.as.connector.logging.ConnectorLogger.DEPLOYMENT_CONNECTOR_LOGGER;
-import static org.jboss.as.connector.logging.ConnectorMessages.MESSAGES;
-
 import java.io.File;
 import java.net.URL;
 
@@ -117,8 +114,10 @@ public final class ResourceAdapterXmlDeploymentService extends AbstractResourceA
                     WritableServiceBasedNamingStore.popOwner();
                 }
             } catch (Throwable t) {
-                unregisterAll(raName);
-                throw MESSAGES.failedToStartRaDeployment(t, raName);
+                // To clean up we need to invoke blocking behavior, so do that in another thread
+                // and let this MSC thread return
+                cleanupStartAsync(context, raName, t);
+                return;
             }
             String id = ((ModifiableResourceAdapter) raxml).getId();
             final ServiceName raServiceName;
@@ -148,8 +147,7 @@ public final class ResourceAdapterXmlDeploymentService extends AbstractResourceA
      */
     @Override
     public void stop(StopContext context) {
-        DEPLOYMENT_CONNECTOR_LOGGER.debugf("Stopping service %s",deploymentServiceName);
-        unregisterAll(raName);
+        stopAsync(context, raName, deploymentServiceName);
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.security.service.SubjectFactoryService;
+import org.jboss.as.server.Services;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.jca.core.api.connectionmanager.ccm.CachedConnectionManager;
@@ -146,8 +147,10 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
         final ManagementResourceRegistration registration = context.getResourceRegistrationForUpdate();
 
         final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
-        final ServiceBuilder<?> dataSourceServiceBuilder = serviceTarget
-                .addService(dataSourceServiceName, dataSourceService)
+        final ServiceBuilder<?> dataSourceServiceBuilder =
+                Services.addServerExecutorDependency(
+                        serviceTarget.addService(dataSourceServiceName, dataSourceService),
+                        dataSourceService.getExecutorServiceInjector(), false)
                 .addDependency(ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE, ManagementRepository.class,
                         dataSourceService.getManagementRepositoryInjector())
                 .addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class,

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceService.java
@@ -26,7 +26,6 @@ import org.jboss.jca.common.api.validator.ValidateException;
 import org.jboss.jca.core.spi.transaction.recovery.XAResourceRecovery;
 import org.jboss.jca.core.spi.transaction.recovery.XAResourceRecoveryRegistry;
 import org.jboss.msc.inject.Injector;
-import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 
 /**
@@ -45,24 +44,24 @@ public class XaDataSourceService extends AbstractDataSourceService {
     public XaDataSourceService(final String jndiName) {
         this(jndiName, null);
     }
+
     @Override
-    public synchronized void stop(StopContext stopContext) {
-        if (deploymentMD != null) {
-            if (deploymentMD.getRecovery() != null &&
+    protected synchronized void stopService() {
+        if (deploymentMD != null &&
+                deploymentMD.getRecovery() != null &&
                 transactionIntegrationValue.getValue() != null &&
                 transactionIntegrationValue.getValue().getRecoveryRegistry() != null) {
 
-                XAResourceRecoveryRegistry rr = transactionIntegrationValue.getValue().getRecoveryRegistry();
+            XAResourceRecoveryRegistry rr = transactionIntegrationValue.getValue().getRecoveryRegistry();
 
-                for (XAResourceRecovery recovery : deploymentMD.getRecovery()) {
-                    if (recovery != null) {
-                        rr.removeXAResourceRecovery(recovery);
-                    }
+            for (XAResourceRecovery recovery : deploymentMD.getRecovery()) {
+                if (recovery != null) {
+                    rr.removeXAResourceRecovery(recovery);
                 }
             }
         }
 
-        super.stop(stopContext);
+        super.stopService();
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/util/RaServicesFactory.java
+++ b/connector/src/main/java/org/jboss/as/connector/util/RaServicesFactory.java
@@ -40,6 +40,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.security.service.SubjectFactoryService;
+import org.jboss.as.server.Services;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.common.api.metadata.resourceadapter.v11.ResourceAdapter;
 import org.jboss.jca.core.api.connectionmanager.ccm.CachedConnectionManager;
@@ -66,8 +67,10 @@ public class RaServicesFactory {
         if (raxml.getBootstrapContext() != null && !raxml.getBootstrapContext().equals("undefined")) {
             bootStrapCtxName = raxml.getBootstrapContext();
         }
-        ServiceBuilder builder = serviceTarget
-                .addService(serviceName, service)
+        ServiceBuilder builder =
+                Services.addServerExecutorDependency(
+                        serviceTarget.addService(serviceName, service),
+                        service.getExecutorServiceInjector(), false)
                 .addDependency(ConnectorServices.IRONJACAMAR_MDR, AS7MetadataRepository.class, service.getMdrInjector())
                 .addDependency(ConnectorServices.RA_REPOSITORY_SERVICE, ResourceAdapterRepository.class,
                         service.getRaRepositoryInjector())

--- a/ee/src/main/java/org/jboss/as/ee/component/ComponentStartService.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/ComponentStartService.java
@@ -64,17 +64,22 @@ public final class ComponentStartService implements Service<Component> {
      * {@inheritDoc}
      */
     public void stop(final StopContext context) {
-        context.asynchronous();
-        executor.getValue().submit(new Runnable() {
+        Runnable r = new Runnable() {
             @Override
             public void run() {
-                try {
-                    getValue().stop();
-                } finally {
-                    context.complete();
+                synchronized (this) {
+                    try {
+                        getValue().stop();
+                    } finally {
+                        context.complete();
+                    }
                 }
             }
-        });
+        };
+        synchronized (r) {
+            executor.getValue().submit(r);
+            context.asynchronous();
+        }
     }
 
     /**

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.remote;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
 
 import javax.transaction.xa.XAResource;
 
@@ -60,6 +61,7 @@ public class EJBTransactionRecoveryService implements Service<EJBTransactionReco
     private final List<EJBReceiverContext> receiverContexts = Collections.synchronizedList(new ArrayList<EJBReceiverContext>());
     private final InjectedValue<RecoveryManagerService> recoveryManagerService = new InjectedValue<RecoveryManagerService>();
     private final InjectedValue<CoreEnvironmentBean> arjunaTxCoreEnvironmentBean = new InjectedValue<CoreEnvironmentBean>();
+    private final InjectedValue<ExecutorService> executor = new InjectedValue<ExecutorService>();
 
     private EJBTransactionRecoveryService() {
     }
@@ -72,12 +74,29 @@ public class EJBTransactionRecoveryService implements Service<EJBTransactionReco
     }
 
     @Override
-    public void stop(StopContext stopContext) {
-        // we no longer bother about the XAResource(s)
-        this.receiverContexts.clear();
-        // un-register ourselves from the recovery manager service
-        recoveryManagerService.getValue().removeXAResourceRecovery(this);
-        logger.debug("Un-registered " + this + " from the transaction recovery manager");
+    public void stop(final StopContext stopContext) {
+        ExecutorService executorService = executor.getValue();
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                synchronized (this) {
+                    try {
+                        // we no longer bother about the XAResource(s)
+                        EJBTransactionRecoveryService.this.receiverContexts.clear();
+                        // un-register ourselves from the recovery manager service
+                        recoveryManagerService.getValue().removeXAResourceRecovery(EJBTransactionRecoveryService.this);
+                        logger.debug("Un-registered " + this + " from the transaction recovery manager");
+
+                    } finally {
+                        stopContext.complete();
+                    }
+                }
+            }
+        };
+        synchronized (r) {
+            executorService.execute(r);
+            stopContext.asynchronous();
+        }
     }
 
     @Override
@@ -116,6 +135,10 @@ public class EJBTransactionRecoveryService implements Service<EJBTransactionReco
 
     public Injector<CoreEnvironmentBean> getCoreEnvironmentBeanInjector() {
         return this.arjunaTxCoreEnvironmentBean;
+    }
+
+    public InjectedValue<ExecutorService> getExecutorInjector() {
+        return executor;
     }
 
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -115,6 +115,7 @@ import org.jboss.as.security.service.SimpleSecurityManagerService;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.server.deployment.jbossallxml.JBossAllXmlParserRegisteringProcessor;
 import org.jboss.as.txn.service.ArjunaRecoveryManagerService;
@@ -395,7 +396,10 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                 TCCLEJBClientContextSelectorService.class, clientContextService.getTCCLBasedEJBClientContextSelectorInjector());
 
         // add the EJB remote tx recovery service
-        newControllers.add(serviceTarget.addService(EJBTransactionRecoveryService.SERVICE_NAME, EJBTransactionRecoveryService.INSTANCE)
+        newControllers.add(
+                Services.addServerExecutorDependency(
+                    serviceTarget.addService(EJBTransactionRecoveryService.SERVICE_NAME, EJBTransactionRecoveryService.INSTANCE),
+                        EJBTransactionRecoveryService.INSTANCE.getExecutorInjector(), false)
                 .addDependency(ArjunaRecoveryManagerService.SERVICE_NAME, RecoveryManagerService.class, EJBTransactionRecoveryService.INSTANCE.getRecoveryManagerServiceInjector())
                 .addDependency(TxnServices.JBOSS_TXN_CORE_ENVIRONMENT, CoreEnvironmentBean.class, EJBTransactionRecoveryService.INSTANCE.getCoreEnvironmentBeanInjector())
                 .install());

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryService.java
@@ -55,6 +55,7 @@ import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.security.service.SubjectFactoryService;
+import org.jboss.as.server.Services;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.common.api.metadata.common.CommonAdminObject;
@@ -397,8 +398,10 @@ public class PooledConnectionFactoryService implements Service<Void> {
             activator.setBindInfo(bindInfo);
             activator.setCreateBinderService(createBinderService);
 
-            ServiceController<ResourceAdapterDeployment> controller = serviceTarget
-                    .addService(ConnectorServices.RESOURCE_ADAPTER_ACTIVATOR_SERVICE.append(name), activator)
+            ServiceController<ResourceAdapterDeployment> controller =
+                    Services.addServerExecutorDependency(
+                        serviceTarget.addService(ConnectorServices.RESOURCE_ADAPTER_ACTIVATOR_SERVICE.append(name), activator),
+                            activator.getExecutorServiceInjector(), false)
                     .addDependency(HornetQActivationService.getHornetQActivationServiceName(getHornetQServiceName(hqServerName)))
                     .addDependency(ConnectorServices.IRONJACAMAR_MDR, AS7MetadataRepository.class,
                             activator.getMdrInjector())


### PR DESCRIPTION
XAResourceRecoveryRegistry.removeXAResourceRecovery can be a blocking call, so MSC services that call it in start/stop need to use the MSC async API to do so.
