### PR TITLE
[WFLY-2185] Core Model Test classloader improvements

### DIFF
--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractCoreModelTest.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/AbstractCoreModelTest.java
@@ -54,6 +54,10 @@ public abstract class AbstractCoreModelTest {
         delegate.cleanup();
     }
 
+    CoreModelTestDelegate getDelegate() {
+        return delegate;
+    }
+
     protected KernelServicesBuilder createKernelServicesBuilder(TestModelType type) {
         return delegate.createKernelServicesBuilder(type);
     }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/ClassloaderParameter.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/ClassloaderParameter.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.core.model.test;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class ClassloaderParameter {
+
+    private volatile ClassLoader classloader;
+
+    void setClassLoader(ClassLoader classloader) {
+        this.classloader = classloader;
+    }
+
+    ClassLoader getClassLoader() {
+        return classloader;
+    }
+}

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TransformersTestParameterized.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TransformersTestParameterized.java
@@ -1,0 +1,213 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.core.model.test;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.runner.Runner;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.Suite;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+
+/**
+ *
+ * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
+ */
+public class TransformersTestParameterized extends Suite {
+        /**
+         * Annotation for a method which provides parameters to be injected into the
+         * test class constructor by <code>Parameterized</code>
+         */
+        @Retention(RetentionPolicy.RUNTIME)
+        @Target(ElementType.METHOD)
+        public static @interface TransformersParameter {
+            /**
+             * <p>
+             * Optional pattern to derive the test's name from the parameters. Use
+             * numbers in braces to refer to the parameters or the additional data
+             * as follows:
+             * </p>
+             *
+             * <pre>
+             * {index} - the current parameter index
+             * {0} - the first parameter value
+             * {1} - the second parameter value
+             * etc...
+             * </pre>
+             * <p>
+             * Default value is "{index}" for compatibility with previous JUnit
+             * versions.
+             * </p>
+             *
+             * @return {@link MessageFormat} pattern string, except the index
+             *         placeholder.
+             * @see MessageFormat
+             */
+            String name() default "{index}";
+        }
+
+
+        private class TestClassRunnerForParameters extends BlockJUnit4ClassRunner {
+            private final ClassloaderParameter fParameters;
+
+            private final String fName;
+
+            TestClassRunnerForParameters(Class<?> type, ClassloaderParameter parameters,
+                    String name) throws InitializationError {
+                super(type);
+                fParameters = parameters;
+                fName = name;
+            }
+
+            @Override
+            public Object createTest() throws Exception {
+                Object o =  createTestUsingConstructorInjection();
+                if (o instanceof AbstractCoreModelTest) {
+                    CoreModelTestDelegate delegate = ((AbstractCoreModelTest)o).getDelegate();
+                    delegate.setCurrentTransformerClassloaderParameter(fParameters);
+                }
+                return o;
+            }
+
+            private Object createTestUsingConstructorInjection() throws Exception {
+                return getTestClass().getOnlyConstructor().newInstance(fParameters);
+            }
+
+
+            @Override
+            protected String getName() {
+                return fName;
+            }
+
+            @Override
+            protected String testName(FrameworkMethod method) {
+                return method.getName() + getName();
+            }
+
+            @Override
+            protected void validateConstructor(List<Throwable> errors) {
+                validateOnlyOneConstructor(errors);
+            }
+
+            @Override
+            protected void validateFields(List<Throwable> errors) {
+                super.validateFields(errors);
+            }
+
+            @Override
+            protected Statement classBlock(RunNotifier notifier) {
+                return childrenInvoker(notifier);
+            }
+
+            @Override
+            protected Annotation[] getRunnerAnnotations() {
+                return new Annotation[0];
+            }
+        }
+
+        private static final List<Runner> NO_RUNNERS = Collections
+                .<Runner>emptyList();
+
+        private final ArrayList<Runner> runners = new ArrayList<Runner>();
+
+        /**
+         * Only called reflectively. Do not use programmatically.
+         */
+        public TransformersTestParameterized(Class<?> klass) throws Throwable {
+            super(klass, NO_RUNNERS);
+            TransformersParameter parameters = getParametersMethod().getAnnotation(
+                    TransformersParameter.class);
+            createRunnersForParameters(allParameters(), parameters.name());
+        }
+
+        @Override
+        protected List<Runner> getChildren() {
+            return runners;
+        }
+
+        @SuppressWarnings("unchecked")
+        private Iterable<ClassloaderParameter> allParameters() throws Throwable {
+            Object parameters = getParametersMethod().invokeExplosively(null);
+            if (parameters instanceof Iterable) {
+                return (Iterable<ClassloaderParameter>) parameters;
+            } else {
+                throw parametersMethodReturnedWrongType();
+            }
+        }
+
+        private FrameworkMethod getParametersMethod() throws Exception {
+            List<FrameworkMethod> methods = getTestClass().getAnnotatedMethods(
+                    TransformersParameter.class);
+            for (FrameworkMethod each : methods) {
+                if (each.isStatic() && each.isPublic()) {
+                    return each;
+                }
+            }
+
+            throw new Exception("No public static parameters method on class "
+                    + getTestClass().getName());
+        }
+
+        private void createRunnersForParameters(Iterable<ClassloaderParameter> allParameters,
+                String namePattern) throws Exception {
+            try {
+                int i = 0;
+                for (ClassloaderParameter parametersOfSingleTest : allParameters) {
+                    String name = nameFor(namePattern, i, parametersOfSingleTest);
+                    TestClassRunnerForParameters runner = new TestClassRunnerForParameters(
+                            getTestClass().getJavaClass(), parametersOfSingleTest,
+                            name);
+                    runners.add(runner);
+                    ++i;
+                }
+            } catch (ClassCastException e) {
+                throw parametersMethodReturnedWrongType();
+            }
+        }
+
+        private String nameFor(String namePattern, int index, ClassloaderParameter parameters) {
+            String finalPattern = namePattern.replaceAll("\\{index\\}",
+                    Integer.toString(index));
+            String name = MessageFormat.format(finalPattern, parameters);
+            return "[" + name + "]";
+        }
+
+        private Exception parametersMethodReturnedWrongType() throws Exception {
+            String className = getTestClass().getName();
+            String methodName = getParametersMethod().getName();
+            String message = MessageFormat.format(
+                    "{0}.{1}() must return an Iterable of arrays.",
+                    className, methodName);
+            return new Exception(message);
+        }
+    }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/AccessAuthorizationTransformationTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/access/AccessAuthorizationTransformationTestCase.java
@@ -31,7 +31,9 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.access.AccessAuthorizationResourceDefinition;
 import org.jboss.as.model.test.ModelTestControllerVersion;
