### PR TITLE
Some more tests for RBAC

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -118,4 +118,48 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>rbac-soak</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <properties>
+                <!-- default values usable for development -->
+                <jboss.test.rbac.soak.clients>10</jboss.test.rbac.soak.clients>
+                <jboss.test.rbac.soak.iterations>5</jboss.test.rbac.soak.iterations>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <failIfNoTests>false</failIfNoTests>
+                            <!-- parallel>none</parallel -->
+                            <redirectTestOutputToFile>${testLogToFile}</redirectTestOutputToFile>
+
+                            <!-- System properties to forked surefire JVM which runs clients. -->
+                            <argLine>${jvm.args.ip.client} ${jvm.args.timeouts}</argLine>
+
+                            <systemPropertyVariables>
+                                <jboss.options>${surefire.system.args}</jboss.options>
+                                <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
+                                <jboss.home>${jboss.home}</jboss.home>
+                                <module.path>${jboss.home}/modules</module.path>
+                                <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
+                                <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
+                                <jboss.test.rbac.soak.clients>${jboss.test.rbac.soak.clients}</jboss.test.rbac.soak.clients>
+                                <jboss.test.rbac.soak.iterations>${jboss.test.rbac.soak.iterations}</jboss.test.rbac.soak.iterations>
+                            </systemPropertyVariables>
+                            <includes>
+                                <include>org/jboss/as/test/integration/domain/rbac/RbacSoakTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
 </project>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractHostScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractHostScopedRolesTestCase.java
