### PR TITLE
WFLY-2108 Add module attribute to JASPI auth-modules

### DIFF
--- a/security/src/main/java/org/jboss/as/security/JASPIMappingModuleDefinition.java
+++ b/security/src/main/java/org/jboss/as/security/JASPIMappingModuleDefinition.java
@@ -49,7 +49,7 @@ public class JASPIMappingModuleDefinition extends MappingModuleDefinition {
 
 
 
-    private static final AttributeDefinition[] ATTRIBUTES = {CODE, FLAG, LOGIN_MODULE_STACK_REF, MODULE_OPTIONS};
+    private static final AttributeDefinition[] ATTRIBUTES = {CODE, FLAG, LOGIN_MODULE_STACK_REF, MODULE_OPTIONS, LoginModuleResourceDefinition.MODULE};
 
     JASPIMappingModuleDefinition() {
         super(Constants.AUTH_MODULE);

--- a/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
@@ -38,6 +38,7 @@ import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.RejectExpressionsConfig;
+import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.model.test.SingleClassFilter;
@@ -162,9 +163,8 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         ModelTestUtils.checkOutcome(mainServices.executeOperation(composite));
         ModelTestUtils.checkOutcome(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, composite)));
 
-        Assert.assertEquals(mainServices.readWholeModel(false), mainServices.getLegacyServices(modelVersion).readWholeModel(false));
+        checkSubsystemModelTransformation(mainServices, modelVersion);
     }
-
 
     private void testOperationTransformers_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
         ModelVersion modelVersion = ModelVersion.create(1, 1, 0);

