### PR TITLE
Test subsystem transformers against eap versions

### DIFF
--- a/ee/src/test/java/org/jboss/as/ee/subsystem/EeSubsystemTestCase.java
+++ b/ee/src/test/java/org/jboss/as/ee/subsystem/EeSubsystemTestCase.java
@@ -21,6 +21,13 @@
 */
 package org.jboss.as.ee.subsystem;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.ANNOTATIONS;
+import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.GLOBAL_MODULES;
+import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.META_INF;
+import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.SERVICES;
+import static org.jboss.as.model.test.FailedOperationTransformationConfig.REJECTED_RESOURCE;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -41,13 +48,6 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.ANNOTATIONS;
-import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.GLOBAL_MODULES;
-import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.META_INF;
-import static org.jboss.as.ee.subsystem.GlobalModulesDefinition.SERVICES;
-import static org.jboss.as.model.test.FailedOperationTransformationConfig.REJECTED_RESOURCE;
-
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  * @author Eduardo Martins
@@ -62,6 +62,8 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
     protected String getSubsystemXml() throws IOException {
         return readResource("subsystem.xml");
     }
+
+
     @Test
     public void testTransformers712() throws Exception {
         //Due to https://issues.jboss.org/browse/AS7-4892 the jboss-descriptor-property-replacement
@@ -69,9 +71,20 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformers712(ModelTestControllerVersion.V7_1_2_FINAL);
     }
 
