### PR TITLE
[WFLY-2402] fix clustered attribute transformer

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
@@ -24,7 +24,6 @@ package org.jboss.as.messaging;
 
 import static org.jboss.as.controller.PathElement.pathElement;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.transform.description.DiscardAttributeChecker.DiscardAttributeValueChecker;
 import static org.jboss.as.controller.transform.description.DiscardAttributeChecker.UNDEFINED;
@@ -215,7 +214,7 @@ public class MessagingTransformers {
                         // before discarding
 
                         // the real clustered HornetQ state
-                        Set<String> clusterConnectionNames = context.readResource(PathAddress.EMPTY_ADDRESS).getChildrenNames(ClusterConnectionDefinition.PATH.getKey());
+                        Set<String> clusterConnectionNames = context.readResource(address).getChildrenNames(ClusterConnectionDefinition.PATH.getKey());
                         boolean clustered = !clusterConnectionNames.isEmpty();
                         // whether the user wants the server to be clustered
                         // We use a short-cut vs AD.resolveModelValue to avoid having to hack in an OperationContext
@@ -223,9 +222,8 @@ public class MessagingTransformers {
                         // Treat 'undefined' as 'ignore this and match the actual config' instead of the legacy default 'false'
                         boolean wantsClustered = attributeValue.asBoolean(clustered);
                         if (clustered && !wantsClustered) {
-                            PathAddress serverAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
-                            String msg = MessagingMessages.MESSAGES.canNotChangeClusteredAttribute(serverAddress);
-                            context.getLogger().logAttributeWarning(serverAddress, operation, msg, CLUSTERED.getName());
+                            String msg = MessagingMessages.MESSAGES.canNotChangeClusteredAttribute(address);
+                            context.getLogger().logAttributeWarning(address, operation, msg, CLUSTERED.getName());
                         }
                         return true;
                     }

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
@@ -79,10 +79,10 @@ import org.jboss.as.messaging.DiscoveryGroupDefinition;
 import org.jboss.as.messaging.DivertDefinition;
 import org.jboss.as.messaging.GroupingHandlerDefinition;
 import org.jboss.as.messaging.HornetQServerResourceDefinition;
-import org.jboss.as.messaging.ServletConnectorDefinition;
 import org.jboss.as.messaging.InVMTransportDefinition;
 import org.jboss.as.messaging.MessagingExtension;
 import org.jboss.as.messaging.QueueDefinition;
+import org.jboss.as.messaging.ServletConnectorDefinition;
 import org.jboss.as.messaging.TransportParamDefinition;
 import org.jboss.as.messaging.jms.ConnectionFactoryAttributes;
 import org.jboss.as.messaging.jms.ConnectionFactoryDefinition;
@@ -158,7 +158,8 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testClusteredTo120() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0, "empty_subsystem_2_0.xml");
+        // this hornetq-server has 1 cluster-connection resource defined and so is clustered.
+        KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0, "subsystem_with_cluster_connection_2_0.xml");
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_2_0);
@@ -173,7 +174,8 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
     private void clusteredTo120Test(ModelVersion version120, KernelServices mainServices, boolean clustered) throws OperationFailedException {
 
         PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME),
-                PathElement.pathElement(HornetQServerResourceDefinition.HORNETQ_SERVER_PATH.getKey(), String.valueOf(clustered)));
+                // stuff if the empty hornetq-server defined in empty_subsystem_2_0
+                PathElement.pathElement(HornetQServerResourceDefinition.HORNETQ_SERVER_PATH.getKey(), "stuff"));
 
         ModelNode addOp = Util.createAddOperation(pa);
         addOp.get(CommonAttributes.CLUSTERED.getName()).set(clustered);

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_with_cluster_connection_2_0.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_with_cluster_connection_2_0.xml
@@ -1,0 +1,14 @@
+
+    <subsystem xmlns="urn:jboss:domain:messaging:2.0">
+        <hornetq-server name="stuff">
+            <connectors>
+                <netty-connector name="netty" socket-binding="messaging" />
+            </connectors>
+            <cluster-connections>
+                <cluster-connection name="cc5">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                </cluster-connection>
+            </cluster-connections>
+        </hornetq-server>
+    </subsystem>


### PR DESCRIPTION
- get the hornetq-server resource by reading context.readResource(address)
  instead of PathAddress.EMPTY_ADDRESS.
- update the testClusteredTo120() test to use a hornetq-server resource
  with 1 cluster-connection (and thus clustered) to make sure the
  warning is logged as expected if the user wants to set the clustered
  attribute to false