--- a/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/security-1.2.0.dmr
+++ b/subsystem-test/framework/src/main/resources/org/jboss/as/subsystem/test/security-1.2.0.dmr
@@ -1,0 +1,1120 @@
+{
+    "model-description" => {
+        "description" => "The configuration of the security subsystem.",
+        "attributes" => {"deep-copy-subject-mode" => {
+            "type" => BOOLEAN,
+            "description" => "Sets the copy mode of subjects done by the security managers to be deep copies that makes copies of the subject principals and credentials if they are cloneable. It should be set to true if subject include mutable content that can be corrupted when multiple threads have the same identity and cache flushes/logout clearing the subject in one thread results in subject references affecting other threads.",
+            "expressions-allowed" => true,
+            "nillable" => true,
+            "default" => false
+        }},
+        "operations" => undefined,
+        "children" => {
+            "security-domain" => {
+                "description" => "Configures a security domain. Authentication, authorization, ACL, mapping, auditing and identity trust are configured here.",
+                "model-description" => undefined
+            },
+            "vault" => {
+                "description" => "Security Vault for attributes.",
+                "model-description" => undefined
+            }
+        }
+    },
+    "address" => [("subsystem" => "security")],
+    "children" => [
+        {
+            "model-description" => {
+                "description" => "Configures a security domain. Authentication, authorization, ACL, mapping, auditing and identity trust are configured here.",
+                "attributes" => {"cache-type" => {
+                    "type" => STRING,
+                    "description" => "Adds a cache to speed up authentication checks. Allowed values are 'default' to use simple map as the cache and 'infinispan' to use an Infinispan cache.",
+                    "expressions-allowed" => true,
+                    "nillable" => true,
+                    "min-length" => 1L,
+                    "max-length" => 2147483647L
+                }},
+                "operations" => undefined,
+                "children" => {
+                    "identity-trust" => {
+                        "description" => "Identity trust configuration. Configures a list of trust modules to be used.",
+                        "model-description" => undefined
+                    },
+                    "authentication" => {
+                        "description" => "\"Authentication configuration for this domain. Can either be classic or jaspi.",
+                        "model-description" => undefined
+                    },
+                    "acl" => {
+                        "description" => "Access control list configuration. Configures a list of ACL modules to be used.",
+                        "model-description" => undefined
+                    },
+                    "audit" => {
+                        "description" => "Auditing configuration. Configures a list of provider modules to be used.",
+                        "model-description" => undefined
+                    },
+                    "mapping" => {
+                        "description" => "Mapping configuration. Configures a list of mapping modules to be used for principal, role, attribute and credential mapping.",
+                        "model-description" => undefined
+                    },
+                    "jsse" => {
+                        "description" => "JSSE configuration. Configures attributes for keystores that can be used for setting up SSL.",
+                        "model-description" => undefined
+                    },
+                    "authorization" => {
+                        "description" => "Authorization configuration. Configures a list of authorization policy modules to be used.",
+                        "model-description" => undefined
+                    }
+                }
+            },
+            "address" => [
+                ("subsystem" => "security"),
+                ("security-domain" => "*")
+            ],
+            "children" => [
+                {
+                    "model-description" => {
+                        "description" => "Identity trust configuration. Configures a list of trust modules to be used.",
+                        "attributes" => {"trust-modules" => {
+                            "type" => LIST,
+                            "description" => "List of trust modules",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "deprecated" => {
+                                "since" => "1.2.0",
+                                "reason" => "This attribute was replaced with sub resource"
+                            },
+                            "value-type" => {
+                                "code" => {
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "min-length" => 1
+                                },
+                                "flag" => {
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "module" => {
+                                    "type" => STRING,
+                                    "nillable" => true,
+                                    "description" => "Name of JBoss Module where the identity trust module code is located."
+                                },
+                                "module-options" => {
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "type" => OBJECT,
+                                    "value-type" => STRING,
+                                    "nillable" => true
+                                }
+                            }
+                        }},
+                        "operations" => undefined,
+                        "children" => {"trust-module" => {
+                            "description" => "Trust module",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("identity-trust" => "classic")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "List of authentication modules",
+                            "attributes" => {
+                                "module" => {
+                                    "type" => STRING,
+                                    "description" => "Name of JBoss Module where the login module is located.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "flag" => {
+                                    "type" => STRING,
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "code" => {
+                                    "type" => STRING,
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "module-options" => {
+                                    "type" => OBJECT,
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => true,
+                                    "value-type" => STRING
+                                }
+                            },
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "security"),
+                            ("security-domain" => "*"),
+                            ("identity-trust" => "classic"),
+                            ("trust-module" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Traditional authentication configuration.  Configures a list of login modules to be used.",
+                        "attributes" => {"login-modules" => {
+                            "type" => LIST,
+                            "description" => "List of authentication modules",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "deprecated" => {
+                                "since" => "1.2.0",
+                                "reason" => "This attribute was replaced with sub resource"
+                            },
+                            "value-type" => {
+                                "code" => {
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "min-length" => 1
+                                },
+                                "flag" => {
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "module" => {
+                                    "type" => STRING,
+                                    "nillable" => true,
+                                    "description" => "Name of JBoss Module where the login module code is located."
+                                },
+                                "module-options" => {
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "type" => OBJECT,
+                                    "value-type" => STRING,
+                                    "nillable" => true
+                                }
+                            }
+                        }},
+                        "operations" => undefined,
+                        "children" => {"login-module" => {
+                            "description" => "Login module",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("authentication" => "classic")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "List of authentication modules",
+                            "attributes" => {
+                                "module" => {
+                                    "type" => STRING,
+                                    "description" => "Name of JBoss Module where the login module is located.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "flag" => {
+                                    "type" => STRING,
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "code" => {
+                                    "type" => STRING,
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "module-options" => {
+                                    "type" => OBJECT,
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => true,
+                                    "value-type" => STRING
+                                }
+                            },
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "security"),
+                            ("security-domain" => "*"),
+                            ("authentication" => "classic"),
+                            ("login-module" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Access control list configuration. Configures a list of ACL modules to be used.",
+                        "attributes" => {"acl-modules" => {
+                            "type" => LIST,
+                            "description" => "List of acl modules",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "deprecated" => {
+                                "since" => "1.2.0",
+                                "reason" => "This attribute is replaced with sub resource"
+                            },
+                            "value-type" => {
+                                "code" => {
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "min-length" => 1
+                                },
+                                "flag" => {
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "module" => {
+                                    "type" => STRING,
+                                    "nillable" => true,
+                                    "description" => "Name of JBoss Module where the acl provider module code is located."
+                                },
+                                "module-options" => {
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "type" => OBJECT,
+                                    "value-type" => STRING,
+                                    "nillable" => true
+                                }
+                            }
+                        }},
+                        "operations" => undefined,
+                        "children" => {"login-module" => {
+                            "description" => "Login module",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("acl" => "classic")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "List of authentication modules",
+                            "attributes" => {
+                                "module" => {
+                                    "type" => STRING,
+                                    "description" => "Name of JBoss Module where the login module is located.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "flag" => {
+                                    "type" => STRING,
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "code" => {
+                                    "type" => STRING,
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "module-options" => {
+                                    "type" => OBJECT,
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => true,
+                                    "value-type" => STRING
+                                }
+                            },
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "security"),
+                            ("security-domain" => "*"),
+                            ("acl" => "classic"),
+                            ("login-module" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Auditing configuration. Configures a list of provider modules to be used.",
+                        "attributes" => {"provider-modules" => {
+                            "type" => LIST,
+                            "description" => "List of provider modules",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "deprecated" => {
+                                "since" => "1.2.0",
+                                "reason" => "This attribute is replaced with sub resource"
+                            },
+                            "value-type" => {
+                                "code" => {
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "min-length" => 1
+                                },
+                                "module-options" => {
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "type" => OBJECT,
+                                    "value-type" => STRING,
+                                    "nillable" => true
+                                }
+                            }
+                        }},
+                        "operations" => undefined,
+                        "children" => {"provider-module" => {
+                            "description" => "Provider module",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("audit" => "classic")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "List of modules that map principal, role, and credential information",
+                            "attributes" => {
+                                "code" => {
+                                    "type" => STRING,
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "module-options" => {
+                                    "type" => OBJECT,
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => true,
+                                    "value-type" => STRING
+                                }
+                            },
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "security"),
+                            ("security-domain" => "*"),
+                            ("audit" => "classic"),
+                            ("provider-module" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Mapping configuration. Configures a list of mapping modules to be used for principal, role, attribute and credential mapping.",
+                        "attributes" => {"mapping-modules" => {
+                            "type" => LIST,
+                            "description" => "List of modules that map principal, role, and credential information",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "deprecated" => {
+                                "since" => "1.2.0",
+                                "reason" => "Use of this attribute is deprecated, use resource"
+                            },
+                            "value-type" => {
+                                "code" => {
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "min-length" => 1
+                                },
+                                "type" => {
+                                    "description" => "Type of mapping this module performs. Allowed values are principal, role, attribute or credential..",
+                                    "type" => STRING,
+                                    "nillable" => false
+                                },
+                                "module-options" => {
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "type" => OBJECT,
+                                    "value-type" => STRING,
+                                    "nillable" => true
+                                }
+                            }
+                        }},
+                        "operations" => undefined,
+                        "children" => {"mapping-module" => {
+                            "description" => "List of modules that map principal, role, and credential information",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("mapping" => "classic")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "List of modules that map principal, role, and credential information",
+                            "attributes" => {
+                                "module" => {
+                                    "type" => STRING,
+                                    "description" => "Name of JBoss Module where the mapping module code is located.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "code" => {
+                                    "type" => STRING,
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "type" => {
+                                    "type" => STRING,
+                                    "description" => "Type of mapping this module performs. Allowed values are principal, role, attribute or credential..",
+                                    "expressions-allowed" => true,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "module-options" => {
+                                    "type" => OBJECT,
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => true,
+                                    "value-type" => STRING
+                                }
+                            },
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "security"),
+                            ("security-domain" => "*"),
+                            ("mapping" => "classic"),
+                            ("mapping-module" => "*")
+                        ]
+                    }]
+                },
+                {
+                    "model-description" => {
+                        "description" => "JSSE configuration. Configures attributes for keystores that can be used for setting up SSL.",
+                        "attributes" => {
+                            "client-auth" => {
+                                "type" => BOOLEAN,
+                                "description" => "Boolean attribute to indicate if client's certificates should also be authenticated on the server side.",
+                                "expressions-allowed" => true,
+                                "nillable" => true
+                            },
+                            "protocols" => {
+                                "type" => STRING,
+                                "description" => "Comma separated list of protocols to enable on SSLSockets.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "truststore" => {
+                                "type" => OBJECT,
+                                "description" => "Configures a JSSE trust store",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "password" => {
+                                        "type" => STRING,
+                                        "description" => "Sets the password of the truststore. Either this or 'keystore-password' must be present otherwise the security domain will be useless.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "type" => {
+                                        "type" => STRING,
+                                        "description" => "Type of the truststore. If not set, type defaults to 'JKS'.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "url" => {
+                                        "type" => STRING,
+                                        "description" => "URL of the truststore.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "provider" => {
+                                        "type" => STRING,
+                                        "description" => "Provider class name to use when creating the truststore.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "provider-argument" => {
+                                        "type" => STRING,
+                                        "description" => "String argument to pass to the truststore Provider constructor when instantiating it.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                }
+                            },
+                            "trust-manager" => {
+                                "type" => OBJECT,
+                                "description" => "JSEE Trust Manager factory",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "algorithm" => {
+                                        "type" => STRING,
+                                        "description" => "Algorithm to use when creating the TrustManagerFactory.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "provider" => {
+                                        "type" => STRING,
+                                        "description" => "Provider class name to use when creating the TrustManagerFactory.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                }
+                            },
+                            "key-manager" => {
+                                "type" => OBJECT,
+                                "description" => "JSEE Key Manager factory",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "algorithm" => {
+                                        "type" => STRING,
+                                        "description" => "Algorithm to use when creating the KeyManagerFactory.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "provider" => {
+                                        "type" => STRING,
+                                        "description" => "Provider class name to use when creating the KeyManagerFactory.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                }
+                            },
+                            "service-auth-token" => {
+                                "type" => STRING,
+                                "description" => "Token to retrieve PrivateKeys from the KeyStore.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "keystore" => {
+                                "type" => OBJECT,
+                                "description" => "Configures a JSSE key store",
+                                "expressions-allowed" => false,
+                                "nillable" => true,
+                                "value-type" => {
+                                    "password" => {
+                                        "type" => STRING,
+                                        "description" => "Sets the password of the keystore. Either this or 'truststore-password' must be present otherwise the security domain will be useless.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "type" => {
+                                        "type" => STRING,
+                                        "description" => "Type of the keystore. If not set, type defaults to 'JKS'.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "url" => {
+                                        "type" => STRING,
+                                        "description" => "URL of the keystore.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "provider" => {
+                                        "type" => STRING,
+                                        "description" => "Provider class name to use when creating the KeyStore.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "provider-argument" => {
+                                        "type" => STRING,
+                                        "description" => "String argument to pass to the keystore Provider constructor when instantiating it.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                }
+                            },
+                            "additional-properties" => {
+                                "type" => OBJECT,
+                                "description" => "Additional properties that may be necessary to configure JSSE.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "value-type" => STRING
+                            },
+                            "server-alias" => {
+                                "type" => STRING,
+                                "description" => "Preferred alias to use when the KeyManager chooses the server alias.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "client-alias" => {
+                                "type" => STRING,
+                                "description" => "Preferred alias to use when the KeyManager chooses the client alias.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            },
+                            "cipher-suites" => {
+                                "type" => STRING,
+                                "description" => "Comma separated list of cipher suites to enable on SSLSockets.",
+                                "expressions-allowed" => true,
+                                "nillable" => true,
+                                "min-length" => 1L,
+                                "max-length" => 2147483647L
+                            }
+                        },
+                        "operations" => undefined,
+                        "children" => {}
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("jsse" => "classic")
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "JASPI authentication configuration.",
+                        "attributes" => {"auth-modules" => {
+                            "type" => LIST,
+                            "description" => "List of authentication modules to be used.",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "deprecated" => {
+                                "since" => "1.2.0",
+                                "reason" => "Use of this attribute is deprecated, use resource"
+                            },
+                            "value-type" => {
+                                "code" => {
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "min-length" => 1
+                                },
+                                "flag" => {
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "type" => STRING,
+                                    "nillable" => true,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "module" => {
+                                    "type" => STRING,
+                                    "nillable" => true,
+                                    "description" => "Name of JBoss Module where the auth module code is located."
+                                },
+                                "module-options" => {
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "type" => OBJECT,
+                                    "value-type" => STRING,
+                                    "nillable" => true
+                                },
+                                "login-module-stack-ref" => {
+                                    "description" => "Reference to a login module stack name previously configured in the same security domain.",
+                                    "type" => STRING,
+                                    "nillable" => true,
+                                    "min-length" => 1
+                                }
+                            }
+                        }},
+                        "operations" => undefined,
+                        "children" => {
+                            "login-module-stack" => {
+                                "description" => "List of \"named\" login modules that are used by jaspi authentication modules.",
+                                "model-description" => undefined
+                            },
+                            "auth-module" => {
+                                "description" => "Auth module",
+                                "model-description" => undefined
+                            }
+                        }
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("authentication" => "jaspi")
+                    ],
+                    "children" => [
+                        {
+                            "model-description" => {
+                                "description" => "List of \"named\" login modules that are used by jaspi authentication modules.",
+                                "attributes" => {"login-modules" => {
+                                    "type" => LIST,
+                                    "description" => "List of authentication modules",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "deprecated" => {
+                                        "since" => "1.2.0",
+                                        "reason" => "This attribute is replaced with sub resource"
+                                    },
+                                    "value-type" => {
+                                        "code" => {
+                                            "description" => "Class name of the module to be instantiated.",
+                                            "type" => STRING,
+                                            "nillable" => false,
+                                            "min-length" => 1
+                                        },
+                                        "flag" => {
+                                            "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                            "type" => STRING,
+                                            "nillable" => false,
+                                            "allowed" => [
+                                                "required",
+                                                "requisite",
+                                                "sufficient",
+                                                "optional"
+                                            ]
+                                        },
+                                        "module" => {
+                                            "type" => STRING,
+                                            "nillable" => true,
+                                            "description" => "Name of JBoss Module where the login module is located."
+                                        },
+                                        "module-options" => {
+                                            "description" => "List of module options containing a name/value pair.",
+                                            "type" => OBJECT,
+                                            "value-type" => STRING,
+                                            "nillable" => true
+                                        }
+                                    }
+                                }},
+                                "operations" => undefined,
+                                "children" => {"login-module" => {
+                                    "description" => "Login module",
+                                    "model-description" => undefined
+                                }}
+                            },
+                            "address" => [
+                                ("subsystem" => "security"),
+                                ("security-domain" => "*"),
+                                ("authentication" => "jaspi"),
+                                ("login-module-stack" => "*")
+                            ],
+                            "children" => [{
+                                "model-description" => {
+                                    "description" => "List of authentication modules",
+                                    "attributes" => {
+                                        "module" => {
+                                            "type" => STRING,
+                                            "description" => "Name of JBoss Module where the login module is located.",
+                                            "expressions-allowed" => false,
+                                            "nillable" => true,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "flag" => {
+                                            "type" => STRING,
+                                            "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                            "expressions-allowed" => true,
+                                            "nillable" => false,
+                                            "allowed" => [
+                                                "required",
+                                                "requisite",
+                                                "sufficient",
+                                                "optional"
+                                            ]
+                                        },
+                                        "code" => {
+                                            "type" => STRING,
+                                            "description" => "Class name of the module to be instantiated.",
+                                            "expressions-allowed" => false,
+                                            "nillable" => false,
+                                            "min-length" => 1L,
+                                            "max-length" => 2147483647L
+                                        },
+                                        "module-options" => {
+                                            "type" => OBJECT,
+                                            "description" => "List of module options containing a name/value pair.",
+                                            "expressions-allowed" => true,
+                                            "nillable" => true,
+                                            "value-type" => STRING
+                                        }
+                                    },
+                                    "operations" => undefined,
+                                    "children" => {}
+                                },
+                                "address" => [
+                                    ("subsystem" => "security"),
+                                    ("security-domain" => "*"),
+                                    ("authentication" => "jaspi"),
+                                    ("login-module-stack" => "*"),
+                                    ("login-module" => "*")
+                                ]
+                            }]
+                        },
+                        {
+                            "model-description" => {
+                                "description" => "List of modules that map principal, role, and credential information",
+                                "attributes" => {
+                                    "flag" => {
+                                        "type" => STRING,
+                                        "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "allowed" => [
+                                            "required",
+                                            "requisite",
+                                            "sufficient",
+                                            "optional"
+                                        ]
+                                    },
+                                    "code" => {
+                                        "type" => STRING,
+                                        "description" => "Class name of the module to be instantiated.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => false,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    },
+                                    "module-options" => {
+                                        "type" => OBJECT,
+                                        "description" => "List of module options containing a name/value pair.",
+                                        "expressions-allowed" => true,
+                                        "nillable" => true,
+                                        "value-type" => STRING
+                                    },
+                                    "login-module-stack-ref" => {
+                                        "type" => STRING,
+                                        "description" => "Reference to a login module stack name previously configured in the same security domain.",
+                                        "expressions-allowed" => false,
+                                        "nillable" => true,
+                                        "min-length" => 1L,
+                                        "max-length" => 2147483647L
+                                    }
+                                },
+                                "operations" => undefined,
+                                "children" => {}
+                            },
+                            "address" => [
+                                ("subsystem" => "security"),
+                                ("security-domain" => "*"),
+                                ("authentication" => "jaspi"),
+                                ("auth-module" => "*")
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "model-description" => {
+                        "description" => "Authorization configuration. Configures a list of authorization policy modules to be used.",
+                        "attributes" => {"policy-modules" => {
+                            "type" => LIST,
+                            "description" => "List of authorization modules",
+                            "expressions-allowed" => false,
+                            "nillable" => true,
+                            "deprecated" => {
+                                "since" => "1.2.0",
+                                "reason" => "Use of this attribute is deprecated, use resource"
+                            },
+                            "value-type" => {
+                                "code" => {
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "min-length" => 1
+                                },
+                                "flag" => {
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "type" => STRING,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "module" => {
+                                    "type" => STRING,
+                                    "nillable" => true,
+                                    "description" => "Name of JBoss Module where the policy module code is located."
+                                },
+                                "module-options" => {
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "type" => OBJECT,
+                                    "value-type" => STRING,
+                                    "nillable" => true
+                                }
+                            }
+                        }},
+                        "operations" => undefined,
+                        "children" => {"policy-module" => {
+                            "description" => "Policy module",
+                            "model-description" => undefined
+                        }}
+                    },
+                    "address" => [
+                        ("subsystem" => "security"),
+                        ("security-domain" => "*"),
+                        ("authorization" => "classic")
+                    ],
+                    "children" => [{
+                        "model-description" => {
+                            "description" => "List of authentication modules",
+                            "attributes" => {
+                                "module" => {
+                                    "type" => STRING,
+                                    "description" => "Name of JBoss Module where the login module is located.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => true,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "flag" => {
+                                    "type" => STRING,
+                                    "description" => "The flag controls how the module participates in the overall procedure. Allowed values are requisite, required, sufficient or optional.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => false,
+                                    "allowed" => [
+                                        "required",
+                                        "requisite",
+                                        "sufficient",
+                                        "optional"
+                                    ]
+                                },
+                                "code" => {
+                                    "type" => STRING,
+                                    "description" => "Class name of the module to be instantiated.",
+                                    "expressions-allowed" => false,
+                                    "nillable" => false,
+                                    "min-length" => 1L,
+                                    "max-length" => 2147483647L
+                                },
+                                "module-options" => {
+                                    "type" => OBJECT,
+                                    "description" => "List of module options containing a name/value pair.",
+                                    "expressions-allowed" => true,
+                                    "nillable" => true,
+                                    "value-type" => STRING
+                                }
+                            },
+                            "operations" => undefined,
+                            "children" => {}
+                        },
+                        "address" => [
+                            ("subsystem" => "security"),
+                            ("security-domain" => "*"),
+                            ("authorization" => "classic"),
+                            ("policy-module" => "*")
+                        ]
+                    }]
+                }
+            ]
+        },
+        {
+            "model-description" => {
+                "description" => "Security Vault for attributes.",
+                "attributes" => {
+                    "vault-options" => {
+                        "type" => OBJECT,
+                        "description" => "Security Vault options.",
+                        "expressions-allowed" => true,
+                        "nillable" => true,
+                        "value-type" => STRING
+                    },
+                    "code" => {
+                        "type" => STRING,
+                        "description" => "Fully Qualified Name of the Security Vault Implementation.",
+                        "expressions-allowed" => false,
+                        "nillable" => true,
+                        "min-length" => 1L,
+                        "max-length" => 2147483647L
+                    }
+                },
+                "operations" => undefined,
+                "children" => {}
+            },
+            "address" => [
+                ("subsystem" => "security"),
+                ("vault" => "classic")
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This change enables configuration of custom auth-modules by allowing users to specify the jboss-module that should be used to load the auth-module implementation.