-    private void testTransformers712(ModelTestControllerVersion controllerVersion) throws Exception {
+    @Test
+    public void testTransformersEAP600() throws Exception {
         //Due to https://issues.jboss.org/browse/AS7-4892 the jboss-descriptor-property-replacement
         //does not get set properly on 7.1.2, so let's do a reject test.
+        testTransformers712(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    private void testTransformers712(ModelTestControllerVersion controllerVersion) throws Exception {
+        //Due to https://issues.jboss.org/browse/AS7-4892 the jboss-descriptor-property-replacement
+        //does not get set properly on 7.1.2, so let's do a reject test
+
+        if (controllerVersion.isEap()){
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
 
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
 
@@ -114,8 +127,34 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testTransformers713() throws Exception {
-        //We are 100% compatible with 7.1.3 so do a normal transformation test
+        testTransformers1_0_0_post712(ModelTestControllerVersion.V7_1_3_FINAL);
+    }
 
+    @Test
+    public void testTransformers720() throws Exception {
+        testTransformers1_0_0_post712(ModelTestControllerVersion.V7_2_0_FINAL);
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformers1_0_0_post712(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers1_0_0_post712(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testTransformers1_0_0_post712(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+    private void testTransformers1_0_0_post712(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+        //Do a normal transformation test containing parts of the subsystem that work everywhere
         String subsystemXml = readResource("subsystem-transformers.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
@@ -123,8 +162,8 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
                 .setSubsystemXml(subsystemXml);
 
         // Add legacy subsystems
-        builder.createLegacyKernelServicesBuilder(null, ModelTestControllerVersion.V7_1_3_FINAL, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-ee:7.1.3.Final");
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
+                .addMavenResourceURL("org.jboss.as:jboss-as-ee:" + controllerVersion.getMavenGavVersion());
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
@@ -136,6 +175,33 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testTransformers713Reject() throws Exception {
+        testTransformers1_0_0_reject(ModelTestControllerVersion.V7_1_3_FINAL);
+    }
+
+    @Test
+    public void testTransformers720Reject() throws Exception {
+        testTransformers1_0_0_reject(ModelTestControllerVersion.V7_2_0_FINAL);
+    }
+
+    @Test
+    public void testTransformersEAP601Reject() throws Exception {
+        testTransformers1_0_0_reject(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
+    @Test
+    public void testTransformersEAP610Reject() throws Exception {
+        testTransformers1_0_0_reject(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP611Reject() throws Exception {
+        testTransformers1_0_0_reject(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+    private void testTransformers1_0_0_reject(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
 
         String subsystemXml = readResource("subsystem.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
@@ -145,8 +211,8 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
         List<ModelNode> xmlOps = builder.parseXml(subsystemXml);
 
         // Add legacy subsystems
-        builder.createLegacyKernelServicesBuilder(null, ModelTestControllerVersion.V7_1_3_FINAL, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-ee:7.1.3.Final");
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
+                .addMavenResourceURL("org.jboss.as:jboss-as-ee:" + controllerVersion.getMavenGavVersion());
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());
@@ -162,7 +228,31 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testTransformersDiscardGlobalModules() throws Exception {
+    public void testTransformersDiscardGlobalModules713() throws Exception {
+        testTransformersDiscardGlobalModules1_0_0(ModelTestControllerVersion.V7_1_3_FINAL);
+    }
+
+    @Test
+    public void testTransformersDiscardGlobalModules720() throws Exception {
+        testTransformersDiscardGlobalModules1_0_0(ModelTestControllerVersion.V7_2_0_FINAL);
+    }
+
+    @Test
+    public void testTransformersDiscardGlobalModulesEAP601() throws Exception {
+        testTransformersDiscardGlobalModules1_0_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
+    @Test
+    public void testTransformersDiscardGlobalModulesEAP610() throws Exception {
+        testTransformersDiscardGlobalModules1_0_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersDiscardGlobalModulesEAP611() throws Exception {
+        testTransformersDiscardGlobalModules1_0_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+    private void testTransformersDiscardGlobalModules1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
 
         String subsystemXml = readResource("subsystem-transformers-discard.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
@@ -171,8 +261,8 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
                 .setSubsystemXml(subsystemXml);
 
         // Add legacy subsystems
-        builder.createLegacyKernelServicesBuilder(null, ModelTestControllerVersion.V7_1_3_FINAL, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-ee:7.1.3.Final")
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
+                .addMavenResourceURL("org.jboss.as:jboss-as-ee:" + controllerVersion.getMavenGavVersion())
                 .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, new ModelFixer() {
                     // The regular model will have the new attributes because they are in the xml,
                     // but the reverse controller model will not because transformation strips them

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -247,6 +247,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     static void registerTransformers(SubsystemRegistration subsystemRegistration) {
         registerTransformers_1_1_0(subsystemRegistration);
         registerTransformers_1_2_0(subsystemRegistration);
+        registerTransformers_1_2_1(subsystemRegistration);
     }
 
     private static void registerTransformers_1_1_0(SubsystemRegistration subsystemRegistration) {
@@ -289,8 +290,14 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     }
 
     private static void registerTransformers_1_2_0(SubsystemRegistration subsystemRegistration) {
+        registerTransformers1_2(subsystemRegistration, ModelVersion.create(1, 2, 0));
+    }
 
-        final ModelVersion subsystem120 = ModelVersion.create(1, 2);
+    private static void registerTransformers_1_2_1(SubsystemRegistration subsystemRegistration) {
+        registerTransformers1_2(subsystemRegistration, ModelVersion.create(1, 2, 1));
+    }
+
+    private static void registerTransformers1_2(SubsystemRegistration subsystemRegistration, ModelVersion subsystem12) {
         final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE);
         builder.getAttributeBuilder().setDiscard(DiscardAttributeChecker.UNDEFINED, EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE);
@@ -301,9 +308,9 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         builder.getAttributeBuilder().setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS);
 
         TimerServiceResourceDefinition.registerTransformers_1_2_0(builder);
-        TransformationDescription.Tools.register(builder.build(), subsystemRegistration, subsystem120);
-    }
+        TransformationDescription.Tools.register(builder.build(), subsystemRegistration, subsystem12);
 
+    }
 
 
 

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -70,12 +70,25 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         testTransformer_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+    @Test
+    public void testTransformerEAP600() throws Exception {
+        testTransformer_1_1_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testTransformerEAP601() throws Exception {
+        testTransformer_1_1_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
     /**
      * Tests transformation of model from 1.2.0 version into 1.1.0 version.
      *
      * @throws Exception
      */
     private void testTransformer_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = "transform_1_1_0.xml";   //This has no expressions not understood by 1.1.0
         ModelVersion modelVersion = ModelVersion.create(1, 1, 0); //The old model version
         //Use the non-runtime version of the extension which will happen on the HC
@@ -97,13 +110,33 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         checkSubsystemModelTransformation(mainServices, modelVersion, V_1_1_0_FIXER);
     }
 
+
     @Test
     public void testTransformerAS720() throws Exception {
-        ModelTestControllerVersion controllerVersion = ModelTestControllerVersion.V7_2_0_FINAL;
-        //TODO Update to include the extra stuff needed for 1.2.0
-        String subsystemXml = "transform_1_2_0.xml";   //This has no expressions not understood by 1.1.0
+        testTransformer_1_2_x(ModelTestControllerVersion.V7_2_0_FINAL, 0);
+    }
 
-        ModelVersion modelVersion = ModelVersion.create(1, 2, 0); //The old model version
+    @Test
+    public void testTransformerEAP610() throws Exception {
+        testTransformer_1_2_x(ModelTestControllerVersion.EAP_6_1_0, 1);
+    }
+
+    @Test
+    public void testTransformerEAP611() throws Exception {
+        testTransformer_1_2_x(ModelTestControllerVersion.EAP_6_1_1, 1);
+    }
+
+    /**
+     * Tests transformation of model from 1.2.0 version into 1.1.0 version.
+     *
+     * @throws Exception
+     */
+    private void testTransformer_1_2_x(ModelTestControllerVersion controllerVersion, int modelVersionMicro) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+        String subsystemXml = "transform_1_2_0.xml";
+        ModelVersion modelVersion = ModelVersion.create(1, 2, modelVersionMicro);
         //Use the non-runtime version of the extension which will happen on the HC
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource(subsystemXml);
@@ -112,19 +145,13 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-ejb3:" + controllerVersion.getMavenGavVersion())
                 .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + controllerVersion.getMavenGavVersion())
-                .skipReverseControllerCheck()
-                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName())))
-                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()), PathElement.pathElement("strict-max-bean-instance-pool")));
+                .skipReverseControllerCheck();
 
         KernelServices mainServices = builder.build();
-        Assert.assertTrue(mainServices.isSuccessfulBoot());
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
-        Assert.assertTrue(legacyServices.isSuccessfulBoot());
         Assert.assertNotNull(mainServices);
         Assert.assertNotNull(legacyServices);
-        generateLegacySubsystemResourceRegistrationDmr(mainServices, modelVersion);
-
-        checkSubsystemModelTransformation(mainServices, modelVersion);
+        checkSubsystemModelTransformation(mainServices, modelVersion, V_1_1_0_FIXER);
     }
 
     @Test
@@ -137,7 +164,20 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+    @Test
+    public void testRejectExpressionsEAP600() throws Exception {
+        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testRejectExpressionsAS601() throws Exception {
+        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
     private void testRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         // create builder for current subsystem version
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 

--- a/jaxrs/src/test/java/org/jboss/as/jaxrs/JaxrsSubsystemTestCase.java
+++ b/jaxrs/src/test/java/org/jboss/as/jaxrs/JaxrsSubsystemTestCase.java
@@ -62,7 +62,30 @@ public class JaxrsSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformers_1_0_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)

--- a/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrSubsystemTestCase.java
+++ b/jdr/jboss-as-jdr/src/test/java/org/jboss/as/jdr/JdrSubsystemTestCase.java
@@ -83,7 +83,30 @@ public class JdrSubsystemTestCase extends AbstractSubsystemBaseTest {
         testJdrTransformers(ModelTestControllerVersion.V7_2_0_FINAL, ModelVersion.create(1, 1, 0));
     }
 
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        testJdrTransformers(ModelTestControllerVersion.EAP_6_0_0, ModelVersion.create(1, 1, 0));
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testJdrTransformers(ModelTestControllerVersion.EAP_6_0_1, ModelVersion.create(1, 1, 0));
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testJdrTransformers(ModelTestControllerVersion.EAP_6_1_0, ModelVersion.create(1, 1, 0));
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testJdrTransformers(ModelTestControllerVersion.EAP_6_1_1, ModelVersion.create(1, 1, 0));
+    }
+
     private void testJdrTransformers(ModelTestControllerVersion controllerVersion, ModelVersion modelVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = "subsystem.xml";
         //Use the non-runtime version of the extension which will happen on the HC
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)

--- a/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/JMXSubsystemTestCase.java
@@ -614,7 +614,20 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
         testTransformation_1_0_0(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+    @Test
+    public void testTransformationEAP600() throws Exception {
+        testTransformation_1_0_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testTransformationAS600() throws Exception {
+        testTransformation_1_0_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
     private void testTransformation_1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml =
                 "<subsystem xmlns=\"" + Namespace.CURRENT.getUriString() + "\">" +
                 "   <expose-resolved-model domain-name=\"jboss.as\" proper-property-format=\"false\"/>" +
@@ -768,8 +781,20 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
         testTransformation_1_1_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testTransformationEAP610() throws Exception {
+        testTransformation_1_1_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformationEAP611() throws Exception {
+        testTransformation_1_1_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
 
     private void testTransformation_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml =
                 "<subsystem xmlns=\"" + Namespace.CURRENT.getUriString() + "\">" +
                 "   <expose-resolved-model domain-name=\"jboss.as\" proper-property-format=\"false\"/>" +
@@ -862,12 +887,25 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
         testRejectExpressions_1_0_0(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+    @Test
+    public void testRejectExpressionsEAP600() throws Exception {
+        testRejectExpressions_1_0_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testRejectExpressionsEAP601() throws Exception {
+        testRejectExpressions_1_0_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
     /**
      * Tests rejection of expressions in 1.1.0 model.
      *
      * @throws Exception
      */
     private void testRejectExpressions_1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml =
             "<subsystem xmlns=\"" + Namespace.CURRENT.getUriString() + "\">" +
                     "   <expose-resolved-model domain-name=\"${test.domain-name:non-standard}\" proper-property-format=\"${test.proper-property-format:true}\"/>" +
@@ -927,12 +965,25 @@ public class JMXSubsystemTestCase extends AbstractSubsystemTest {
         testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testRejectionEAP610() throws Exception {
+        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testRejectionEAP611() throws Exception {
+        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
     /**
      * Tests rejection of expressions in 1.1.0 model.
      *
      * @throws Exception
      */
     private void testRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml =
             "<subsystem xmlns=\"" + Namespace.CURRENT.getUriString() + "\">" +
                     "   <expose-resolved-model domain-name=\"${test.domain-name:non-standard}\" proper-property-format=\"${test.proper-property-format:true}\"/>" +

--- a/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
+++ b/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
@@ -63,7 +63,32 @@ public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest 
         testTransformers_1_0_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)

--- a/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
+++ b/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
@@ -178,11 +178,23 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    public void testRejectExpressionsEAP600() throws Exception {
+        testRejectExpressions_1_1_x(ModelTestControllerVersion.EAP_6_0_0, ModelVersion.create(1, 1, 0));
+    }
+    @Test
     public void testRejectExpressionsAS713() throws Exception {
         testRejectExpressions_1_1_x(ModelTestControllerVersion.V7_1_3_FINAL, ModelVersion.create(1, 1, 1));
     }
 
+    @Test
+    public void testRejectExpressionsEAP601() throws Exception {
+        testRejectExpressions_1_1_x(ModelTestControllerVersion.EAP_6_0_1, ModelVersion.create(1, 1, 1));
+    }
+
     private void testRejectExpressions_1_1_x(ModelTestControllerVersion controllerVersion, ModelVersion modelVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
 
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
@@ -264,11 +276,24 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    public void testTransformationEAP600() throws Exception {
+        testTransformation_1_1_0(ModelTestControllerVersion.EAP_6_0_0, ModelVersion.create(1, 1, 0));
+    }
+
+    @Test
     public void testTransformationAS713() throws Exception {
         testTransformation_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL, ModelVersion.create(1, 1, 1));
     }
 
+    @Test
+    public void testTransformationEAP601() throws Exception {
+        testTransformation_1_1_0(ModelTestControllerVersion.EAP_6_0_1, ModelVersion.create(1, 1, 1));
+    }
+
     private void testTransformation_1_1_0(ModelTestControllerVersion controllerVersion, ModelVersion modelVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = readResource("subsystem-1.1.0.xml");
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXml(subsystemXml);
@@ -399,7 +424,20 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformation_1_2_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testTransformationEAP610() throws Exception {
+        testTransformation_1_2_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformationEAP611() throws Exception {
+        testTransformation_1_2_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
     private void testTransformation_1_2_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         ModelVersion modelVersion = ModelVersion.create(1, 2, 0);
         String subsystemXml = readResource("subsystem-1.2.0.xml");
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
@@ -423,8 +461,21 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
         testRejectingTransformers_1_2_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
-    private void testRejectingTransformers_1_2_0(ModelTestControllerVersion controllerVersion) throws Exception {
+    @Test
+    public void testRejectingTransformersEAP610() throws Exception {
+        testRejectingTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
 
+
+    @Test
+    public void testRejectingTransformersAS611() throws Exception {
+        testRejectingTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+    private void testRejectingTransformers_1_2_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         ModelVersion modelVersion = ModelVersion.create(1, 2, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
@@ -266,10 +266,11 @@ public class MessagingTransformers {
         ResourceTransformationDescriptionBuilder hornetqServer = subsystemRoot.addChildResource(pathElement(HORNETQ_SERVER));
 
         ResourceTransformationDescriptionBuilder bridge = hornetqServer.addChildResource(BridgeDefinition.PATH);
-        rejectDefinedAttribute(bridge, RECONNECT_ATTEMPTS_ON_SAME_NODE);
+        rejectDefinedAttributeWithDefaultValue(bridge, RECONNECT_ATTEMPTS_ON_SAME_NODE);
+        discardAttribute(bridge, FAILOVER_ON_SERVER_SHUTDOWN);
 
         ResourceTransformationDescriptionBuilder addressSetting = hornetqServer.addChildResource(AddressSettingDefinition.PATH);
-        rejectDefinedAttribute(addressSetting, AddressSettingDefinition.EXPIRY_DELAY);
+        rejectDefinedAttributeWithDefaultValue(addressSetting, EXPIRY_DELAY);
 
         hornetqServer.rejectChildResource(ServletConnectorDefinition.PATH);
 

--- a/messaging/src/test/java/org/jboss/as/messaging/test/HornetQDependencies.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/HornetQDependencies.java
@@ -56,6 +56,30 @@ public class HornetQDependencies {
                 "org.hornetq:hornetq-jms-client:2.3.0.CR1",
                 "org.hornetq:hornetq-ra:2.3.0.CR1"});
 
+        map.put(ModelTestControllerVersion.EAP_6_0_0, new String[] {
+                "org.hornetq:hornetq-core:2.2.16.Final-redhat-1",
+                "org.hornetq:hornetq-jms:2.2.16.Final-redhat-1",
+                "org.hornetq:hornetq-ra:2.2.16.Final-redhat-1"});
+
+        map.put(ModelTestControllerVersion.EAP_6_0_1, new String[] {
+                "org.hornetq:hornetq-core:2.2.23.Final-redhat-1",
+                "org.hornetq:hornetq-jms:2.2.23.Final-redhat-1",
+                "org.hornetq:hornetq-ra:2.2.23.Final-redhat-1"});
+
+        map.put(ModelTestControllerVersion.EAP_6_1_0, new String[] {
+                "org.hornetq:hornetq-server:2.3.1.Final-redhat-1",
+                "org.hornetq:hornetq-jms-server:2.3.1.Final-redhat-1",
+                "org.hornetq:hornetq-core-client:2.3.1.Final-redhat-1",
+                "org.hornetq:hornetq-jms-client:2.3.1.Final-redhat-1",
+                "org.hornetq:hornetq-ra:2.3.1.Final-redhat-1"});
+
+        map.put(ModelTestControllerVersion.EAP_6_1_1, new String[] {
+                "org.hornetq:hornetq-server:2.3.5.Final-redhat-2",
+                "org.hornetq:hornetq-jms-server:2.3.5.Final-redhat-2",
+                "org.hornetq:hornetq-core-client:2.3.5.Final-redhat-2",
+                "org.hornetq:hornetq-jms-client:2.3.5.Final-redhat-2",
+                "org.hornetq:hornetq-ra:2.3.5.Final-redhat-2"});
+
         HORNET_Q_DEPENDENCIES = Collections.unmodifiableMap(map);
     }
 

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
@@ -41,10 +41,15 @@ import static org.jboss.as.messaging.CommonAttributes.PARAM;
 import static org.jboss.as.messaging.HornetQServerResourceDefinition.HORNETQ_SERVER_PATH;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_1_0;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_0;
+import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_1;
 import static org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Regular.FACTORY_TYPE;
 import static org.jboss.as.messaging.test.TransformerUtils.RejectExpressionsConfigWithAddOnlyParam;
 import static org.jboss.as.messaging.test.TransformerUtils.concat;
 import static org.jboss.as.messaging.test.TransformerUtils.createChainedConfig;
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_0_0;
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_0_1;
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_1_0;
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_1_1;
 import static org.jboss.as.model.test.ModelTestControllerVersion.V7_1_2_FINAL;
 import static org.jboss.as.model.test.ModelTestControllerVersion.V7_1_3_FINAL;
 import static org.jboss.as.model.test.ModelTestControllerVersion.V7_2_0_FINAL;
@@ -136,24 +141,72 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    public void testTransformersEAP600() throws Exception {
+        testTransformers(EAP_6_0_0, VERSION_1_1_0, FIXER_1_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformers(EAP_6_0_1, VERSION_1_1_0, FIXER_1_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers(EAP_6_1_0, VERSION_1_2_1, FIXER_1_2_0);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testTransformers(EAP_6_1_1, VERSION_1_2_1, FIXER_1_2_0);
+    }
+
+    @Test
     public void testRejectExpressionsAS712() throws Exception {
         KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_2_FINAL, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
 
-        doTestRejectExpressions_1_1_0(builder);
+        doTestRejectExpressions_1_1_0(V7_1_2_FINAL, builder);
     }
 
     @Test
     public void testRejectExpressionsAS713() throws Exception {
         KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_3_FINAL, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
 
-        doTestRejectExpressions_1_1_0(builder);
+        doTestRejectExpressions_1_1_0(V7_1_3_FINAL, builder);
     }
 
     @Test
     public void testRejectExpressionsAS720() throws Exception {
         KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0, "empty_subsystem_2_0.xml");
 
-        doTestRejectExpressions_1_2_0(builder);
+        doTestRejectExpressions_1_2_0(V7_2_0_FINAL, builder);
+    }
+
+    @Test
+    public void testRejectExpressionsEAP600() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_0, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
+
+        doTestRejectExpressions_1_1_0(EAP_6_0_0, builder);
+    }
+
+    @Test
+    public void testRejectExpressionsEAP601() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_1, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
+
+        doTestRejectExpressions_1_1_0(EAP_6_0_1, builder);
+    }
+
+    @Test
+    public void testRejectExpressionsEAP610() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_0, VERSION_1_2_1, FIXER_1_2_0, "empty_subsystem_2_0.xml");
+
+        doTestRejectExpressions_1_2_1(EAP_6_1_0, builder);
+    }
+
+    @Test
+    public void testRejectExpressionsEAP611() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_1, VERSION_1_2_1, FIXER_1_2_0, "empty_subsystem_2_0.xml");
+
+        doTestRejectExpressions_1_2_1(EAP_6_1_1, builder);
     }
 
     @Test
@@ -202,7 +255,12 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
      *
      * @throws Exception
      */
-    private void doTestRejectExpressions_1_1_0(KernelServicesBuilder builder) throws Exception {
+    private void doTestRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
+
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
         KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_1_0);
@@ -345,7 +403,12 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
      *
      * @throws Exception
      */
-    private void doTestRejectExpressions_1_2_0(KernelServicesBuilder builder) throws Exception {
+    private void doTestRejectExpressions_1_2_0(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
+
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
         KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_2_0);
@@ -377,6 +440,49 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
         );
     }
 
+
+    /**
+     * Tests rejection of expressions in 1.2.1 model.
+     *
+     * @throws Exception
+     */
+    private void doTestRejectExpressions_1_2_1(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
+
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_2_1);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+
+        //Use the real xml with expressions for testing all the attributes
+        PathAddress subsystemAddress = PathAddress.pathAddress(pathElement(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME));
+        List<ModelNode> modelNodes = builder.parseXmlResource("subsystem_2_0_expressions.xml");
+        // remove the messaging subsystem add operation that fails on AS7 7.2.0.Final
+        modelNodes.remove(0);
+        checkFailedTransformedBootOperations(
+                mainServices,
+                VERSION_1_2_1,
+                modelNodes,
+                new FailedOperationTransformationConfig()
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, ServletConnectorDefinition.PATH),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, BridgeDefinition.PATH),
+                                createChainedConfig(new AttributeDefinition[]{},
+                                        new AttributeDefinition[]{BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE}))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(AddressSettingDefinition.PATH),
+                                createChainedConfig(new AttributeDefinition[]{},
+                                        new AttributeDefinition[]{AddressSettingDefinition.EXPIRY_DELAY}))
+        );
+    }
+
     private KernelServicesBuilder createKernelServicesBuilder(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion, ModelFixer fixer, String xmlFileName) throws IOException, XMLStreamException, ClassNotFoundException {
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource(xmlFileName);
@@ -389,6 +495,9 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
     }
 
     private void testTransformers(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion, ModelFixer fixer) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         //Boot up empty controllers with the resources needed for the ops coming from the xml to work
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource("subsystem_2_0.xml");

--- a/mod_cluster/extension/src/test/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemTestCase.java
+++ b/mod_cluster/extension/src/test/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemTestCase.java
@@ -101,37 +101,21 @@ public class ModClusterSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testTransformers720() throws Exception {
-        testTransformers_1_3_0(ModelTestControllerVersion.V7_2_0_FINAL);
+    public void testTransformersEAP600() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_0_0);
     }
 
-    private void testTransformers_1_3_0(ModelTestControllerVersion controllerVersion) throws Exception {
-        String subsystemXml = readResource("subsystem_1_1.xml");
-        ModelVersion modelVersion = ModelVersion.create(1, 3, 0);
-        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
-                .setSubsystemXml(subsystemXml);
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-modcluster:" + controllerVersion.getMavenGavVersion())
-                .configureReverseControllerCheck(null, new Undo71TransformModelFixer())
-                .setExtensionClassName("org.jboss.as.modcluster.ModClusterExtension");
-        KernelServices mainServices = builder.build();
-        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
-        Assert.assertNotNull(legacyServices);
-        Assert.assertTrue(mainServices.isSuccessfulBoot());
-        Assert.assertTrue(legacyServices.isSuccessfulBoot());
-
-        ModelNode legacySubsystem = checkSubsystemModelTransformation(mainServices, modelVersion);
-
-        ModelNode mainSessionCapacity = mainServices.readWholeModel().get(SUBSYSTEM, ModClusterExtension.SUBSYSTEM_NAME, MOD_CLUSTER_CONFIG, CONFIGURATION,
-                CommonAttributes.DYNAMIC_LOAD_PROVIDER, CONFIGURATION, CommonAttributes.LOAD_METRIC, "sessions", CommonAttributes.CAPACITY);
-        ModelNode legacySessionCapacity = legacySubsystem.get(SUBSYSTEM, ModClusterExtension.SUBSYSTEM_NAME, MOD_CLUSTER_CONFIG, CONFIGURATION,
-                CommonAttributes.DYNAMIC_LOAD_PROVIDER, CONFIGURATION, CommonAttributes.LOAD_METRIC, "sessions", CommonAttributes.CAPACITY);
-        Assert.assertEquals(legacySessionCapacity.getType(), mainSessionCapacity.getType());
-        Assert.assertTrue(mainSessionCapacity.asString().equals(legacySessionCapacity.asString()));
-        Assert.assertEquals(mainSessionCapacity.asInt(), legacySessionCapacity.asInt());
+    @Test
+    public void testTransformers601() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_0_1);
     }
 
     private void testTransformers_1_2_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = readResource("subsystem_1_1.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 2, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
@@ -175,6 +159,52 @@ public class ModClusterSubsystemTestCase extends AbstractSubsystemBaseTest {
         Assert.assertEquals(mainSessionCapacity.asInt(), legacySessionCapacity.asInt());
     }
 
+    @Test
+    public void testTransformers720() throws Exception {
+        testTransformers_1_3_0(ModelTestControllerVersion.V7_2_0_FINAL);
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+        testTransformers_1_3_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformers611() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+        testTransformers_1_3_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+    private void testTransformers_1_3_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+        String subsystemXml = readResource("subsystem_1_1.xml");
+        ModelVersion modelVersion = ModelVersion.create(1, 3, 0);
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXml(subsystemXml);
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
+                .addMavenResourceURL("org.jboss.as:jboss-as-modcluster:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(null, new Undo71TransformModelFixer())
+                .setExtensionClassName("org.jboss.as.modcluster.ModClusterExtension");
+        KernelServices mainServices = builder.build();
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        Assert.assertNotNull(legacyServices);
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        ModelNode legacySubsystem = checkSubsystemModelTransformation(mainServices, modelVersion);
+
+        ModelNode mainSessionCapacity = mainServices.readWholeModel().get(SUBSYSTEM, ModClusterExtension.SUBSYSTEM_NAME, MOD_CLUSTER_CONFIG, CONFIGURATION,
+                CommonAttributes.DYNAMIC_LOAD_PROVIDER, CONFIGURATION, CommonAttributes.LOAD_METRIC, "sessions", CommonAttributes.CAPACITY);
+        ModelNode legacySessionCapacity = legacySubsystem.get(SUBSYSTEM, ModClusterExtension.SUBSYSTEM_NAME, MOD_CLUSTER_CONFIG, CONFIGURATION,
+                CommonAttributes.DYNAMIC_LOAD_PROVIDER, CONFIGURATION, CommonAttributes.LOAD_METRIC, "sessions", CommonAttributes.CAPACITY);
+        Assert.assertEquals(legacySessionCapacity.getType(), mainSessionCapacity.getType());
+        Assert.assertTrue(mainSessionCapacity.asString().equals(legacySessionCapacity.asString()));
+        Assert.assertEquals(mainSessionCapacity.asInt(), legacySessionCapacity.asInt());
+    }
+
     // --------------------------------------------------- Expressions Rejected prior to 7.1.2 and 7.1.3
 
     @Test
@@ -188,11 +218,19 @@ public class ModClusterSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testRejection720() throws Exception {
-        testRejection1_3_0(ModelTestControllerVersion.V7_2_0_FINAL);
+    public void testExpressionsAreRejectedEAP600() throws Exception {
+        testExpressionsAreRejectedByVersion_1_2(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testExpressionsAreRejectedEAP601() throws Exception {
+        testExpressionsAreRejectedByVersion_1_2(ModelTestControllerVersion.EAP_6_0_1);
     }
 
     private void testExpressionsAreRejectedByVersion_1_2(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = readResource("subsystem_1_2.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 2, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
@@ -252,7 +290,25 @@ public class ModClusterSubsystemTestCase extends AbstractSubsystemBaseTest {
         );
     }
 
+    @Test
+    public void testRejection720() throws Exception {
+        testRejection1_3_0(ModelTestControllerVersion.V7_2_0_FINAL);
+    }
+
+    @Test
+    public void testRejectionEAP610() throws Exception {
+        testRejection1_3_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testRejectionEAP611() throws Exception {
+        testRejection1_3_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
     private void testRejection1_3_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = readResource("subsystem_1_2.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 3, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());

--- a/model-test/src/main/java/org/jboss/as/model/test/EAPRepositoryReachableUtil.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/EAPRepositoryReachableUtil.java
@@ -39,7 +39,7 @@ public class EAPRepositoryReachableUtil {
 
     public static boolean isReachable() {
         if (reachable == null) {
-            if (System.getProperties().contains(TEST_TRANSFORMERS_EAP)) {
+            if (System.getProperties().containsKey(TEST_TRANSFORMERS_EAP)) {
                 try {
                     InetAddress.getByName(EAP_REPOSITORY_HOST);
                     reachable = true;

--- a/naming/src/test/java/org/jboss/as/naming/subsystem/NamingTransformersTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/subsystem/NamingTransformersTestCase.java
@@ -117,7 +117,21 @@ public class NamingTransformersTestCase extends AbstractSubsystemBaseTest {
         testTransformers_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+
+    @Test
+    public void testTransformers_EAP600() throws Exception {
+        testTransformers_1_1_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testTransformers_EAP601() throws Exception {
+        testTransformers_1_1_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
     private void testTransformers_1_1_0(ModelTestControllerVersion version) throws Exception {
+        if (version.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXmlResource("subsystem_with_expressions_compatible_1.1.0.xml");
 
@@ -227,12 +241,25 @@ public class NamingTransformersTestCase extends AbstractSubsystemBaseTest {
         doTestRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+    @Test
+    public void testRejectExpressionsEAP600() throws Exception {
+        doTestRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testRejectExpressionsEAP601() throws Exception {
+        doTestRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
     /**
      * Tests rejection of expressions in 1.1.0 model.
      *
      * @throws Exception
      */
     private void doTestRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
 
         // create builder for legacy subsystem version
@@ -259,7 +286,21 @@ public class NamingTransformersTestCase extends AbstractSubsystemBaseTest {
         testTransformers_1_2_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testTransformers_EAP610() throws Exception {
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformers_EAP611() throws Exception {
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
     private void testTransformers_1_2_0(ModelTestControllerVersion version) throws Exception {
+        if (version.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXmlResource("subsystem_with_expressions_compatible_1.2.0.xml");
 

--- a/pojo/src/test/java/org/jboss/as/pojo/PojoSubsystemTestCase.java
+++ b/pojo/src/test/java/org/jboss/as/pojo/PojoSubsystemTestCase.java
@@ -63,7 +63,30 @@ public class PojoSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformers_1_0_0(ModelTestControllerVersion.V7_2_0_FINAL, null);
     }
 
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_0, "1.0.0.Final-redhat-1");
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_1, "1.0.0.Final-redhat-2");
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_1_0, null);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+    }
+
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion, String commonBeansVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)

--- a/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
+++ b/remoting-test/src/test/java/org/jboss/as/remoting/RemotingSubsystemTransformersTestCase.java
@@ -82,7 +82,21 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBase
         testExpressionsAreRejectedByVersion_1_1(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+
+    @Test
+    public void testExpressionsAreRejectedEAP600() throws Exception {
+        testExpressionsAreRejectedByVersion_1_1(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testExpressionsAreRejectedEAP601() throws Exception {
+        testExpressionsAreRejectedByVersion_1_1(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
     private void testExpressionsAreRejectedByVersion_1_1(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = readResource("remoting-with-expressions.xml");
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
@@ -155,7 +169,20 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBase
         testNonRemotingProtocolRejectedByVersion1_2(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testNonRemotingProtocolRejectedEAP610() throws Exception {
+        testNonRemotingProtocolRejectedByVersion1_2(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testNonRemotingProtocolRejectedEAP611() throws Exception {
+        testNonRemotingProtocolRejectedByVersion1_2(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
     private void testNonRemotingProtocolRejectedByVersion1_2(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = readResource("remoting-with-expressions.xml");
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
@@ -185,6 +212,18 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBase
     @Test
     public void testTransformersAS713() throws Exception {
         testTransformers_1_1(ModelTestControllerVersion.V7_1_3_FINAL);
+    }
+
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+        testTransformers_1_1(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+        testTransformers_1_1(ModelTestControllerVersion.EAP_6_0_1);
     }
 
     private void testTransformers_1_1(ModelTestControllerVersion controllerVersion) throws Exception {
@@ -220,10 +259,24 @@ public class RemotingSubsystemTransformersTestCase extends AbstractSubsystemBase
 
     @Test
     public void testTransformersAS720() throws Exception {
-        testTransformers_1_2(ModelTestControllerVersion.V7_2_0_FINAL);
+        testTransformers_1_2_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
-    private void testTransformers_1_2(ModelTestControllerVersion controllerVersion) throws Exception {
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+
+    private void testTransformers_1_2_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
                 .setSubsystemXmlResource("remoting-with-expressions-and-good-legacy-protocol.xml");
         ModelVersion oldVersion = ModelVersion.create(1, 2, 0);

--- a/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
+++ b/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
@@ -63,7 +63,30 @@ public class SarSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformers_1_0_0(ModelTestControllerVersion.V7_2_0_FINAL, null);
     }
 
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_0, "1.0.0.Final-redhat-1");
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_0_1, "1.0.0.Final-redhat-2");
+    }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_1_0, null);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        testTransformers_1_0_0(ModelTestControllerVersion.EAP_6_1_1, null);
+    }
+
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion, String commonBeansVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
@@ -355,10 +355,10 @@ public abstract class AbstractSubsystemTest {
     }
 
     /**
-     * Uses {@link org.junit.Assume#assumeTrue(boolean)} to check that the EAP repository is reachable. If it is not reachable an {@linke org.junit.AssumptionViolatedException}
-     * is thrown causing the test to be conditionally ignored. The purpose of this method is to be called at the beginning of transformers tests against legacy EAP versions. If the
-     * internal EAP repository is not available to the caller, the test is conditionally @Ignored if running with the standard JUnit test runner. This means that no special setup
-     * is needed for being on the VPN or not.
+     * Uses {@link org.junit.Assume#assumeTrue(boolean)} to check that  -Djboss.test.transformers.eap is set AND the EAP repository is reachable. If those two conditions are not true,
+     * an {@linke org.junit.AssumptionViolatedException} is thrown causing the test to be conditionally ignored. The purpose of this method is to be called at the beginning of transformers
+     * tests against legacy EAP versions. If the internal EAP repository is not available to the caller, the test is conditionally @Ignored if running with the standard JUnit test runner.
+     * This means that no special setup is needed for being on the VPN or not. The -Dboss.test.transformers.eap is required to not add unnecessary time to every day builds.
      */
     protected void ignoreThisTestIfEAPRepositoryIsNotReachable() {
         Assume.assumeTrue(EAPRepositoryReachableUtil.isReachable());

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
@@ -81,6 +81,7 @@ class KnownVersions {
         addSubsystemVersion(map, "mail", "1.1.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "messaging", "1.1.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "messaging", "1.2.0", CORE_MODEL_7_2_0);
+        addSubsystemVersion(map, "messaging", "1.2.1", CORE_MODEL_7_2_0);
         addSubsystemVersion(map, "modcluster", "1.2.0", CORE_MODEL_7_1_2);
         addSubsystemVersion(map, "modcluster", "1.2.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "modcluster", "1.3.0", CORE_MODEL_7_2_0);

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
@@ -111,6 +111,7 @@ class KnownVersions {
         addSubsystemVersion(map, "weld", "1.0.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "weld", "1.0.0", CORE_MODEL_7_2_0);
         addSubsystemVersion(map, "webservices", "1.1.0", CORE_MODEL_7_1_3);
+        addSubsystemVersion(map, "webservices", "1.2.0", CORE_MODEL_7_2_0);
 
         KNOWN_SUBSYSTEM_VERSIONS = Collections.unmodifiableMap(map);
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KnownVersions.java
@@ -61,6 +61,7 @@ class KnownVersions {
         addSubsystemVersion(map, "jacorb", "1.1.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "ejb3", "1.1.0", CORE_MODEL_7_1_2);
         addSubsystemVersion(map, "ejb3", "1.2.0", CORE_MODEL_7_2_0);
+        addSubsystemVersion(map, "ejb3", "1.2.1", CORE_MODEL_7_2_0);
         addSubsystemVersion(map, "infinispan", "1.3.0", CORE_MODEL_7_1_3);
         addSubsystemVersion(map, "infinispan", "1.4.0", CORE_MODEL_7_2_0);
         addSubsystemVersion(map, "jacorb", "1.1.0", CORE_MODEL_7_1_3);

--- a/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/ejb3-1.2.1.dmr
+++ b/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/ejb3-1.2.1.dmr
@@ -1,0 +1,584 @@
+{
+    "model-description" => {
+        "description" => "The configuration of the ejb3 subsystem.",
+        "attributes" => {
+            "default-security-domain" => {
+                "type" => STRING,
+                "description" => "The default security domain that will be used for EJBs if the bean doesn't explicitly specify one",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-mdb-instance-pool" => {
+                "type" => STRING,
+                "description" => "Name of the default MDB instance pool, which will be applicable to all MDBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-entity-bean-optimistic-locking" => {
+                "type" => BOOLEAN,
+                "description" => "If set to true entity beans will use optimistic locking by default",
+                "expressions-allowed" => true,
+                "nillable" => true
+            },
+            "in-vm-remote-interface-invocation-pass-by-value" => {
+                "type" => BOOLEAN,
+                "description" => "If set to false, the parameters to invocations on remote interface of an EJB, will be passed by reference. Else, the parameters will be passed by value.",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => true
+            },
+            "default-missing-method-permissions-deny-access" => {
+                "type" => BOOLEAN,
+                "description" => "If this is set to true then methods on an EJB with a security domain specified or with other methods with security metadata will have an implicit @DenyAll unless other security metadata is present",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => false
+            },
+            "default-clustered-sfsb-cache" => {
+                "type" => STRING,
+                "description" => "Name of the default stateful bean cache, which will be applicable to all clustered stateful EJBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-entity-bean-instance-pool" => {
+                "type" => STRING,
+                "description" => "Name of the default entity bean instance pool, which will be applicable to all entity beans, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-distinct-name" => {
+                "type" => STRING,
+                "description" => "The default distinct name that is applied to every EJB deployed on this server",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 0L,
+                "max-length" => 2147483647L
+            },
+            "default-singleton-bean-access-timeout" => {
+                "type" => LONG,
+                "description" => "The default access timeout for singleton beans",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => 5000,
+                "min" => 1L,
+                "max" => 2147483647L
+            },
+            "default-sfsb-cache" => {
+                "type" => STRING,
+                "description" => "Name of the default stateful bean cache, which will be applicable to all stateful EJBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "default-resource-adapter-name" => {
+                "type" => STRING,
+                "description" => "Name of the default resource adapter name that will be used by MDBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => "hornetq-ra",
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            },
+            "enable-statistics" => {
+                "type" => BOOLEAN,
+                "description" => "If set to true, enable the collection of invocation statistics.",
+                "expressions-allowed" => true,
+                "nillable" => true
+            },
+            "default-stateful-bean-access-timeout" => {
+                "type" => LONG,
+                "description" => "The default access timeout for stateful beans",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => 5000,
+                "min" => 1L,
+                "max" => 2147483647L
+            },
+            "default-slsb-instance-pool" => {
+                "type" => STRING,
+                "description" => "Name of the default stateless bean instance pool, which will be applicable to all stateless EJBs, unless overridden at the deployment or bean level",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }
+        },
+        "operations" => undefined,
+        "children" => {
+            "service" => {
+                "description" => "Centrally configurable services that are part of the EJB3 subsystem.",
+                "model-description" => undefined
+            },
+            "thread-pool" => {
+                "description" => "An EJB thread pool",
+                "model-description" => undefined
+            },
+            "file-passivation-store" => {
+                "description" => "A file system based passivation store",
+                "model-description" => undefined
+            },
+            "strict-max-bean-instance-pool" => {
+                "description" => "A bean instance pool with a strict upper limit",
+                "model-description" => undefined
+            },
+            "cache" => {
+                "description" => "A SFSB cache",
+                "model-description" => undefined
+            },
+            "cluster-passivation-store" => {
+                "description" => "A clustered passivation store",
+                "model-description" => undefined
+            }
+        }
+    },
+    "address" => [("subsystem" => "ejb3")],
+    "children" => [
+        {
+            "model-description" => {
+                "description" => "The EJB3 Asynchronous Invocation Service",
+                "attributes" => {"thread-pool-name" => {
+                    "type" => STRING,
+                    "description" => "The name of the thread pool which handles asynchronous invocations",
+                    "expressions-allowed" => true,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }},
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "async")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "The IIOP service",
+                "attributes" => {
+                    "enable-by-default" => {
+                        "type" => BOOLEAN,
+                        "description" => "If this is true EJB's will be exposed over IIOP by default, otherwise it needs to be explicitly enabled in the deployment descriptor",
+                        "expressions-allowed" => true,
+                        "nillable" => true
+                    },
+                    "use-qualified-name" => {
+                        "type" => BOOLEAN,
+                        "description" => "If true EJB names will be bound into the naming service with the application and module name prepended to the name (e.g. myapp/mymodule/MyEjb)",
+                        "expressions-allowed" => true,
+                        "nillable" => true
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "iiop")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A thread pool executor with an unbounded queue.  Such a thread pool has a core size and a queue with no upper bound.  When a task is submitted, if the number of running threads is less than the core size, a new thread is created.  Otherwise, the task is placed in queue.  If too many tasks are allowed to be submitted to this type of executor, an out of memory condition may occur.",
+                "attributes" => {
+                    "max-threads" => {
+                        "type" => INT,
+                        "description" => "The maximum thread pool size.",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "min" => 0L,
+                        "max" => 2147483647L
+                    },
+                    "thread-factory" => {
+                        "type" => STRING,
+                        "description" => "Specifies the name of a specific thread factory to use to create worker threads. If not defined an appropriate default thread factory will be used.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "keepalive-time" => {
+                        "type" => OBJECT,
+                        "description" => "Used to specify the amount of time that pool threads should be kept running when idle; if not specified, threads will run until the executor is shut down.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => {
+                            "time" => {
+                                "type" => LONG,
+                                "description" => "The time",
+                                "expressions-allowed" => true,
+                                "nillable" => false
+                            },
+                            "unit" => {
+                                "type" => STRING,
+                                "description" => "The time unit",
+                                "expressions-allowed" => true,
+                                "nillable" => false
+                            }
+                        }
+                    },
+                    "name" => {
+                        "type" => STRING,
+                        "description" => "The name of the thread pool.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("thread-pool" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A file system based passivation store",
+                "attributes" => {
+                    "idle-timeout" => {
+                        "type" => LONG,
+                        "description" => "The timeout in units specified by idle-timeout-unit, after which a bean will passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 300L,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "groups-path" => {
+                        "type" => STRING,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ejb3/groups",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "sessions-path" => {
+                        "type" => STRING,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ejb3/sessions",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "relative-to" => {
+                        "type" => STRING,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "jboss.server.data.dir",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "subdirectory-count" => {
+                        "type" => LONG,
+                        "description" => "",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 100,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "max-size" => {
+                        "type" => INT,
+                        "description" => "The maximum number of beans this cache should store before forcing old beans to passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 100000,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "idle-timeout-unit" => {
+                        "type" => STRING,
+                        "description" => "The unit of idle-timeout",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "SECONDS",
+                        "allowed" => [
+                            "NANOSECONDS",
+                            "MICROSECONDS",
+                            "MILLISECONDS",
+                            "SECONDS",
+                            "MINUTES",
+                            "HOURS",
+                            "DAYS"
+                        ]
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("file-passivation-store" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A bean instance pool with a strict upper limit",
+                "attributes" => {
+                    "timeout-unit" => {
+                        "type" => STRING,
+                        "description" => "The instance acquisition timeout unit",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "MINUTES",
+                        "allowed" => [
+                            "NANOSECONDS",
+                            "MICROSECONDS",
+                            "MILLISECONDS",
+                            "SECONDS",
+                            "MINUTES",
+                            "HOURS",
+                            "DAYS"
+                        ]
+                    },
+                    "max-pool-size" => {
+                        "type" => INT,
+                        "description" => "The maximum number of bean instances that the pool can hold at a given point in time",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 20,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "timeout" => {
+                        "type" => LONG,
+                        "description" => "The maximum amount of time to wait for a bean instance to be available from the pool",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 5L,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("strict-max-bean-instance-pool" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "The EJB3 Remote Service",
+                "attributes" => {
+                    "thread-pool-name" => {
+                        "type" => STRING,
+                        "description" => "The name of the thread pool that handles remote invocations",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "connector-ref" => {
+                        "type" => STRING,
+                        "description" => "The name of the connector on which the EJB3 remoting channel is registered",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {"channel-creation-options" => {
+                    "description" => "The options that will be used during the EJB remote channel creation",
+                    "model-description" => undefined
+                }}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "remote")
+            ],
+            "children" => [{
+                "model-description" => {
+                    "description" => "The options that will be used during the EJB remote channel creation",
+                    "attributes" => {
+                        "value" => {
+                            "type" => STRING,
+                            "description" => "The value for the EJB remote channel creation option",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        },
+                        "type" => {
+                            "type" => STRING,
+                            "description" => "The type of the channel creation option",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "allowed" => [
+                                "remoting",
+                                "xnio"
+                            ]
+                        }
+                    },
+                    "operations" => undefined,
+                    "children" => {}
+                },
+                "address" => [
+                    ("subsystem" => "ejb3"),
+                    ("service" => "remote"),
+                    ("channel-creation-options" => "*")
+                ]
+            }]
+        },
+        {
+            "model-description" => {
+                "description" => "A SFSB cache",
+                "attributes" => {
+                    "aliases" => {
+                        "type" => LIST,
+                        "description" => "The aliases by which this cache may also be referenced",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    },
+                    "passivation-store" => {
+                        "type" => STRING,
+                        "description" => "The passivation store used by this cache",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("cache" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "The EJB timer service",
+                "attributes" => {
+                    "path" => {
+                        "type" => STRING,
+                        "description" => "The directory to store persistent timer information in",
+                        "expressions-allowed" => true,
+                        "nillable" => true
+                    },
+                    "thread-pool-name" => {
+                        "type" => STRING,
+                        "description" => "The name of the thread pool used to run timer service invocations",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "relative-to" => {
+                        "type" => STRING,
+                        "description" => "The relative path that is used to resolve the timer data store location",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("service" => "timer-service")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A clustered passivation store",
+                "attributes" => {
+                    "idle-timeout" => {
+                        "type" => LONG,
+                        "description" => "The timeout in units specified by idle-timeout-unit, after which a bean will passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 300L,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "cache-container" => {
+                        "type" => STRING,
+                        "description" => "The name of the cache container used for the bean and client-mappings caches",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ejb",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "client-mappings-cache" => {
+                        "type" => STRING,
+                        "description" => "The name of the cache used to store client-mappings of the EJB remoting connector's socket-bindings",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "remote-connector-client-mappings",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "bean-cache" => {
+                        "type" => STRING,
+                        "description" => "The name of the cache used to store bean instances.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "passivate-events-on-replicate" => {
+                        "type" => BOOLEAN,
+                        "description" => "Indicates whether replication should trigger passivation events on the bean",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "max-size" => {
+                        "type" => INT,
+                        "description" => "The maximum number of beans this cache should store before forcing old beans to passivate",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 10000,
+                        "min" => 1L,
+                        "max" => 2147483647L
+                    },
+                    "idle-timeout-unit" => {
+                        "type" => STRING,
+                        "description" => "The unit of idle-timeout",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "SECONDS",
+                        "allowed" => [
+                            "NANOSECONDS",
+                            "MICROSECONDS",
+                            "MILLISECONDS",
+                            "SECONDS",
+                            "MINUTES",
+                            "HOURS",
+                            "DAYS"
+                        ]
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "ejb3"),
+                ("cluster-passivation-store" => "*")
+            ]
+        }
+    ]
+}

--- a/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/messaging-1.2.1.dmr
+++ b/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/messaging-1.2.1.dmr
@@ -1,0 +1,2921 @@
+{
+    "model-description" => {
+        "description" => "The messaging subsystem.",
+        "attributes" => {},
+        "operations" => undefined,
+        "children" => {
+            "jms-bridge" => {
+                "description" => "A JMS bridge instance.",
+                "model-description" => undefined
+            },
+            "hornetq-server" => {
+                "description" => "A HornetQ server instance.",
+                "model-description" => undefined
+            }
+        }
+    },
+    "address" => [("subsystem" => "messaging")],
+    "children" => [
+        {
+            "model-description" => {
+                "description" => "A JMS bridge instance.",
+                "attributes" => {
+                    "selector" => {
+                        "type" => STRING,
+                        "description" => "A JMS selector expression used for consuming messages from the source destination. Only messages that match the selector expression will be bridged from the source to the target destination.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "failure-retry-interval" => {
+                        "type" => LONG,
+                        "description" => "The amount of time in milliseconds to wait between trying to recreate connections to the source or target servers when the bridge has detected they have failed.",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "source-destination" => {
+                        "type" => STRING,
+                        "description" => "The name of the source destination to lookup on the source messaging server.",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "quality-of-service" => {
+                        "type" => STRING,
+                        "description" => "The desired quality of service mode (AT_MOST_ONCE, DUPLICATES_OK or ONCE_AND_ONLY_ONCE).",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "allowed" => [
+                            "AT_MOST_ONCE",
+                            "DUPLICATES_OK",
+                            "ONCE_AND_ONLY_ONCE"
+                        ]
+                    },
+                    "target-password" => {
+                        "type" => STRING,
+                        "description" => "The password for creating the target connection.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "max-batch-size" => {
+                        "type" => INT,
+                        "description" => "The maximum number of messages to consume from the source destination before sending them in a batch to the target destination. Its value must >= 1.",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "min" => 0L,
+                        "max" => 2147483647L
+                    },
+                    "max-retries" => {
+                        "type" => INT,
+                        "description" => "The number of times to attempt to recreate connections to the source or target servers when the bridge has detected they have failed. The bridge will give up after trying this number of times. -1 represents 'try forever'.",
+                        "expressions-allowed" => true,
+                        "nillable" => false
+                    },
+                    "client-id" => {
+                        "type" => STRING,
+                        "description" => "The JMS client ID to use when creating/looking up the subscription if it is durable and the source destination is a topic.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "source-password" => {
+                        "type" => STRING,
+                        "description" => "The password for creating the source connection.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "target-connection-factory" => {
+                        "type" => STRING,
+                        "description" => "The name of the target connection factory to lookup on the target messaging server.",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "target-destination" => {
+                        "type" => STRING,
+                        "description" => "The name of the target destination to lookup on the target messaging server.",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "module" => {
+                        "type" => STRING,
+                        "description" => "The name of AS7 module containing the resources required to lookup source and target JMS resources.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "source-context" => {
+                        "type" => OBJECT,
+                        "description" => "he properties used to configure the source JNDI initial context.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    },
+                    "paused" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the JMS bridge is paused.",
+                        "expressions-allowed" => false,
+                        "nillable" => false
+                    },
+                    "source-connection-factory" => {
+                        "type" => STRING,
+                        "description" => "The name of the source connection factory to lookup on the source messaging server.",
+                        "expressions-allowed" => false,
+                        "nillable" => false,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "add-messageID-in-header" => {
+                        "type" => BOOLEAN,
+                        "description" => "If true, then the original message's message ID will be appended in the message sent to the destination in the header HORNETQ_BRIDGE_MSG_ID_LIST. If the message is bridged more than once, each message ID will be appended.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "source-user" => {
+                        "type" => STRING,
+                        "description" => "The name of the user for creating the source connection.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "target-user" => {
+                        "type" => STRING,
+                        "description" => "The name of the user for creating the target connection.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "subscription-name" => {
+                        "type" => STRING,
+                        "description" => "The name of the subscription if it is durable and the source destination is a topic.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "max-batch-time" => {
+                        "type" => LONG,
+                        "description" => "The maximum number of milliseconds to wait before sending a batch to target, even if the number of messages consumed has not reached max-batch-size. Its value must be -1 to represent 'wait forever', or >= 1 to specify an actual time.",
+                        "expressions-allowed" => true,
+                        "nillable" => false,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "started" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the JMS bridge is started.",
+                        "expressions-allowed" => false,
+                        "nillable" => false
+                    },
+                    "target-context" => {
+                        "type" => OBJECT,
+                        "description" => "The properties used to configure the target JNDI initial context.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "messaging"),
+                ("jms-bridge" => "*")
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "A HornetQ server instance.",
+                "attributes" => {
+                    "shared-store" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether this server is using a shared store for failover.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "thread-pool-max-size" => {
+                        "type" => INT,
+                        "description" => "The number of threads that the main thread pool has. -1 means no limit.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 30
+                    },
+                    "clustered" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the server is clustered.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "default" => false,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "To create a clustered HornetQ server, define at least one cluster-connection."
+                        }
+                    },
+                    "remoting-interceptors" => {
+                        "type" => LIST,
+                        "description" => "The list of interceptor classes used by this server.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Deprecated. Use remoting-incoming-interceptors instead."
+                        },
+                        "value-type" => STRING
+                    },
+                    "create-bindings-dir" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the server should create the bindings directory on start up.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "journal-buffer-size" => {
+                        "type" => LONG,
+                        "description" => "The size of the internal buffer on the journal.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "unit" => "BYTES"
+                    },
+                    "security-invalidation-interval" => {
+                        "type" => LONG,
+                        "description" => "How long (in ms) to wait before invalidating the security cache.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 10000L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "message-counter-enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether message counters are enabled.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "journal-type" => {
+                        "type" => STRING,
+                        "description" => "The type of journal to use.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "ASYNCIO",
+                        "allowed" => [
+                            "NIO",
+                            "ASYNCIO"
+                        ]
+                    },
+                    "journal-sync-transactional" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether to wait for transaction data to be synchronized to the journal before returning a response to the client.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "journal-compact-min-files" => {
+                        "type" => INT,
+                        "description" => "The minimal number of journal data files before we can start compacting.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 10
+                    },
+                    "log-journal-write-rate" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether to periodically log the journal's write rate and flush rate.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "journal-max-io" => {
+                        "type" => INT,
+                        "description" => "The maximum number of write requests that can be in the AIO queue at any one time.",
+                        "expressions-allowed" => true,
+                        "nillable" => true
+                    },
+                    "scheduled-thread-pool-max-size" => {
+                        "type" => INT,
+                        "description" => "The number of threads that the main scheduled thread pool has.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 5
+                    },
+                    "security-enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether security is enabled.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "memory-warning-threshold" => {
+                        "type" => INT,
+                        "description" => "Percentage of available memory which if exceeded results in a warning log",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 25,
+                        "unit" => "PERCENTAGE"
+                    },
+                    "journal-compact-percentage" => {
+                        "type" => INT,
+                        "description" => "The percentage of live data on which we consider compacting the journal.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 30,
+                        "unit" => "PERCENTAGE"
+                    },
+                    "failover-on-shutdown" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether this backup server (if it is a backup server) should come live on a normal server shutdown.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "backup-group-name" => {
+                        "type" => STRING,
+                        "description" => "The name of a set of live/backups that should replicate with each other",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "cluster-user" => {
+                        "type" => STRING,
+                        "description" => "The user used by cluster connections to communicate between the clustered nodes.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "HORNETQ.CLUSTER.ADMIN.USER",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "run-sync-speed-test" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether on startup to perform a diagnostic test on how fast your disk can sync. Useful when determining performance issues.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "jmx-domain" => {
+                        "type" => STRING,
+                        "description" => "The JMX domain used to register internal HornetQ MBeans in the MBeanServer.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "org.hornetq",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "transaction-timeout" => {
+                        "type" => LONG,
+                        "description" => "How long (in ms) before a transaction can be removed from the resource manager after create time.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 300000L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "cluster-password" => {
+                        "type" => STRING,
+                        "description" => "The password used by cluster connections to communicate between the clustered nodes.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "CHANGE ME!!",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "create-journal-dir" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the server should create the journal directory on start up.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "message-counter-sample-period" => {
+                        "type" => LONG,
+                        "description" => "The sample period (in ms) to use for message counters.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 10000L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "connection-ttl-override" => {
+                        "type" => LONG,
+                        "description" => "If set, this will override how long (in ms) to keep a connection alive without receiving a ping.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => -1L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "persistence-enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the server will use the file based journal for persistence.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "allow-failback" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether this server will automatically shutdown if the original live server comes back up.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "remoting-outgoing-interceptors" => {
+                        "type" => LIST,
+                        "description" => "The list of outgoing interceptor classes used by this server.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    },
+                    "transaction-timeout-scan-period" => {
+                        "type" => LONG,
+                        "description" => "How often (in ms) to scan for timeout transactions.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 1000L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "persist-delivery-count-before-delivery" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the delivery count is persisted before delivery. False means that this only happens after a message has been cancelled.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "page-max-concurrent-io" => {
+                        "type" => INT,
+                        "description" => "The maximum number of concurrent reads allowed on paging",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 5
+                    },
+                    "journal-min-files" => {
+                        "type" => INT,
+                        "description" => "How many journal files to pre-create.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 2
+                    },
+                    "check-for-live-server" => {
+                        "type" => BOOLEAN,
+                        "description" => "If a replicated live server should check the current cluster to see if there is already a live server with the same node id",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "management-notification-address" => {
+                        "type" => STRING,
+                        "description" => "The name of the address that consumers bind to  to receive management notifications.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "hornetq.notifications",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "journal-buffer-timeout" => {
+                        "type" => LONG,
+                        "description" => "The timeout (in nanoseconds) used to flush internal buffers on the journal.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "management-address" => {
+                        "type" => STRING,
+                        "description" => "Address to send management messages to.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => "jms.queue.hornetq.management",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "journal-file-size" => {
+                        "type" => LONG,
+                        "description" => "The size (in bytes) of each journal file.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 10485760,
+                        "unit" => "BYTES"
+                    },
+                    "journal-sync-non-transactional" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether to wait for non transaction data to be synced to the journal before returning a response to the client.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "persist-id-cache" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether IDs are persisted to the journal.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "backup" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether this server is a backup server.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "jmx-management-enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether HornetQ should expose its internal management API via JMX. This is not recommended, as accessing these MBeans can lead to inconsistent configuration.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => false
+                    },
+                    "async-connection-execution-enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether incoming packets on the server should be handed off to a thread from the thread pool for processing. False if they should be handled on the remoting thread.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "perf-blast-pages" => {
+                        "type" => INT,
+                        "description" => "TODO",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => -1
+                    },
+                    "memory-measure-interval" => {
+                        "type" => LONG,
+                        "description" => "Frequency to sample JVM memory in ms (or -1 to disable memory sampling)",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => -1L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "server-dump-interval" => {
+                        "type" => LONG,
+                        "description" => "How often to dump basic runtime information to the server log. A value less than 1 disables this feature.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => -1L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "message-expiry-thread-priority" => {
+                        "type" => INT,
+                        "description" => "The priority of the thread expiring messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 3
+                    },
+                    "live-connector-ref" => {
+                        "type" => STRING,
+                        "description" => "The name of the connector used to connect to the live connector. If this server is not a backup that uses shared nothing HA, it's value is \"undefined\".",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L,
+                        "deprecated" => {
+                            "since" => "1.2.0",
+                            "reason" => "Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute."
+                        }
+                    },
+                    "replication-clustername" => {
+                        "type" => STRING,
+                        "description" => "The name of the cluster connection to replicate from if more than one cluster connection is configured",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "failback-delay" => {
+                        "type" => LONG,
+                        "description" => "How long to wait before failback occurs on live server restart.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 5000L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "id-cache-size" => {
+                        "type" => INT,
+                        "description" => "The size of the cache for pre-creating message IDs.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 20000
+                    },
+                    "security-domain" => {
+                        "type" => STRING,
+                        "description" => "The security domain to use to verify user and role information",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "default" => "other",
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    },
+                    "message-expiry-scan-period" => {
+                        "type" => LONG,
+                        "description" => "How often (in ms) to scan for expired messages.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 30000L,
+                        "unit" => "MILLISECONDS"
+                    },
+                    "remoting-incoming-interceptors" => {
+                        "type" => LIST,
+                        "description" => "The list of incoming interceptor classes used by this server.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    },
+                    "wild-card-routing-enabled" => {
+                        "type" => BOOLEAN,
+                        "description" => "Whether the server supports wild card routing.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => true
+                    },
+                    "message-counter-max-day-history" => {
+                        "type" => INT,
+                        "description" => "How many days to keep message counter history.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "default" => 10,
+                        "unit" => "DAYS"
+                    }
+                },
+                "operations" => undefined,
+                "children" => {
+                    "in-vm-acceptor" => {
+                        "description" => "Defines a way in which in-VM connections can be made to the HornetQ server.",
+                        "model-description" => undefined
+                    },
+                    "jms-queue" => {
+                        "description" => "Defines a JMS queue.",
+                        "model-description" => undefined
+                    },
+                    "security-setting" => {
+                        "description" => "A security setting allows sets of permissions to be defined against queues based on their address.",
+                        "model-description" => undefined
+                    },
+                    "address-setting" => {
+                        "description" => "An address setting defines some attributes that are defined against an address wildcard rather than a specific queue.",
+                        "model-description" => undefined
+                    },
+                    "grouping-handler" => {
+                        "description" => "Makes decisions about which node in a cluster should handle a message with a group id assigned.",
+                        "model-description" => undefined
+                    },
+                    "acceptor" => {
+                        "description" => "An acceptor defines a way in which connections can be made to the HornetQ server.",
+                        "model-description" => undefined
+                    },
+                    "jms-topic" => {
+                        "description" => "Defines a JMS topic.",
+                        "model-description" => undefined
+                    },
+                    "in-vm-connector" => {
+                        "description" => "Used by an in-VM client to define how it connects to a server.",
+                        "model-description" => undefined
+                    },
+                    "divert" => {
+                        "description" => "A messaging resource that allows you to transparently divert messages routed to one address to some other address, without making any changes to any client application logic.",
+                        "model-description" => undefined
+                    },
+                    "queue" => {
+                        "description" => "A Queue.",
+                        "model-description" => undefined
+                    },
+                    "runtime-queue" => {
+                        "description" => "A runtime queue.",
+                        "model-description" => undefined
+                    },
+                    "pooled-connection-factory" => {
+                        "description" => "Defines a managed connection factory.",
+                        "model-description" => undefined
+                    },
+                    "connector" => {
+                        "description" => "A connector can be used by a client to define how it connects to a server.",
+                        "model-description" => undefined
+                    },
+                    "remote-connector" => {
+                        "description" => "Used by a remote client to define how it connects to a server.",
+                        "model-description" => undefined
+                    },
+                    "remote-acceptor" => {
+                        "description" => "Defines a way in which remote connections can be made to the HornetQ server.",
+                        "model-description" => undefined
+                    },
+                    "cluster-connection" => {
+                        "description" => "Cluster connections group servers into clusters so that messages can be load balanced between the nodes of the cluster.",
+                        "model-description" => undefined
+                    },
+                    "connection-factory" => {
+                        "description" => "Defines a connection factory.",
+                        "model-description" => undefined
+                    },
+                    "broadcast-group" => {
+                        "description" => "A broadcast group is the means by which a server broadcasts connectors over the network.",
+                        "model-description" => undefined
+                    },
+                    "path" => {
+                        "description" => "A filesystem path pointing to one of the locations where HornetQ stores persistent data.",
+                        "model-description" => undefined,
+                        "min-occurs" => 4,
+                        "max-occurs" => 4
+                    },
+                    "bridge" => {
+                        "description" => "The function of a bridge is to consume messages from a source queue, and forward them to a target address, typically on a different HornetQ server.",
+                        "model-description" => undefined
+                    },
+                    "discovery-group" => {
+                        "description" => "Multicast group to listen to receive broadcast from other servers announcing their connectors.",
+                        "model-description" => undefined
+                    },
+                    "connector-service" => {
+                        "description" => "TODO",
+                        "model-description" => undefined
+                    }
+                }
+            },
+            "address" => [
+                ("subsystem" => "messaging"),
+                ("hornetq-server" => "*")
+            ],
+            "children" => [
+                {
+                    "model-description" => {
+                        "description" => "Defines a way in which in-VM connections can be made to the HornetQ server.",
+                        "attributes" => {"server-id" => {
+                            "type" => INT,
+                            "description" => "The server id.",
+                            "expressions-allowed" => true,
+                            "nillable" => false,
+                            "default" => 0
+                        }},
+                        "operations" => undefined,
+                        "children" => {"param" => {
+                            "description" => "A key-value pair understood by the acceptor factory-class and used to configure it.",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("in-vm-acceptor" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A parameter",
+                            "attributes" => {"value" => {
+                                "type" => STRING,
+                                "description" => "The parameter value",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("in-vm-acceptor" => "*"),
+                            ("param" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines a JMS queue.",
+                        "attributes" => {
+                            "selector" => {
+                                "type" => STRING,
+                                "description" => "The queue selector.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "entries" => {
+                                "type" => LIST,
+                                "description" => "The jndi names the queue will be bound to.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "value-type" => STRING
+                            },
+                            "durable" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether the queue is durable or not.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("jms-queue" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A security setting allows sets of permissions to be defined against queues based on their address.",
+                        "attributes" => {},
+                        "operations" => undefined,
+                        "children" => {"role" => {
+                            "description" => "A security role.",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("security-setting" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A security role.",
+                            "attributes" => {
+                                "delete-non-durable-queue" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "This permission allows the user to delete a temporary queue.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "default" => false
+                                },
+                                "create-non-durable-queue" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "This permission allows the user to create a temporary queue.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "default" => false
+                                },
+                                "send" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "This permission allows the user to send a message to matching addresses.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "default" => false
+                                },
+                                "delete-durable-queue" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "This permission allows the user to delete a durable queue.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "default" => false
+                                },
+                                "manage" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "This permission allows the user to invoke management operations by sending management messages to the management address.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "default" => false
+                                },
+                                "create-durable-queue" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "This permission allows the user to create a durable queue.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "default" => false
+                                },
+                                "consume" => {
+                                    "type" => BOOLEAN,
+                                    "description" => "his permission allows the user to consume a message from a queue bound to matching addresses.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "default" => false
+                                }
+                            },
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("security-setting" => "*"),
+                            ("role" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "An address setting defines some attributes that are defined against an address wildcard rather than a specific queue.",
+                        "attributes" => {
+                            "redistribution-delay" => {
+                                "type" => LONG,
+                                "description" => "Defines how long to wait when the last consumer is closed on a queue before redistributing any messages",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "last-value-queue" => {
+                                "type" => BOOLEAN,
+                                "description" => "Defines whether a queue only uses last values or not",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "page-size-bytes" => {
+                                "type" => LONG,
+                                "description" => "The paging size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 10485760L,
+                                "unit" => "BYTES"
+                            },
+                            "address-full-policy" => {
+                                "type" => STRING,
+                                "description" => "Determines what happens when an address where max-size-bytes is specified becomes full. (PAGE, DROP or BLOCK)",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "PAGE",
+                                "allowed" => [
+                                    "DROP",
+                                    "PAGE",
+                                    "BLOCK",
+                                    "FAIL"
+                                ]
+                            },
+                            "max-delivery-attempts" => {
+                                "type" => INT,
+                                "description" => "Defines how many time a cancelled message can be redelivered before sending to the dead-letter-address",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 10
+                            },
+                            "max-size-bytes" => {
+                                "type" => LONG,
+                                "description" => "The max bytes size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1L,
+                                "unit" => "BYTES"
+                            },
+                            "expiry-address" => {
+                                "type" => STRING,
+                                "description" => "Defines where to send a message that has expired.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "dead-letter-address" => {
+                                "type" => STRING,
+                                "description" => "The dead letter address",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "page-max-cache-size" => {
+                                "type" => INT,
+                                "description" => "The number of page files to keep in memory to optimize IO during paging navigation.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 5
+                            },
+                            "redelivery-delay" => {
+                                "type" => LONG,
+                                "description" => "Defines how long to wait before attempting redelivery of a cancelled message",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 0L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "send-to-dla-on-no-route" => {
+                                "type" => BOOLEAN,
+                                "description" => "If this parameter is set to true for that address, if the message is not routed to any queues it will instead be sent to the dead letter address (DLA) for that address, if it exists.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "message-counter-history-day-limit" => {
+                                "type" => INT,
+                                "description" => "Day limit for the message counter history.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 0,
+                                "unit" => "DAYS"
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("address-setting" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Makes decisions about which node in a cluster should handle a message with a group id assigned.",
+                        "attributes" => {
+                            "type" => {
+                                "type" => STRING,
+                                "description" => "Whether the handler is the single \"Local\" handler for the cluster, which makes handling decisions, or a \"Remote\" handler which converses with the local handler.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "allowed" => [
+                                    "LOCAL",
+                                    "REMOTE"
+                                ]
+                            },
+                            "timeout" => {
+                                "type" => INT,
+                                "description" => "How long to wait for a handling decision to be made; an exception will be thrown during the send if this timeout is reached, ensuring that strict ordering is kept.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 5000,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "grouping-handler-address" => {
+                                "type" => STRING,
+                                "description" => "A reference to a cluster connection and the address it uses.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("grouping-handler" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "An acceptor defines a way in which connections can be made to the HornetQ server.",
+                        "attributes" => {
+                            "factory-class" => {
+                                "type" => STRING,
+                                "description" => "Class name of the factory class that can instantiate the acceptor.",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "socket-binding" => {
+                                "type" => STRING,
+                                "description" => "The socket binding that the acceptor will use to accept connections.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {"param" => {
+                            "description" => "A key-value pair understood by the acceptor factory-class and used to configure it.",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("acceptor" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A parameter",
+                            "attributes" => {"value" => {
+                                "type" => STRING,
+                                "description" => "The parameter value",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("acceptor" => "*"),
+                            ("param" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines a JMS topic.",
+                        "attributes" => {"entries" => {
+                            "type" => LIST,
+                            "description" => "The jndi names the topic will be bound to.",
+                            "expressions-allowed" => true,
+                            "nillable" => false,
+                            "value-type" => STRING
+                        }},
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("jms-topic" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Used by an in-VM client to define how it connects to a server.",
+                        "attributes" => {"server-id" => {
+                            "type" => INT,
+                            "description" => "The server id.",
+                            "expressions-allowed" => true,
+                            "nillable" => false,
+                            "default" => 0
+                        }},
+                        "operations" => undefined,
+                        "children" => {"param" => {
+                            "description" => "A key-value pair understood by the connector factory-class and used to configure it.",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("in-vm-connector" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A parameter",
+                            "attributes" => {"value" => {
+                                "type" => STRING,
+                                "description" => "The parameter value",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("in-vm-connector" => "*"),
+                            ("param" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A messaging resource that allows you to transparently divert messages routed to one address to some other address, without making any changes to any client application logic.",
+                        "attributes" => {
+                            "divert-address" => {
+                                "type" => STRING,
+                                "description" => "Address to divert from",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "exclusive" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether the divert is exclusive, meaning that the message is diverted to the new address, and does not go to the old address at all.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "routing-name" => {
+                                "type" => STRING,
+                                "description" => "Routing name of the divert",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "forwarding-address" => {
+                                "type" => STRING,
+                                "description" => "Address to divert to",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "filter" => {
+                                "type" => STRING,
+                                "description" => "An optional filter string. If specified then only messages which match the filter expression specified will be diverted. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "transformer-class-name" => {
+                                "type" => STRING,
+                                "description" => "The name of a class used to transform the message's body or properties before it is diverted.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("divert" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A Queue.",
+                        "attributes" => {
+                            "durable" => {
+                                "type" => BOOLEAN,
+                                "description" => "Defines whether the queue is durable.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "queue-address" => {
+                                "type" => STRING,
+                                "description" => "The queue address defines what address is used for routing messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "filter" => {
+                                "type" => STRING,
+                                "description" => "A queue message filter definition. An undefined or empty filter will match all messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("queue" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A Queue.",
+                        "attributes" => {
+                            "durable" => {
+                                "type" => BOOLEAN,
+                                "description" => "Defines whether the queue is durable.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "queue-address" => {
+                                "type" => STRING,
+                                "description" => "The queue address defines what address is used for routing messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "filter" => {
+                                "type" => STRING,
+                                "description" => "A queue message filter definition. An undefined or empty filter will match all messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("runtime-queue" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines a managed connection factory.",
+                        "attributes" => {
+                            "use-jndi" => {
+                                "type" => BOOLEAN,
+                                "description" => "Use JNDI to locate the destination for incoming connections",
+                                "expressions-allowed" => true,
+                                "nillable" => true
+                            },
+                            "jndi-params" => {
+                                "type" => STRING,
+                                "description" => "The JNDI params to use for locating the destination for incoming connections.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "use-local-tx" => {
+                                "type" => BOOLEAN,
+                                "description" => "Use a local transaction for incoming sessions",
+                                "expressions-allowed" => true,
+                                "nillable" => true
+                            },
+                            "setup-attempts" => {
+                                "type" => INT,
+                                "description" => "The number of times to set up an MDB endpoint",
+                                "expressions-allowed" => true,
+                                "nillable" => true
+                            },
+                            "setup-interval" => {
+                                "type" => LONG,
+                                "description" => "The interval between attempts at setting up an MDB endpoint.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "transaction" => {
+                                "type" => STRING,
+                                "description" => "TODO",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "transaction",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "user" => {
+                                "type" => STRING,
+                                "description" => "The default username to use with this connection factory. This is only needed when pointing the connection factory to a remote host.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "password" => {
+                                "type" => STRING,
+                                "description" => "The default password to use with this connection factory. This is only needed when pointing the connection factory to a remote host.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "min-pool-size" => {
+                                "type" => INT,
+                                "description" => "The minimum size for the pool",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1
+                            },
+                            "max-pool-size" => {
+                                "type" => INT,
+                                "description" => "The maximum size for the pool",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1
+                            },
+                            "use-auto-recovery" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to use auto recovery.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "initial-message-packet-size" => {
+                                "type" => INT,
+                                "description" => "The initial size of messages created through this factory.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1500
+                            },
+                            "initial-connect-attempts" => {
+                                "type" => INT,
+                                "description" => "The number of attempts to connect initially with this factory.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1
+                            },
+                            "discovery-group-name" => {
+                                "type" => STRING,
+                                "description" => "The discovery group name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => ["connector"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "connector" => {
+                                "type" => OBJECT,
+                                "description" => "Defines the connectors. These are stored in a map by connector name (with an undefined value).",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => ["discovery-group-name"],
+                                "value-type" => STRING
+                            },
+                            "entries" => {
+                                "type" => LIST,
+                                "description" => "The jndi names the connection factory should be bound to.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "value-type" => STRING
+                            },
+                            "ha" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether the connection factory supports High Availability.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "client-failure-check-period" => {
+                                "type" => LONG,
+                                "description" => "The client failure check period.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "connection-ttl" => {
+                                "type" => LONG,
+                                "description" => "The connection ttl.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 60000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "call-timeout" => {
+                                "type" => LONG,
+                                "description" => "The call time out.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "call-failover-timeout" => {
+                                "type" => LONG,
+                                "description" => "The timeout to use when fail over is in process (in ms).",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "consumer-window-size" => {
+                                "type" => INT,
+                                "description" => "The consumer window size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576,
+                                "unit" => "BYTES"
+                            },
+                            "consumer-max-rate" => {
+                                "type" => INT,
+                                "description" => "The consumer max rate.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1,
+                                "unit" => "PER_SECOND"
+                            },
+                            "confirmation-window-size" => {
+                                "type" => INT,
+                                "description" => "The confirmation window size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1,
+                                "unit" => "BYTES"
+                            },
+                            "producer-window-size" => {
+                                "type" => INT,
+                                "description" => "The producer window size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 65536,
+                                "unit" => "BYTES"
+                            },
+                            "producer-max-rate" => {
+                                "type" => INT,
+                                "description" => "The producer max rate.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1,
+                                "unit" => "PER_SECOND"
+                            },
+                            "compress-large-messages" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether large messages should be compressed.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "cache-large-message-client" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to cache large messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "min-large-message-size" => {
+                                "type" => INT,
+                                "description" => "The min large message size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 102400,
+                                "unit" => "BYTES"
+                            },
+                            "client-id" => {
+                                "type" => STRING,
+                                "description" => "The client id.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "dups-ok-batch-size" => {
+                                "type" => INT,
+                                "description" => "The dups ok batch size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576
+                            },
+                            "transaction-batch-size" => {
+                                "type" => INT,
+                                "description" => "The transaction batch size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576
+                            },
+                            "block-on-acknowledge" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to set block on acknowledge.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "block-on-non-durable-send" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to set block on non durable send.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "block-on-durable-send" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to set block on durable send.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "auto-group" => {
+                                "type" => BOOLEAN,
+                                "description" => "The autogroup.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "pre-acknowledge" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to pre-acknowledge.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The retry interval.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "retry-interval-multiplier" => {
+                                "type" => BIG_DECIMAL,
+                                "description" => "The retry interval multiplier.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1.0
+                            },
+                            "max-retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The max retry interval.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "reconnect-attempts" => {
+                                "type" => INT,
+                                "description" => "The reconnect attempts. By default, a pooled connection factory will try to reconnect infinitely to the messaging server(s).",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1
+                            },
+                            "failover-on-initial-connection" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to fail over on initial connection.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "failover-on-server-shutdown" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to fail over on server shutdown.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "deprecated" => {
+                                    "since" => "1.1.0",
+                                    "reason" => "Deprecated. Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute."
+                                }
+                            },
+                            "connection-load-balancing-policy-class-name" => {
+                                "type" => STRING,
+                                "description" => "Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => "org.hornetq.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "use-global-pools" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to use global pools.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "scheduled-thread-pool-max-size" => {
+                                "type" => INT,
+                                "description" => "The scheduled thread pool max size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 5
+                            },
+                            "thread-pool-max-size" => {
+                                "type" => INT,
+                                "description" => "The thread pool max size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30
+                            },
+                            "group-id" => {
+                                "type" => STRING,
+                                "description" => "The group id.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "discovery-initial-wait-timeout" => {
+                                "type" => LONG,
+                                "description" => "The discovery initial wait time out.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "unit" => "MILLISECONDS",
+                                "deprecated" => {
+                                    "since" => "1.1.0",
+                                    "reason" => "Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute."
+                                }
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("pooled-connection-factory" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A connector can be used by a client to define how it connects to a server.",
+                        "attributes" => {
+                            "factory-class" => {
+                                "type" => STRING,
+                                "description" => "Class name of the factory class that can instantiate the connector.",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "socket-binding" => {
+                                "type" => STRING,
+                                "description" => "The socket binding that the connector will use to create connections.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {"param" => {
+                            "description" => "A key-value pair understood by the connector factory-class and used to configure it.",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("connector" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A parameter",
+                            "attributes" => {"value" => {
+                                "type" => STRING,
+                                "description" => "The parameter value",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("connector" => "*"),
+                            ("param" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Used by a remote client to define how it connects to a server.",
+                        "attributes" => {"socket-binding" => {
+                            "type" => STRING,
+                            "description" => "The socket binding that the connector will use to create connections.",
+                            "expressions-allowed" => false,
+                            "nillable" => false,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {"param" => {
+                            "description" => "A key-value pair understood by the connector factory-class and used to configure it.",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("remote-connector" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A parameter",
+                            "attributes" => {"value" => {
+                                "type" => STRING,
+                                "description" => "The parameter value",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("remote-connector" => "*"),
+                            ("param" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines a way in which remote connections can be made to the HornetQ server.",
+                        "attributes" => {"socket-binding" => {
+                            "type" => STRING,
+                            "description" => "The socket binding that the acceptor will use to accept connections.",
+                            "expressions-allowed" => false,
+                            "nillable" => false,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {"param" => {
+                            "description" => "A key-value pair understood by the acceptor factory-class and used to configure it.",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("remote-acceptor" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A parameter",
+                            "attributes" => {"value" => {
+                                "type" => STRING,
+                                "description" => "The parameter value",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("remote-acceptor" => "*"),
+                            ("param" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Cluster connections group servers into clusters so that messages can be load balanced between the nodes of the cluster.",
+                        "attributes" => {
+                            "min-large-message-size" => {
+                                "type" => INT,
+                                "description" => "The minimum size (in bytes) for a message before it is considered as a large message.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 102400,
+                                "unit" => "BYTES"
+                            },
+                            "connection-ttl" => {
+                                "type" => LONG,
+                                "description" => "The maximum time (in milliseconds) for which the connections used by the cluster connections are considered alive (in the absence of heartbeat).",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 60000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "cluster-connection-address" => {
+                                "type" => STRING,
+                                "description" => "Each cluster connection only applies to messages sent to an address that starts with this value.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "retry-interval-multiplier" => {
+                                "type" => BIG_DECIMAL,
+                                "description" => "A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1.0
+                            },
+                            "forward-when-no-consumers" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether messages will be distributed round robin between other nodes of the cluster irrespective of whether there are matching or indeed any consumers on other nodes. If this is set to false (the default) then HornetQ will only forward messages to other nodes of the cluster if the address to which they are being forwarded has queues which have consumers, and if those consumers have message filters (selectors) at least one of those selectors must match the message.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "call-timeout" => {
+                                "type" => LONG,
+                                "description" => "The timeout (in ms) for remote calls made by the cluster connection.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "reconnect-attempts" => {
+                                "type" => INT,
+                                "description" => "The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1
+                            },
+                            "static-connectors" => {
+                                "type" => LIST,
+                                "description" => "The statically defined list of connectors to which this cluster connection will make connections. Must be undefined (null) if 'discovery-group-name' is defined.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => ["discovery-group-name"],
+                                "value-type" => STRING
+                            },
+                            "notification-attempts" => {
+                                "type" => INT,
+                                "description" => "How many times the cluster connection will broadcast itself",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "max-hops" => {
+                                "type" => INT,
+                                "description" => "The maximum number of times a message can be forwarded. HornetQ can be configured to also load balance messages to nodes which might be connected to it only indirectly with other HornetQ servers as intermediates in a chain.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1
+                            },
+                            "retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The period in milliseconds between subsequent attempts to reconnect to a target server, if the connection to the target server has failed.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 500L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "notification-interval" => {
+                                "type" => LONG,
+                                "description" => "How often the cluster connection will broadcast itself",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "allow-direct-connections-only" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether, if a node learns of the existence of a node that is more than 1 hop away, we do not create a bridge for direct cluster connection. Only relevant if 'static-connectors' is defined.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false,
+                                "alternatives" => ["discovery-group-name"]
+                            },
+                            "discovery-group-name" => {
+                                "type" => STRING,
+                                "description" => "The discovery group used to obtain the list of other servers in the cluster to which this cluster connection will make connections. Must be undefined (null) if 'static-connectors' is defined.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "allow-direct-connections-only",
+                                    "static-connectors"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "use-duplicate-detection" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether the bridge will automatically insert a duplicate id property into each message that it forwards.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "call-failover-timeout" => {
+                                "type" => LONG,
+                                "description" => "The timeout to use when fail over is in process (in ms) for remote calls made by the cluster connection.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "max-retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The maximum interval of time used to retry connections",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "confirmation-window-size" => {
+                                "type" => INT,
+                                "description" => "The confirmation-window-size to use for the connection used to forward messages to a target node.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576,
+                                "unit" => "BYTES"
+                            },
+                            "check-period" => {
+                                "type" => LONG,
+                                "description" => "The period (in milliseconds) between client failure check.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "connector-ref" => {
+                                "type" => STRING,
+                                "description" => "The name of connector to use for live connection",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("cluster-connection" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Defines a connection factory.",
+                        "attributes" => {
+                            "min-large-message-size" => {
+                                "type" => INT,
+                                "description" => "The min large message size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 102400,
+                                "unit" => "BYTES"
+                            },
+                            "producer-max-rate" => {
+                                "type" => INT,
+                                "description" => "The producer max rate.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1,
+                                "unit" => "PER_SECOND"
+                            },
+                            "thread-pool-max-size" => {
+                                "type" => INT,
+                                "description" => "The thread pool max size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30
+                            },
+                            "discovery-initial-wait-timeout" => {
+                                "type" => LONG,
+                                "description" => "The discovery initial wait time out.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "unit" => "MILLISECONDS",
+                                "deprecated" => {
+                                    "since" => "1.1.0",
+                                    "reason" => "Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute."
+                                }
+                            },
+                            "compress-large-messages" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether large messages should be compressed.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "retry-interval-multiplier" => {
+                                "type" => BIG_DECIMAL,
+                                "description" => "The retry interval multiplier.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1.0
+                            },
+                            "dups-ok-batch-size" => {
+                                "type" => INT,
+                                "description" => "The dups ok batch size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576
+                            },
+                            "pre-acknowledge" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to pre-acknowledge.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "consumer-window-size" => {
+                                "type" => INT,
+                                "description" => "The consumer window size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576,
+                                "unit" => "BYTES"
+                            },
+                            "reconnect-attempts" => {
+                                "type" => INT,
+                                "description" => "The reconnect attempts.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 0
+                            },
+                            "block-on-acknowledge" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to set block on acknowledge.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "block-on-durable-send" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to set block on durable send.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "scheduled-thread-pool-max-size" => {
+                                "type" => INT,
+                                "description" => "The scheduled thread pool max size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 5
+                            },
+                            "client-failure-check-period" => {
+                                "type" => LONG,
+                                "description" => "The client failure check period.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "client-id" => {
+                                "type" => STRING,
+                                "description" => "The client id.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "entries" => {
+                                "type" => LIST,
+                                "description" => "The jndi names the connection factory should be bound to.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "value-type" => STRING
+                            },
+                            "call-failover-timeout" => {
+                                "type" => LONG,
+                                "description" => "The timeout to use when fail over is in process (in ms).",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "confirmation-window-size" => {
+                                "type" => INT,
+                                "description" => "The confirmation window size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1,
+                                "unit" => "BYTES"
+                            },
+                            "factory-type" => {
+                                "type" => STRING,
+                                "description" => "The type of connection factory.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "GENERIC",
+                                "allowed" => [
+                                    "GENERIC",
+                                    "TOPIC",
+                                    "QUEUE",
+                                    "XA_GENERIC",
+                                    "XA_QUEUE",
+                                    "XA_TOPIC"
+                                ]
+                            },
+                            "connection-ttl" => {
+                                "type" => LONG,
+                                "description" => "The connection ttl.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 60000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "connection-load-balancing-policy-class-name" => {
+                                "type" => STRING,
+                                "description" => "Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => "org.hornetq.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "use-global-pools" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to use global pools.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "failover-on-server-shutdown" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to fail over on server shutdown.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "deprecated" => {
+                                    "since" => "1.1.0",
+                                    "reason" => "Deprecated. Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute."
+                                }
+                            },
+                            "group-id" => {
+                                "type" => STRING,
+                                "description" => "The group id.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "consumer-max-rate" => {
+                                "type" => INT,
+                                "description" => "The consumer max rate.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1,
+                                "unit" => "PER_SECOND"
+                            },
+                            "transaction-batch-size" => {
+                                "type" => INT,
+                                "description" => "The transaction batch size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576
+                            },
+                            "call-timeout" => {
+                                "type" => LONG,
+                                "description" => "The call time out.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "failover-on-initial-connection" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to fail over on initial connection.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "ha" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether the connection factory supports High Availability.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The retry interval.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "discovery-group-name" => {
+                                "type" => STRING,
+                                "description" => "The discovery group name.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => ["connector"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "producer-window-size" => {
+                                "type" => INT,
+                                "description" => "The producer window size.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 65536,
+                                "unit" => "BYTES"
+                            },
+                            "block-on-non-durable-send" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to set block on non durable send.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "auto-group" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether or not message grouping is automatically used",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "connector" => {
+                                "type" => OBJECT,
+                                "description" => "Defines the connectors. These are stored in a map by connector name (with an undefined value).",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => ["discovery-group-name"],
+                                "value-type" => STRING
+                            },
+                            "cache-large-message-client" => {
+                                "type" => BOOLEAN,
+                                "description" => "True to cache large messages.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "max-retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The max retry interval.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("connection-factory" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "A broadcast group is the means by which a server broadcasts connectors over the network.",
+                        "attributes" => {
+                            "connectors" => {
+                                "type" => LIST,
+                                "description" => "Specifies the names of connectors that will be broadcast.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => STRING
+                            },
+                            "jgroups-stack" => {
+                                "type" => STRING,
+                                "description" => "The name of a stack defined in the org.jboss.as.clustering.jgroups subsystem that is used to form a cluster.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "group-address",
+                                    "group-port",
+                                    "local-bind-address",
+                                    "local-bind-port"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "jgroups-channel" => {
+                                "type" => STRING,
+                                "description" => "The name used by a JGroups channel to join a cluster.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "group-address",
+                                    "group-port",
+                                    "local-bind-address",
+                                    "local-bind-port"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "group-address" => {
+                                "type" => STRING,
+                                "description" => "Deprecated. The multicast address to which the data will be broadcast. It is a class D IP address in the range 224.0.0.0 to 239.255.255.255, inclusive. The address 224.0.0.0 is reserved and is not available for use.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Use instead a socket-binding to specify the broadcast group's group address."
+                                }
+                            },
+                            "group-port" => {
+                                "type" => INT,
+                                "description" => "Deprecated. The UDP port number used for broadcasting.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Use instead a socket-binding to specify the broadcast group's group port."
+                                }
+                            },
+                            "local-bind-address" => {
+                                "type" => STRING,
+                                "description" => "Deprecated. The local bind address that the datagram socket is bound to. If you have multiple network interfaces on your server, you would specify which one you wish to use for broadcasts by setting this attribute. If this attribute is not specified then the socket will be bound to the wildcard address, an IP address chosen by the kernel.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Use instead a socket-binding to specify the broadcast group's local bind address."
+                                }
+                            },
+                            "local-bind-port" => {
+                                "type" => INT,
+                                "description" => "Deprecated. The local port to which the datagram socket is bound. Normally you would just use the default value of -1 which signifies that an anonymous port should be used. This parameter is always specified in conjunction with local-bind-address.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => -1,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Use instead a socket-binding to specify the broadcast group's local bind port."
+                                }
+                            },
+                            "socket-binding" => {
+                                "type" => STRING,
+                                "description" => "The broadcast group socket binding.",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "alternatives" => [
+                                    "group-address",
+                                    "group-port",
+                                    "local-bind-address",
+                                    "local-bind-port",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "broadcast-period" => {
+                                "type" => LONG,
+                                "description" => "The period in milliseconds between consecutive broadcasts.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("broadcast-group" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "The directory in which the message journal lives. The default is ${jboss.server.data.dir}/messagingjournal.",
+                        "attributes" => {
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The actual filesystem path. Treated as an absolute path, unless the 'relative-to' attribute is specified, in which case the value is treated as relative to that path. <p>If treated as an absolute path, the actual runtime pathname specified by the value of this attribute will be determined as follows: </p>If this value is already absolute, then the value is directly used.  Otherwise the runtime pathname is resolved in a system-dependent way.  On UNIX systems, a relative pathname is made absolute by resolving it against the current user directory. On Microsoft Windows systems, a relative pathname is made absolute by resolving it against the current directory of the drive named by the pathname, if any; if not, it is resolved against the current user directory.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "messagingjournal",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => "jboss.server.data.dir",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("path" => "journal-directory")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "The directory where page files are stored. The default is ${jboss.server.data.dir}/messagingpaging.",
+                        "attributes" => {
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The actual filesystem path. Treated as an absolute path, unless the 'relative-to' attribute is specified, in which case the value is treated as relative to that path. <p>If treated as an absolute path, the actual runtime pathname specified by the value of this attribute will be determined as follows: </p>If this value is already absolute, then the value is directly used.  Otherwise the runtime pathname is resolved in a system-dependent way.  On UNIX systems, a relative pathname is made absolute by resolving it against the current user directory. On Microsoft Windows systems, a relative pathname is made absolute by resolving it against the current directory of the drive named by the pathname, if any; if not, it is resolved against the current user directory.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "messagingpaging",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => "jboss.server.data.dir",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("path" => "paging-directory")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "The function of a bridge is to consume messages from a source queue, and forward them to a target address, typically on a different HornetQ server.",
+                        "attributes" => {
+                            "min-large-message-size" => {
+                                "type" => INT,
+                                "description" => "The minimum size (in bytes) for a message before it is considered as a large message.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 102400,
+                                "unit" => "BYTES"
+                            },
+                            "connection-ttl" => {
+                                "type" => LONG,
+                                "description" => "The maximum time (in milliseconds) for which the connections used by the bridges are considered alive (in the absence of heartbeat).",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 60000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "failover-on-server-shutdown" => {
+                                "type" => BOOLEAN,
+                                "description" => "Deprecated. Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Deprecated. Has no runtime effect and a warning will be issued if an attempt is made to set the value of this attribute."
+                                }
+                            },
+                            "retry-interval-multiplier" => {
+                                "type" => BIG_DECIMAL,
+                                "description" => "A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1.0
+                            },
+                            "forwarding-address" => {
+                                "type" => STRING,
+                                "description" => "The address on the target server that the message will be forwarded to. If a forwarding address is not specified then the original destination of the message will be retained.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "transformer-class-name" => {
+                                "type" => STRING,
+                                "description" => "The name of a user-defined class which implements the org.hornetq.core.server.cluster.Transformer interface.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "ha" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether or not this bridge should support high availability. True means it will connect to any available server in a cluster and support failover.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => false
+                            },
+                            "reconnect-attempts" => {
+                                "type" => INT,
+                                "description" => "The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => -1
+                            },
+                            "password" => {
+                                "type" => STRING,
+                                "description" => "The password to use when creating the bridge connection to the remote server. If it is not specified the default cluster password specified by the cluster-password attribute in the root messaging subsystem resource will be used.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "CHANGE ME!!",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "static-connectors" => {
+                                "type" => LIST,
+                                "description" => "A list of names of statically defined connectors used by this bridge. Must be undefined (null) if 'discovery-group-name' is defined.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => ["discovery-group-name"],
+                                "value-type" => STRING
+                            },
+                            "retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The period in milliseconds between subsequent reconnection attempts, if the connection to the target server has failed.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "discovery-group-name" => {
+                                "type" => STRING,
+                                "description" => "The name of the discovery group used by this bridge. Must be undefined (null) if 'static-connectors' is defined.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => ["static-connectors"],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "queue-name" => {
+                                "type" => STRING,
+                                "description" => "The unique name of the local queue that the bridge consumes from.",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "use-duplicate-detection" => {
+                                "type" => BOOLEAN,
+                                "description" => "Whether the bridge will automatically insert a duplicate id property into each message that it forwards.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => true
+                            },
+                            "max-retry-interval" => {
+                                "type" => LONG,
+                                "description" => "The maximum interval of time used to retry connections",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 2000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "confirmation-window-size" => {
+                                "type" => INT,
+                                "description" => "The confirmation-window-size to use for the connection used to forward messages to the target node.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 1048576,
+                                "unit" => "BYTES"
+                            },
+                            "user" => {
+                                "type" => STRING,
+                                "description" => "The user name to use when creating the bridge connection to the remote server. If it is not specified the default cluster user specified by the cluster-user attribute in the root messaging subsystem resource will be used.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "HORNETQ.CLUSTER.ADMIN.USER",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "filter" => {
+                                "type" => STRING,
+                                "description" => "An optional filter string. If specified then only messages which match the filter expression specified will be forwarded. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "check-period" => {
+                                "type" => LONG,
+                                "description" => "The period (in milliseconds) between client failure check.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 30000L,
+                                "unit" => "MILLISECONDS"
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("bridge" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "The directory in which large messages are stored. The default is ${jboss.server.data.dir}/messaginglargemessages.",
+                        "attributes" => {
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The actual filesystem path. Treated as an absolute path, unless the 'relative-to' attribute is specified, in which case the value is treated as relative to that path. <p>If treated as an absolute path, the actual runtime pathname specified by the value of this attribute will be determined as follows: </p>If this value is already absolute, then the value is directly used.  Otherwise the runtime pathname is resolved in a system-dependent way.  On UNIX systems, a relative pathname is made absolute by resolving it against the current user directory. On Microsoft Windows systems, a relative pathname is made absolute by resolving it against the current directory of the drive named by the pathname, if any; if not, it is resolved against the current user directory.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "messaginglargemessages",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => "jboss.server.data.dir",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("path" => "large-messages-directory")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Multicast group to listen to receive broadcast from other servers announcing their connectors.",
+                        "attributes" => {
+                            "refresh-timeout" => {
+                                "type" => LONG,
+                                "description" => "Period the discovery group waits after receiving the last broadcast from a particular server before removing that server's connector pair entry from its list.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 10000L,
+                                "unit" => "MILLISECONDS"
+                            },
+                            "jgroups-stack" => {
+                                "type" => STRING,
+                                "description" => "The name of a stack defined in the org.jboss.as.clustering.jgroups subsystem that is used to form a cluster.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "group-address",
+                                    "group-port",
+                                    "local-bind-address",
+                                    "local-bind-port"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "jgroups-channel" => {
+                                "type" => STRING,
+                                "description" => "The name used by a JGroups channel to join a cluster.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "group-address",
+                                    "group-port",
+                                    "local-bind-address",
+                                    "local-bind-port"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "group-address" => {
+                                "type" => STRING,
+                                "description" => "(Deprecated) Multicast IP address of the group to listen on.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Use instead a socket-binding to specify the discovery group's group address."
+                                }
+                            },
+                            "group-port" => {
+                                "type" => INT,
+                                "description" => "(Deprecated) UDP port of the multicast group.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Use instead a socket-binding to specify the discovery group's group port."
+                                }
+                            },
+                            "local-bind-address" => {
+                                "type" => STRING,
+                                "description" => "(Deprecated) The local bind address that the datagram socket is bound to.",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "alternatives" => [
+                                    "socket-binding",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L,
+                                "deprecated" => {
+                                    "since" => "1.2.0",
+                                    "reason" => "Use instead a socket-binding to specify the discovery group's local bind address."
+                                }
+                            },
+                            "socket-binding" => {
+                                "type" => STRING,
+                                "description" => "The discovery group socket binding.",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "alternatives" => [
+                                    "group-address",
+                                    "group-port",
+                                    "local-bind-address",
+                                    "local-bind-port",
+                                    "jgroups-stack",
+                                    "jgroups-channel"
+                                ],
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "initial-wait-timeout" => {
+                                "type" => LONG,
+                                "description" => "Period, in ms, to wait for an initial broadcast to give us at least one node in the cluster.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => 10000L,
+                                "unit" => "MILLISECONDS"
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("discovery-group" => "*")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "The directory in which the bindings journal lives. The default is ${jboss.server.data.dir}/messagingbindings.",
+                        "attributes" => {
+                            "path" => {
+                                "type" => STRING,
+                                "description" => "The actual filesystem path. Treated as an absolute path, unless the 'relative-to' attribute is specified, in which case the value is treated as relative to that path. <p>If treated as an absolute path, the actual runtime pathname specified by the value of this attribute will be determined as follows: </p>If this value is already absolute, then the value is directly used.  Otherwise the runtime pathname is resolved in a system-dependent way.  On UNIX systems, a relative pathname is made absolute by resolving it against the current user directory. On Microsoft Windows systems, a relative pathname is made absolute by resolving it against the current directory of the drive named by the pathname, if any; if not, it is resolved against the current user directory.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "default" => "messagingbindings",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "relative-to" => {
+                                "type" => STRING,
+                                "description" => "The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute. The standard paths provided by the system include:<ul><li>jboss.home - the root directory of the JBoss AS distribution</li><li>user.home - user's home directory</li><li>user.dir - user's current working directory</li><li>java.home - java installation directory</li><li>jboss.server.base.dir - root directory for an individual server instance</li><li>jboss.server.data.dir - directory the server will use for persistent data file storage</li><li>jboss.server.log.dir - directory the server will use for log file storage</li><li>jboss.server.tmp.dir - directory the server will use for temporary file storage</li><li>jboss.domain.servers.dir - directory under which a host controller will create the working area for individual server instances</li></ul>",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "default" => "jboss.server.data.dir",
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("path" => "bindings-directory")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "TODO",
+                        "attributes" => {"factory-class" => {
+                            "type" => STRING,
+                            "description" => "Class name of the factory class that can instantiate the connector service.",
+                            "expressions-allowed" => false,
+                            "nillable" => false,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {"param" => {
+                            "description" => "A key/value pair understood by the connector service's factory-class",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "messaging"),
+                        ("hornetq-server" => "*"),
+                        ("connector-service" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "A key/value pair understood by the connector service's factory-class",
+                            "attributes" => {"value" => {
+                                "type" => STRING,
+                                "description" => "Value portion of a key/value pair understood by the connector service's factory-class",
+                                "expressions-allowed" => true,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "messaging"),
+                            ("hornetq-server" => "*"),
+                            ("connector-service" => "*"),
+                            ("param" => "*")
+                        ]
+                    }]
+                }
+            ]
+        }
+    ]
+}

--- a/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/webservices-1.2.0.dmr
+++ b/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/webservices-1.2.0.dmr
@@ -1,0 +1,322 @@
+{
+    "model-description" => {
+        "description" => "The configuration of the web services subsystem.",
+        "attributes" => {
+            "wsdl-secure-port" => {
+                "type" => INT,
+                "description" => "The secure port that will be used for rewriting the SOAP address. If absent the port will be identified by querying the list of installed connectors.",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min" => 1L,
+                "max" => 2147483647L
+            },
+            "wsdl-port" => {
+                "type" => INT,
+                "description" => "The non-secure port that will be used for rewriting the SOAP address. If absent the port will be identified by querying the list of installed connectors.",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min" => 1L,
+                "max" => 2147483647L
+            },
+            "modify-wsdl-address" => {
+                "type" => BOOLEAN,
+                "description" => "Whether the soap address can be modified.",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "default" => true
+            },
+            "wsdl-host" => {
+                "type" => STRING,
+                "description" => "The WSDL, that is a required deployment artifact for an endpoint, has a <soap:address> element which points to the location of the endpoint. JBoss supports rewriting of that SOAP address. If the content of <soap:address> is a valid URL, JBossWS will not rewrite it unless 'modify-wsdl-address' is true. If the content of <soap:address> is not a valid URL, JBossWS will rewrite it using the attribute values given below. If 'wsdl-host' is set to 'jbossws.undefined.host', JBossWS uses requesters host when rewriting the <soap:address>",
+                "expressions-allowed" => true,
+                "nillable" => true,
+                "min-length" => 1L,
+                "max-length" => 2147483647L
+            }
+        },
+        "operations" => undefined,
+        "children" => {
+            "client-config" => {
+                "description" => "Webservice client configuration",
+                "model-description" => undefined
+            },
+            "endpoint-config" => {
+                "description" => "Webservice endpoint configuration",
+                "model-description" => undefined
+            }
+        }
+    },
+    "address" => [("subsystem" => "webservices")],
+    "children" => [
+        {
+            "model-description" => {
+                "description" => "Webservice client configuration",
+                "attributes" => {},
+                "operations" => undefined,
+                "children" => {
+                    "pre-handler-chain" => {
+                        "description" => "Client configuration PRE handler chain",
+                        "model-description" => undefined
+                    },
+                    "post-handler-chain" => {
+                        "description" => "Client configuration POST handler chain",
+                        "model-description" => undefined
+                    },
+                    "property" => {
+                        "description" => "Client configuration property",
+                        "model-description" => undefined
+                    }
+                }
+            },
+            "address" => [
+                ("subsystem" => "webservices"),
+                ("client-config" => "*")
+            ],
+            "children" => [
+                {
+                    "model-description" => {
+                        "description" => "Endpoint configuration PRE handler chain",
+                        "attributes" => {"protocol-bindings" => {
+                            "type" => STRING,
+                            "description" => "Protocol binding",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {"handler" => {
+                            "description" => "Handler",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "webservices"),
+                        ("client-config" => "*"),
+                        ("pre-handler-chain" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "Endpoint handler",
+                            "attributes" => {"class" => {
+                                "type" => STRING,
+                                "description" => "Handler class",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "webservices"),
+                            ("client-config" => "*"),
+                            ("pre-handler-chain" => "*"),
+                            ("handler" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Endpoint configuration POST handler chain",
+                        "attributes" => {"protocol-bindings" => {
+                            "type" => STRING,
+                            "description" => "Protocol binding",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {"handler" => {
+                            "description" => "Handler",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "webservices"),
+                        ("client-config" => "*"),
+                        ("post-handler-chain" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "Endpoint handler",
+                            "attributes" => {"class" => {
+                                "type" => STRING,
+                                "description" => "Handler class",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "webservices"),
+                            ("client-config" => "*"),
+                            ("post-handler-chain" => "*"),
+                            ("handler" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Endpoint configuration property",
+                        "attributes" => {"value" => {
+                            "type" => STRING,
+                            "description" => "Endpoint configuration property value",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "webservices"),
+                        ("client-config" => "*"),
+                        ("property" => "*")
+                    ]
+                }
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "Webservice endpoint configuration",
+                "attributes" => {},
+                "operations" => undefined,
+                "children" => {
+                    "pre-handler-chain" => {
+                        "description" => "Pre handler chain",
+                        "model-description" => undefined
+                    },
+                    "post-handler-chain" => {
+                        "description" => "Post handler chain",
+                        "model-description" => undefined
+                    },
+                    "property" => {
+                        "description" => "Configuration property",
+                        "model-description" => undefined
+                    }
+                }
+            },
+            "address" => [
+                ("subsystem" => "webservices"),
+                ("endpoint-config" => "*")
+            ],
+            "children" => [
+                {
+                    "model-description" => {
+                        "description" => "Endpoint configuration PRE handler chain",
+                        "attributes" => {"protocol-bindings" => {
+                            "type" => STRING,
+                            "description" => "Protocol binding",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {"handler" => {
+                            "description" => "Handler",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "webservices"),
+                        ("endpoint-config" => "*"),
+                        ("pre-handler-chain" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "Endpoint handler",
+                            "attributes" => {"class" => {
+                                "type" => STRING,
+                                "description" => "Handler class",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "webservices"),
+                            ("endpoint-config" => "*"),
+                            ("pre-handler-chain" => "*"),
+                            ("handler" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Endpoint configuration POST handler chain",
+                        "attributes" => {"protocol-bindings" => {
+                            "type" => STRING,
+                            "description" => "Protocol binding",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {"handler" => {
+                            "description" => "Handler",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "webservices"),
+                        ("endpoint-config" => "*"),
+                        ("post-handler-chain" => "*")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "Endpoint handler",
+                            "attributes" => {"class" => {
+                                "type" => STRING,
+                                "description" => "Handler class",
+                                "expressions-allowed" => false,
+                                "nillable" => false,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }},
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "webservices"),
+                            ("endpoint-config" => "*"),
+                            ("post-handler-chain" => "*"),
+                            ("handler" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Endpoint configuration property",
+                        "attributes" => {"value" => {
+                            "type" => STRING,
+                            "description" => "Endpoint configuration property value",
+                            "expressions-allowed" => true,
+                            "nillable" => true,
+                            "min-length" => 1L,
+                            "max-length" => 2147483647L
+                        }},
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "webservices"),
+                        ("endpoint-config" => "*"),
+                        ("property" => "*")
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
+++ b/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
@@ -135,7 +135,16 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
         testTransformersFull110(ModelTestControllerVersion.V7_1_2_FINAL);
     }
 
+    @Test
+    public void testTransformersFullEAP600() throws Exception {
+        testTransformersFull110(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
     private void testTransformersFull110(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
         String subsystemXml = readResource("full.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 1, 0);
         //Use the non-runtime version of the extension which will happen on the HC
@@ -172,11 +181,29 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
+    public void testTransformersEAP601() throws Exception {
+        testTransformersFull(ModelTestControllerVersion.EAP_6_0_1, ModelVersion.create(1, 1, 1));
+    }
+
+    @Test
     public void testTransformersFull720() throws Exception {
         testTransformersFull(ModelTestControllerVersion.V7_2_0_FINAL, ModelVersion.create(1, 2, 0));
     }
 
+    @Test
+    public void testTransformersFullEAP610() throws Exception {
+        testTransformersFull(ModelTestControllerVersion.EAP_6_1_0, ModelVersion.create(1, 2, 0));
+    }
+
+    @Test
+    public void testTransformersFullEAP611() throws Exception {
+        testTransformersFull(ModelTestControllerVersion.EAP_6_1_1, ModelVersion.create(1, 2, 0));
+    }
+
     private void testTransformersFull(ModelTestControllerVersion controllerVersion, ModelVersion modelVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         String subsystemXml = readResource("full-expressions.xml");
         //Use the non-runtime version of the extension which will happen on the HC
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
@@ -200,7 +227,16 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testRejectTransformersAS712() throws Exception {
-        FailedOperationTransformationConfig config = new FailedOperationTransformationConfig()
+        testRejectTransformers(ModelTestControllerVersion.V7_1_2_FINAL, ModelVersion.create(1, 1, 0), get1_1_0_config());
+    }
+
+    @Test
+    public void testRejectTransformerEAP600() throws Exception {
+        testRejectTransformers(ModelTestControllerVersion.EAP_6_0_0, ModelVersion.create(1, 1, 0), get1_1_0_config());
+    }
+
+    private FailedOperationTransformationConfig get1_1_0_config() {
+        return new FailedOperationTransformationConfig()
         .addFailedAttribute(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME)),
                 new FailedOperationTransformationConfig.ChainedConfig(Arrays.asList(new FailedOperationTransformationConfig.AttributesPathAddressConfig<?>[] {
                         new FailedOperationTransformationConfig.RejectExpressionsConfig(
@@ -234,7 +270,6 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
                         OBJECT_STORE_PATH,
                         OBJECT_STORE_RELATIVE_TO,
                         HORNETQ_STORE_ENABLE_ASYNC_IO));
-        testRejectTransformers(ModelTestControllerVersion.V7_1_2_FINAL, ModelVersion.create(1, 1, 0), config);
     }
 
     @Test
@@ -252,7 +287,24 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
                     new ChangeToTrueConfig(HORNETQ_STORE_ENABLE_ASYNC_IO)));
     }
 
+    @Test
+    public void testRejectTransformersEAP610() throws Exception {
+        testRejectTransformers(ModelTestControllerVersion.EAP_6_1_0, ModelVersion.create(1, 2, 0), new FailedOperationTransformationConfig()
+            .addFailedAttribute(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME)),
+                    new ChangeToTrueConfig(HORNETQ_STORE_ENABLE_ASYNC_IO)));
+    }
+
+    @Test
+    public void testRejectTransformersEAP611() throws Exception {
+        testRejectTransformers(ModelTestControllerVersion.EAP_6_1_1, ModelVersion.create(1, 2, 0), new FailedOperationTransformationConfig()
+            .addFailedAttribute(PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME)),
+                    new ChangeToTrueConfig(HORNETQ_STORE_ENABLE_ASYNC_IO)));
+    }
+
     private void testRejectTransformers(ModelTestControllerVersion controllerVersion, ModelVersion modelVersion, FailedOperationTransformationConfig config) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
         // Add legacy subsystems

--- a/webservices/server-integration/src/test/java/org/jboss/as/webservices/dmr/WebservicesSubsystemParserTestCase.java
+++ b/webservices/server-integration/src/test/java/org/jboss/as/webservices/dmr/WebservicesSubsystemParserTestCase.java
@@ -168,6 +168,9 @@ public class WebservicesSubsystemParserTestCase extends AbstractSubsystemBaseTes
 
 
    private void testRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+       if (controllerVersion.isEap()) {
+           ignoreThisTestIfEAPRepositoryIsNotReachable();
+       }
         // create builder for current subsystem version
         KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
 
@@ -190,7 +193,7 @@ public class WebservicesSubsystemParserTestCase extends AbstractSubsystemBaseTes
 
     @Test
     public void testTransformersAS712() throws Exception {
-    testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_2_FINAL);
+        testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_2_FINAL);
     }
 
     @Test
@@ -198,9 +201,55 @@ public class WebservicesSubsystemParserTestCase extends AbstractSubsystemBaseTes
         testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
+    @Test
+    public void testTransformersEAP600() throws Exception {
+        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testTransformersEAP601() throws Exception {
+        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
 
     @Test
     public void testTransformersAS720() throws Exception {
-        testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_2_0_FINAL);
+        testTransformers_1_2_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
+
+    @Test
+    public void testTransformersEAP610() throws Exception {
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersEAP611() throws Exception {
+        ignoreThisTestIfEAPRepositoryIsNotReachable();
+        testTransformers_1_2_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+    private void testTransformers_1_2_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
+        // create builder for current subsystem version
+        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization())
+                .setSubsystemXmlResource("ws-subsystem12.xml");
+
+        // create builder for legacy subsystem version
+        ModelVersion version_1_2_0 = ModelVersion.create(1, 2, 0);
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version_1_2_0)
+                .addMavenResourceURL("org.jboss.as:jboss-as-webservices-server-integration:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, null);
+
+        KernelServices mainServices = builder.build();
+        KernelServices legacyServices = mainServices.getLegacyServices(version_1_2_0);
+
+        Assert.assertNotNull(legacyServices);
+        Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        checkSubsystemModelTransformation(mainServices, version_1_2_0);
+    }
+
 }

--- a/weld/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
+++ b/weld/src/test/java/org/jboss/as/weld/WeldSubsystemTestCase.java
@@ -58,42 +58,42 @@ public class WeldSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Test
     public void testTransformersAS712() throws Exception {
-        testTransformers10(ModelTestControllerVersion.V7_1_2_FINAL, false);
+        testTransformers10(ModelTestControllerVersion.V7_1_2_FINAL);
     }
 
     @Test
     public void testTransformersAS713() throws Exception {
-        testTransformers10(ModelTestControllerVersion.V7_1_3_FINAL, false);
+        testTransformers10(ModelTestControllerVersion.V7_1_3_FINAL);
     }
 
     @Test
-    public void testTransformersAS72() throws Exception {
-        testTransformers10(ModelTestControllerVersion.V7_2_0_FINAL, false);
+    public void testTransformersAS720() throws Exception {
+        testTransformers10(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
     @Test
     public void testTransformersEAP600() throws Exception {
-        testTransformers10(ModelTestControllerVersion.EAP_6_0_0, true);
+        testTransformers10(ModelTestControllerVersion.EAP_6_0_0);
     }
 
     @Test
     public void testTransformersEAP601() throws Exception {
-        testTransformers10(ModelTestControllerVersion.EAP_6_0_1, true);
+        testTransformers10(ModelTestControllerVersion.EAP_6_0_1);
     }
 
     @Test
     public void testTransformersEAP610() throws Exception {
-        testTransformers10(ModelTestControllerVersion.EAP_6_1_0, true);
+        testTransformers10(ModelTestControllerVersion.EAP_6_1_0);
     }
 
     @Test
     public void testTransformersEAP611() throws Exception {
-        testTransformers10(ModelTestControllerVersion.EAP_6_1_1, true);
+        testTransformers10(ModelTestControllerVersion.EAP_6_1_1);
     }
 
 
-    private void testTransformers10(ModelTestControllerVersion controllerVersion, boolean eap) throws Exception {
-        if (eap) {
+    private void testTransformers10(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
             ignoreThisTestIfEAPRepositoryIsNotReachable();
         }
 
@@ -126,13 +126,35 @@ public class WeldSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testTransformersRejectionAS72() throws Exception {
+    public void testTransformersRejectionAS720() throws Exception {
         testRejectTransformers10(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testTransformersRejectionEAP600() throws Exception {
+        testRejectTransformers10(ModelTestControllerVersion.EAP_6_0_0);
+    }
 
+    @Test
+    public void testTransformersRejectionEAP601() throws Exception {
+        testRejectTransformers10(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
+    @Test
+    public void testTransformersRejectionEAP610() throws Exception {
+        testRejectTransformers10(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testTransformersRejectionEAP611() throws Exception {
+        testRejectTransformers10(ModelTestControllerVersion.EAP_6_1_1);
+    }
 
     private void testRejectTransformers10(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
+
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
 

--- a/xts/src/test/java/org/jboss/as/xts/XTSSubsystemTestCase.java
+++ b/xts/src/test/java/org/jboss/as/xts/XTSSubsystemTestCase.java
@@ -64,7 +64,31 @@ public class XTSSubsystemTestCase extends AbstractSubsystemBaseTest {
         testBoot1_1_0(ModelTestControllerVersion.V7_2_0_FINAL);
     }
 
+    @Test
+    public void testBootEAP600() throws Exception {
+        testBoot1_1_0(ModelTestControllerVersion.EAP_6_0_0);
+    }
+
+    @Test
+    public void testBootEAP601() throws Exception {
+        testBoot1_1_0(ModelTestControllerVersion.EAP_6_0_1);
+    }
+
+    @Test
+    public void testBootEAP610() throws Exception {
+        testBoot1_1_0(ModelTestControllerVersion.EAP_6_1_0);
+    }
+
+    @Test
+    public void testBootEAP611() throws Exception {
+        testBoot1_1_0(ModelTestControllerVersion.EAP_6_1_1);
+    }
+
+
     private void testBoot1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
+        if (controllerVersion.isEap()) {
+            ignoreThisTestIfEAPRepositoryIsNotReachable();
+        }
 
         String subsystemXml = readResource("subsystem.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 1, 0);


### PR DESCRIPTION
Done for subsystems where we have existing tests against 7.2.0.
The tests will not be run unless the EAP repository is reachable, i.e. whoever runs it is on the VPN and -Djboss.test.transformers.eap is set. Once this is merged I'll work with @ctomc on getting it set up on appropriate CI jobs