@@ -39,25 +41,24 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  * Tests transformation of /core-service=management/access=authorization.
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class AccessAuthorizationTransformationTestCase extends AbstractCoreModelTest {
 
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    @Parameterized.Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
-    public AccessAuthorizationTransformationTestCase(TransformersTestParameters params) {
+    public AccessAuthorizationTransformationTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deploymentoverlay/DomainDeploymentOverlayTransformersTestCase.java
@@ -36,9 +36,11 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.ExcludeCommonOperations;
 import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.host.controller.ignored.IgnoreDomainResourceTypeResource;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
@@ -46,25 +48,23 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class DomainDeploymentOverlayTransformersTestCase extends AbstractCoreModelTest {
 
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    @Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
-    public DomainDeploymentOverlayTransformersTestCase(TransformersTestParameters params) {
+    public DomainDeploymentOverlayTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/InterfacesTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/interfaces/InterfacesTransformersTestCase.java
@@ -28,29 +28,29 @@ import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.TestModelType;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class InterfacesTransformersTestCase extends AbstractCoreModelTest {
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    @Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
-    public InterfacesTransformersTestCase(TransformersTestParameters params) {
+    public InterfacesTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/jvm/JvmTransformersTestCase.java
@@ -45,36 +45,36 @@ import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelFixer;
-import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.model.test.ModelTestControllerVersion;
+import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
  * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat, inc
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class JvmTransformersTestCase extends AbstractCoreModelTest {
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    public JvmTransformersTestCase(TransformersTestParameters params) {
+    public JvmTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }
 
-    @Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
     @Test

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/PathsTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/paths/PathsTransformersTestCase.java
@@ -34,8 +34,10 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
@@ -43,26 +45,24 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class PathsTransformersTestCase extends AbstractCoreModelTest {
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    public PathsTransformersTestCase(TransformersTestParameters params) {
+    public PathsTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }
 
-    @Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
     @Test

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/profile/ProfileTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/profile/ProfileTransformersTestCase.java
@@ -28,30 +28,30 @@ import org.jboss.as.core.model.test.AbstractCoreModelTest;
 import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.TestModelType;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class ProfileTransformersTestCase extends AbstractCoreModelTest {
 
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    @Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
-    public ProfileTransformersTestCase(TransformersTestParameters params) {
+    public ProfileTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/servergroup/DomainServerGroupTransformersTestCase.java
@@ -36,9 +36,11 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.ExcludeCommonOperations;
 import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.domain.controller.resources.ServerGroupResourceDefinition;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelFixer;
@@ -48,25 +50,24 @@ import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  * Tests transformation of server-groups.
  *
  * @author Brian Stansberry (c) 2012 Red Hat Inc.
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class DomainServerGroupTransformersTestCase extends AbstractCoreModelTest {
 
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    @Parameterized.Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
-    public DomainServerGroupTransformersTestCase(TransformersTestParameters params) {
+    public DomainServerGroupTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/SocketBindingGroupTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/SocketBindingGroupTransformersTestCase.java
@@ -29,31 +29,31 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.ExcludeCommonOperations;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class SocketBindingGroupTransformersTestCase extends AbstractCoreModelTest {
 
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    @Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
-    public SocketBindingGroupTransformersTestCase(TransformersTestParameters params) {
+    public SocketBindingGroupTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/SocketBindingTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/socketbindinggroups/SocketBindingTransformersTestCase.java
@@ -46,21 +46,22 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.ExcludeCommonOperations;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  * Tests of socket-binding transformation.
  *
  * @author Brian Stansberry (c) 2012 Red Hat Inc.
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class SocketBindingTransformersTestCase extends AbstractCoreModelTest {
 
     private static final String CLIENT_MAPPING_SOURCE_NETWORK = AbstractSocketBindingResourceDefinition.CLIENT_MAPPING_SOURCE_NETWORK.getName();
@@ -70,12 +71,12 @@ public class SocketBindingTransformersTestCase extends AbstractCoreModelTest {
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    @Parameterized.Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
-    public SocketBindingTransformersTestCase(TransformersTestParameters params) {
+    public SocketBindingTransformersTestCase(TransformersTestParameter params) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
     }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/AbstractSystemPropertyTransformersTest.java
@@ -38,8 +38,9 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.LegacyKernelServicesInitializer;
 import org.jboss.as.core.model.test.TestModelType;
+import org.jboss.as.core.model.test.TransformersTestParameterized.TransformersParameter;
 import org.jboss.as.core.model.test.util.StandardServerGroupInitializers;
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
@@ -48,7 +49,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
@@ -61,16 +61,16 @@ public abstract class AbstractSystemPropertyTransformersTest extends AbstractCor
     private final boolean serverGroup;
     private final ModelNode expectedUndefined;
 
-    public AbstractSystemPropertyTransformersTest(TransformersTestParameters params, boolean serverGroup) {
+    public AbstractSystemPropertyTransformersTest(TransformersTestParameter params, boolean serverGroup) {
         this.modelVersion = params.getModelVersion();
         this.testControllerVersion = params.getTestControllerVersion();
         this.serverGroup = serverGroup;
         this.expectedUndefined = getExpectedUndefined(params.getModelVersion());
     }
 
-    @Parameters
-    public static List<Object[]> parameters(){
-        return TransformersTestParameters.setupVersions();
+    @TransformersParameter
+    public static List<TransformersTestParameter> parameters(){
+        return TransformersTestParameter.setupVersions();
     }
 
     @Test

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainServerGroupSystemPropertyTransformersTestCase.java
@@ -21,19 +21,19 @@
 */
 package org.jboss.as.core.model.test.systemproperty;
 
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class DomainServerGroupSystemPropertyTransformersTestCase extends AbstractSystemPropertyTransformersTest {
 
-    public DomainServerGroupSystemPropertyTransformersTestCase(TransformersTestParameters params) {
+    public DomainServerGroupSystemPropertyTransformersTestCase(TransformersTestParameter params) {
         super(params, true);
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainSystemPropertyTransformersTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/systemproperty/DomainSystemPropertyTransformersTestCase.java
@@ -21,18 +21,18 @@
 */
 package org.jboss.as.core.model.test.systemproperty;
 
-import org.jboss.as.core.model.test.util.TransformersTestParameters;
+import org.jboss.as.core.model.test.TransformersTestParameterized;
+import org.jboss.as.core.model.test.util.TransformersTestParameter;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-@RunWith(Parameterized.class)
+@RunWith(TransformersTestParameterized.class)
 public class DomainSystemPropertyTransformersTestCase extends AbstractSystemPropertyTransformersTest {
 
-    public DomainSystemPropertyTransformersTestCase(TransformersTestParameters params) {
+    public DomainSystemPropertyTransformersTestCase(TransformersTestParameter params) {
         super(params, false);
     }
 

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.core.model.test.ClassloaderParameter;
 import org.jboss.as.model.test.EAPRepositoryReachableUtil;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 
@@ -32,17 +33,17 @@ import org.jboss.as.model.test.ModelTestControllerVersion;
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
-public class TransformersTestParameters {
+public class TransformersTestParameter extends ClassloaderParameter {
 
     private final ModelVersion modelVersion;
     private final ModelTestControllerVersion testControllerVersion;
 
-    public TransformersTestParameters(ModelVersion modelVersion, ModelTestControllerVersion testControllerVersion) {
+    public TransformersTestParameter(ModelVersion modelVersion, ModelTestControllerVersion testControllerVersion) {
         this.modelVersion = modelVersion;
         this.testControllerVersion = testControllerVersion;
     }
 
-    protected TransformersTestParameters(TransformersTestParameters delegate) {
+    protected TransformersTestParameter(TransformersTestParameter delegate) {
         this(delegate.getModelVersion(), delegate.getTestControllerVersion());
     }
 
@@ -54,26 +55,26 @@ public class TransformersTestParameters {
         return testControllerVersion;
     }
 
-    public static List<Object[]> setupVersions(){
-        List<Object[]> data = new ArrayList<Object[]>();
+    public static List<TransformersTestParameter> setupVersions(){
+        List<TransformersTestParameter> data = new ArrayList<TransformersTestParameter>();
         //AS releases
-        data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.V7_1_2_FINAL)});
-        data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.V7_1_3_FINAL)});
-        data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.V7_2_0_FINAL)});
-        data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(2, 0, 0), ModelTestControllerVersion.MASTER)});
+        data.add(new TransformersTestParameter(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.V7_1_2_FINAL));
+        data.add(new TransformersTestParameter(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.V7_1_3_FINAL));
+        data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.V7_2_0_FINAL));
+        data.add(new TransformersTestParameter(ModelVersion.create(2, 0, 0), ModelTestControllerVersion.MASTER));
 
         //EAP releases - these will only get tested if the EAPRepositoryReachableUtil.TEST_TRANSFORMERS_EAP system property is set AND the EAP repostitory is available
         if (EAPRepositoryReachableUtil.isReachable()) {
-            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.EAP_6_0_0)});
-            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.EAP_6_0_1)});
-            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0)});
-            data.add(new Object[] {new TransformersTestParameters(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1)});
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 2, 0), ModelTestControllerVersion.EAP_6_0_0));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.EAP_6_0_1));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1));
         }
 
 
         for (int i = 0 ; i < data.size() ; i++) {
-            Object[] entry = data.get(i);
-            System.out.println("Parameter " + i + ": " + entry[0]);
+            Object entry = data.get(i);
+            System.out.println("Parameter " + i + ": " + entry);
         }
         return data;
     }


### PR DESCRIPTION
Only create one childfirst classloader per old version in core-model transformers tests to a) optimize b) avoid PermGen issues

Previously a child first class loader was created for every single test method/old version combination, causing occasional PermGen problems with tests containing many test methods
