### PR TITLE
[WFLY-2393] Deprecate -jms.xml deployment

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -202,4 +202,8 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 11614, value = "Ignoring %s property that is not a known property for pooled connection factory.")
     void unknownPooledConnectionFactoryAttribute(String name);
+
+    @LogMessage(level = WARN)
+    @Message(id = 11615, value = "Deployment of JMS using non-portable %s is deprecated. Please consider using standard Java EE7 deployment descriptor with jms-destination elements to deploy JMS destinations.")
+    void jmsDeploymentIsDeprecated(String file);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingXmlParsingDeploymentUnitProcessor.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/MessagingXmlParsingDeploymentUnitProcessor.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.messaging.deployment;
 
+import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -74,6 +76,7 @@ public class MessagingXmlParsingDeploymentUnitProcessor implements DeploymentUni
         mapper.registerRootElement(ROOT_NO_NAMESPACE, messagingDeploymentParser_1_0);
 
         for (final VirtualFile file : files) {
+            MESSAGING_LOGGER.jmsDeploymentIsDeprecated(file.getName());
             InputStream xmlStream = null;
 
             try {


### PR DESCRIPTION
log a warning when deploying a -jms.xml file that it is deprecated and
standard Java EE 7 deployment descriptor should be used instead.
