### PR TITLE
[WFLY-1458] handle the managed domain container startup timeout properly

### DIFF
--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainDeployableContainer.java
@@ -118,7 +118,9 @@ public class ManagedDomainDeployableContainer extends CommonDomainDeployableCont
             boolean serverAvailable = false;
             long sleep = 1000;
             while (timeout > 0 && serverAvailable == false) {
+                long before = System.currentTimeMillis();
                 serverAvailable = getManagementClient().isDomainInRunningState();
+                timeout -= (System.currentTimeMillis() - before);
                 if (!serverAvailable) {
                     if (processHasDied(proc))
                         break;


### PR DESCRIPTION
I've heard that there are people using the Arquillian managed _domain_ container too, so here's the same fix as in wildfly/wildfly#5334 for the managed domain container.
