### PR TITLE
Remove circular module reference in JSON-P module

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -29,7 +29,6 @@
     </properties>
 
     <dependencies>
-        <module name="javax.json.api"/>
     </dependencies>
     <resources>
         <!-- Insert resources here -->


### PR DESCRIPTION
The javax.json module is an alias to the org.glassfish one, which then
expresses a dependency back to the javax.json module.
