### PR TITLE
WFLY-1995, allow property substitution for some EJB annotations.

### DIFF
--- a/build/src/main/resources/configuration/subsystems/ee.xml
+++ b/build/src/main/resources/configuration/subsystems/ee.xml
@@ -5,6 +5,7 @@
    <subsystem xmlns="urn:jboss:domain:ee:2.0">
         <spec-descriptor-property-replacement>false</spec-descriptor-property-replacement>
         <jboss-descriptor-property-replacement>true</jboss-descriptor-property-replacement>
+        <ejb-annotation-property-replacement>false</ejb-annotation-property-replacement>
         <concurrent>
             <context-services>
                 <context-service name="default" jndi-name="java:jboss/ee/concurrency/context/default" use-transaction-setup-provider="true"/>

--- a/build/src/main/resources/docs/schema/jboss-as-ee_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ee_2_0.xsd
@@ -40,6 +40,7 @@
             <xs:element name="ear-subdeployments-isolated" default="false" type="ear-subdeployments-isolatedType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="spec-descriptor-property-replacement" type="descriptor-property-replacementType" minOccurs="0" maxOccurs="1" />
             <xs:element name="jboss-descriptor-property-replacement" type="descriptor-property-replacementType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="ejb-annotation-property-replacement" type="annotation-property-replacementType" minOccurs="0" maxOccurs="1" />
             <xs:element name="concurrent" type="concurrentType" minOccurs="0" maxOccurs="1" />
             <xs:element name="default-bindings" type="defaultBindingsType" minOccurs="0" maxOccurs="1" />
         </xs:sequence>
@@ -92,6 +93,22 @@
         <xs:annotation>
             <xs:documentation>
                 Flag indicating whether system property replacement will be performed on a descriptor. This defaults to
+                true, however it is disabled in the default configurations.
+
+                Security Node: System properties etc are resolved in the security context of the application server
+                itself, not the deployment that contains the file. This means that if you are running with a security
+                manager and enable this property, a deployment can potentially access system properties or environment
+                entries that the security manager would have otherwise prevented.
+            </xs:documentation>
+        </xs:annotation>
+
+        <xs:restriction base="xs:boolean"/>
+    </xs:simpleType>
+
+    <xs:simpleType name="annotation-property-replacementType">
+        <xs:annotation>
+            <xs:documentation>
+                Flag indicating whether system property replacement will be performed on an annotation. This defaults to
                 true, however it is disabled in the default configurations.
 
                 Security Node: System properties etc are resolved in the security context of the application server

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/BooleanAnnotationInformationFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/BooleanAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class BooleanAnnotationInformationFactory<T extends Annotation> extends C
     }
 
     @Override
-    protected Boolean fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected Boolean fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return true;
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/InterceptorsAnnotationInformationFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/InterceptorsAnnotationInformationFactory.java
@@ -37,7 +37,7 @@ public class InterceptorsAnnotationInformationFactory extends ClassAnnotationInf
     }
 
     @Override
-    protected String[] fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String[] fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         final Type[] classes =  annotationInstance.value().asClassArray();
         final String[] ret = new String[classes.length];
         for(int i = 0; i < classes.length; ++i) {

--- a/ee/src/main/java/org/jboss/as/ee/metadata/AbstractEEAnnotationProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/AbstractEEAnnotationProcessor.java
@@ -45,13 +45,14 @@ public abstract class AbstractEEAnnotationProcessor implements DeploymentUnitPro
 
         final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
         final CompositeIndex index = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.COMPOSITE_ANNOTATION_INDEX);
+        final Boolean replacement = deploymentUnit.getAttachment(org.jboss.as.ee.structure.Attachments.EJB_ANNOTATION_PROPERTY_REPLACEMENT);
         if (index == null || eeModuleDescription == null) {
             return;
         }
 
         final List<ClassAnnotationInformationFactory> factories = annotationInformationFactories();
         for (final ClassAnnotationInformationFactory factory : factories) {
-            final Map<String, ClassAnnotationInformation<?, ?>> data = factory.createAnnotationInformation(index);
+            final Map<String, ClassAnnotationInformation<?, ?>> data = factory.createAnnotationInformation(index, replacement);
             for (Map.Entry<String, ClassAnnotationInformation<?, ?>> entry : data.entrySet()) {
                 EEModuleClassDescription clazz = eeModuleDescription.addOrGetLocalClassDescription(entry.getKey());
                 clazz.addAnnotationInformation(entry.getValue());

--- a/ee/src/main/java/org/jboss/as/ee/metadata/ClassAnnotationInformationFactory.java
+++ b/ee/src/main/java/org/jboss/as/ee/metadata/ClassAnnotationInformationFactory.java
@@ -67,7 +67,7 @@ public abstract class ClassAnnotationInformationFactory<A extends Annotation, T>
         }
     }
 
-    public Map<String, ClassAnnotationInformation<A, T>> createAnnotationInformation(final CompositeIndex index) {
+    public Map<String, ClassAnnotationInformation<A, T>> createAnnotationInformation(final CompositeIndex index, final boolean replacement) {
 
         final List<TargetAnnotation> annotations = new ArrayList<TargetAnnotation>();
         if (multiAnnotationDotName != null) {
@@ -124,7 +124,7 @@ public abstract class ClassAnnotationInformationFactory<A extends Annotation, T>
             } else {
                 classData = new ArrayList<T>(classAnnotations.size());
                 for (TargetAnnotation instance : classAnnotations) {
-                    classData.add(fromAnnotation(instance.instance()));
+                    classData.add(fromAnnotation(instance.instance(), replacement));
                 }
             }
 
@@ -141,7 +141,7 @@ public abstract class ClassAnnotationInformationFactory<A extends Annotation, T>
                     if (data == null) {
                         fieldData.put(name, data = new ArrayList<T>(1));
                     }
-                    data.add(fromAnnotation(instance.instance()));
+                    data.add(fromAnnotation(instance.instance(), replacement));
                 }
             }
 