@@ -53,7 +53,7 @@ import org.junit.Test;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCase {
+public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCase implements RbacDomainRolesTests {
 
     public static final String MONITOR_USER = "HostMasterMonitor";
     public static final String OPERATOR_USER = "HostMasterOperator";
@@ -131,6 +131,10 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         checkSecurityDomainRead(client, SLAVE, SLAVE_B, Outcome.HIDDEN, MONITOR_USER);
         checkSensitiveAttribute(client, null, null, false, MONITOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, MONITOR_USER);
+        testHostScopedRoleCanReadHostChildResources(client, MONITOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, MONITOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, MONITOR_USER);
         runGC(client, SLAVE, SLAVE_B, Outcome.HIDDEN, MONITOR_USER);
@@ -138,8 +142,6 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         addPath(client, Outcome.UNAUTHORIZED, MONITOR_USER);
         addJvm(client, HOST, MASTER, Outcome.UNAUTHORIZED, MONITOR_USER);
         addJvm(client, HOST, SLAVE, Outcome.HIDDEN, MONITOR_USER);
-
-        testHostScopedRoleCanReadHostChildResources(client, MONITOR_USER);
 
         testWLFY2299(client, Outcome.UNAUTHORIZED, MONITOR_USER);
         restartServer(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, MONITOR_USER);
@@ -162,6 +164,10 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         checkSecurityDomainRead(client, SLAVE, SLAVE_B, Outcome.HIDDEN, OPERATOR_USER);
         checkSensitiveAttribute(client, null, null, false, OPERATOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, OPERATOR_USER);
+        testHostScopedRoleCanReadHostChildResources(client, OPERATOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, OPERATOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, OPERATOR_USER);
         runGC(client, SLAVE, SLAVE_B, Outcome.HIDDEN, OPERATOR_USER);
@@ -169,8 +175,6 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         addPath(client, Outcome.UNAUTHORIZED, OPERATOR_USER);
         addJvm(client, HOST, MASTER, Outcome.UNAUTHORIZED, OPERATOR_USER);
         addJvm(client, HOST, SLAVE, Outcome.HIDDEN, OPERATOR_USER);
-
-        testHostScopedRoleCanReadHostChildResources(client, OPERATOR_USER);
 
         testWLFY2299(client, Outcome.UNAUTHORIZED, OPERATOR_USER);
         restartServer(client, MASTER, MASTER_A, Outcome.SUCCESS, OPERATOR_USER);
@@ -193,6 +197,10 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         checkSecurityDomainRead(client, SLAVE, SLAVE_B, Outcome.HIDDEN, MAINTAINER_USER);
         checkSensitiveAttribute(client, null, null, false, MAINTAINER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, MAINTAINER_USER);
+        testHostScopedRoleCanReadHostChildResources(client, MAINTAINER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, MAINTAINER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, MAINTAINER_USER);
         runGC(client, SLAVE, SLAVE_B, Outcome.HIDDEN, MAINTAINER_USER);
@@ -200,8 +208,6 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         addPath(client, Outcome.UNAUTHORIZED, MAINTAINER_USER);
         addJvm(client, HOST, MASTER, Outcome.SUCCESS, MAINTAINER_USER);
         addJvm(client, HOST, SLAVE, Outcome.HIDDEN, MAINTAINER_USER);
-
-        testHostScopedRoleCanReadHostChildResources(client, MAINTAINER_USER);
 
         testWLFY2299(client, Outcome.SUCCESS, MAINTAINER_USER);
     }
@@ -223,6 +229,10 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         checkSecurityDomainRead(client, SLAVE, SLAVE_B, Outcome.HIDDEN, DEPLOYER_USER);
         checkSensitiveAttribute(client, null, null, false, DEPLOYER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, DEPLOYER_USER);
+        testHostScopedRoleCanReadHostChildResources(client, DEPLOYER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         runGC(client, SLAVE, SLAVE_B, Outcome.HIDDEN, DEPLOYER_USER);
@@ -230,8 +240,6 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         addPath(client, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         addJvm(client, HOST, MASTER, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         addJvm(client, HOST, SLAVE, Outcome.HIDDEN, DEPLOYER_USER);
-
-        testHostScopedRoleCanReadHostChildResources(client, DEPLOYER_USER);
 
         testWLFY2299(client, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         restartServer(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, DEPLOYER_USER);
@@ -254,6 +262,10 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         checkSecurityDomainRead(client, SLAVE, SLAVE_B, Outcome.HIDDEN, ADMINISTRATOR_USER);
         checkSensitiveAttribute(client, null, null, false, ADMINISTRATOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, ADMINISTRATOR_USER);
+        testHostScopedRoleCanReadHostChildResources(client, ADMINISTRATOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, ADMINISTRATOR_USER);
         runGC(client, SLAVE, SLAVE_B, Outcome.HIDDEN, ADMINISTRATOR_USER);
@@ -261,8 +273,6 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         addPath(client, Outcome.UNAUTHORIZED, ADMINISTRATOR_USER);
         addJvm(client, HOST, MASTER, Outcome.SUCCESS, ADMINISTRATOR_USER);
         addJvm(client, HOST, SLAVE, Outcome.HIDDEN, ADMINISTRATOR_USER);
-
-        testHostScopedRoleCanReadHostChildResources(client, ADMINISTRATOR_USER);
 
         testWLFY2299(client, Outcome.SUCCESS, ADMINISTRATOR_USER);
     }
@@ -284,6 +294,10 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         checkSecurityDomainRead(client, SLAVE, SLAVE_B, Outcome.HIDDEN, AUDITOR_USER);
         checkSensitiveAttribute(client, null, null, false, AUDITOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, AUDITOR_USER);
+        testHostScopedRoleCanReadHostChildResources(client, AUDITOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, AUDITOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, AUDITOR_USER);
         runGC(client, SLAVE, SLAVE_B, Outcome.HIDDEN, AUDITOR_USER);
@@ -291,8 +305,6 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         addPath(client, Outcome.UNAUTHORIZED, AUDITOR_USER);
         addJvm(client, HOST, MASTER, Outcome.UNAUTHORIZED, AUDITOR_USER);
         addJvm(client, HOST, SLAVE, Outcome.HIDDEN, AUDITOR_USER);
-
-        testHostScopedRoleCanReadHostChildResources(client, AUDITOR_USER);
 
         testWLFY2299(client, Outcome.UNAUTHORIZED, AUDITOR_USER);
         restartServer(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, AUDITOR_USER);
@@ -315,6 +327,10 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         checkSecurityDomainRead(client, SLAVE, SLAVE_B, Outcome.HIDDEN, SUPERUSER_USER);
         checkSensitiveAttribute(client, null, null, false, SUPERUSER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, SUPERUSER_USER);
+        testHostScopedRoleCanReadHostChildResources(client, SUPERUSER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, SUPERUSER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, SUPERUSER_USER);
         runGC(client, SLAVE, SLAVE_B, Outcome.HIDDEN, SUPERUSER_USER);
@@ -322,8 +338,6 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
         addPath(client, Outcome.UNAUTHORIZED, SUPERUSER_USER);
         addJvm(client, HOST, MASTER, Outcome.SUCCESS, SUPERUSER_USER);
         addJvm(client, HOST, SLAVE, Outcome.HIDDEN, SUPERUSER_USER);
-
-        testHostScopedRoleCanReadHostChildResources(client, SUPERUSER_USER);
 
         testWLFY2299(client, Outcome.SUCCESS, SUPERUSER_USER);
     }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractHostScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractHostScopedRolesTestCase.java
@@ -117,6 +117,7 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
     @Test
     public void testMonitor() throws Exception {
         ModelControllerClient client = getClientForUser(MONITOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, MONITOR_USER);
         checkStandardReads(client, null, null, MONITOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, MONITOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, MONITOR_USER);
@@ -147,6 +148,7 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
     @Test
     public void testOperator() throws Exception {
         ModelControllerClient client = getClientForUser(OPERATOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, OPERATOR_USER);
         checkStandardReads(client, null, null, OPERATOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, OPERATOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, OPERATOR_USER);
@@ -177,6 +179,7 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
     @Test
     public void testMaintainer() throws Exception {
         ModelControllerClient client = getClientForUser(MAINTAINER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, MAINTAINER_USER);
         checkStandardReads(client, null, null, MAINTAINER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, MAINTAINER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, MAINTAINER_USER);
@@ -206,6 +209,7 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
     @Test
     public void testDeployer() throws Exception {
         ModelControllerClient client = getClientForUser(DEPLOYER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         checkStandardReads(client, null, null, DEPLOYER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, DEPLOYER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, DEPLOYER_USER);
@@ -236,6 +240,7 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
     @Test
     public void testAdministrator() throws Exception {
         ModelControllerClient client = getClientForUser(ADMINISTRATOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, ADMINISTRATOR_USER);
         checkStandardReads(client, null, null, ADMINISTRATOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
@@ -265,6 +270,7 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
     @Test
     public void testAuditor() throws Exception {
         ModelControllerClient client = getClientForUser(AUDITOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, AUDITOR_USER);
         checkStandardReads(client, null, null, AUDITOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, AUDITOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, AUDITOR_USER);
@@ -295,6 +301,7 @@ public abstract class AbstractHostScopedRolesTestCase extends AbstractRbacTestCa
     @Test
     public void testSuperUser() throws Exception {
         ModelControllerClient client = getClientForUser(SUPERUSER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, SUPERUSER_USER);
         checkStandardReads(client, null, null, SUPERUSER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, SUPERUSER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, SUPERUSER_USER);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractRbacTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractRbacTestCase.java
@@ -27,7 +27,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUTO_START;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BYTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIBE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
@@ -36,11 +38,14 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PASSWORD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CONFIG_AS_XML_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 import static org.junit.Assert.assertEquals;
@@ -167,6 +172,51 @@ public abstract class AbstractRbacTestCase {
     }
 
     protected abstract void configureRoles(ModelNode op, String[] roles);
+
+    /**
+     * @param expectedOutcome for standard and host-scoped roles tests, this is the expected outcome of all operations;
+     *                        for server-group-scoped roles tests, this is the expected outcome for the profile of the server group the user
+     *                        is member of, as for the other profiles and for read-config-as-xml, the outcome is well known
+     */
+    protected void readWholeConfig(ModelControllerClient client, Outcome expectedOutcome, String... roles) throws IOException {
+        Outcome expectedOutcomeForReadConfigAsXml = expectedOutcome;
+        if (this instanceof AbstractServerGroupScopedRolesTestCase) {
+            expectedOutcomeForReadConfigAsXml = Outcome.UNAUTHORIZED;
+        }
+
+        ModelNode op = createOpNode(null, READ_CONFIG_AS_XML_OPERATION);
+        configureRoles(op, roles);
+        RbacUtil.executeOperation(client, op, expectedOutcomeForReadConfigAsXml);
+
+        // the code below calls the non-published operation 'describe'; see WFLY-2379 for more info
+
+        ModelControllerClient domainClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        op = createOpNode(null, READ_CHILDREN_NAMES_OPERATION);
+        op.get(CHILD_TYPE).set(PROFILE);
+        ModelNode profiles = RbacUtil.executeOperation(domainClient, op, Outcome.SUCCESS);
+        for (ModelNode profile : profiles.get(RESULT).asList()) {
+            Outcome expectedOutcomeForProfile = expectedOutcome;
+            if (this instanceof AbstractServerGroupScopedRolesTestCase) {
+                expectedOutcomeForProfile = "profile-a".equals(profile.asString()) ? expectedOutcome : Outcome.HIDDEN;
+            }
+
+            op = createOpNode("profile=" + profile.asString(), DESCRIBE);
+            configureRoles(op, roles);
+            ModelNode result = RbacUtil.executeOperation(client, op, expectedOutcomeForProfile);
+            assertEquals(expectedOutcomeForProfile == Outcome.SUCCESS, result.hasDefined(RESULT));
+
+            op = createOpNode("profile=" + profile.asString(), READ_CHILDREN_NAMES_OPERATION);
+            op.get(CHILD_TYPE).set(SUBSYSTEM);
+            ModelNode subsystems = RbacUtil.executeOperation(domainClient, op, Outcome.SUCCESS);
+            for (ModelNode subsystem : subsystems.get(RESULT).asList()) {
+                op = createOpNode("profile=" + profile.asString() + "/subsystem=" + subsystem.asString(), DESCRIBE);
+                configureRoles(op, roles);
+                result = RbacUtil.executeOperation(client, op, expectedOutcomeForProfile);
+                assertEquals(expectedOutcomeForProfile == Outcome.SUCCESS, result.hasDefined(RESULT));
+            }
+        }
+    }
 
     protected void checkStandardReads(ModelControllerClient client, String host, String server, String... roles) throws IOException {
         readResource(client, DEPLOYMENT_1, host, server, Outcome.SUCCESS, roles);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractRbacTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractRbacTestCase.java
@@ -173,6 +173,8 @@ public abstract class AbstractRbacTestCase {
 
     protected abstract void configureRoles(ModelNode op, String[] roles);
 
+    boolean readOnly = false; // used by RbacSoakTest
+
     /**
      * @param expectedOutcome for standard and host-scoped roles tests, this is the expected outcome of all operations;
      *                        for server-group-scoped roles tests, this is the expected outcome for the profile of the server group the user

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractServerGroupScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractServerGroupScopedRolesTestCase.java
@@ -61,7 +61,7 @@ import org.junit.Test;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRbacTestCase {
+public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRbacTestCase implements RbacDomainRolesTests {
 
     public static final String MONITOR_USER = "MainGroupMonitor";
     public static final String OPERATOR_USER = "MainGroupOperator";
@@ -162,6 +162,9 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
         checkSecurityDomainRead(client, MASTER, SLAVE_B, Outcome.HIDDEN, MONITOR_USER);
         checkSensitiveAttribute(client, null, null, false, MONITOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, MONITOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, MONITOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, MONITOR_USER);
         runGC(client, SLAVE, null, Outcome.UNAUTHORIZED, MONITOR_USER);
@@ -199,6 +202,9 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
         checkSecurityDomainRead(client, MASTER, SLAVE_B, Outcome.HIDDEN, OPERATOR_USER);
         checkSensitiveAttribute(client, null, null, false, OPERATOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, OPERATOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, OPERATOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, OPERATOR_USER);
         runGC(client, SLAVE, null, Outcome.UNAUTHORIZED, OPERATOR_USER);
@@ -236,6 +242,9 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
         checkSecurityDomainRead(client, MASTER, SLAVE_B, Outcome.HIDDEN, MAINTAINER_USER);
         checkSensitiveAttribute(client, null, null, false, MAINTAINER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, MAINTAINER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, MAINTAINER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, MAINTAINER_USER);
         runGC(client, SLAVE, null, Outcome.UNAUTHORIZED, MAINTAINER_USER);
@@ -273,6 +282,9 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
         checkSecurityDomainRead(client, MASTER, SLAVE_B, Outcome.HIDDEN, DEPLOYER_USER);
         checkSensitiveAttribute(client, null, null, false, DEPLOYER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, DEPLOYER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         runGC(client, SLAVE, null, Outcome.UNAUTHORIZED, DEPLOYER_USER);
@@ -310,6 +322,9 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
         checkSecurityDomainRead(client, MASTER, SLAVE_B, Outcome.HIDDEN, ADMINISTRATOR_USER);
         checkSensitiveAttribute(client, null, null, true, ADMINISTRATOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, ADMINISTRATOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, ADMINISTRATOR_USER);
         runGC(client, SLAVE, null, Outcome.UNAUTHORIZED, ADMINISTRATOR_USER);
@@ -347,6 +362,9 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
         checkSecurityDomainRead(client, MASTER, SLAVE_B, Outcome.HIDDEN, AUDITOR_USER);
         checkSensitiveAttribute(client, null, null, true, AUDITOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, AUDITOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, AUDITOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, AUDITOR_USER);
         runGC(client, SLAVE, null, Outcome.UNAUTHORIZED, AUDITOR_USER);
@@ -384,6 +402,9 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
         checkSecurityDomainRead(client, MASTER, SLAVE_B, Outcome.HIDDEN, SUPERUSER_USER);
         checkSensitiveAttribute(client, null, null, true, SUPERUSER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, SUPERUSER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, SUPERUSER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, SUPERUSER_USER);
         runGC(client, SLAVE, null, Outcome.UNAUTHORIZED, SUPERUSER_USER);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractServerGroupScopedRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractServerGroupScopedRolesTestCase.java
@@ -102,6 +102,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
 
         WFLY_1916_OP.protect();
     }
+
     protected static void setupRoles(DomainClient domainClient) throws IOException {
         for (int i = 0; i < USERS.length; i++) {
             ModelNode op = createOpNode(SCOPED_ROLE + USERS[i], ADD);
@@ -147,6 +148,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
     @Test
     public void testMonitor() throws Exception {
         ModelControllerClient client = getClientForUser(MONITOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, MONITOR_USER);
         checkStandardReads(client, null, null, MONITOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, MONITOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, MONITOR_USER);
@@ -183,6 +185,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
     @Test
     public void testOperator() throws Exception {
         ModelControllerClient client = getClientForUser(OPERATOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, OPERATOR_USER);
         checkStandardReads(client, null, null, OPERATOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, OPERATOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, OPERATOR_USER);
@@ -219,6 +222,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
     @Test
     public void testMaintainer() throws Exception {
         ModelControllerClient client = getClientForUser(MAINTAINER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, MAINTAINER_USER);
         checkStandardReads(client, null, null, MAINTAINER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, MAINTAINER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, MAINTAINER_USER);
@@ -255,6 +259,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
     @Test
     public void testDeployer() throws Exception {
         ModelControllerClient client = getClientForUser(DEPLOYER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         checkStandardReads(client, null, null, DEPLOYER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, DEPLOYER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, DEPLOYER_USER);
@@ -291,6 +296,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
     @Test
     public void testAdministrator() throws Exception {
         ModelControllerClient client = getClientForUser(ADMINISTRATOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.SUCCESS, ADMINISTRATOR_USER);
         checkStandardReads(client, null, null, ADMINISTRATOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
@@ -327,6 +333,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
     @Test
     public void testAuditor() throws Exception {
         ModelControllerClient client = getClientForUser(AUDITOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.SUCCESS, AUDITOR_USER);
         checkStandardReads(client, null, null, AUDITOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, AUDITOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, AUDITOR_USER);
@@ -363,6 +370,7 @@ public abstract class AbstractServerGroupScopedRolesTestCase extends AbstractRba
     @Test
     public void testSuperUser() throws Exception {
         ModelControllerClient client = getClientForUser(SUPERUSER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.SUCCESS, SUPERUSER_USER);
         checkStandardReads(client, null, null, SUPERUSER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, SUPERUSER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, SUPERUSER_USER);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractStandardRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractStandardRolesTestCase.java
@@ -72,6 +72,7 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
     @Test
     public void testMonitor() throws Exception {
         ModelControllerClient client = getClientForUser(MONITOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, MONITOR_USER);
         checkStandardReads(client, null, null, MONITOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, MONITOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, MONITOR_USER);
@@ -91,6 +92,7 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
     @Test
     public void testOperator() throws Exception {
         ModelControllerClient client = getClientForUser(OPERATOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, OPERATOR_USER);
         checkStandardReads(client, null, null, OPERATOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, OPERATOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, OPERATOR_USER);
@@ -110,6 +112,7 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
     @Test
     public void testMaintainer() throws Exception {
         ModelControllerClient client = getClientForUser(MAINTAINER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, MAINTAINER_USER);
         checkStandardReads(client, null, null, MAINTAINER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, MAINTAINER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, MAINTAINER_USER);
@@ -128,6 +131,7 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
     @Test
     public void testDeployer() throws Exception {
         ModelControllerClient client = getClientForUser(DEPLOYER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         checkStandardReads(client, null, null, DEPLOYER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, DEPLOYER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, DEPLOYER_USER);
@@ -147,6 +151,7 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
     @Test
     public void testAdministrator() throws Exception {
         ModelControllerClient client = getClientForUser(ADMINISTRATOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.SUCCESS, ADMINISTRATOR_USER);
         checkStandardReads(client, null, null, ADMINISTRATOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
@@ -165,6 +170,7 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
     @Test
     public void testAuditor() throws Exception {
         ModelControllerClient client = getClientForUser(AUDITOR_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.SUCCESS, AUDITOR_USER);
         checkStandardReads(client, null, null, AUDITOR_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, AUDITOR_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, AUDITOR_USER);
@@ -184,6 +190,7 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
     @Test
     public void testSuperUser() throws Exception {
         ModelControllerClient client = getClientForUser(SUPERUSER_USER, isAllowLocalAuth(), masterClientConfig);
+        readWholeConfig(client, Outcome.SUCCESS, SUPERUSER_USER);
         checkStandardReads(client, null, null, SUPERUSER_USER);
         checkRootRead(client, null, null, Outcome.SUCCESS, SUPERUSER_USER);
         checkRootRead(client, MASTER, null, Outcome.SUCCESS, SUPERUSER_USER);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractStandardRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractStandardRolesTestCase.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.test.integration.domain.rbac;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEFAULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.ADMINISTRATOR_USER;
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.AUDITOR_USER;
@@ -31,7 +33,6 @@ import static org.jboss.as.test.integration.management.rbac.RbacUtil.MONITOR_USE
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.OPERATOR_USER;
 import static org.jboss.as.test.integration.management.rbac.RbacUtil.SUPERUSER_USER;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
@@ -164,7 +165,8 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, ADMINISTRATOR_USER);
         addDeployment2(client, Outcome.SUCCESS, ADMINISTRATOR_USER);
         addPath(client, Outcome.SUCCESS, ADMINISTRATOR_USER);
-        // no test of security domain remove; too lazy to add a domain just to prove we can remove
+        addSecurityDomain(client, "test1", Outcome.SUCCESS, ADMINISTRATOR_USER);
+        removeSecurityDomain(client, "test1", Outcome.SUCCESS, ADMINISTRATOR_USER);
     }
 
     @Test
@@ -203,13 +205,24 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, SUPERUSER_USER);
         addDeployment2(client, Outcome.SUCCESS, SUPERUSER_USER);
         addPath(client, Outcome.SUCCESS, SUPERUSER_USER);
-        // no test of security domain remove; too lazy to add a domain just to prove we can remove
+        addSecurityDomain(client, "test2", Outcome.SUCCESS, SUPERUSER_USER);
+        removeSecurityDomain(client, "test2", Outcome.SUCCESS, SUPERUSER_USER);
     }
 
-    private void removeSecurityDomain(ModelControllerClient client, Outcome expected, String... roles) throws IOException {
-        ModelNode op = createOpNode("profile=profile-a/subsystem=security/security-domain=other", REMOVE);
+    private void addSecurityDomain(ModelControllerClient client, String name, Outcome expected, String... roles) throws IOException {
+        ModelNode op = createOpNode("profile=profile-a/subsystem=security/security-domain=" + name, ADD);
+        op.get("cache-type").set(DEFAULT);
         configureRoles(op, roles);
         RbacUtil.executeOperation(client, op, expected);
     }
 
+    private void removeSecurityDomain(ModelControllerClient client, String name, Outcome expected, String... roles) throws IOException {
+        ModelNode op = createOpNode("profile=profile-a/subsystem=security/security-domain=" + name, REMOVE);
+        configureRoles(op, roles);
+        RbacUtil.executeOperation(client, op, expected);
+    }
+
+    private void removeSecurityDomain(ModelControllerClient client, Outcome expected, String... roles) throws IOException {
+        removeSecurityDomain(client, "other", expected, roles);
+    }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractStandardRolesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/AbstractStandardRolesTestCase.java
@@ -48,7 +48,7 @@ import org.junit.Test;
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase {
+public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase implements RbacDomainRolesTests {
 
 
     @After
@@ -82,6 +82,9 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         checkSecurityDomainRead(client, MASTER, MASTER_A, Outcome.HIDDEN, MONITOR_USER);
         checkSensitiveAttribute(client, null, null, false, MONITOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, MONITOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, MONITOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, MONITOR_USER);
         addDeployment2(client, Outcome.UNAUTHORIZED, MONITOR_USER);
@@ -102,6 +105,9 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         checkSecurityDomainRead(client, MASTER, MASTER_A, Outcome.HIDDEN, OPERATOR_USER);
         checkSensitiveAttribute(client, null, null, false, OPERATOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, OPERATOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, OPERATOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, OPERATOR_USER);
         addDeployment2(client, Outcome.UNAUTHORIZED, OPERATOR_USER);
@@ -122,6 +128,9 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         checkSecurityDomainRead(client, MASTER, MASTER_A, Outcome.HIDDEN, MAINTAINER_USER);
         checkSensitiveAttribute(client, null, null, false, MAINTAINER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, MAINTAINER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, MAINTAINER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, MAINTAINER_USER);
         addDeployment2(client, Outcome.SUCCESS, MAINTAINER_USER);
@@ -141,6 +150,9 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         checkSecurityDomainRead(client, MASTER, MASTER_A, Outcome.HIDDEN, DEPLOYER_USER);
         checkSensitiveAttribute(client, null, null, false, DEPLOYER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, false, DEPLOYER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, DEPLOYER_USER);
         addDeployment2(client, Outcome.SUCCESS, DEPLOYER_USER);
@@ -161,6 +173,9 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         checkSecurityDomainRead(client, MASTER, MASTER_A, Outcome.SUCCESS, ADMINISTRATOR_USER);
         checkSensitiveAttribute(client, null, null, true, ADMINISTRATOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, ADMINISTRATOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, ADMINISTRATOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, ADMINISTRATOR_USER);
         addDeployment2(client, Outcome.SUCCESS, ADMINISTRATOR_USER);
@@ -181,6 +196,9 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         checkSecurityDomainRead(client, MASTER, MASTER_A, Outcome.SUCCESS, AUDITOR_USER);
         checkSensitiveAttribute(client, null, null, true, AUDITOR_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, AUDITOR_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.UNAUTHORIZED, AUDITOR_USER);
         runGC(client, MASTER, MASTER_A, Outcome.UNAUTHORIZED, AUDITOR_USER);
         addDeployment2(client, Outcome.UNAUTHORIZED, AUDITOR_USER);
@@ -201,6 +219,9 @@ public abstract class AbstractStandardRolesTestCase extends AbstractRbacTestCase
         checkSecurityDomainRead(client, MASTER, MASTER_A, Outcome.SUCCESS, SUPERUSER_USER);
         checkSensitiveAttribute(client, null, null, true, SUPERUSER_USER);
         checkSensitiveAttribute(client, MASTER, MASTER_A, true, SUPERUSER_USER);
+
+        if (readOnly) return;
+
         runGC(client, MASTER, null, Outcome.SUCCESS, SUPERUSER_USER);
         runGC(client, MASTER, MASTER_A, Outcome.SUCCESS, SUPERUSER_USER);
         addDeployment2(client, Outcome.SUCCESS, SUPERUSER_USER);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RbacDomainRolesTests.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RbacDomainRolesTests.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.rbac;
+
+import java.io.IOException;
+
+/**
+ * @author Ladislav Thon <lthon@redhat.com>
+ */
+interface RbacDomainRolesTests {
+    void testMonitor() throws Exception;
+    void testOperator() throws Exception;
+    void testMaintainer() throws Exception;
+    void testDeployer() throws Exception;
+    void testAdministrator() throws Exception;
+    void testAuditor() throws Exception;
+    void testSuperUser() throws Exception;
+
+    void tearDown() throws IOException;
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RbacSoakTest.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/rbac/RbacSoakTest.java
@@ -1,0 +1,201 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.rbac;
+
+import static org.junit.Assert.fail;
+
+import java.util.Random;
+
+import org.jboss.as.controller.access.rbac.StandardRole;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.suites.FullRbacProviderTestSuite;
+import org.jboss.as.test.integration.management.rbac.UserRolesMappingServerSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Ladislav Thon <lthon@redhat.com>
+ */
+public class RbacSoakTest extends AbstractRbacTestCase {
+    private static final Logger log = Logger.getLogger(RbacSoakTest.class);
+
+    private static final int numClients = Integer.parseInt(System.getProperty("jboss.test.rbac.soak.clients"));
+    private static final int numIterations = Integer.parseInt(System.getProperty("jboss.test.rbac.soak.iterations"));
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = FullRbacProviderTestSuite.createSupport(RbacSoakTest.class.getSimpleName());
+        masterClientConfig = testSupport.getDomainMasterConfiguration();
+        DomainClient domainClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        UserRolesMappingServerSetupTask.StandardUsersSetup.INSTANCE.setup(domainClient);
+        AbstractServerGroupScopedRolesTestCase.setupRoles(domainClient);
+        RBACProviderServerGroupScopedRolesTestCase.ServerGroupRolesMappingSetup.INSTANCE.setup(domainClient);
+        AbstractHostScopedRolesTestCase.setupRoles(domainClient);
+        RBACProviderHostScopedRolesTestCase.HostRolesMappingSetup.INSTANCE.setup(domainClient);
+        deployDeployment1(domainClient);
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        DomainClient domainClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        try {
+            RBACProviderHostScopedRolesTestCase.HostRolesMappingSetup.INSTANCE.tearDown(domainClient);
+        } finally {
+            try {
+                AbstractHostScopedRolesTestCase.tearDownRoles(domainClient);
+            } finally {
+                try {
+                    RBACProviderServerGroupScopedRolesTestCase.ServerGroupRolesMappingSetup.INSTANCE.tearDown(domainClient);
+                } finally {
+                    try {
+                        AbstractServerGroupScopedRolesTestCase.tearDownRoles(domainClient);
+                    } finally {
+                        try {
+                            UserRolesMappingServerSetupTask.StandardUsersSetup.INSTANCE.tearDown(domainClient);
+                        } finally {
+                            try {
+                                removeDeployment1(domainClient);
+                            } finally {
+                                FullRbacProviderTestSuite.stopSupport();
+                                testSupport = null;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    protected void configureRoles(ModelNode op, String[] roles) {
+        // no-op. Role mapping is done based on the client's authenticated Subject
+    }
+
+    @Test
+    public void soakTest() {
+        log.info("Starting RBAC soak test: " + numClients + " concurrent clients, " + numIterations + " iterations each");
+
+        TestClient[] clients = new TestClient[numClients];
+        for (int i = 0; i < numClients; i++) {
+            TestClient client = new TestClient(i + 1, pickTestClientType(), pickRole());
+            client.start();
+            clients[i] = client;
+        }
+
+        int failures = 0;
+        for (TestClient client : clients) {
+            try {
+                client.join();
+            } catch (InterruptedException e) {
+            }
+            if (client.failed) {
+                failures++;
+            }
+        }
+
+        log.info("Finished RBAC soak test with " + failures + " clients failing");
+
+        if (failures > 0) {
+            fail("Got " + failures + " clients failing");
+        }
+    }
+
+    // test utils
+
+    private final Random random = new Random();
+
+    private TestClientType pickTestClientType() {
+        TestClientType[] allTypes = TestClientType.values();
+        int i = random.nextInt(allTypes.length);
+        return allTypes[i];
+    }
+
+    private StandardRole pickRole() {
+        StandardRole[] allRoles = StandardRole.values();
+        int i = random.nextInt(allRoles.length);
+        return allRoles[i];
+    }
+
+    private static enum TestClientType { STANDARD, SERVER_GROUP_SCOPED, HOST_SCOPED }
+
+    private static final class TestClient extends Thread {
+        private final String description;
+        private final TestClientType type;
+        private final StandardRole role;
+        private boolean failed = false;
+
+        private TestClient(int id, TestClientType type, StandardRole role) {
+            super("TestClient-" + id + " (" + type.toString().toLowerCase() + " " + role.toString().toLowerCase() + ")");
+            this.description = "TestClient-" + id + " (" + type.toString().toLowerCase() + " " + role.toString().toLowerCase() + ")";
+            this.type = type;
+            this.role = role;
+        }
+
+        @Override
+        public void run() {
+            log.info("Started " + description);
+            try {
+                for (int i = 0; i < numIterations; i++) {
+                    log.debug("Running iteration " + (i + 1));
+                    runTest();
+                }
+                log.info("Finished successfully " + description);
+            } catch (Throwable e) { // need to catch AssertionError
+                failed = true;
+                log.error("Failed " + description, e);
+            }
+        }
+
+        private void runTest() throws Exception {
+            RbacDomainRolesTests test;
+
+            switch (type) {
+                case STANDARD: test = new RBACProviderStandardRolesTestCase(); break;
+                case SERVER_GROUP_SCOPED: test = new RBACProviderServerGroupScopedRolesTestCase(); break;
+                case HOST_SCOPED: test = new RBACProviderHostScopedRolesTestCase(); break;
+                default: throw new AssertionError();
+            }
+
+            ((AbstractRbacTestCase) test).readOnly = true;
+
+            try {
+                switch (role) {
+                    case MONITOR: test.testMonitor(); break;
+                    case OPERATOR: test.testOperator(); break;
+                    case MAINTAINER: test.testMaintainer(); break;
+                    case DEPLOYER: test.testDeployer(); break;
+                    case ADMINISTRATOR: test.testAdministrator(); break;
+                    case AUDITOR: test.testAuditor(); break;
+                    case SUPERUSER: test.testSuperUser(); break;
+                    default: throw new AssertionError();
+                }
+            } finally {
+                test.tearDown();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Here's another bunch of tests for RBAC. Namely:
- tests for `read-whole-config` operations, that is `read-config-as-xml` and the non-published `describe`
- added few missing tests for removing security domains
- most notably, a soak test for RBAC (this is not enabled by default, only in a specific Maven profile called `rbac-soak`)
