### PR TITLE
[WFLY-1458] handle the managed container startup timeout properly

### DIFF
--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedDeployableContainer.java
@@ -181,7 +181,9 @@ public final class ManagedDeployableContainer extends CommonDeployableContainer<
             boolean serverAvailable = false;
             long sleep = 1000;
             while (timeout > 0 && serverAvailable == false) {
+                long before = System.currentTimeMillis();
                 serverAvailable = getManagementClient().isServerInRunningState();
+                timeout -= (System.currentTimeMillis() - before);
                 if (!serverAvailable) {
                     if (processHasDied(proc))
                         break;


### PR DESCRIPTION
My proposed fix for https://issues.jboss.org/browse/WFLY-1458. If we decide that this fix is OK, we'll probably need to apply it to `ManagedDomainDeployableContainer` too.
