### PR TITLE
WFLY-2371 Increase allowed size for rotation test

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/operations/SizeRotatingHandlerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/operations/SizeRotatingHandlerTestCase.java
@@ -148,7 +148,9 @@ public class SizeRotatingHandlerTestCase extends AbstractLoggingOperationsTestCa
         int count = 0;
         for (File file : logFile.getParentFile().listFiles()) {
             if (file.getName().contains(logFile.getName())) {
-                Assert.assertTrue("This file is bigger than allowed rotate-size: " + file.getName(), file.length() < 2200);
+                long length = file.length();
+                Assert.assertTrue(String.format("File %s is bigger than allowed rotate-size. File length = %d",
+                        file.getName(), length), length < 2500);
                 checkLogs(message, true, file);
                 count++;
             }
@@ -201,8 +203,8 @@ public class SizeRotatingHandlerTestCase extends AbstractLoggingOperationsTestCa
     private ModelNode validateResponse(ModelNode operation, boolean validateResult) throws Exception {
         final ModelNode response = executeOperation(operation);
         if (!Operations.isSuccessfulOutcome(response)) {
-           Assert.fail(Operations.getFailureDescription(response).toString());
-  	}
+            Assert.fail(Operations.getFailureDescription(response).toString());
+        }
         if (validateResult) {
             Assert.assertTrue("result exists", response.hasDefined(RESULT));
         }


### PR DESCRIPTION
Increased allowed rotation size as on some platforms file size can slightly exceed previously set value and fail the test.

https://issues.jboss.org/browse/WFLY-2371 - SizeRotatingHandlerTestCase.rotationTest fails with "the file is bigger than allowed size"