@@ -158,7 +158,7 @@ public abstract class ClassAnnotationInformationFactory<A extends Annotation, T>
                     if (data == null) {
                         methodData.put(identifier, data = new ArrayList<T>(1));
                     }
-                    data.add(fromAnnotation(instance.instance()));
+                    data.add(fromAnnotation(instance.instance(), replacement));
                 }
             }
             ClassAnnotationInformation<A, T> information = new ClassAnnotationInformation<A, T>(annotationType, classData, methodData, fieldData);
@@ -183,7 +183,7 @@ public abstract class ClassAnnotationInformationFactory<A extends Annotation, T>
     }
 
 
-    protected abstract T fromAnnotation(AnnotationInstance annotationInstance);
+    protected abstract T fromAnnotation(AnnotationInstance annotationInstance, boolean replacement);
 
     protected List<TargetAnnotation> fromMultiAnnotation(AnnotationInstance multiAnnotationInstance) {
         List<TargetAnnotation> instances = new ArrayList<TargetAnnotation>();

--- a/ee/src/main/java/org/jboss/as/ee/structure/AnnotationPropertyReplacementProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/AnnotationPropertyReplacementProcessor.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ee.structure;
+
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+
+/**
+ * {@link org.jboss.as.server.deployment.DeploymentUnitProcessor} responsible for determining if property replacement should be
+ * done on EJB annotations.
+ */
+public class AnnotationPropertyReplacementProcessor implements DeploymentUnitProcessor {
+
+    private volatile boolean annotationPropertyReplacement = false;
+    private final AttachmentKey<Boolean> attachmentKey;
+
+    public AnnotationPropertyReplacementProcessor(final AttachmentKey<Boolean> attachmentKey) {
+        this.attachmentKey = attachmentKey;
+    }
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        deploymentUnit.putAttachment(attachmentKey, annotationPropertyReplacement);
+
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+
+    }
+
+    public void setDescriptorPropertyReplacement(boolean annotationPropertyReplacement) {
+        this.annotationPropertyReplacement = annotationPropertyReplacement;
+    }
+
+}

