### PR TITLE
[WFLY-2238] Add model version 2.0.0 transformers to logging.

### DIFF
--- a/legacy/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem11TestCase.java
+++ b/legacy/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem11TestCase.java
@@ -132,7 +132,7 @@ public class CmpKeyGeneratorSubsystem11TestCase extends CmpKeyGeneratorSubsystem
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-cmp:" + controllerVersion.getMavenGavVersion())
                 .configureReverseControllerCheck(createAdditionalInitialization(), null);
 

--- a/legacy/jaxr/src/test/java/org/jboss/as/jaxr/extension/JaxrSubsystemTestCase.java
+++ b/legacy/jaxr/src/test/java/org/jboss/as/jaxr/extension/JaxrSubsystemTestCase.java
@@ -93,7 +93,7 @@ public class JaxrSubsystemTestCase extends AbstractSubsystemBaseTest {
                 .setSubsystemXmlResource(subsystemXml);
 
         // Add legacy subsystems
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-jaxr:" + controllerVersion.getMavenGavVersion())
                 .setExtensionClassName("org.jboss.as.jaxr.extension.JAXRSubsystemExtension")
                 .configureReverseControllerCheck(createAdditionalInitialization(), null);
@@ -120,7 +120,7 @@ public class JaxrSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         // create builder for legacy subsystem version
         ModelVersion version_1_1_0 = ModelVersion.create(1, 1, 0);
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, version_1_1_0)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version_1_1_0)
                 .addMavenResourceURL("org.jboss.as:jboss-as-jaxr:" + controllerVersion.getMavenGavVersion())
                 .setExtensionClassName("org.jboss.as.jaxr.extension.JAXRSubsystemExtension")
                 .configureReverseControllerCheck(createAdditionalInitialization(), null);

--- a/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
+++ b/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
@@ -154,7 +154,7 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXml(subsystemXml);
 
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), ModelTestControllerVersion.V7_1_2_FINAL, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, ModelTestControllerVersion.V7_1_2_FINAL, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-web:7.1.2.Final")
                 .skipReverseControllerCheck();
 
@@ -186,7 +186,7 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
 
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-web:" + controllerVersion.getMavenGavVersion())
                 .setExtensionClassName("org.jboss.as.web.WebExtension")
                 .configureReverseControllerCheck(createAdditionalInitialization(), null);
@@ -273,7 +273,7 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXml(subsystemXml);
 
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-web:" + controllerVersion.getMavenGavVersion())
                 .setExtensionClassName("org.jboss.as.web.WebExtension")
                 .configureReverseControllerCheck(createAdditionalInitialization(), null);
@@ -405,7 +405,7 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXml(subsystemXml);
 
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-web:" + controllerVersion.getMavenGavVersion())
                 .setExtensionClassName("org.jboss.as.web.WebExtension")
                 .configureReverseControllerCheck(createAdditionalInitialization(), null);
