### PR TITLE
WFLY-2212 Update JPA subsystem to use EE default datasource

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -160,6 +160,12 @@ public class Configuration {
      * which uses two phases to start the persistence unit).
      */
     public static final String JPA_ALLOW_TWO_PHASE_BOOTSTRAP = "wildfly.jpa.twophasebootstrap";
+
+    /**
+     * set to false to ignore default data source (defaults to true)
+     */
+    private static final String JPA_ALLOW_DEFAULT_DATA_SOURCE_USE = "wildfly.jpa.allowdefaultdatasourceuse";
+
     /**
      * name of the persistence provider adapter class
      */
@@ -245,6 +251,20 @@ public class Configuration {
         boolean result = true;
         if (pu.getProperties().containsKey(Configuration.JPA_ALLOW_TWO_PHASE_BOOTSTRAP)) {
             result = Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_ALLOW_TWO_PHASE_BOOTSTRAP));
+        }
+        return result;
+    }
+
+    /**
+     * Determine if the default data-source should be used
+     *
+     * @param pu
+     * @return true if the default data-source should be used
+     */
+    public static boolean allowDefaultDataSourceUse(PersistenceUnitMetadata pu) {
+        boolean result = true;
+        if (pu.getProperties().containsKey(Configuration.JPA_ALLOW_DEFAULT_DATA_SOURCE_USE)) {
+            result = Boolean.parseBoolean(pu.getProperties().getProperty(Configuration.JPA_ALLOW_DEFAULT_DATA_SOURCE_USE));
         }
         return result;
     }

--- a/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -373,7 +373,14 @@ public class PersistenceUnitServiceHandler {
             }
             // JPA 2.0 8.2.1.5, container provides default JTA datasource
             if (useDefaultDataSource) {
-                final String defaultJtaDataSource = adjustJndi(JPAService.getDefaultDataSourceName());
+                // try the one defined in the jpa subsystem
+                String defaultJtaDataSource = adjustJndi(JPAService.getDefaultDataSourceName());
+                if ((defaultJtaDataSource == null ||
+                        defaultJtaDataSource.isEmpty()) &&
+                        eeModuleDescription != null) {
+                    // try the one defined in the ee subsystem
+                    defaultJtaDataSource = eeModuleDescription.getDefaultResourceJndiNames().getDataSource();
+                }
                 if (defaultJtaDataSource != null &&
                     defaultJtaDataSource.length() > 0) {
                     builder.addDependency(AbstractDataSourceService.SERVICE_NAME_BASE.append(defaultJtaDataSource), new CastingInjector<DataSource>(service.getJtaDataSourceInjector(), DataSource.class));
@@ -500,7 +507,14 @@ public class PersistenceUnitServiceHandler {
             }
             // JPA 2.0 8.2.1.5, container provides default JTA datasource
             if (useDefaultDataSource) {
-                final String defaultJtaDataSource = adjustJndi(JPAService.getDefaultDataSourceName());
+                // try the one defined in the jpa subsystem
+                String defaultJtaDataSource = adjustJndi(JPAService.getDefaultDataSourceName());
+                if ((defaultJtaDataSource == null ||
+                        defaultJtaDataSource.isEmpty()) &&
+                        eeModuleDescription != null) {
+                    // try the one defined in the ee subsystem
+                    defaultJtaDataSource = eeModuleDescription.getDefaultResourceJndiNames().getDataSource();
+                }
                 if (defaultJtaDataSource != null &&
                     defaultJtaDataSource.length() > 0) {
                     builder.addDependency(AbstractDataSourceService.SERVICE_NAME_BASE.append(defaultJtaDataSource), new CastingInjector<DataSource>(service.getJtaDataSourceInjector(), DataSource.class));
@@ -612,7 +626,14 @@ public class PersistenceUnitServiceHandler {
             }
             // JPA 2.0 8.2.1.5, container provides default JTA datasource
             if (useDefaultDataSource) {
-                final String defaultJtaDataSource = adjustJndi(JPAService.getDefaultDataSourceName());
+                // try the one defined in the jpa subsystem
+                String defaultJtaDataSource = adjustJndi(JPAService.getDefaultDataSourceName());
+                if ((defaultJtaDataSource == null ||
+                        defaultJtaDataSource.isEmpty()) &&
+                        eeModuleDescription != null) {
+                    // try the one defined in the ee subsystem
+                    defaultJtaDataSource = eeModuleDescription.getDefaultResourceJndiNames().getDataSource();
+                }
                 if (defaultJtaDataSource != null &&
                     defaultJtaDataSource.length() > 0) {
                     builder.addDependency(AbstractDataSourceService.SERVICE_NAME_BASE.append(defaultJtaDataSource), new CastingInjector<DataSource>(service.getJtaDataSourceInjector(), DataSource.class));

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/entitymanagerfactorytest/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/basic/entitymanagerfactorytest/persistence.xml
@@ -2,7 +2,11 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" version="2.0">
 
     <persistence-unit name="mypc">
+        <!--
+        purposely leave datasource out to test WFLY-2122 (use default EE datasource)
         <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+        -->
+
         <properties>
             <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
             <property name="jboss.entity.manager.factory.jndi.name" value="myEMF" />


### PR DESCRIPTION
Now that EE 7 has an EE level default datasource, we can support that also (if JPA default datasource is not already set).  Persistence units that include hint wildfly.jpa.allowdefaultdatasourceuse set to false will ignore default datasource settings.