--- a/ee/src/main/java/org/jboss/as/ee/structure/Attachments.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/Attachments.java
@@ -70,6 +70,11 @@ public final class Attachments {
      */
     public static final AttachmentKey<Boolean> JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT = AttachmentKey.create(Boolean.class);
 
+    /**
+     * If this is set to true property replacement will be enabled for EJB annotations
+     */
+    public static final AttachmentKey<Boolean> EJB_ANNOTATION_PROPERTY_REPLACEMENT = AttachmentKey.create(Boolean.class);
+
     private Attachments() {
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EESubsystemModel.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EESubsystemModel.java
@@ -33,6 +33,7 @@ public interface EESubsystemModel {
     String EAR_SUBDEPLOYMENTS_ISOLATED = "ear-subdeployments-isolated";
     String SPEC_DESCRIPTOR_PROPERTY_REPLACEMENT = "spec-descriptor-property-replacement";
     String JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT = "jboss-descriptor-property-replacement";
+    String EJB_ANNOTATION_PROPERTY_REPLACEMENT = "ejb-annotation-property-replacement";
 
     String DEFAULT_BINDINGS = "default-bindings";
 

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EESubsystemParser20.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EESubsystemParser20.java
@@ -38,7 +38,6 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.parsing.ParseUtils.*;
-import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
 import static org.jboss.as.ee.EeMessages.MESSAGES;
 
 /**
@@ -92,6 +91,11 @@ class EESubsystemParser20 implements XMLStreamConstants, XMLElementReader<List<M
                         case JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT: {
                             final String enabled = parseJBossDescriptorPropertyReplacement(reader);
                             EeSubsystemRootResource.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT.parseAndSetParameter(enabled, eeSubSystem, reader);
+                            break;
+                        }
+                        case EJB_ANNOTATION_PROPERTY_REPLACEMENT: {
+                            final String enabled = parseEJBAnnotationPropertyReplacement(reader);
+                            EeSubsystemRootResource.EJB_ANNOTATION_PROPERTY_REPLACEMENT.parseAndSetParameter(enabled, eeSubSystem, reader);
                             break;
                         }
                         case CONCURRENT: {
@@ -229,6 +233,14 @@ class EESubsystemParser20 implements XMLStreamConstants, XMLElementReader<List<M
         if (value == null || value.trim().isEmpty()) {
             throw MESSAGES.invalidValue(value, Element.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT.getLocalName(), reader.getLocation());
         }
+        return value.trim();
+    }
+
+    static String parseEJBAnnotationPropertyReplacement(XMLExtendedStreamReader reader) throws XMLStreamException {
+        // we don't expect any attributes for this element.
+        requireNoAttributes(reader);
+
+        final String value = reader.getElementText();
         return value.trim();
     }
 

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EESubsystemXmlPersister.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EESubsystemXmlPersister.java
@@ -54,6 +54,7 @@ class EESubsystemXmlPersister implements XMLStreamConstants, XMLElementWriter<Su
         EeSubsystemRootResource.EAR_SUBDEPLOYMENTS_ISOLATED.marshallAsElement(eeSubSystem, writer);
         EeSubsystemRootResource.SPEC_DESCRIPTOR_PROPERTY_REPLACEMENT.marshallAsElement(eeSubSystem, writer);
         EeSubsystemRootResource.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT.marshallAsElement(eeSubSystem, writer);
+        EeSubsystemRootResource.EJB_ANNOTATION_PROPERTY_REPLACEMENT.marshallAsElement(eeSubSystem, writer);
         writeConcurrentElement(writer,eeSubSystem);
         writeDefaultBindingsElement(writer,eeSubSystem);
         writer.writeEndElement();

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeExtension.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeExtension.java
@@ -43,6 +43,7 @@ import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.AttributeConverter;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescription;
@@ -122,8 +123,10 @@ public class EeExtension implements Extension {
                         EeSubsystemRootResource.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT)
                 // Deal with new attributes added to global-modules elements
                 .addRejectCheck(globalModulesRejecterConverter, GlobalModulesDefinition.INSTANCE)
-                .setValueConverter(globalModulesRejecterConverter, GlobalModulesDefinition.INSTANCE);
-
+                .setValueConverter(globalModulesRejecterConverter, GlobalModulesDefinition.INSTANCE)
+                // Deal with new attribute ejb-annotation-property-replacement
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, false, new ModelNode(false)), EeSubsystemRootResource.EJB_ANNOTATION_PROPERTY_REPLACEMENT)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, EeSubsystemRootResource.EJB_ANNOTATION_PROPERTY_REPLACEMENT);
         builder.rejectChildResource(PathElement.pathElement(EESubsystemModel.CONTEXT_SERVICE));
         builder.rejectChildResource(PathElement.pathElement(EESubsystemModel.MANAGED_THREAD_FACTORY));
         builder.rejectChildResource(PathElement.pathElement(EESubsystemModel.MANAGED_EXECUTOR_SERVICE));

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemAdd.java
@@ -69,6 +69,7 @@ import org.jboss.as.ee.metadata.property.SystemPropertyResolverProcessor;
 import org.jboss.as.ee.metadata.property.VaultPropertyResolverProcessor;
 import org.jboss.as.ee.naming.ApplicationContextProcessor;
 import org.jboss.as.ee.naming.ModuleContextProcessor;
+import org.jboss.as.ee.structure.AnnotationPropertyReplacementProcessor;
 import org.jboss.as.ee.structure.ApplicationClientDeploymentProcessor;
 import org.jboss.as.ee.structure.ComponentAggregationProcessor;
 import org.jboss.as.ee.structure.EJBClientDescriptorParsingProcessor;
@@ -102,14 +103,16 @@ public class EeSubsystemAdd extends AbstractBoottimeAddStepHandler {
     private final GlobalModuleDependencyProcessor moduleDependencyProcessor;
     private final DescriptorPropertyReplacementProcessor specDescriptorPropertyReplacementProcessor;
     private final DescriptorPropertyReplacementProcessor jbossDescriptorPropertyReplacementProcessor;
+    private final AnnotationPropertyReplacementProcessor ejbAnnotationPropertyReplacementProcessor;
 
 
     public EeSubsystemAdd(final DefaultEarSubDeploymentsIsolationProcessor isolationProcessor,
-                          final GlobalModuleDependencyProcessor moduleDependencyProcessor, final DescriptorPropertyReplacementProcessor specDescriptorPropertyReplacementProcessor, final DescriptorPropertyReplacementProcessor jbossDescriptorPropertyReplacementProcessor) {
+                          final GlobalModuleDependencyProcessor moduleDependencyProcessor, final DescriptorPropertyReplacementProcessor specDescriptorPropertyReplacementProcessor, final DescriptorPropertyReplacementProcessor jbossDescriptorPropertyReplacementProcessor, final AnnotationPropertyReplacementProcessor ejbAnnotationPropertyReplacementProcessor) {
         this.isolationProcessor = isolationProcessor;
         this.moduleDependencyProcessor = moduleDependencyProcessor;
         this.specDescriptorPropertyReplacementProcessor = specDescriptorPropertyReplacementProcessor;
         this.jbossDescriptorPropertyReplacementProcessor = jbossDescriptorPropertyReplacementProcessor;
+        this.ejbAnnotationPropertyReplacementProcessor = ejbAnnotationPropertyReplacementProcessor;
     }
 
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
@@ -135,11 +138,13 @@ public class EeSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final boolean earSubDeploymentsIsolated = EeSubsystemRootResource.EAR_SUBDEPLOYMENTS_ISOLATED.resolveModelAttribute(context, model).asBoolean();
         final boolean specDescriptorPropertyReplacement = EeSubsystemRootResource.SPEC_DESCRIPTOR_PROPERTY_REPLACEMENT.resolveModelAttribute(context, model).asBoolean();
         final boolean jbossDescriptorPropertyReplacement = EeSubsystemRootResource.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT.resolveModelAttribute(context, model).asBoolean();
+        final boolean ejbAnnotationPropertyReplacement = EeSubsystemRootResource.EJB_ANNOTATION_PROPERTY_REPLACEMENT.resolveModelAttribute(context, model).asBoolean();
 
         moduleDependencyProcessor.setGlobalModules(GlobalModulesDefinition.createModuleList(context, globalModules));
         isolationProcessor.setEarSubDeploymentsIsolated(earSubDeploymentsIsolated);
         specDescriptorPropertyReplacementProcessor.setDescriptorPropertyReplacement(specDescriptorPropertyReplacement);
         jbossDescriptorPropertyReplacementProcessor.setDescriptorPropertyReplacement(jbossDescriptorPropertyReplacement);
+        ejbAnnotationPropertyReplacementProcessor.setDescriptorPropertyReplacement(ejbAnnotationPropertyReplacement);
 
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
@@ -154,6 +159,7 @@ public class EeSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_REGISTER_JBOSS_ALL_EE_APP, new JBossAllXmlParserRegisteringProcessor<JBossAppMetaData>(AppJBossAllParser.ROOT_ELEMENT, AppJBossAllParser.ATTACHMENT_KEY, new AppJBossAllParser()));
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_SPEC_DESC_PROPERTY_REPLACEMENT, specDescriptorPropertyReplacementProcessor);
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_JBOSS_DESC_PROPERTY_REPLACEMENT, jbossDescriptorPropertyReplacementProcessor);
+                processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EE_EJB_ANNOTATION_PROPERTY_REPLACEMENT, ejbAnnotationPropertyReplacementProcessor);
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EAR_DEPLOYMENT_INIT, new EarInitializationProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_EAR_APP_XML_PARSE, new EarMetaDataParsingProcessor());
                 processorTarget.addDeploymentProcessor(EeExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_JBOSS_EJB_CLIENT_XML_PARSE, new EJBClientDescriptorParsingProcessor());

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemRootResource.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeSubsystemRootResource.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.ee.component.deployers.DefaultEarSubDeploymentsIsolationProcessor;
+import org.jboss.as.ee.structure.AnnotationPropertyReplacementProcessor;
 import org.jboss.as.ee.structure.Attachments;
 import org.jboss.as.ee.structure.DescriptorPropertyReplacementProcessor;
 import org.jboss.as.ee.structure.GlobalModuleDependencyProcessor;
@@ -69,8 +70,14 @@ public class EeSubsystemRootResource extends SimpleResourceDefinition {
                     .setDefaultValue(new ModelNode(true))
                     .build();
 
+    public static final SimpleAttributeDefinition EJB_ANNOTATION_PROPERTY_REPLACEMENT =
+            new SimpleAttributeDefinitionBuilder(EESubsystemModel.EJB_ANNOTATION_PROPERTY_REPLACEMENT, ModelType.BOOLEAN, true)
+                    .setAllowExpression(true)
+                    .setDefaultValue(new ModelNode(false))
+                    .build();
+
     static final AttributeDefinition[] ATTRIBUTES = { GlobalModulesDefinition.INSTANCE, EAR_SUBDEPLOYMENTS_ISOLATED,
-            SPEC_DESCRIPTOR_PROPERTY_REPLACEMENT, JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT};
+            SPEC_DESCRIPTOR_PROPERTY_REPLACEMENT, JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT, EJB_ANNOTATION_PROPERTY_REPLACEMENT };
 
     public static final EeSubsystemRootResource INSTANCE = new EeSubsystemRootResource();
 
@@ -79,6 +86,7 @@ public class EeSubsystemRootResource extends SimpleResourceDefinition {
     private final GlobalModuleDependencyProcessor moduleDependencyProcessor = new GlobalModuleDependencyProcessor();
     private final DescriptorPropertyReplacementProcessor specDescriptorPropertyReplacementProcessor = new DescriptorPropertyReplacementProcessor(Attachments.SPEC_DESCRIPTOR_PROPERTY_REPLACEMENT);
     private final DescriptorPropertyReplacementProcessor jbossDescriptorPropertyReplacementProcessor = new DescriptorPropertyReplacementProcessor(Attachments.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT);
+    private final AnnotationPropertyReplacementProcessor annotationPropertyReplacementProcessor = new AnnotationPropertyReplacementProcessor(Attachments.EJB_ANNOTATION_PROPERTY_REPLACEMENT);
 
     private EeSubsystemRootResource() {
         super(EeExtension.PATH_SUBSYSTEM,
@@ -91,7 +99,7 @@ public class EeSubsystemRootResource extends SimpleResourceDefinition {
         final ResourceDescriptionResolver rootResolver = getResourceDescriptionResolver();
 
         // Ops to add and remove the root resource
-        final EeSubsystemAdd subsystemAdd = new EeSubsystemAdd(isolationProcessor, moduleDependencyProcessor, specDescriptorPropertyReplacementProcessor, jbossDescriptorPropertyReplacementProcessor);
+        final EeSubsystemAdd subsystemAdd = new EeSubsystemAdd(isolationProcessor, moduleDependencyProcessor, specDescriptorPropertyReplacementProcessor, jbossDescriptorPropertyReplacementProcessor, annotationPropertyReplacementProcessor);
         final DescriptionProvider subsystemAddDescription = new DefaultResourceAddDescriptionProvider(rootResourceRegistration, rootResolver);
         rootResourceRegistration.registerOperationHandler(ADD, subsystemAdd, subsystemAddDescription, EnumSet.of(OperationEntry.Flag.RESTART_ALL_SERVICES));
         final DescriptionProvider subsystemRemoveDescription = new DefaultResourceRemoveDescriptionProvider(rootResolver);
@@ -102,7 +110,7 @@ public class EeSubsystemRootResource extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(final ManagementResourceRegistration rootResourceRegistration) {
         EeWriteAttributeHandler writeHandler = new EeWriteAttributeHandler(isolationProcessor, moduleDependencyProcessor,
-                specDescriptorPropertyReplacementProcessor, jbossDescriptorPropertyReplacementProcessor);
+                specDescriptorPropertyReplacementProcessor, jbossDescriptorPropertyReplacementProcessor, annotationPropertyReplacementProcessor);
         writeHandler.registerAttributes(rootResourceRegistration);
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/EeWriteAttributeHandler.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/EeWriteAttributeHandler.java
@@ -28,6 +28,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.ee.component.deployers.DefaultEarSubDeploymentsIsolationProcessor;
+import org.jboss.as.ee.structure.AnnotationPropertyReplacementProcessor;
 import org.jboss.as.ee.structure.DescriptorPropertyReplacementProcessor;
 import org.jboss.as.ee.structure.GlobalModuleDependencyProcessor;
 import org.jboss.dmr.ModelNode;
@@ -43,16 +44,19 @@ public class EeWriteAttributeHandler extends AbstractWriteAttributeHandler<Void>
     private final GlobalModuleDependencyProcessor moduleDependencyProcessor;
     private final DescriptorPropertyReplacementProcessor specDescriptorPropertyReplacementProcessor;
     private final DescriptorPropertyReplacementProcessor jbossDescriptorPropertyReplacementProcessor;
+    private final AnnotationPropertyReplacementProcessor annotationPropertyReplacementProcessor;
 
     public EeWriteAttributeHandler(final DefaultEarSubDeploymentsIsolationProcessor isolationProcessor,
                                    final GlobalModuleDependencyProcessor moduleDependencyProcessor,
                                    final DescriptorPropertyReplacementProcessor specDescriptorPropertyReplacementProcessor,
-                                   final DescriptorPropertyReplacementProcessor jbossDescriptorPropertyReplacementProcessor) {
+                                   final DescriptorPropertyReplacementProcessor jbossDescriptorPropertyReplacementProcessor,
+                                   final AnnotationPropertyReplacementProcessor annotationPropertyReplacementProcessor) {
         super(EeSubsystemRootResource.ATTRIBUTES);
         this.isolationProcessor = isolationProcessor;
         this.moduleDependencyProcessor = moduleDependencyProcessor;
         this.specDescriptorPropertyReplacementProcessor = specDescriptorPropertyReplacementProcessor;
         this.jbossDescriptorPropertyReplacementProcessor = jbossDescriptorPropertyReplacementProcessor;
+        this.annotationPropertyReplacementProcessor = annotationPropertyReplacementProcessor;
     }
 
     public void registerAttributes(final ManagementResourceRegistration registry) {
@@ -88,6 +92,9 @@ public class EeWriteAttributeHandler extends AbstractWriteAttributeHandler<Void>
         } else if (EeSubsystemRootResource.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT.getName().equals(attributeName)) {
             boolean enabled = newValue.asBoolean();
             jbossDescriptorPropertyReplacementProcessor.setDescriptorPropertyReplacement(enabled);
+        } else if(EeSubsystemRootResource.EJB_ANNOTATION_PROPERTY_REPLACEMENT.getName().equals(attributeName)){
+            boolean enabled = newValue.asBoolean();
+            annotationPropertyReplacementProcessor.setDescriptorPropertyReplacement(enabled);
         }
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/Element.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/Element.java
@@ -40,6 +40,8 @@ enum Element {
 
     JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT(EeSubsystemRootResource.JBOSS_DESCRIPTOR_PROPERTY_REPLACEMENT.getXmlName()),
 
+    EJB_ANNOTATION_PROPERTY_REPLACEMENT(EeSubsystemRootResource.EJB_ANNOTATION_PROPERTY_REPLACEMENT.getXmlName()),
+
     CONCURRENT("concurrent"),
     CONTEXT_SERVICES("context-services"),
     CONTEXT_SERVICE("context-service"),

--- a/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
+++ b/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
@@ -10,6 +10,7 @@ ee.global-modules.services=If any services exposed in META-INF/services should b
 ee.ear-subdeployments-isolated=Flag indicating whether each of the subdeployments within a .ear can access classes belonging to another subdeployment within the same .ear. A value of false means the subdeployments can see classes belonging to other subdeployments within the .ear.
 ee.spec-descriptor-property-replacement=Flag indicating whether descriptors defined by the Java EE specification will have property replacements applied
 ee.jboss-descriptor-property-replacement=Flag indicating whether JBoss specific deployment descriptors will have property replacements applied
+ee.ejb-annotation-property-replacement=Flag indicating whether EJB annotations will have property replacements applied
 
 service=Centrally configurable services that are part of the EE subsystem.
 

--- a/ee/src/test/java/org/jboss/as/ee/subsystem/EeSubsystemTestCase.java
+++ b/ee/src/test/java/org/jboss/as/ee/subsystem/EeSubsystemTestCase.java
@@ -157,6 +157,7 @@ public class EeSubsystemTestCase extends AbstractSubsystemBaseTest {
                 .addFailedAttribute(PathAddress.pathAddress(EeExtension.PATH_SUBSYSTEM, PathElement.pathElement(EESubsystemModel.MANAGED_THREAD_FACTORY)), REJECTED_RESOURCE)
                 .addFailedAttribute(PathAddress.pathAddress(EeExtension.PATH_SUBSYSTEM, PathElement.pathElement(EESubsystemModel.MANAGED_EXECUTOR_SERVICE)), REJECTED_RESOURCE)
                 .addFailedAttribute(PathAddress.pathAddress(EeExtension.PATH_SUBSYSTEM, PathElement.pathElement(EESubsystemModel.MANAGED_SCHEDULED_EXECUTOR_SERVICE)), REJECTED_RESOURCE)
+                .addFailedAttribute(PathAddress.pathAddress(EeExtension.PATH_SUBSYSTEM, PathElement.pathElement(EESubsystemModel.EJB_ANNOTATION_PROPERTY_REPLACEMENT)), REJECTED_RESOURCE)
         );
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/AccessTimeoutAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/AccessTimeoutAnnotationInformationFactory.java
@@ -41,7 +41,7 @@ public class AccessTimeoutAnnotationInformationFactory extends ClassAnnotationIn
     }
 
     @Override
-    protected AccessTimeoutDetails fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected AccessTimeoutDetails fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         final long timeout = annotationInstance.value().asLong();
         AnnotationValue unitAnnVal = annotationInstance.value("unit");
         final TimeUnit unit = unitAnnVal != null ? TimeUnit.valueOf(unitAnnVal.asEnum()) : TimeUnit.MILLISECONDS;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/CacheAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/CacheAnnotationInformationFactory.java
@@ -36,7 +36,7 @@ public class CacheAnnotationInformationFactory extends ClassAnnotationInformatio
     }
 
     @Override
-    protected CacheInfo fromAnnotation(AnnotationInstance annotationInstance) {
+    protected CacheInfo fromAnnotation(AnnotationInstance annotationInstance, boolean replacement) {
         String value = annotationInstance.value().asString();
         return new CacheInfo(value);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ClusteredAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ClusteredAnnotationInformationFactory.java
@@ -36,7 +36,7 @@ public class ClusteredAnnotationInformationFactory extends ClassAnnotationInform
     }
 
     @Override
-    protected ClusteringInfo fromAnnotation(AnnotationInstance annotationInstance) {
+    protected ClusteringInfo fromAnnotation(AnnotationInstance annotationInstance, boolean replacement) {
         return new ClusteringInfo();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ConcurrencyManagementAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ConcurrencyManagementAnnotationInformationFactory.java
@@ -40,7 +40,7 @@ public class ConcurrencyManagementAnnotationInformationFactory extends ClassAnno
     }
 
     @Override
-    protected ConcurrencyManagementType fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected ConcurrencyManagementType fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         final AnnotationValue value = annotationInstance.value();
         if(value == null) {
             return ConcurrencyManagementType.CONTAINER;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DeclareRolesAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DeclareRolesAnnotationInformationFactory.java
@@ -36,7 +36,7 @@ public class DeclareRolesAnnotationInformationFactory extends ClassAnnotationInf
     }
 
     @Override
-    protected String[] fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String[] fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asStringArray();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DeliveryActiveAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DeliveryActiveAnnotationInformationFactory.java
@@ -37,7 +37,7 @@ public class DeliveryActiveAnnotationInformationFactory extends ClassAnnotationI
     }
 
     @Override
-    protected Boolean fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected Boolean fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asBoolean();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DependsOnAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DependsOnAnnotationInformationFactory.java
@@ -36,7 +36,7 @@ public class DependsOnAnnotationInformationFactory extends ClassAnnotationInform
     }
 
     @Override
-    protected String[] fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String[] fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asStringArray();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/InitAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/InitAnnotationInformationFactory.java
@@ -37,7 +37,7 @@ public class InitAnnotationInformationFactory extends ClassAnnotationInformation
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         AnnotationValue value = annotationInstance.value();
         if (value == null) {
             return null;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/LocalHomeAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/LocalHomeAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class LocalHomeAnnotationInformationFactory extends ClassAnnotationInform
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         AnnotationValue value = annotationInstance.value();
         return value.asClass().toString();
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/LockAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/LockAnnotationInformationFactory.java
@@ -41,7 +41,7 @@ public class LockAnnotationInformationFactory extends ClassAnnotationInformation
     }
 
     @Override
-    protected LockType fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected LockType fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         AnnotationValue value = annotationInstance.value();
         if(value == null) {
             return LockType.WRITE;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/PoolAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/PoolAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class PoolAnnotationInformationFactory extends ClassAnnotationInformation
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RemoteHomeAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RemoteHomeAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class RemoteHomeAnnotationInformationFactory extends ClassAnnotationInfor
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         AnnotationValue value = annotationInstance.value();
         return value.asClass().toString();
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RemoveAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RemoveAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class RemoveAnnotationInformationFactory extends ClassAnnotationInformati
     }
 
     @Override
-    protected Boolean fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected Boolean fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         AnnotationValue value = annotationInstance.value("retainIfException");
         if(value == null) {
             return false;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ResourceAdaptorAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ResourceAdaptorAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.jandex.AnnotationInstance;
 
 /**
@@ -36,7 +37,11 @@ public class ResourceAdaptorAnnotationInformationFactory extends ClassAnnotation
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
-        return annotationInstance.value().asString();
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
+        String resourceAdapterValue = annotationInstance.value().asString();
+        if(replacement)
+            return PropertiesValueResolver.replaceProperties(resourceAdapterValue);
+        else
+            return resourceAdapterValue;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RolesAllowedAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RolesAllowedAnnotationInformationFactory.java
@@ -36,7 +36,7 @@ public class RolesAllowedAnnotationInformationFactory extends ClassAnnotationInf
     }
 
     @Override
-    protected String[] fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String[] fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asStringArray();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsAnnotationInformationFactory.java
@@ -38,7 +38,7 @@ public class RunAsAnnotationInformationFactory extends ClassAnnotationInformatio
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsPrincipalAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsPrincipalAnnotationInformationFactory.java
@@ -38,7 +38,7 @@ public class RunAsPrincipalAnnotationInformationFactory extends ClassAnnotationI
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ScheduleAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ScheduleAnnotationInformationFactory.java
@@ -41,7 +41,7 @@ public class ScheduleAnnotationInformationFactory extends ClassAnnotationInforma
     }
 
     @Override
-    protected AutoTimer fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected AutoTimer fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         final AutoTimer timer = new AutoTimer();
         for (ScheduleValues schedulePart : ScheduleValues.values()) {
             schedulePart.set(timer, annotationInstance);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/SecurityDomainAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/SecurityDomainAnnotationInformationFactory.java
@@ -37,7 +37,7 @@ public class SecurityDomainAnnotationInformationFactory extends ClassAnnotationI
     }
 
     @Override
-    protected String fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         return annotationInstance.value().asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/StatefulTimeoutAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/StatefulTimeoutAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class StatefulTimeoutAnnotationInformationFactory extends ClassAnnotation
     }
 
     @Override
-    protected StatefulTimeoutInfo fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected StatefulTimeoutInfo fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         final long value = annotationInstance.value().asLong();
         final AnnotationValue unitValue = annotationInstance.value("unit");
         final TimeUnit unit;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/TransactionAttributeAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/TransactionAttributeAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class TransactionAttributeAnnotationInformationFactory extends ClassAnnot
     }
 
     @Override
-    protected TransactionAttributeType fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected TransactionAttributeType fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
 
         final AnnotationValue value = annotationInstance.value();
         if(value == null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/TransactionManagementAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/TransactionManagementAnnotationInformationFactory.java
@@ -40,7 +40,7 @@ public class TransactionManagementAnnotationInformationFactory extends ClassAnno
     }
 
     @Override
-    protected TransactionManagementType fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected TransactionManagementType fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         final AnnotationValue value = annotationInstance.value();
         if(value == null) {
             return TransactionManagementType.CONTAINER;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/TransactionTimeoutAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/TransactionTimeoutAnnotationInformationFactory.java
@@ -35,7 +35,7 @@ public class TransactionTimeoutAnnotationInformationFactory extends ClassAnnotat
     }
 
     @Override
-    protected Integer fromAnnotation(final AnnotationInstance annotationInstance) {
+    protected Integer fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
         final long timeout = annotationInstance.value().asLong();
         AnnotationValue unitAnnVal = annotationInstance.value("unit");
         final TimeUnit unit = unitAnnVal != null ? TimeUnit.valueOf(unitAnnVal.asEnum()) : TimeUnit.SECONDS;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/util/PropertiesValueResolver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/util/PropertiesValueResolver.java
@@ -1,0 +1,184 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.util;
+
+import java.io.File;
+import java.util.Properties;
+
+/**
+ * Parses a string and replaces any references to system properties or environment variables in the string
+ *
+ * @author Jaikiran Pai (copied from JBoss DMR project)
+ * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
+ */
+public class PropertiesValueResolver {
+
+    private static final int INITIAL = 0;
+    private static final int GOT_DOLLAR = 1;
+    private static final int GOT_OPEN_BRACE = 2;
+    private static final int RESOLVED = 3;
+    private static final int DEFAULT = 4;
+
+    /**
+     * Replace properties of the form:
+     * <code>${<i>&lt;[env.]name&gt;[</i>,<i>&lt;[env.]name2&gt;[</i>,<i>&lt;[env.]name3&gt;...]][</i>:<i>&lt;default&gt;]</i>}</code>
+     *
+     * @param value - either a system property or environment variable reference
+     * @return the value of the system property or environment variable referenced if
+     *         it exists
+     */
+    public static String replaceProperties(final String value) {
+        return replaceProperties(value, System.getProperties());
+    }
+    /**
+     * Replace properties of the form:
+     * <code>${<i>&lt;[env.]name&gt;[</i>,<i>&lt;[env.]name2&gt;[</i>,<i>&lt;[env.]name3&gt;...]][</i>:<i>&lt;default&gt;]</i>}</code>
+     *
+     * @param value - either a system property or environment variable reference
+     * @return the value of the system property or environment variable referenced if
+     *         it exists
+     */
+    public static String replaceProperties(final String value, final Properties properties) {
+        final StringBuilder builder = new StringBuilder();
+        final int len = value.length();
+        int state = INITIAL;
+        int start = -1;
+        int nameStart = -1;
+        String resolvedValue = null;
+        for (int i = 0; i < len; i = value.offsetByCodePoints(i, 1)) {
+            final int ch = value.codePointAt(i);
+            switch (state) {
+                case INITIAL: {
+                    switch (ch) {
+                        case '$': {
+                            state = GOT_DOLLAR;
+                            continue;
+                        }
+                        default: {
+                            builder.appendCodePoint(ch);
+                            continue;
+                        }
+                    }
+                    // not reachable
+                }
+                case GOT_DOLLAR: {
+                    switch (ch) {
+                        case '$': {
+                            builder.appendCodePoint(ch);
+                            state = INITIAL;
+                            continue;
+                        }
+                        case '{': {
+                            start = i + 1;
+                            nameStart = start;
+                            state = GOT_OPEN_BRACE;
+                            continue;
+                        }
+                        default: {
+                            // invalid; emit and resume
+                            builder.append('$').appendCodePoint(ch);
+                            state = INITIAL;
+                            continue;
+                        }
+                    }
+                    // not reachable
+                }
+                case GOT_OPEN_BRACE: {
+                    switch (ch) {
+                        case ':':
+                        case '}':
+                        case ',': {
+                            final String name = value.substring(nameStart, i).trim();
+                            if ("/".equals(name)) {
+                                builder.append(File.separator);
+                                state = ch == '}' ? INITIAL : RESOLVED;
+                                continue;
+                            } else if (":".equals(name)) {
+                                builder.append(File.pathSeparator);
+                                state = ch == '}' ? INITIAL : RESOLVED;
+                                continue;
+                            }
+                            // First check for system property, then env variable
+                            String val = (String) properties.get(name);
+                            if (val == null && name.startsWith("env."))
+                                val = System.getenv(name.substring(4));
+
+                            if (val != null) {
+                                builder.append(val);
+                                resolvedValue = val;
+                                state = ch == '}' ? INITIAL : RESOLVED;
+                                continue;
+                            } else if (ch == ',') {
+                                nameStart = i + 1;
+                                continue;
+                            } else if (ch == ':') {
+                                start = i + 1;
+                                state = DEFAULT;
+                                continue;
+                            } else {
+                                throw new IllegalStateException("Failed to resolve expression: " + value.substring(start - 2, i + 1));
+                            }
+                        }
+                        default: {
+                            continue;
+                        }
+                    }
+                    // not reachable
+                }
+                case RESOLVED: {
+                    if (ch == '}') {
+                        state = INITIAL;
+                    }
+                    continue;
+                }
+                case DEFAULT: {
+                    if (ch == '}') {
+                        state = INITIAL;
+                        builder.append(value.substring(start, i));
+                    }
+                    continue;
+                }
+                default:
+                    throw new IllegalStateException("Unexpected char seen: " + ch);
+            }
+        }
+        switch (state) {
+            case GOT_DOLLAR: {
+                builder.append('$');
+                break;
+            }
+            case DEFAULT: {
+                builder.append(value.substring(start - 2));
+                break;
+            }
+            case GOT_OPEN_BRACE: {
+                // We had a reference that was not resolved, throw ISE
+                if (resolvedValue == null)
+                    throw new IllegalStateException("Incomplete expression: " + builder.toString());
+                break;
+            }
+        }
+        return builder.toString();
+    }
+
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -194,6 +194,7 @@ public enum Phase {
     public static final int STRUCTURE_REMOUNT_EXPLODED                  = 0x0450;
     public static final int STRUCTURE_EE_SPEC_DESC_PROPERTY_REPLACEMENT = 0x0500;
     public static final int STRUCTURE_EE_JBOSS_DESC_PROPERTY_REPLACEMENT= 0x0550;
+    public static final int STRUCTURE_EE_EJB_ANNOTATION_PROPERTY_REPLACEMENT  =  0x0555;
     public static final int STRUCTURE_EE_DEPLOYMENT_PROPERTIES          = 0x0560;
     public static final int STRUCTURE_EE_DEPLOYMENT_PROPERTY_RESOLVER   = 0x0561;
     public static final int STRUCTURE_EE_VAULT_PROPERTY_RESOLVER        = 0x0562;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/AnnoBasedMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/AnnoBasedMDB.java
@@ -1,0 +1,41 @@
+package org.jboss.as.test.integration.ejb.mdb;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.EJB;
+import javax.ejb.MessageDriven;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+import org.jboss.ejb3.annotation.ResourceAdapter;
+import org.jboss.logging.Logger;
+
+@MessageDriven(name = "AnnoBasedBean", activationConfig = {
+        @ActivationConfigProperty(propertyName = "destinationType", propertyValue = "javax.jms.Queue"),
+        @ActivationConfigProperty(propertyName = "destination", propertyValue = "${destination}") })
+@ResourceAdapter("${resource.adapter}")
+public class AnnoBasedMDB implements MessageListener {
+
+    @EJB
+    private JMSMessagingUtil jmsMessagingUtil;
+
+    private static final Logger logger = Logger.getLogger(DDBasedMDB.class);
+
+    @Override
+    public void onMessage(Message message) {
+        logger.info("Received message " + message + " in MDB " + this.getClass().getName());
+        try {
+            final Destination replyTo = message.getJMSReplyTo();
+            if (replyTo == null) {
+                return;
+            }
+
+            logger.info("Sending a reply to destination " + replyTo);
+            jmsMessagingUtil.reply(message);
+        } catch (JMSException e) {
+            throw new RuntimeException(e);
+        } finally {
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/JMSMessageDrivenBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/JMSMessageDrivenBeanTestCase.java
@@ -57,7 +57,7 @@ public class JMSMessageDrivenBeanTestCase {
     @Deployment
     public static Archive<?> deployment() {
         final Archive<?> deployment = ShrinkWrap.create(JavaArchive.class, "ejb3mdb.jar")
-                .addPackage(ReplyingMDB.class.getPackage())
+                .addClasses(ReplyingMDB.class,JMSMessagingUtil.class)
                 .addClass(CreateQueueSetupTask.class);
         return deployment;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/MDBTestCase.java
@@ -63,6 +63,12 @@ public class MDBTestCase {
     @Resource (mappedName = "java:jboss/mdbtest/replyQueue")
     private Queue replyQueue;
 
+    @Resource (mappedName = "java:jboss/mdbtest/annoQueue")
+    private Queue annoQueue;
+
+    @Resource (mappedName = "java:jboss/mdbtest/annoReplyQueue")
+    private Queue annoReplyQueue;
+
     static class JmsQueueSetup implements ServerSetupTask {
 
         private JMSOperations jmsAdminOperations;
@@ -72,6 +78,9 @@ public class MDBTestCase {
             jmsAdminOperations = JMSOperationsProvider.getInstance(managementClient);
             jmsAdminOperations.createJmsQueue("mdbtest/queue", "java:jboss/mdbtest/queue");
             jmsAdminOperations.createJmsQueue("mdbtest/replyQueue", "java:jboss/mdbtest/replyQueue");
+            jmsAdminOperations.createJmsQueue("mdbtest/annoQueue", "java:jboss/mdbtest/annoQueue");
+            jmsAdminOperations.createJmsQueue("mdbtest/annoReplyQueue", "java:jboss/mdbtest/annoReplyQueue");
+            jmsAdminOperations.setSystemProperties("jboss/mdbtest/annoQueue", "hornetq-ra");
         }
 
         @Override
@@ -79,6 +88,9 @@ public class MDBTestCase {
             if (jmsAdminOperations != null) {
                 jmsAdminOperations.removeJmsQueue("mdbtest/queue");
                 jmsAdminOperations.removeJmsQueue("mdbtest/replyQueue");
+                jmsAdminOperations.removeJmsQueue("mdbtest/annoQueue");
+                jmsAdminOperations.removeJmsQueue("mdbtest/annoReplyQueue");
+                jmsAdminOperations.removeSystemProperties();
                 jmsAdminOperations.close();
             }
         }
@@ -106,5 +118,16 @@ public class MDBTestCase {
         this.jmsUtil.sendTextMessage("Say hello to " + DDBasedMDB.class.getName(), this.queue, this.replyQueue);
         final Message reply = this.jmsUtil.receiveMessage(replyQueue, 5000);
         Assert.assertNotNull("Reply message was null on reply queue: " + this.replyQueue, reply);
+    }
+
+    /**
+     * Test an annotation based MDB with properties substitution
+     * @throws Exception
+     */
+    @Test
+    public void testAnnoBasedMDB() throws Exception {
+        this.jmsUtil.sendTextMessage("Say Nihao to " + AnnoBasedMDB.class.getName(), this.annoQueue, this.annoReplyQueue);
+        final Message reply = this.jmsUtil.receiveMessage(annoReplyQueue, 5000);
+        Assert.assertNotNull("Reply message was null on reply queue: " + this.annoReplyQueue, reply);
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/JMSOperations.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/common/jms/JMSOperations.java
@@ -42,4 +42,8 @@ public interface JMSOperations {
 
     void close();
 
+    void setSystemProperties(String destination, String destinationType);
+
+    void removeSystemProperties();
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-1995
This is from an EAP5 RFE https://issues.jboss.org/browse/PRODMGT-282  
Add an new option "ejb-annotation-property-replacement" to allow property substitution in EJB Annotations(for some reasonable annotations, currently only apply as customer required to MDB usage with @ActivationConfigProperty and @ResourceAdapter)