@@ -428,7 +428,7 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
         ModelVersion modelVersion = ModelVersion.create(1, 2, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-web:" + controllerVersion.getMavenGavVersion())
                 .setExtensionClassName("org.jboss.as.web.WebExtension")
                 .configureReverseControllerCheck(createAdditionalInitialization(), null);

--- a/logging/pom.xml
+++ b/logging/pom.xml
@@ -129,6 +129,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>log4j-jboss-logmanager</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>

--- a/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
@@ -46,7 +46,6 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinition;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
@@ -60,7 +59,7 @@ import org.jboss.dmr.ModelType;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-abstract class AbstractHandlerDefinition extends SimpleResourceDefinition {
+abstract class AbstractHandlerDefinition extends TransformerResourceDefinition {
 
     public static final String UPDATE_OPERATION_NAME = "update-properties";
     public static final String CHANGE_LEVEL_OPERATION_NAME = "change-log-level";
@@ -214,6 +213,44 @@ abstract class AbstractHandlerDefinition extends SimpleResourceDefinition {
                 .build();
         registration.registerOperationHandler(updateProperties, new HandlerOperations.HandlerUpdateOperationStepHandler(propertySorter, writableAttributes));
     }
+
+    @Override
+    public void registerTransformers(final KnownModelVersion modelVersion,
+                                                final ResourceTransformationDescriptionBuilder rootResourceBuilder,
+                                                final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        if (modelVersion.hasTransformers()) {
+            final PathElement pathElement = getPathElement();
+            final ResourceTransformationDescriptionBuilder resourceBuilder = rootResourceBuilder.addChildResource(pathElement);
+            final ResourceTransformationDescriptionBuilder loggingProfileResourceBuilder = loggingProfileBuilder.addChildResource(pathElement);
+            switch (modelVersion) {
+                case VERSION_1_2_0:
+                case VERSION_1_3_0: {
+                    resourceBuilder
+                            .getAttributeBuilder()
+                            .setDiscard(DiscardAttributeChecker.UNDEFINED, NAMED_FORMATTER)
+                            .addRejectCheck(RejectAttributeChecker.DEFINED, NAMED_FORMATTER)
+                            .end();
+                    loggingProfileResourceBuilder
+                            .getAttributeBuilder()
+                            .setDiscard(DiscardAttributeChecker.UNDEFINED, NAMED_FORMATTER)
+                            .addRejectCheck(RejectAttributeChecker.DEFINED, NAMED_FORMATTER)
+                            .end();
+                }
+            }
+            registerResourceTransformers(modelVersion, resourceBuilder, loggingProfileResourceBuilder);
+        }
+    }
+
+    /**
+     * Register the transformers for the resource.
+     *
+     * @param modelVersion          the model version we're registering
+     * @param resourceBuilder       the builder for the resource
+     * @param loggingProfileBuilder the builder for the logging profile
+     */
+    protected abstract void registerResourceTransformers(KnownModelVersion modelVersion,
+                                                         ResourceTransformationDescriptionBuilder resourceBuilder,
+                                                         ResourceTransformationDescriptionBuilder loggingProfileBuilder);
 
     /**
      * Register the transformers for the handler.

--- a/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
@@ -221,8 +221,32 @@ abstract class AbstractHandlerDefinition extends TransformerResourceDefinition {
         if (modelVersion.hasTransformers()) {
             final PathElement pathElement = getPathElement();
             final ResourceTransformationDescriptionBuilder resourceBuilder = rootResourceBuilder.addChildResource(pathElement);
-            final ResourceTransformationDescriptionBuilder loggingProfileResourceBuilder = loggingProfileBuilder.addChildResource(pathElement);
+            ResourceTransformationDescriptionBuilder loggingProfileResourceBuilder = null;
             switch (modelVersion) {
+                case VERSION_1_1_0:
+                    resourceBuilder
+                            .getAttributeBuilder()
+                                    // discard level="ALL"
+                            .setDiscard(Transformers1_1_0.LEVEL_ALL_DISCARD_CHECKER, LEVEL)
+                                    // Strip console color from format patterns
+                            .setValueConverter(Transformers1_1_0.CONSOLE_COLOR_CONVERTER, FORMATTER)
+                                    // Discard undefined filter-spec, else convert the value and rename to "filter"
+                            .setDiscard(DiscardAttributeChecker.UNDEFINED, FILTER_SPEC)
+                            .setValueConverter(Transformers1_1_0.FILTER_SPEC_CONVERTER, FILTER_SPEC)
+                            .addRename(FILTER_SPEC, FILTER.getName())
+                                    // Discard 'enabled' if undefined or true, else reject
+                            .setDiscard(Transformers1_1_0.DISCARD_ENABLED, ENABLED)
+                            .addRejectCheck(RejectAttributeChecker.DEFINED, ENABLED)
+                                    // Standard expression rejection
+                            .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, DEFAULT_ATTRIBUTES)
+                            .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, LEGACY_ATTRIBUTES)
+                            .end()
+                            .addOperationTransformationOverride(ADD)
+                            .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
+                            .inheritResourceAttributeDefinitions()
+                            .end()
+                                    // Discard 'name' as legacy slaves didn't store it in resources
+                            .setCustomResourceTransformer(new LoggingResourceTransformer(NAME));
                 case VERSION_1_2_0:
                 case VERSION_1_3_0: {
                     resourceBuilder
@@ -230,11 +254,14 @@ abstract class AbstractHandlerDefinition extends TransformerResourceDefinition {
                             .setDiscard(DiscardAttributeChecker.UNDEFINED, NAMED_FORMATTER)
                             .addRejectCheck(RejectAttributeChecker.DEFINED, NAMED_FORMATTER)
                             .end();
-                    loggingProfileResourceBuilder
-                            .getAttributeBuilder()
-                            .setDiscard(DiscardAttributeChecker.UNDEFINED, NAMED_FORMATTER)
-                            .addRejectCheck(RejectAttributeChecker.DEFINED, NAMED_FORMATTER)
-                            .end();
+                    if (loggingProfileBuilder != null) {
+                        loggingProfileResourceBuilder = loggingProfileBuilder.addChildResource(pathElement);
+                        loggingProfileResourceBuilder
+                                .getAttributeBuilder()
+                                .setDiscard(DiscardAttributeChecker.UNDEFINED, NAMED_FORMATTER)
+                                .addRejectCheck(RejectAttributeChecker.DEFINED, NAMED_FORMATTER)
+                                .end();
+                    }
                 }
             }
             registerResourceTransformers(modelVersion, resourceBuilder, loggingProfileResourceBuilder);
@@ -251,44 +278,4 @@ abstract class AbstractHandlerDefinition extends TransformerResourceDefinition {
     protected abstract void registerResourceTransformers(KnownModelVersion modelVersion,
                                                          ResourceTransformationDescriptionBuilder resourceBuilder,
                                                          ResourceTransformationDescriptionBuilder loggingProfileBuilder);
-
-    /**
-     * Register the transformers for the handler.
-     * <p/>
-     * By default the {@link #DEFAULT_ATTRIBUTES default attributes} and {@link #LEGACY_ATTRIBUTES legacy attributes}
-     * are added to the reject transformer.
-     *
-     * @param handlerBuilder the default handler builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder registerTransformers(final ResourceTransformationDescriptionBuilder handlerBuilder) {
-        // Add default operation transformers
-        return handlerBuilder
-                .getAttributeBuilder()
-                        // discard level="ALL"
-                .setDiscard(Transformers1_1_0.LEVEL_ALL_DISCARD_CHECKER, LEVEL)
-                        // Strip console color from format patterns
-                .setValueConverter(Transformers1_1_0.CONSOLE_COLOR_CONVERTER, FORMATTER)
-                        // Discard named formatters
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, NAMED_FORMATTER)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, NAMED_FORMATTER)
-                        // Discard undefined filter-spec, else convert the value and rename to "filter"
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, FILTER_SPEC)
-                .setValueConverter(Transformers1_1_0.FILTER_SPEC_CONVERTER, FILTER_SPEC)
-                .addRename(FILTER_SPEC, FILTER.getName())
-                        // Discard 'enabled' if undefined or true, else reject
-                .setDiscard(Transformers1_1_0.DISCARD_ENABLED, ENABLED)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, ENABLED)
-                        // Standard expression rejection
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, DEFAULT_ATTRIBUTES)
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, LEGACY_ATTRIBUTES)
-                .end()
-                .addOperationTransformationOverride(ADD)
-                .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
-                .inheritResourceAttributeDefinitions()
-                .end()
-                        // Discard 'name' as legacy slaves didn't store it in resources
-                .setCustomResourceTransformer(new LoggingResourceTransformer(NAME));
-    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
@@ -127,34 +127,19 @@ class AsyncHandlerResourceDefinition extends AbstractHandlerDefinition {
 
     @Override
     protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-
-    }
-
-    /**
-     * Add the transformers for the async handler.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        // Register the logger resource
-        final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(ASYNC_HANDLER_PATH)
-                .getAttributeBuilder()
-                    .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, QUEUE_LENGTH, OVERFLOW_ACTION)
-                    .end()
-                .addOperationTransformationOverride(ADD_HANDLER_OPERATION_NAME)
-                    .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
-                    .end()
-                .addOperationTransformationOverride(REMOVE_HANDLER_OPERATION_NAME)
-                    .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
-                    .end();
-
-        // Reject logging profile resources
-        loggingProfileBuilder.rejectChildResource(ASYNC_HANDLER_PATH);
-
-        return registerTransformers(child);
+        switch (modelVersion) {
+            case VERSION_1_1_0: {
+                resourceBuilder
+                        .getAttributeBuilder()
+                            .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, QUEUE_LENGTH, OVERFLOW_ACTION)
+                            .end()
+                        .addOperationTransformationOverride(ADD_HANDLER_OPERATION_NAME)
+                            .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
+                            .end()
+                        .addOperationTransformationOverride(REMOVE_HANDLER_OPERATION_NAME)
+                            .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
+                            .end();
+            }
+        }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AsyncHandlerResourceDefinition.java
@@ -125,6 +125,11 @@ class AsyncHandlerResourceDefinition extends AbstractHandlerDefinition {
         registration.registerOperationHandler(REMOVE_HANDLER, HandlerOperations.REMOVE_SUBHANDLER);
     }
 
+    @Override
+    protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+
+    }
+
     /**
      * Add the transformers for the async handler.
      *

--- a/logging/src/main/java/org/jboss/as/logging/ConsoleHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/ConsoleHandlerResourceDefinition.java
@@ -57,31 +57,16 @@ class ConsoleHandlerResourceDefinition extends AbstractHandlerDefinition {
                 (includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
     }
 
-    /**
-     * Add the transformers for the console handler.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        // Register the logger resource
-        final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(CONSOLE_HANDLER_PATH)
-                .getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, TARGET)
-                .end()
-                .discardOperations();
-
-        // Reject logging profile resources
-        loggingProfileBuilder.rejectChildResource(CONSOLE_HANDLER_PATH);
-
-        return registerTransformers(child);
-    }
-
     @Override
     protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-
+        switch (modelVersion) {
+            case VERSION_1_1_0: {
+                resourceBuilder
+                        .getAttributeBuilder()
+                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, TARGET)
+                        .end()
+                        .discardOperations();
+            }
+        }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/ConsoleHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/ConsoleHandlerResourceDefinition.java
@@ -79,4 +79,9 @@ class ConsoleHandlerResourceDefinition extends AbstractHandlerDefinition {
 
         return registerTransformers(child);
     }
+
+    @Override
+    protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+
+    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
@@ -83,30 +83,15 @@ class CustomHandlerResourceDefinition extends AbstractHandlerDefinition {
                 (includeLegacyAttributes ? Logging.join(WRITABLE_ATTRIBUTES, LEGACY_ATTRIBUTES) : WRITABLE_ATTRIBUTES));
     }
 
-    /**
-     * Add the transformers for the custom handler.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        // Register the logger resource
-        final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(CUSTOM_HANDLE_PATH)
-                .getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, PROPERTIES)
-                .end();
-
-        // Reject logging profile resources
-        loggingProfileBuilder.rejectChildResource(CUSTOM_HANDLE_PATH);
-
-        return registerTransformers(child);
-    }
-
     @Override
     protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-
+        switch (modelVersion) {
+            case VERSION_1_1_0: {
+                resourceBuilder
+                        .getAttributeBuilder()
+                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, PROPERTIES)
+                        .end();
+            }
+        }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
@@ -104,4 +104,9 @@ class CustomHandlerResourceDefinition extends AbstractHandlerDefinition {
 
         return registerTransformers(child);
     }
+
+    @Override
+    protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+
+    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/FileHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/FileHandlerResourceDefinition.java
@@ -70,4 +70,9 @@ class FileHandlerResourceDefinition extends AbstractFileHandlerDefinition {
 
         return registerTransformers(child);
     }
+
+    @Override
+    protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+
+    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/FileHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/FileHandlerResourceDefinition.java
@@ -49,30 +49,15 @@ class FileHandlerResourceDefinition extends AbstractFileHandlerDefinition {
                 includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
     }
 
-    /**
-     * Add the transformers for the file handler.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        // Register the logger resource
-        final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(FILE_HANDLER_PATH)
-                .getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE)
-                .end();
-
-        // Reject logging profile resources
-        loggingProfileBuilder.rejectChildResource(FILE_HANDLER_PATH);
-
-        return registerTransformers(child);
-    }
-
     @Override
     protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-
+        switch (modelVersion) {
+            case VERSION_1_1_0: {
+                resourceBuilder
+                        .getAttributeBuilder()
+                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE)
+                        .end();
+            }
+        }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
+++ b/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
@@ -1,0 +1,41 @@
+package org.jboss.as.logging;
+
+import org.jboss.as.controller.ModelVersion;
+
+/**
+ * Known model versions for the logging extension.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+enum KnownModelVersion {
+    VERSION_1_1_0(ModelVersion.create(1, 1, 0), true),
+    VERSION_1_2_0(ModelVersion.create(1, 2, 0), true),
+    VERSION_1_3_0(ModelVersion.create(1, 3, 0), true),
+    VERSION_2_0_0(ModelVersion.create(2, 0, 0), false),
+    ;
+    private final ModelVersion modelVersion;
+    private final boolean hasTransformers;
+
+    private KnownModelVersion(final ModelVersion modelVersion, final boolean hasTransformers) {
+        this.modelVersion = modelVersion;
+        this.hasTransformers = hasTransformers;
+    }
+
+    /**
+     * Returns {@code true} if transformers should be registered against the model version.
+     *
+     * @return {@code true} if transformers should be registered, otherwise {@code false}
+     */
+    public boolean hasTransformers() {
+        return hasTransformers;
+    }
+
+    /**
+     * The model version.
+     *
+     * @return the model version
+     */
+    public ModelVersion getModelVersion() {
+        return modelVersion;
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/LoggerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggerResourceDefinition.java
@@ -42,7 +42,6 @@ import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
@@ -59,7 +58,7 @@ import org.jboss.dmr.ModelType;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class LoggerResourceDefinition extends SimpleResourceDefinition {
+public class LoggerResourceDefinition extends TransformerResourceDefinition {
 
     public static final String CHANGE_LEVEL_OPERATION_NAME = "change-log-level";
     public static final String LEGACY_ADD_HANDLER_OPERATION_NAME = "assign-handler";
@@ -207,5 +206,24 @@ public class LoggerResourceDefinition extends SimpleResourceDefinition {
                     .inheritResourceAttributeDefinitions()
                     .end()
                 .setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY));
+    }
+
+    @Override
+    public void registerTransformers(final KnownModelVersion modelVersion,
+                                     final ResourceTransformationDescriptionBuilder rootResourceBuilder,
+                                     final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        if (modelVersion.hasTransformers()) {
+            final PathElement pathElement = getPathElement();
+            final ResourceTransformationDescriptionBuilder resourceBuilder = rootResourceBuilder.addChildResource(pathElement);
+            final ResourceTransformationDescriptionBuilder loggingProfileResourceBuilder = loggingProfileBuilder.addChildResource(pathElement);
+            switch (modelVersion) {
+                case VERSION_1_2_0:
+                case VERSION_1_3_0: {
+                    resourceBuilder.setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY));
+                    loggingProfileResourceBuilder.setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY));
+                    break;
+                }
+            }
+        }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggerResourceDefinition.java
@@ -167,47 +167,6 @@ public class LoggerResourceDefinition extends TransformerResourceDefinition {
         return accessConstraints;
     }
 
-    /**
-     * Add the transformers for the logger.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-
-        // Reject logging profile resources
-        loggingProfileBuilder.rejectChildResource(LOGGER_PATH);
-
-        // Register the logger resource
-        return subsystemBuilder.addChildResource(LOGGER_PATH)
-                .getAttributeBuilder()
-                    // discard level="ALL"
-                    .setDiscard(Transformers1_1_0.LEVEL_ALL_DISCARD_CHECKER, LEVEL)
-                    .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, EXPRESSION_ATTRIBUTES)
-                    // Discard undefined filter-spec, else convert the value and rename to "filter"
-                    .setDiscard(DiscardAttributeChecker.UNDEFINED, FILTER_SPEC)
-                    .setValueConverter(Transformers1_1_0.FILTER_SPEC_CONVERTER, FILTER_SPEC)
-                    .addRename(FILTER_SPEC, FILTER.getName())
-                    .end()
-                // Register operation transformers
-                .addOperationTransformationOverride(ADD)
-                    .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
-                    .inheritResourceAttributeDefinitions()
-                    .end()
-                .addOperationTransformationOverride(ADD_HANDLER_OPERATION_NAME)
-                    .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
-                    .inheritResourceAttributeDefinitions()
-                    .end()
-                .addOperationTransformationOverride(REMOVE_HANDLER_OPERATION_NAME)
-                    .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
-                    .inheritResourceAttributeDefinitions()
-                    .end()
-                .setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY));
-    }
-
     @Override
     public void registerTransformers(final KnownModelVersion modelVersion,
                                      final ResourceTransformationDescriptionBuilder rootResourceBuilder,
@@ -215,13 +174,39 @@ public class LoggerResourceDefinition extends TransformerResourceDefinition {
         if (modelVersion.hasTransformers()) {
             final PathElement pathElement = getPathElement();
             final ResourceTransformationDescriptionBuilder resourceBuilder = rootResourceBuilder.addChildResource(pathElement);
-            final ResourceTransformationDescriptionBuilder loggingProfileResourceBuilder = loggingProfileBuilder.addChildResource(pathElement);
             switch (modelVersion) {
+                case VERSION_1_1_0: {
+                    resourceBuilder
+                         .getAttributeBuilder()
+                            // discard level="ALL"
+                            .setDiscard(Transformers1_1_0.LEVEL_ALL_DISCARD_CHECKER, LEVEL)
+                            .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, EXPRESSION_ATTRIBUTES)
+                                    // Discard undefined filter-spec, else convert the value and rename to "filter"
+                            .setDiscard(DiscardAttributeChecker.UNDEFINED, FILTER_SPEC)
+                            .setValueConverter(Transformers1_1_0.FILTER_SPEC_CONVERTER, FILTER_SPEC)
+                            .addRename(FILTER_SPEC, FILTER.getName())
+                            .end()
+                                    // Register operation transformers
+                            .addOperationTransformationOverride(ADD)
+                            .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
+                            .inheritResourceAttributeDefinitions()
+                            .end()
+                            .addOperationTransformationOverride(ADD_HANDLER_OPERATION_NAME)
+                            .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
+                            .inheritResourceAttributeDefinitions()
+                            .end()
+                            .addOperationTransformationOverride(REMOVE_HANDLER_OPERATION_NAME)
+                            .setCustomOperationTransformer(LoggingOperationTransformer.INSTANCE)
+                            .inheritResourceAttributeDefinitions()
+                            .end();
+                }
                 case VERSION_1_2_0:
                 case VERSION_1_3_0: {
                     resourceBuilder.setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY));
-                    loggingProfileResourceBuilder.setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY));
-                    break;
+                    if (loggingProfileBuilder != null) {
+                        final ResourceTransformationDescriptionBuilder loggingProfileResourceBuilder = loggingProfileBuilder.addChildResource(pathElement);
+                        loggingProfileResourceBuilder.setCustomResourceTransformer(new LoggingResourceTransformer(CATEGORY));
+                    }
                 }
             }
         }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
@@ -122,7 +122,6 @@ public class LoggingRootResource extends SimpleResourceDefinition {
         super.registerOperations(resourceRegistration);
         // Only register on server
         if (pathManager != null) {
-            // TODO WFLY-1807 add 2.0.0 transformers for new operations
             resourceRegistration.registerOperationHandler(LIST_LOG_FILES, new ListLogFilesOperation(pathManager));
             resourceRegistration.registerOperationHandler(READ_LOG_FILE, new ReadLogFileOperation(pathManager));
         }

--- a/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
@@ -35,7 +35,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.logging.LoggingOperations.LoggingWriteAttributeHandler;
@@ -49,7 +48,7 @@ import org.jboss.logmanager.formatters.PatternFormatter;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-public class PatternFormatterResourceDefinition extends SimpleResourceDefinition {
+public class PatternFormatterResourceDefinition extends TransformerResourceDefinition {
 
     static final String COLOR_MAP_VALIDATION_PATTERN = "^((severe|fatal|error|warn|warning|info|debug|trace|config|fine|finer|finest|):(black|green|red|yellow|blue|magenta|cyan|white|brightblack|brightred|brightgreen|brightblue|brightyellow|brightmagenta|brightcyan|brightwhite|)(,(?!$)|$))*$";
 
@@ -176,18 +175,14 @@ public class PatternFormatterResourceDefinition extends SimpleResourceDefinition
         }
     }
 
-    /**
-     * Add the transformers for the logger.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        subsystemBuilder.rejectChildResource(PATTERN_FORMATTER_PATH);
-        loggingProfileBuilder.rejectChildResource(PATTERN_FORMATTER_PATH);
-        return subsystemBuilder;
+    @Override
+    public void registerTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        switch (modelVersion) {
+            case VERSION_1_1_0:
+            case VERSION_1_2_0:
+            case VERSION_1_3_0:
+                resourceBuilder.rejectChildResource(PATTERN_FORMATTER_PATH);
+                loggingProfileBuilder.rejectChildResource(PATTERN_FORMATTER_PATH);
+        }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PatternFormatterResourceDefinition.java
@@ -182,7 +182,9 @@ public class PatternFormatterResourceDefinition extends TransformerResourceDefin
             case VERSION_1_2_0:
             case VERSION_1_3_0:
                 resourceBuilder.rejectChildResource(PATTERN_FORMATTER_PATH);
-                loggingProfileBuilder.rejectChildResource(PATTERN_FORMATTER_PATH);
+                if (loggingProfileBuilder != null) {
+                    loggingProfileBuilder.rejectChildResource(PATTERN_FORMATTER_PATH);
+                }
         }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/PeriodicHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PeriodicHandlerResourceDefinition.java
@@ -79,4 +79,8 @@ class PeriodicHandlerResourceDefinition extends AbstractFileHandlerDefinition {
         return registerTransformers(child);
     }
 
+    @Override
+    protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+
+    }
 }

--- a/logging/src/main/java/org/jboss/as/logging/PeriodicHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PeriodicHandlerResourceDefinition.java
@@ -57,30 +57,15 @@ class PeriodicHandlerResourceDefinition extends AbstractFileHandlerDefinition {
                 (includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
     }
 
-    /**
-     * Add the transformers for the periodic file handler.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        // Register the logger resource
-        final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(PERIODIC_HANDLER_PATH)
-                .getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE, SUFFIX)
-                .end();
-
-        // Reject logging profile resources
-        loggingProfileBuilder.rejectChildResource(PERIODIC_HANDLER_PATH);
-
-        return registerTransformers(child);
-    }
-
     @Override
     protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-
+        switch (modelVersion) {
+            case VERSION_1_1_0: {
+                resourceBuilder
+                        .getAttributeBuilder()
+                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE, SUFFIX)
+                        .end();
+            }
+        }
     }
 }

--- a/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
@@ -75,7 +75,26 @@ class SizeRotatingHandlerResourceDefinition extends AbstractFileHandlerDefinitio
 
     public SizeRotatingHandlerResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean includeLegacyAttributes) {
         super(SIZE_ROTATING_HANDLER_PATH, SizeRotatingFileHandler.class, resolvePathHandler,
-                (includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
+                     (includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
+    }
+
+    @Override
+    protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        switch (modelVersion) {
+            case VERSION_1_2_0: {
+                resourceBuilder
+                        .getAttributeBuilder()
+                        .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
+                        .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
+                        .end();
+                loggingProfileBuilder
+                        .getAttributeBuilder()
+                        .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
+                        .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
+                        .end();
+            }
+        }
+
     }
 
     /**
@@ -100,23 +119,6 @@ class SizeRotatingHandlerResourceDefinition extends AbstractFileHandlerDefinitio
         loggingProfileBuilder.rejectChildResource(SIZE_ROTATING_HANDLER_PATH);
 
         return registerTransformers(child);
-    }
-
-    /**
-     * Add the transformers for the size rotating file handler.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers_1_2(final ResourceTransformationDescriptionBuilder subsystemBuilder) {
-        // Register the logger resource
-        final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(SIZE_ROTATING_HANDLER_PATH)
-                .getAttributeBuilder()
-                .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
-                .end();
-        return child;
     }
 
 }

--- a/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/SizeRotatingHandlerResourceDefinition.java
@@ -75,50 +75,34 @@ class SizeRotatingHandlerResourceDefinition extends AbstractFileHandlerDefinitio
 
     public SizeRotatingHandlerResourceDefinition(final ResolvePathHandler resolvePathHandler, final boolean includeLegacyAttributes) {
         super(SIZE_ROTATING_HANDLER_PATH, SizeRotatingFileHandler.class, resolvePathHandler,
-                     (includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
+                (includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
     }
 
     @Override
     protected void registerResourceTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder resourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
         switch (modelVersion) {
+            case VERSION_1_1_0: {
+                resourceBuilder
+                        .getAttributeBuilder()
+                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE, MAX_BACKUP_INDEX, ROTATE_SIZE)
+                        .end();
+            }
             case VERSION_1_2_0: {
                 resourceBuilder
                         .getAttributeBuilder()
                         .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
                         .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
                         .end();
-                loggingProfileBuilder
-                        .getAttributeBuilder()
-                        .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
-                        .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
-                        .end();
+                if (loggingProfileBuilder != null) {
+                    loggingProfileBuilder
+                            .getAttributeBuilder()
+                            .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
+                            .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
+                            .end();
+                }
             }
         }
 
-    }
-
-    /**
-     * Add the transformers for the size rotating file handler.
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static ResourceTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                    final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        // Register the logger resource
-        final ResourceTransformationDescriptionBuilder child = subsystemBuilder.addChildResource(SIZE_ROTATING_HANDLER_PATH)
-                .getAttributeBuilder()
-                .setDiscard(new DiscardAttributeValueChecker(new ModelNode(false)), ROTATE_ON_BOOT)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, ROTATE_ON_BOOT)
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, AUTOFLUSH, APPEND, FILE, MAX_BACKUP_INDEX, ROTATE_SIZE)
-                .end();
-
-        // Reject logging profile resources
-        loggingProfileBuilder.rejectChildResource(SIZE_ROTATING_HANDLER_PATH);
-
-        return registerTransformers(child);
     }
 
 }

--- a/logging/src/main/java/org/jboss/as/logging/SyslogHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/SyslogHandlerResourceDefinition.java
@@ -36,11 +36,9 @@ import org.jboss.as.controller.DefaultAttributeMarshaller;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.transform.description.RejectTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.logging.HandlerOperations.HandlerAddOperationStepHandler;
 import org.jboss.as.logging.HandlerOperations.LogHandlerWriteAttributeHandler;
@@ -55,7 +53,7 @@ import org.jboss.logmanager.handlers.SyslogHandler.SyslogType;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-class SyslogHandlerResourceDefinition extends SimpleResourceDefinition {
+class SyslogHandlerResourceDefinition extends TransformerResourceDefinition {
 
     static final String SYSLOG_HANDLER = "syslog-handler";
     static final PathElement SYSLOG_HANDLER_PATH = PathElement.pathElement(SYSLOG_HANDLER);
@@ -149,19 +147,15 @@ class SyslogHandlerResourceDefinition extends SimpleResourceDefinition {
         }
     }
 
-    /**
-     * Add the transformers for the custom handler.
-     *
-     *
-     * @param subsystemBuilder      the default subsystem builder
-     * @param loggingProfileBuilder the logging profile builder
-     *
-     * @return the builder created for the resource
-     */
-    static RejectTransformationDescriptionBuilder addTransformers(final ResourceTransformationDescriptionBuilder subsystemBuilder,
-                                                                  final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
-        loggingProfileBuilder.rejectChildResource(SYSLOG_HANDLER_PATH);
-        return subsystemBuilder.rejectChildResource(SYSLOG_HANDLER_PATH);
+    @Override
+    public void registerTransformers(final KnownModelVersion modelVersion, final ResourceTransformationDescriptionBuilder rootResourceBuilder, final ResourceTransformationDescriptionBuilder loggingProfileBuilder) {
+        if (modelVersion.hasTransformers()) {
+            switch (modelVersion) {
+                case VERSION_1_1_0:
+                    final PathElement pathElement = getPathElement();
+                    rootResourceBuilder.rejectChildResource(pathElement);
+            }
+        }
     }
 
     static enum FacilityAttribute {

--- a/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
@@ -1,0 +1,39 @@
+package org.jboss.as.logging;
+
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.registry.OperationEntry.Flag;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+
+/**
+ * Adds the ability to register transformers in a resource definition.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class TransformerResourceDefinition extends SimpleResourceDefinition {
+
+    protected TransformerResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver) {
+        super(pathElement, descriptionResolver);
+    }
+
+    protected TransformerResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver, final OperationStepHandler addHandler, final OperationStepHandler removeHandler) {
+        super(pathElement, descriptionResolver, addHandler, removeHandler);
+    }
+
+    protected TransformerResourceDefinition(final PathElement pathElement, final ResourceDescriptionResolver descriptionResolver, final OperationStepHandler addHandler, final OperationStepHandler removeHandler, final Flag addRestartLevel, final Flag removeRestartLevel) {
+        super(pathElement, descriptionResolver, addHandler, removeHandler, addRestartLevel, removeRestartLevel);
+    }
+
+    /**
+     * Register the transformers for the resource.
+     *
+     * @param modelVersion          the model version we're registering
+     * @param rootResourceBuilder   the builder for the root resource
+     * @param loggingProfileBuilder the builder for the logging profile
+     */
+    public abstract void registerTransformers(KnownModelVersion modelVersion,
+                                              ResourceTransformationDescriptionBuilder rootResourceBuilder,
+                                              ResourceTransformationDescriptionBuilder loggingProfileBuilder);
+}

--- a/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/TransformerResourceDefinition.java
@@ -31,7 +31,7 @@ abstract class TransformerResourceDefinition extends SimpleResourceDefinition {
      *
      * @param modelVersion          the model version we're registering
      * @param rootResourceBuilder   the builder for the root resource
-     * @param loggingProfileBuilder the builder for the logging profile
+     * @param loggingProfileBuilder the builder for the logging profile, {@code null} if the profile was rejected
      */
     public abstract void registerTransformers(KnownModelVersion modelVersion,
                                               ResourceTransformationDescriptionBuilder rootResourceBuilder,

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.client.helpers.ClientConstants;
 import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
-import org.jboss.as.controller.transform.description.RejectAttributeChecker.DefaultRejectAttributeChecker;
 import org.jboss.as.logging.logmanager.ConfigurationPersistence;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.RejectExpressionsConfig;
@@ -119,7 +118,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
                 .setSubsystemXml(subsystemXml);
 
         // Create the legacy kernel
-        builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-logging:" + controllerVersion.getMavenGavVersion())
                 //TODO storing the model triggers the weirdness mentioned in SubsystemTestDelegate.LegacyKernelServiceInitializerImpl.install()
                 //which is strange since it should be loading it all from the current jboss modules
@@ -140,7 +139,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         final KernelServicesBuilder builder = createKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance());
 
         // Create the legacy kernel
-        builder.createLegacyKernelServicesBuilder(LoggingTestEnvironment.getManagementInstance(), controllerVersion, modelVersion)
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-logging:" + controllerVersion.getMavenGavVersion())
                 //TODO storing the model triggers the weirdness mentioned in SubsystemTestDelegate.LegacyKernelServiceInitializerImpl.install()
                 //which is strange since it should be loading it all from the current jboss modules

--- a/logging/src/test/java/org/jboss/as/logging/LoggingTestEnvironment.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingTestEnvironment.java
@@ -23,6 +23,10 @@
 package org.jboss.as.logging;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
@@ -33,8 +37,9 @@ import org.jboss.as.subsystem.test.ControllerInitializer;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-class LoggingTestEnvironment extends AdditionalInitialization {
+class LoggingTestEnvironment extends AdditionalInitialization implements Serializable {
 
+    private static final long serialVersionUID = 1L;
     private static final LoggingTestEnvironment INSTANCE;
     private static final LoggingTestEnvironment MANAGEMENT_INSTANCE;
 
@@ -80,11 +85,21 @@ class LoggingTestEnvironment extends AdditionalInitialization {
 
     @Override
     protected ControllerInitializer createControllerInitializer() {
-        return new ControllerInitializer() {
-            {
-                addPath("jboss.server.log.dir", logDir.getAbsolutePath(), null);
-                addPath("jboss.server.config.dir", configDir.getAbsolutePath(), null);
-            }
-        };
+        return new LoggingInitializer();
+    }
+
+    private void writeObject(final ObjectOutputStream out) throws IOException {
+        out.defaultWriteObject();
+    }
+
+    private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+        in.defaultReadObject();
+    }
+
+    class LoggingInitializer extends ControllerInitializer {
+        public LoggingInitializer() {
+            addPath("jboss.server.log.dir", logDir.getAbsolutePath(), null);
+            addPath("jboss.server.config.dir", configDir.getAbsolutePath(), null);
+        }
     }
 }

--- a/logging/src/test/resources/expressions.xml
+++ b/logging/src/test/resources/expressions.xml
@@ -59,7 +59,7 @@
         <suffix value="${test.file.suffix:.yyyy-MM-dd}"/>
     </periodic-rotating-file-handler>
 
-    <size-rotating-file-handler name="sizeLogger" autoflush="${test.autoflush:true}">
+    <size-rotating-file-handler name="sizeLogger" autoflush="${test.autoflush:true}" rotate-on-boot="${test.rotate-on-boot:false}">
         <level name="${test.file.level:INFO}"/>
         <encoding value="${test.encoding:UTF-8}"/>
         <formatter>

--- a/model-test/src/main/java/org/jboss/as/model/test/ChildFirstClassLoader.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ChildFirstClassLoader.java
@@ -23,7 +23,8 @@ package org.jboss.as.model.test;
 
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.List;
+import java.util.Collections;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.jboss.modules.filter.ClassFilter;
@@ -36,19 +37,19 @@ import org.jboss.modules.filter.ClassFilter;
 public class ChildFirstClassLoader extends URLClassLoader {
 
     private final ClassLoader parent;
-    private final List<Pattern> parentFirst;
-    private final List<Pattern> childFirst;
+    private final Set<Pattern> parentFirst;
+    private final Set<Pattern> childFirst;
     private final ClassFilter parentExclusionFilter;
 
 
-    ChildFirstClassLoader(ClassLoader parent, List<Pattern> parentFirst, List<Pattern> childFirst, ClassFilter parentExclusionFilter, URL... urls) {
+    ChildFirstClassLoader(ClassLoader parent, Set<Pattern> parentFirst, Set<Pattern> childFirst, ClassFilter parentExclusionFilter, URL... urls) {
         super(urls, parent);
         assert parent != null : "Null parent";
         assert parentFirst != null : "Null parent first";
         assert childFirst != null : "Null child first";
         this.parent = parent;
-        this.childFirst = childFirst;
-        this.parentFirst = parentFirst;
+        this.childFirst = Collections.unmodifiableSet(childFirst);
+        this.parentFirst = Collections.unmodifiableSet(parentFirst);
         this.parentExclusionFilter = parentExclusionFilter;
 //        System.out.println("---------->");
 //        for (URL url : urls) {

--- a/model-test/src/test/java/org/jboss/as/model/test/api/SingleChildFirst1.java
+++ b/model-test/src/test/java/org/jboss/as/model/test/api/SingleChildFirst1.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.model.test.api;
+
+/**
+ * 
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class SingleChildFirst1 {
+
+}

--- a/model-test/src/test/java/org/jboss/as/model/test/api/SingleChildFirst2.java
+++ b/model-test/src/test/java/org/jboss/as/model/test/api/SingleChildFirst2.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.model.test.api;
+
+/**
+ * 
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class SingleChildFirst2 {
+
+}

--- a/model-test/src/test/java/org/jboss/as/model/test/api/SingleParentFirst.java
+++ b/model-test/src/test/java/org/jboss/as/model/test/api/SingleParentFirst.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.model.test.api;
+
+/**
+ * 
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class SingleParentFirst {
+
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -111,10 +111,6 @@
             <artifactId>jboss-logmanager</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logmanager</groupId>
-            <artifactId>log4j-jboss-logmanager</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.marshalling</groupId>
             <artifactId>jboss-marshalling</artifactId>
         </dependency>

--- a/subsystem-test/framework/pom.xml
+++ b/subsystem-test/framework/pom.xml
@@ -54,6 +54,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.logmanager</groupId>
+            <artifactId>jboss-logmanager</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-controller</artifactId>
         </dependency>

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/bridge/local/ScopedKernelServicesBootstrap.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/bridge/local/ScopedKernelServicesBootstrap.java
@@ -77,7 +77,7 @@ public class ScopedKernelServicesBootstrap {
             }
 
             //Convert additional Init
-            Object convertedAdditionalInit = null;//TODO objectConverter.convertAdditionalInitializationToChildCl(additionalInit);
+            Object convertedAdditionalInit = objectConverter.convertAdditionalInitializationToChildCl(additionalInit);
             Object convertedModelVersion = objectConverter.convertModelVersionToChildCl(legacyModelVersion);
             Object convertedValidateOpsFilter = objectConverter.convertValidateOperationsFilterToChildCl(validateOpsFilter);
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ControllerInitializer.java
@@ -30,12 +30,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT_OFFSET;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT_OFFSET;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -273,7 +273,13 @@ public class ControllerInitializer {
             return;
         }
         rootResource.getModel().get(PATH);
-        ManagementResourceRegistration paths = rootRegistration.registerSubModel(PathResourceDefinition.createSpecified(pathManager));
+        PathResourceDefinition def = PathResourceDefinition.createSpecified(pathManager);
+        if (rootRegistration.getSubModel(PathAddress.pathAddress(def.getPathElement())) != null) {
+            //Older versions of core model tests seem to register this resource, while in newer it does not get registered,
+            //so let's remove it here if it exists already
+            rootRegistration.unregisterSubModel(def.getPathElement());
+        }
+        rootRegistration.registerSubModel(def);
     }
 
     /**

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/LegacyKernelServicesInitializer.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/LegacyKernelServicesInitializer.java
@@ -168,6 +168,7 @@ public interface LegacyKernelServicesInitializer {
      *
      * @param name the name of the operation, or {@code *} as a wildcard capturing all names
      * @param pathAddress the address of the operation, the pathAddress may use {@code *} as a wildcard for both the key and the value of {@link org.jboss.as.controller.PathElement}s
+     * @return this initializer
      */
     LegacyKernelServicesInitializer addOperationValidationResolve(String name, PathAddress pathAddress);
 
@@ -176,6 +177,21 @@ public interface LegacyKernelServicesInitializer {
      * through the service initializer. Thus we provide an exclusion mecanism.
      *
      * @param exclusionFilter the class filter used to exclude class from the the parent classloader when resolving.
+     * @return this initializer
      */
     LegacyKernelServicesInitializer excludeFromParent(ClassFilter exclusionFilter);
+
+    /**
+     * Add classes to be loaded from the child classloader. The url's from the {@code classes} protection domain get added to the
+     * list of URLs used by the child  first classloader. Classes coming from that URL, which are not specified in the {@code classes}
+     * list, are loaded from the parent classloader. URLs implicitely added via this method must not be added via any of the other
+     * methods such as {@link #addSimpleResourceURL(String)} and {@link #addMavenResourceURL(String)}; if that happens an
+     * {@link IllegalStateException} will get thrown when the controllers are built.
+     *
+     * This is useful for adding {@link AdditionalInitialization} implementations for the scoped legacy controller.
+     *
+     * @param classes the classes to be added as child first classes
+     * @return this initializer
+     */
+    LegacyKernelServicesInitializer addSingleChildFirstClass(Class<?>...classes);
 }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -717,6 +717,12 @@ final class SubsystemTestDelegate {
             return this;
         }
 
+        @Override
+        public LegacyKernelServicesInitializer addSingleChildFirstClass(Class<?>...classes) {
+            classLoaderBuilder.addSingleChildFirstClass(classes);
+            return this;
+        }
+
         private LegacyControllerKernelServicesProxy install(KernelServices mainServices, List<ModelNode> bootOperations) throws Exception {
             if (!skipReverseCheck) {
                 bootCurrentVersionWithLegacyBootOperations(bootOperations, mainServices);

--- a/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/logging-1.2.0.dmr
+++ b/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/logging-1.2.0.dmr
@@ -1,0 +1,7218 @@
+{
+    "model-description" => {
+        "description" => "The configuration of the logging subsystem.",
+        "attributes" => {},
+        "operations" => undefined,
+        "children" => {
+            "size-rotating-file-handler" => {
+                "description" => "Defines a handler which writes to a file, rotating the log after a the size of the file grows beyond a certain point and keeping a fixed number of backups.",
+                "model-description" => undefined
+            },
+            "async-handler" => {
+                "description" => "Defines a handler which writes to the sub-handlers in an asynchronous thread. Used for handlers which introduce a substantial amount of lag.",
+                "model-description" => undefined
+            },
+            "periodic-rotating-file-handler" => {
+                "description" => "Defines a handler which writes to a file, rotating the log after a time period derived from the given suffix string, which should be in a format understood by java.text.SimpleDateFormat.",
+                "model-description" => undefined
+            },
+            "logging-profile" => {
+                "description" => "A profile that can be assigned to a deployment for it's logging configuration.",
+                "model-description" => undefined
+            },
+            "custom-handler" => {
+                "description" => "Defines a custom logging handler. The custom handler must extend java.util.logging.Handler.",
+                "model-description" => undefined
+            },
+            "root-logger" => {
+                "description" => "Defines the root logger for this log context.",
+                "model-description" => undefined
+            },
+            "console-handler" => {
+                "description" => "Defines a handler which writes to the console.",
+                "model-description" => undefined
+            },
+            "logger" => {
+                "description" => "Defines a logger category.",
+                "model-description" => undefined
+            },
+            "file-handler" => {
+                "description" => "Defines a handler which writes to a file.",
+                "model-description" => undefined
+            },
+            "syslog-handler" => {
+                "description" => "Defines a syslog handler.",
+                "model-description" => undefined
+            }
+        }
+    },
+    "address" => [("subsystem" => "logging")],
+    "children" => [
+        {
+            "model-description" => {
+                "description" => "A logging handler.",
+                "attributes" => {
+                    "enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "append" => {
+                        "type" => BOOLEAN,
+                        "description" => "Specify whether to append to the target file.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "autoflush" => {
+                        "type" => BOOLEAN,
+                        "description" => "Automatically flush after each write.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "rotate-size" => {
+                        "type" => STRING,
+                        "description" => "The size at which to rotate the log file.",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "default" => "2m"
+                    },
+                    "formatter" => {
+                        "type" => STRING,
+                        "description" => "Defines a pattern for the formatter.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "max-backup-index" => {
+                        "type" => INT,
+                        "description" => "The maximum number of backups to keep.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 1,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "file" => {
+                        "type" => OBJECT,
+                        "description" => "The file description consisting of the path and optional relative to path.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The filesystem path.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        }
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The handler's name.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "The name attribute should not be used as the handler's address contains the name."
+                        }
+                    },
+                    "encoding" => {
+                        "type" => STRING,
+                        "description" => "The character encoding used by this Handler.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("size-rotating-file-handler" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A logging handler.",
+                "attributes" => {
+                    "enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "overflow-action" => {
+                        "type" => STRING,
+                        "description" => "Specify what action to take when the overflowing.  The valid options are 'block' and 'discard'",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "default" => "BLOCK",
+                        "allowed" => [
+                            "BLOCK",
+                            "DISCARD"
+                        ]
+                    },
+                    "formatter" => {
+                        "type" => STRING,
+                        "description" => "Defines a pattern for the formatter.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "queue-length" => {
+                        "type" => INT,
+                        "description" => "The queue length to use before flushing writing",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "subhandlers" => {
+                        "type" => LIST,
+                        "description" => "The Handlers associated with this async handler.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {"handler" => {
+                            "type" => STRING,
+                            "description" => "The subhandler associated with this async handler.",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }}
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The handler's name.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "The name attribute should not be used as the handler's address contains the name."
+                        }
+                    },
+                    "encoding" => {
+                        "type" => STRING,
+                        "description" => "The character encoding used by this Handler.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("async-handler" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A logging handler.",
+                "attributes" => {
+                    "enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "append" => {
+                        "type" => BOOLEAN,
+                        "description" => "Specify whether to append to the target file.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "autoflush" => {
+                        "type" => BOOLEAN,
+                        "description" => "Automatically flush after each write.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "suffix" => {
+                        "type" => STRING,
+                        "description" => "Set the suffix string.  The string is in a format which can be understood by java.text.SimpleDateFormat. The period of the rotation is automatically calculated based on the suffix.",
+                        "expressions-allowed" => true,
+                        "nillable" => false
+                    },
+                    "formatter" => {
+                        "type" => STRING,
+                        "description" => "Defines a pattern for the formatter.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "file" => {
+                        "type" => OBJECT,
+                        "description" => "The file description consisting of the path and optional relative to path.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The filesystem path.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        }
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The handler's name.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "The name attribute should not be used as the handler's address contains the name."
+                        }
+                    },
+                    "encoding" => {
+                        "type" => STRING,
+                        "description" => "The character encoding used by this Handler.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("periodic-rotating-file-handler" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "The configuration of the logging subsystem.",
+                "attributes" => {},
+                "operations" => undefined,
+                "children" => {
+                    "size-rotating-file-handler" => {
+                        "description" => "Defines a handler which writes to a file, rotating the log after a the size of the file grows beyond a certain point and keeping a fixed number of backups.",
+                        "model-description" => undefined
+                    },
+                    "async-handler" => {
+                        "description" => "Defines a handler which writes to the sub-handlers in an asynchronous thread. Used for handlers which introduce a substantial amount of lag.",
+                        "model-description" => undefined
+                    },
+                    "periodic-rotating-file-handler" => {
+                        "description" => "Defines a handler which writes to a file, rotating the log after a time period derived from the given suffix string, which should be in a format understood by java.text.SimpleDateFormat.",
+                        "model-description" => undefined
+                    },
+                    "custom-handler" => {
+                        "description" => "Defines a custom logging handler. The custom handler must extend java.util.logging.Handler.",
+                        "model-description" => undefined
+                    },
+                    "root-logger" => {
+                        "description" => "Defines the root logger for this log context.",
+                        "model-description" => undefined
+                    },
+                    "console-handler" => {
+                        "description" => "Defines a handler which writes to the console.",
+                        "model-description" => undefined
+                    },
+                    "logger" => {
+                        "description" => "Defines a logger category.",
+                        "model-description" => undefined
+                    },
+                    "file-handler" => {
+                        "description" => "Defines a handler which writes to a file.",
+                        "model-description" => undefined
+                    },
+                    "syslog-handler" => {
+                        "description" => "Defines a syslog handler.",
+                        "model-description" => undefined
+                    }
+                }
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("logging-profile" => "*")
+            ],
+            "children" => [
+                {
+                    "model-description" => {
+                        "description" => "A logging handler.",
+                        "attributes" => {
+                            "enabled" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "append" => {
+                                "type" => BOOLEAN,
+                                "description" => "Specify whether to append to the target file.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "autoflush" => {
+                                "type" => BOOLEAN,
+                                "description" => "Automatically flush after each write.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "rotate-size" => {
+                                "type" => STRING,
+                                "description" => "The size at which to rotate the log file.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "default" => "2m"
+                            },
+                            "formatter" => {
+                                "type" => STRING,
+                                "description" => "Defines a pattern for the formatter.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "max-backup-index" => {
+                                "type" => INT,
+                                "description" => "The maximum number of backups to keep.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1,
+                                "min" => 1L,
+                                "max" => 2147483647L
+                            },
+                            "file" => {
+                                "type" => OBJECT,
+                                "description" => "The file description consisting of the path and optional relative to path.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "relative-to" => {
+                                        "type" => STRING,
+                                        "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "path" => {
+                                        "type" => STRING,
+                                        "description" => "The filesystem path.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                }
+                            },
+                            "name" => {
+                                "type" => STRING,
+                                "description" => "The handler's name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "The name attribute should not be used as the handler's address contains the name."
+                                }
+                            },
+                            "encoding" => {
+                                "type" => STRING,
+                                "description" => "The character encoding used by this Handler.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("size-rotating-file-handler" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A logging handler.",
+                        "attributes" => {
+                            "formatter" => {
+                                "type" => STRING,
+                                "description" => "Defines a pattern for the formatter.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "enabled" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "queue-length" => {
+                                "type" => INT,
+                                "description" => "The queue length to use before flushing writing",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min" => 1L,
+                                "max" => 2147483647L
+                            },
+                            "subhandlers" => {
+                                "type" => LIST,
+                                "description" => "The Handlers associated with this async handler.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {"handler" => {
+                                    "type" => STRING,
+                                    "description" => "The subhandler associated with this async handler.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                }}
+                            },
+                            "overflow-action" => {
+                                "type" => STRING,
+                                "description" => "Specify what action to take when the overflowing.  The valid options are 'block' and 'discard'",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "default" => "BLOCK",
+                                "allowed" => [
+                                    "BLOCK",
+                                    "DISCARD"
+                                ]
+                            },
+                            "encoding" => {
+                                "type" => STRING,
+                                "description" => "The character encoding used by this Handler.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "name" => {
+                                "type" => STRING,
+                                "description" => "The handler's name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "The name attribute should not be used as the handler's address contains the name."
+                                }
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("async-handler" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A logging handler.",
+                        "attributes" => {
+                            "enabled" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "append" => {
+                                "type" => BOOLEAN,
+                                "description" => "Specify whether to append to the target file.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "autoflush" => {
+                                "type" => BOOLEAN,
+                                "description" => "Automatically flush after each write.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "suffix" => {
+                                "type" => STRING,
+                                "description" => "Set the suffix string.  The string is in a format which can be understood by java.text.SimpleDateFormat. The period of the rotation is automatically calculated based on the suffix.",
+                                "expressions-allowed" => true,
+                                "nillable" => false
+                            },
+                            "formatter" => {
+                                "type" => STRING,
+                                "description" => "Defines a pattern for the formatter.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "file" => {
+                                "type" => OBJECT,
+                                "description" => "The file description consisting of the path and optional relative to path.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "relative-to" => {
+                                        "type" => STRING,
+                                        "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "path" => {
+                                        "type" => STRING,
+                                        "description" => "The filesystem path.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                }
+                            },
+                            "name" => {
+                                "type" => STRING,
+                                "description" => "The handler's name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "The name attribute should not be used as the handler's address contains the name."
+                                }
+                            },
+                            "encoding" => {
+                                "type" => STRING,
+                                "description" => "The character encoding used by this Handler.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("periodic-rotating-file-handler" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A logging handler.",
+                        "attributes" => {
+                            "formatter" => {
+                                "type" => STRING,
+                                "description" => "Defines a pattern for the formatter.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "enabled" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "module" => {
+                                "type" => STRING,
+                                "description" => "The module that the logging handler depends on.",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "name" => {
+                                "type" => STRING,
+                                "description" => "The handler's name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "The name attribute should not be used as the handler's address contains the name."
+                                }
+                            },
+                            "encoding" => {
+                                "type" => STRING,
+                                "description" => "The character encoding used by this Handler.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "class" => {
+                                "type" => STRING,
+                                "description" => "The logging handler class to be used.",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "properties" => {
+                                "type" => OBJECT,
+                                "description" => "Defines the properties used for the logging handler. All properties must be accessible via a setter method.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "value-type" => STRING
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("custom-handler" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines the root logger for this log context.",
+                        "attributes" => {
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "handlers" => {
+                                "type" => LIST,
+                                "description" => "The Handlers associated with this Logger.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {"handler" => {
+                                    "type" => STRING,
+                                    "description" => "The logging handler.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                }}
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("root-logger" => "ROOT")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A logging handler.",
+                        "attributes" => {
+                            "formatter" => {
+                                "type" => STRING,
+                                "description" => "Defines a pattern for the formatter.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "enabled" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "autoflush" => {
+                                "type" => BOOLEAN,
+                                "description" => "Automatically flush after each write.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "name" => {
+                                "type" => STRING,
+                                "description" => "The handler's name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "The name attribute should not be used as the handler's address contains the name."
+                                }
+                            },
+                            "encoding" => {
+                                "type" => STRING,
+                                "description" => "The character encoding used by this Handler.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "target" => {
+                                "type" => STRING,
+                                "description" => "Defines the target of the console handler. The value can either be SYSTEM_OUT or SYSTEM_ERR.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "System.out",
+                                "allowed" => [
+                                    "System.out",
+                                    "System.err"
+                                ]
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("console-handler" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines a logger category.",
+                        "attributes" => {
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "use-parent-handlers" => {
+                                "type" => BOOLEAN,
+                                "description" => "Specifies whether or not this logger should send its output to it's parent Logger.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "category" => {
+                                "type" => STRING,
+                                "description" => "Specifies the category for the logger.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "handlers" => {
+                                "type" => LIST,
+                                "description" => "The Handlers associated with this Logger.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {"handler" => {
+                                    "type" => STRING,
+                                    "description" => "The logging handler.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                }}
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("logger" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A logging handler.",
+                        "attributes" => {
+                            "formatter" => {
+                                "type" => STRING,
+                                "description" => "Defines a pattern for the formatter.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "enabled" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "filter-spec" => {
+                                "type" => STRING,
+                                "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => ["filter"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "autoflush" => {
+                                "type" => BOOLEAN,
+                                "description" => "Automatically flush after each write.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "append" => {
+                                "type" => BOOLEAN,
+                                "description" => "Specify whether to append to the target file.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "file" => {
+                                "type" => OBJECT,
+                                "description" => "The file description consisting of the path and optional relative to path.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "relative-to" => {
+                                        "type" => STRING,
+                                        "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "path" => {
+                                        "type" => STRING,
+                                        "description" => "The filesystem path.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                }
+                            },
+                            "name" => {
+                                "type" => STRING,
+                                "description" => "The handler's name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "The name attribute should not be used as the handler's address contains the name."
+                                }
+                            },
+                            "encoding" => {
+                                "type" => STRING,
+                                "description" => "The character encoding used by this Handler.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("file-handler" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines a syslog handler.",
+                        "attributes" => {
+                            "port" => {
+                                "type" => INT,
+                                "description" => "The port the syslog server is listening on.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 514,
+                                "min" => 0L,
+                                "max" => 65535L
+                            },
+                            "app-name" => {
+                                "type" => STRING,
+                                "description" => "The app name used when formatting the message in RFC5424 format. By default the app name is \"java\".",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "enabled" => {
+                                "type" => BOOLEAN,
+                                "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL",
+                                "allowed" => [
+                                    "ALL",
+                                    "FINEST",
+                                    "FINER",
+                                    "TRACE",
+                                    "DEBUG",
+                                    "FINE",
+                                    "CONFIG",
+                                    "INFO",
+                                    "WARN",
+                                    "WARNING",
+                                    "ERROR",
+                                    "FATAL",
+                                    "OFF"
+                                ]
+                            },
+                            "facility" => {
+                                "type" => STRING,
+                                "description" => "Facility as defined by RFC-5424 (http://tools.ietf.org/html/rfc5424)and RFC-3164 (http://tools.ietf.org/html/rfc3164).",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "user-level",
+                                "allowed" => [
+                                    "kernel",
+                                    "user-level",
+                                    "mail-system",
+                                    "system-daemons",
+                                    "security",
+                                    "syslogd",
+                                    "line-printer",
+                                    "network-news",
+                                    "uucp",
+                                    "clock-daemon",
+                                    "security2",
+                                    "ftp-daemon",
+                                    "ntp",
+                                    "log-audit",
+                                    "log-alert",
+                                    "clock-daemon2",
+                                    "local-use-0",
+                                    "local-use-1",
+                                    "local-use-2",
+                                    "local-use-3",
+                                    "local-use-4",
+                                    "local-use-5",
+                                    "local-use-6",
+                                    "local-use-7"
+                                ]
+                            },
+                            "server-address" => {
+                                "type" => STRING,
+                                "description" => "The address of the syslog server.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "localhost",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "hostname" => {
+                                "type" => STRING,
+                                "description" => "The name of the host the messages are being sent from. For example the name of the host the application server is running on.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "syslog-format" => {
+                                "type" => STRING,
+                                "description" => "Formats the log message according to the RFC specification.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "RFC5424",
+                                "allowed" => [
+                                    "RFC5424",
+                                    "RFC3164"
+                                ]
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "logging"),
+                        ("logging-profile" => "*"),
+                        ("syslog-handler" => "*")
+                    ]
+                }
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A logging handler.",
+                "attributes" => {
+                    "enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "module" => {
+                        "type" => STRING,
+                        "description" => "The module that the logging handler depends on.",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "class" => {
+                        "type" => STRING,
+                        "description" => "The logging handler class to be used.",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "properties" => {
+                        "type" => OBJECT,
+                        "description" => "Defines the properties used for the logging handler. All properties must be accessible via a setter method.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    },
+                    "formatter" => {
+                        "type" => STRING,
+                        "description" => "Defines a pattern for the formatter.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The handler's name.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "The name attribute should not be used as the handler's address contains the name."
+                        }
+                    },
+                    "encoding" => {
+                        "type" => STRING,
+                        "description" => "The character encoding used by this Handler.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("custom-handler" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "Defines the root logger for this log context.",
+                "attributes" => {
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "handlers" => {
+                        "type" => LIST,
+                        "description" => "The Handlers associated with this Logger.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {"handler" => {
+                            "type" => STRING,
+                            "description" => "The logging handler.",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }}
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("root-logger" => "ROOT")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A logging handler.",
+                "attributes" => {
+                    "formatter" => {
+                        "type" => STRING,
+                        "description" => "Defines a pattern for the formatter.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "autoflush" => {
+                        "type" => BOOLEAN,
+                        "description" => "Automatically flush after each write.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The handler's name.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "The name attribute should not be used as the handler's address contains the name."
+                        }
+                    },
+                    "encoding" => {
+                        "type" => STRING,
+                        "description" => "The character encoding used by this Handler.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "target" => {
+                        "type" => STRING,
+                        "description" => "Defines the target of the console handler. The value can either be SYSTEM_OUT or SYSTEM_ERR.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "System.out",
+                        "allowed" => [
+                            "System.out",
+                            "System.err"
+                        ]
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("console-handler" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "Defines a logger category.",
+                "attributes" => {
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "use-parent-handlers" => {
+                        "type" => BOOLEAN,
+                        "description" => "Specifies whether or not this logger should send its output to it's parent Logger.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "category" => {
+                        "type" => STRING,
+                        "description" => "Specifies the category for the logger.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "handlers" => {
+                        "type" => LIST,
+                        "description" => "The Handlers associated with this Logger.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {"handler" => {
+                            "type" => STRING,
+                            "description" => "The logging handler.",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }}
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("logger" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A logging handler.",
+                "attributes" => {
+                    "enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "append" => {
+                        "type" => BOOLEAN,
+                        "description" => "Specify whether to append to the target file.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "autoflush" => {
+                        "type" => BOOLEAN,
+                        "description" => "Automatically flush after each write.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "formatter" => {
+                        "type" => STRING,
+                        "description" => "Defines a pattern for the formatter.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter-spec" => {
+                        "type" => STRING,
+                        "description" => "A filter expression value to define a filter. Example for a filter that does not match a pattern: not(match(\"JBAS.*\"))",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "alternatives" => ["filter"],
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "file" => {
+                        "type" => OBJECT,
+                        "description" => "The file description consisting of the path and optional relative to path.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The filesystem path.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        }
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The handler's name.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "The name attribute should not be used as the handler's address contains the name."
+                        }
+                    },
+                    "encoding" => {
+                        "type" => STRING,
+                        "description" => "The character encoding used by this Handler.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "filter" => {
+                        "type" => OBJECT,
+                        "description" => "Defines a simple filter type.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "alternatives" => ["filter-spec"],
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Use filter-spec."
+                        },
+                        "value-type" => {
+                            "all" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be unloggable,the message will not be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "any" => {
+                                "type" => OBJECT,
+                                "description" => "A filter consisting of several filters in a chain.  If any filter finds the log message to be loggable, the message will be logged and subsequent filters will not be checked.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "not" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter that inverts the filter that is nested.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "accept" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Accepts all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "change-level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "deny" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "Denys all log messages.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "level" => {
+                                                "type" => STRING,
+                                                "description" => "A filter which excludes a message with the specified level.",
+                                                "expressions-allowed" => true,
+                                                "nillable" => true,
+                                                "default" => "ALL"
+                                            },
+                                            "level-range" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which logs only messages that fall within a level range.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "min-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The minimum (least severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "min-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    },
+                                                    "max-level" => {
+                                                        "type" => STRING,
+                                                        "description" => "The maximum (most severe) level, inclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true
+                                                    },
+                                                    "max-inclusive" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => true,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            },
+                                            "match" => {
+                                                "type" => STRING,
+                                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace" => {
+                                                "type" => OBJECT,
+                                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "value-type" => {
+                                                    "pattern" => {
+                                                        "type" => STRING,
+                                                        "description" => "The pattern to match",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replacement" => {
+                                                        "type" => STRING,
+                                                        "description" => "The string replacement",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "min-length" => 1L,
+                                                        "max-length" => 2147483647L
+                                                    },
+                                                    "replace-all" => {
+                                                        "type" => BOOLEAN,
+                                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                        "expressions-allowed" => false,
+                                                        "nillable" => false,
+                                                        "default" => true
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "accept" => {
+                                "type" => BOOLEAN,
+                                "description" => "Accepts all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "change-level" => {
+                                "type" => STRING,
+                                "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                "expressions-allowed" => false,
+                                "nillable" => true
+                            },
+                            "deny" => {
+                                "type" => BOOLEAN,
+                                "description" => "Denys all log messages.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "level" => {
+                                "type" => STRING,
+                                "description" => "A filter which excludes a message with the specified level.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "ALL"
+                            },
+                            "level-range" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which logs only messages that fall within a level range.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "min-level" => {
+                                        "type" => STRING,
+                                        "description" => "The minimum (least severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "min-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "max-level" => {
+                                        "type" => STRING,
+                                        "description" => "The maximum (most severe) level, inclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "max-inclusive" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    }
+                                }
+                            },
+                            "match" => {
+                                "type" => STRING,
+                                "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "not" => {
+                                "type" => OBJECT,
+                                "description" => "A filter that inverts the filter that is nested.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "accept" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Accepts all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "change-level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which modifies the log record with a new level if the nested filter evaluates true for that record.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true
+                                    },
+                                    "deny" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "Denys all log messages.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "default" => true
+                                    },
+                                    "level" => {
+                                        "type" => STRING,
+                                        "description" => "A filter which excludes a message with the specified level.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "default" => "ALL"
+                                    },
+                                    "level-range" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which logs only messages that fall within a level range.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "min-level" => {
+                                                "type" => STRING,
+                                                "description" => "The minimum (least severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "min-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the min-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            },
+                                            "max-level" => {
+                                                "type" => STRING,
+                                                "description" => "The maximum (most severe) level, inclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true
+                                            },
+                                            "max-inclusive" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if the max-level value is inclusive, false if it is exclusive.",
+                                                "expressions-allowed" => false,
+                                                "nillable" => true,
+                                                "default" => true
+                                            }
+                                        }
+                                    },
+                                    "match" => {
+                                        "type" => STRING,
+                                        "description" => "A regular-expression-based filter. Used to exclude log records which match or don't match the expression. The regular expression is checked against the raw (unformatted) message.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace" => {
+                                        "type" => OBJECT,
+                                        "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "value-type" => {
+                                            "pattern" => {
+                                                "type" => STRING,
+                                                "description" => "The pattern to match",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replacement" => {
+                                                "type" => STRING,
+                                                "description" => "The string replacement",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "min-length" => 1L,
+                                                "max-length" => 2147483647L
+                                            },
+                                            "replace-all" => {
+                                                "type" => BOOLEAN,
+                                                "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                                "expressions-allowed" => false,
+                                                "nillable" => false,
+                                                "default" => true
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "replace" => {
+                                "type" => OBJECT,
+                                "description" => "A filter which applies a text substitution on the message if the nested filter matches.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "pattern" => {
+                                        "type" => STRING,
+                                        "description" => "The pattern to match",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replacement" => {
+                                        "type" => STRING,
+                                        "description" => "The string replacement",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "replace-all" => {
+                                        "type" => BOOLEAN,
+                                        "description" => "True if all occurrences should be replaced; false if only the first occurrence",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "default" => true
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("file-handler" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "Defines a syslog handler.",
+                "attributes" => {
+                    "port" => {
+                        "type" => INT,
+                        "description" => "The port the syslog server is listening on.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 514,
+                        "min" => 0L,
+                        "max" => 65535L
+                    },
+                    "app-name" => {
+                        "type" => STRING,
+                        "description" => "The app name used when formatting the message in RFC5424 format. By default the app name is \"java\".",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "If set to true the handler is enabled and functioning as normal, if set to false the handler is ignored when processing log messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "level" => {
+                        "type" => STRING,
+                        "description" => "The log level specifying which message levels will be logged by this logger. Message levels lower than this value will be discarded.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ALL",
+                        "allowed" => [
+                            "ALL",
+                            "FINEST",
+                            "FINER",
+                            "TRACE",
+                            "DEBUG",
+                            "FINE",
+                            "CONFIG",
+                            "INFO",
+                            "WARN",
+                            "WARNING",
+                            "ERROR",
+                            "FATAL",
+                            "OFF"
+                        ]
+                    },
+                    "facility" => {
+                        "type" => STRING,
+                        "description" => "Facility as defined by RFC-5424 (http://tools.ietf.org/html/rfc5424)and RFC-3164 (http://tools.ietf.org/html/rfc3164).",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "user-level",
+                        "allowed" => [
+                            "kernel",
+                            "user-level",
+                            "mail-system",
+                            "system-daemons",
+                            "security",
+                            "syslogd",
+                            "line-printer",
+                            "network-news",
+                            "uucp",
+                            "clock-daemon",
+                            "security2",
+                            "ftp-daemon",
+                            "ntp",
+                            "log-audit",
+                            "log-alert",
+                            "clock-daemon2",
+                            "local-use-0",
+                            "local-use-1",
+                            "local-use-2",
+                            "local-use-3",
+                            "local-use-4",
+                            "local-use-5",
+                            "local-use-6",
+                            "local-use-7"
+                        ]
+                    },
+                    "server-address" => {
+                        "type" => STRING,
+                        "description" => "The address of the syslog server.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "localhost",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "hostname" => {
+                        "type" => STRING,
+                        "description" => "The name of the host the messages are being sent from. For example the name of the host the application server is running on.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "syslog-format" => {
+                        "type" => STRING,
+                        "description" => "Formats the log message according to the RFC specification.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "RFC5424",
+                        "allowed" => [
+                            "RFC5424",
+                            "RFC3164"
+                        ]
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "logging"),
+                ("syslog-handler" => "*")
+            ]
+        }
+    ]
+}

--- a/subsystem-test/test-controller-7.1.2/src/main/java/org/jboss/as/subsystem/test/AdditionalInitializationUtil.java
+++ b/subsystem-test/test-controller-7.1.2/src/main/java/org/jboss/as/subsystem/test/AdditionalInitializationUtil.java
@@ -51,7 +51,7 @@ public class AdditionalInitializationUtil {
     public static void doExtraInitialization(AdditionalInitialization additionalInit, ControllerInitializer controllerInitializer, ExtensionRegistry extensionRegistry, Resource rootResource, ManagementResourceRegistration rootRegistration) {
         //TODO
         //controllerInitializer.setTestModelControllerService(this);
-        controllerInitializer.initializeModel(rootResource, rootRegistration);
+        //controllerInitializer.initializeModel(rootResource, rootRegistration);
         additionalInit.initializeExtraSubystemsAndModel(extensionRegistry, rootResource, rootRegistration);
     }
 }


### PR DESCRIPTION
Plus maybe a few other small changes. Sorry for the multiple commits in one PR. I can put the first two in a different PR if the committers would prefer that.

The first one just moves the log4j dependency from the server to the logging subsystem which should have been done from the beginning.

The second commit just binds jboss-logmanager and the slf4j binding to aether to get rid of the message that prints in subsystem tests. This would also allow tests to control the logging output with a `logging.properties` file if desired.

Kabir's commit is needed to get the logging transformers working with model version 1.2.0+.

That last commit could be squashed with the 2.0.0 transformer commit, but seemed a little more appropriate as a standalone commit.
