### PR TITLE
[WFLY-2425] Update slf4j version to forked version with concurrency fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         <version.org.picketlink>2.5.1.Final</version.org.picketlink>
         <version.org.powermock>1.5</version.org.powermock>
         <version.org.scannotation>1.0.3</version.org.scannotation>
-        <version.org.slf4j>1.7.2</version.org.slf4j>
+        <version.org.slf4j>1.7.2.jbossorg-1</version.org.slf4j>
         <version.org.eclipse.aether>0.9.0.M3</version.org.eclipse.aether>
         <version.org.testng>6.1.1</version.org.testng>
         <version.org.wildfly.security.manager>1.0.0.Beta3</version.org.wildfly.security.manager>


### PR DESCRIPTION
I've never seen this issue on WildFly, but it shows up in EAP generally in domain mode. Might as well use the patched version in WildFly too.
