### PR TITLE
[WFLY-2446] Invalid value for backup-group-name

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
@@ -341,7 +341,10 @@ class HornetQServerAdd implements OperationStepHandler {
         configuration.setAllowAutoFailBack(ALLOW_FAILBACK.resolveModelAttribute(context, model).asBoolean());
         configuration.setEnabledAsyncConnectionExecution(ASYNC_CONNECTION_EXECUTION_ENABLED.resolveModelAttribute(context, model).asBoolean());
 
-        configuration.setBackupGroupName(BACKUP_GROUP_NAME.resolveModelAttribute(context, model).asString());
+        ModelNode backupGroupName = BACKUP_GROUP_NAME.resolveModelAttribute(context, model);
+        if (backupGroupName.isDefined()) {
+            configuration.setBackupGroupName(backupGroupName.asString());
+        }
         ModelNode replicationClusterName = REPLICATION_CLUSTERNAME.resolveModelAttribute(context, model);
         if (replicationClusterName.isDefined()) {
             configuration.setReplicationClustername(replicationClusterName.asString());


### PR DESCRIPTION
check whether the backup-group-name is defined before setting it on the
HornetQ configuration.
