### PR TITLE
[WFLY-1850] / [WFLY-1664] / [WFLY-2462] Enhancements to CLI configuration and address handling for resolving the 3 parts of a controllers address.

### DIFF
--- a/build/src/main/resources/bin/jboss-cli.xml
+++ b/build/src/main/resources/bin/jboss-cli.xml
@@ -13,6 +13,16 @@
         <host>localhost</host>
         <port>9990</port>
     </default-controller>
+    
+    <!-- Example controller alias named 'Test'  
+    <controllers>
+        <controller name="Test">
+            <protocol>http-remoting</protocol>
+            <host>localhost</host>
+            <port>9990</port>
+        </controller>
+    </controllers>
+    -->    
 
     <validate-operation-requests>true</validate-operation-requests>
 

--- a/build/src/main/resources/bin/jboss-cli.xml
+++ b/build/src/main/resources/bin/jboss-cli.xml
@@ -5,6 +5,8 @@
 -->
 <jboss-cli xmlns="urn:jboss:cli:2.0">
 
+    <default-protocol use-legacy-override="true">http-remoting</default-protocol>
+
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>
         <protocol>http-remoting</protocol>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
@@ -29,7 +29,6 @@
            attributeFormDefault="unqualified"
         >
 
-
     <xs:element name="jboss-cli">
         <xs:annotation>
             <xs:documentation>
@@ -38,9 +37,45 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element ref="default-controller" minOccurs="0"/>
-                <xs:element ref="validate-operation-requests" minOccurs="0"/>
-                <xs:element ref="history" minOccurs="0"/>
+                <xs:element name="default-protocol" minOccurs="0" default="http-remoting">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The default protocol to use when controller addresses are supplied without one.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:complexType>
+                        <xs:simpleContent>
+                            <xs:extension base="xs:string">
+                                <xs:attribute name="use-legacy-override" type="xs:boolean" default="true">
+                                    <xs:annotation>
+                                        <xs:documentation>
+                                            The default protocol is used where a connection address is specified and no protocol is specified, in
+                                            previous versions the port 9999 would have been used with the remoting protocol - this attribute set
+                                            to true causes the protocol to default to remoting if the port number is 9999.
+
+                                            If this attribute is set to false then the specified default is used regardless of the port number for
+                                            addresses with no protocol.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:extension>
+                        </xs:simpleContent>
+                    </xs:complexType>
+                </xs:element>
+
+                <xs:element name="default-controller" type="controllerAddress" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            If no default controller is specifed then the default will be assumed
+                            to be using host 'localhost' along with the default-protocol (Which will be http-remoting if not defined)
+                            and the port will be whatever
+                            default corresponds to the selected protocol.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element ref="validate-operation-requests" minOccurs="0" />
+                <xs:element ref="history" minOccurs="0" />
 
                 <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
                     <xs:annotation>
@@ -52,32 +87,41 @@
                     </xs:annotation>
                 </xs:element>
 
-                <xs:element ref="connection-timeout" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="connection-timeout" minOccurs="0" maxOccurs="1" />
 
-                <xs:element ref="ssl" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="ssl" minOccurs="0" maxOccurs="1" />
 
-                <xs:element ref="silent" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="silent" minOccurs="0" maxOccurs="1" />
 
-                <xs:element ref="access-control" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="access-control" minOccurs="0" maxOccurs="1" />
             </xs:sequence>
         </xs:complexType>
     </xs:element>
 
-    <xs:element name="default-controller">
+    <xs:complexType name="controllerAddress">
         <xs:annotation>
             <xs:documentation>
-                This element contains the configuration of the default controller to connect to
-                when the connect command is executed w/o arguments.
+                The address of a controller.
             </xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="protocol" type="xs:string" minOccurs="0" default="http-remoting"/>
-                <xs:element name="host" type="xs:string" minOccurs="0" default="localhost"/>
-                <xs:element name="port" type="xs:int" minOccurs="0" default="9990"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
+        <xs:sequence>
+            <xs:element name="protocol" type="xs:string" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        If no protocol is specified then the value for 'default-protocol' will be used.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="host" type="xs:string" minOccurs="0" default="localhost" />
+            <xs:element name="port" type="xs:int" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        If a port is not specified then the default port will be identified based on the protocol selected.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
 
     <xs:element name="validate-operation-requests" type="xs:boolean" default="true">
         <xs:annotation>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
@@ -73,6 +73,14 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
+                
+                <xs:element name="controllers" type="controllersType" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The names controller alias mappings.
+                        </xs:documentation>
+                    </xs:annotation>                   
+                </xs:element>
 
                 <xs:element ref="validate-operation-requests" minOccurs="0" />
                 <xs:element ref="history" minOccurs="0" />
@@ -121,6 +129,26 @@
                 </xs:annotation>
             </xs:element>
         </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="namedController">
+        <xs:complexContent>
+            <xs:extension base="controllerAddress">
+                <xs:attribute name="name" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of this controller alias.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    
+    <xs:complexType name="controllersType">
+        <xs:sequence>
+            <xs:element name="controller" type="namedController" maxOccurs="unbounded" />        
+        </xs:sequence>    
     </xs:complexType>
 
     <xs:element name="validate-operation-requests" type="xs:boolean" default="true">

--- a/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
@@ -22,17 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           xmlns="urn:jboss:cli:2.0"
-           targetNamespace="urn:jboss:cli:2.0"
-           elementFormDefault="qualified"
-           attributeFormDefault="unqualified"
-        >
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="urn:jboss:cli:2.0" targetNamespace="urn:jboss:cli:2.0"
+    elementFormDefault="qualified" attributeFormDefault="unqualified">
 
     <xs:element name="jboss-cli">
         <xs:annotation>
             <xs:documentation>
-                Root element for the JBoss Command Line Interface configuration.
+                Root element for the WildFly Command Line Interface configuration.
             </xs:documentation>
         </xs:annotation>
         <xs:complexType>
@@ -49,12 +45,13 @@
                                 <xs:attribute name="use-legacy-override" type="xs:boolean" default="true">
                                     <xs:annotation>
                                         <xs:documentation>
-                                            The default protocol is used where a connection address is specified and no protocol is specified, in
-                                            previous versions the port 9999 would have been used with the remoting protocol - this attribute set
-                                            to true causes the protocol to default to remoting if the port number is 9999.
+                                            The default protocol is used where a connection address is specified and no
+                                            protocol is specified, in previous versions the port 9999 would have been used with the remoting
+                                            protocol - this attribute set to true causes the protocol to default to remoting if the port
+                                            number is 9999.
 
-                                            If this attribute is set to false then the specified default is used regardless of the port number for
-                                            addresses with no protocol.
+                                            If this attribute is set to false then the specified default is used regardless
+                                            of the port number for addresses with no protocol.
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
@@ -66,42 +63,74 @@
                 <xs:element name="default-controller" type="controllerAddress" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                            If no default controller is specifed then the default will be assumed
-                            to be using host 'localhost' along with the default-protocol (Which will be http-remoting if not defined)
-                            and the port will be whatever
+                            If no default controller is specifed then the default will be assumed to be using host 'localhost'
+                            along with the default-protocol (Which will be http-remoting if not defined) and the port will be whatever
                             default corresponds to the selected protocol.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
-                
+
                 <xs:element name="controllers" type="controllersType" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
                             The names controller alias mappings.
                         </xs:documentation>
-                    </xs:annotation>                   
+                    </xs:annotation>
                 </xs:element>
 
-                <xs:element ref="validate-operation-requests" minOccurs="0" />
-                <xs:element ref="history" minOccurs="0" />
-
-                <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                <xs:element name="validate-operation-requests" type="xs:boolean" default="true" minOccurs="0">
                     <xs:annotation>
                         <xs:documentation>
-                            Whether to resolve system properties specified as command argument (or operation parameter)
-                            values before sending the operation request to the controller or let the resolution happen
-                            on the server side.
+                            Indicates whether the parameter list of the operation reuqests should be validated before the
+                            requests are sent to the controller for the execution.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:element>
 
-                <xs:element ref="connection-timeout" minOccurs="0" maxOccurs="1" />
+                <xs:element name="history" type="historyType" minOccurs="0" />
 
-                <xs:element ref="ssl" minOccurs="0" maxOccurs="1" />
+                <xs:element name="resolve-parameter-values" type="xs:boolean" minOccurs="0" maxOccurs="1" default="false">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether to resolve system properties specified as command argument (or operation parameter) values
+                            before sending the operation request to the controller or let the resolution happen on the server side.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
 
-                <xs:element ref="silent" minOccurs="0" maxOccurs="1" />
+                <xs:element name="connection-timeout" type="xs:int" default="5000" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The time allowed to establish a connection with the controller.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
 
-                <xs:element ref="access-control" minOccurs="0" maxOccurs="1" />
+                <xs:element name="ssl" type="sslType" minOccurs="0" />
+
+                <xs:element name="silent" type="xs:boolean" default="false" minOccurs="1">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether to write info and error messages to the terminal output.
+                            
+                            Even if the value is false, the messages will still be logged using 
+                            the logger if its configuration allows and/or if the output target was
+                            specified as part of the command line using '>'.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+
+                <xs:element name="access-control" type="xs:boolean" default="true" minOccurs="0">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Whether the management-related commands and attributes should be filtered for the current user
+                            based on the permissions the user has been granted. In other words, if access-control is true, the
+                            tab-completion will hide commands and attributes the user is not allowed to access. In case the user attempts to
+                            execute a command or an operation without having sufficient permissions to do so, regardless of the value this
+                            element has, the attempt will fail with an access control error.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
             </xs:sequence>
         </xs:complexType>
     </xs:element>
@@ -144,97 +173,50 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-    
+
     <xs:complexType name="controllersType">
         <xs:sequence>
-            <xs:element name="controller" type="namedController" maxOccurs="unbounded" />        
-        </xs:sequence>    
+            <xs:element name="controller" type="namedController" maxOccurs="unbounded" />
+        </xs:sequence>
     </xs:complexType>
 
-    <xs:element name="validate-operation-requests" type="xs:boolean" default="true">
-        <xs:annotation>
-            <xs:documentation>
-                Indicates whether the parameter list of the operation reuqests
-                should be validated before the requests are sent to the controller
-                for the execution.
-            </xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="history">
+    <xs:complexType name="historyType">
         <xs:annotation>
             <xs:documentation>
                 This element contains the configuration for the commands and operations history log.
             </xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="enabled" type="xs:boolean" minOccurs="0" default="true"/>
-                <xs:element name="file-name" type="xs:string" minOccurs="0" default=".jboss-cli-history"/>
-                <xs:element name="file-dir" type="xs:string" minOccurs="0" default="${user.home}"/>
-                <xs:element name="max-size" type="xs:int" minOccurs="0" default="500"/>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
+        <xs:sequence>
+            <xs:element name="enabled" type="xs:boolean" minOccurs="0" default="true" />
+            <xs:element name="file-name" type="xs:string" minOccurs="0" default=".jboss-cli-history" />
+            <xs:element name="file-dir" type="xs:string" minOccurs="0" default="${user.home}" />
+            <xs:element name="max-size" type="xs:int" minOccurs="0" default="500" />
+        </xs:sequence>
+    </xs:complexType>
 
-    <xs:element name="connection-timeout" type="xs:int" default="5000">
-        <xs:annotation>
-            <xs:documentation>
-                The time allowed to establish a connection with the controller.
-            </xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="ssl">
+    <xs:complexType name="sslType">
         <xs:annotation>
             <xs:documentation>
                 This element contains the configuration for the Key and Trust stores
                 used for SSL.
             </xs:documentation>
         </xs:annotation>
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="key-store" type="xs:string" minOccurs="0" />
-                <xs:element name="key-store-password" type="xs:string" minOccurs="0" />
-                <xs:element name="alias" type="xs:string" minOccurs="0" />
-                <xs:element name="key-password" type="xs:string" minOccurs="0" />
-                <xs:element name="trust-store" type="xs:string" minOccurs="0" />
-                <xs:element name="trust-store-password" type="xs:string" minOccurs="0" />
-                <xs:element name="modify-trust-store" type="xs:boolean" default="true" minOccurs="0">
-                    <xs:annotation>
-                        <xs:documentation>
-                            Setting to true will cause the CLI to prompt when unrecognised certificates are received
-                            and allow them to be stored in the truststore.
-                        </xs:documentation>
-                    </xs:annotation>
-                </xs:element>
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
+        <xs:sequence>
+            <xs:element name="key-store" type="xs:string" minOccurs="0" />
+            <xs:element name="key-store-password" type="xs:string" minOccurs="0" />
+            <xs:element name="alias" type="xs:string" minOccurs="0" />
+            <xs:element name="key-password" type="xs:string" minOccurs="0" />
+            <xs:element name="trust-store" type="xs:string" minOccurs="0" />
+            <xs:element name="trust-store-password" type="xs:string" minOccurs="0" />
+            <xs:element name="modify-trust-store" type="xs:boolean" default="true" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation>
+                        Setting to true will cause the CLI to prompt when unrecognised certificates are received and allow
+                        them to be stored in the truststore.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
 
-    <xs:element name="silent" type="xs:boolean" default="false">
-        <xs:annotation>
-            <xs:documentation>
-                Whether to write info and error messages to the terminal output.
-                Even if the value is false, the messages will still be logged
-                using the logger if its configuration allows and/or if the
-                output target was specified as part of the command line using '>'.
-            </xs:documentation>
-        </xs:annotation>
-    </xs:element>
-
-    <xs:element name="access-control" type="xs:boolean" default="true">
-        <xs:annotation>
-            <xs:documentation>
-                Whether the management-related commands and attributes should be 
-                filtered for the current user based on the permissions the user
-                has been granted. In other words, if access-control is true,
-                the tab-completion will hide commands and attributes the user
-                is not allowed to access.
-                In case the user attempts to execute a command or an operation
-                without having sufficient permissions to do so, regardless of the value
-                this element has, the attempt will fail with an access control error. 
-            </xs:documentation>
-        </xs:annotation>
-    </xs:element>
 </xs:schema>

--- a/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -30,25 +30,26 @@ package org.jboss.as.cli;
 public interface CliConfig {
 
     /**
-     * The default server controller protocol
+     * The default server controller protocol for addresses where no protocol is specified.
      *
      * @return default server controller protocol
      */
     String getDefaultControllerProtocol();
 
     /**
-     * The default server controller host to connect to.
+     * If {@code true} then for addresses specified without a protocol but with a port number of 9999 the
+     * protocol should be assumed to be 'remoting://'
      *
-     * @return default server controller host to connect to
+     * @return use legacy override option.
      */
-    String getDefaultControllerHost();
+    boolean isUseLegacyOverride();
 
     /**
-     * The default server controller port to connect to.
+     * The default address of the controller from the configuration.
      *
-     * @return  default server controller port to connect to
+     * @return The defailt address.
      */
-    int getDefaultControllerPort();
+    ControllerAddress getDefaultControllerAddress();
 
     /**
      * Whether the record the history of executed commands and operations.

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -52,6 +52,14 @@ public interface CliConfig {
     ControllerAddress getDefaultControllerAddress();
 
     /**
+     * Obtain the {@link ControllerAddress} for a given alias.
+     *
+     * @param alias - The alias if the address mapping.
+     * @return The {@link ControllerAddress} if defined, otherwise {@code null}
+     */
+    ControllerAddress getAliasedControllerAddress(String alias);
+
+    /**
      * Whether the record the history of executed commands and operations.
      *
      * @return  true if the history is enabled, false - otherwise.

--- a/cli/src/main/java/org/jboss/as/cli/CliConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/CliConfig.java
@@ -30,6 +30,26 @@ package org.jboss.as.cli;
 public interface CliConfig {
 
     /**
+     * The default server controller host to connect to.
+     *
+     * @deprecated Use {@link CliConfig#getDefaultControllerAddress()} instead.
+     *
+     * @return default server controller host to connect to
+     */
+    @Deprecated
+    String getDefaultControllerHost();
+
+    /**
+     * The default server controller port to connect to.
+     *
+     * @deprecated Use {@link CliConfig#getDefaultControllerAddress()} instead.
+     *
+     * @return  default server controller port to connect to
+     */
+    @Deprecated
+    int getDefaultControllerPort();
+
+    /**
      * The default server controller protocol for addresses where no protocol is specified.
      *
      * @return default server controller protocol
@@ -47,7 +67,7 @@ public interface CliConfig {
     /**
      * The default address of the controller from the configuration.
      *
-     * @return The defailt address.
+     * @return The default address.
      */
     ControllerAddress getDefaultControllerAddress();
 

--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -141,6 +141,22 @@ public interface CommandContext {
     void connectController(String controller) throws CommandLineException;
 
     /**
+     * Connects the controller client using the host and the port.
+     * If the host is null, the default controller host will be used,
+     * which is localhost.
+     * If the port is less than zero, the default controller port will be used,
+     * which is 9999.
+     *
+     * @deprecated Use {@link #connectController(String)} instead.
+     *
+     * @param host the host to connect with
+     * @param port the port to connect on
+     * @throws CommandLineException  in case the attempt to connect failed
+     */
+    @Deprecated
+    void connectController(String host, int port) throws CommandLineException;
+
+    /**
      * Bind the controller to an existing, connected client.
      */
     void bindClient(ModelControllerClient newClient);
@@ -150,6 +166,33 @@ public interface CommandContext {
      * If the connection hasn't been established, the method silently returns.
      */
     void disconnectController();
+
+    /**
+     * Returns the default host the controller client will be connected to.
+     *
+     * @deprecated Use {@link CommandContext#getDefaultControllerAddress()} instead.
+     *
+     * @return  the default host the controller client will be connected to.
+     */
+    @Deprecated
+    String getDefaultControllerHost();
+
+    /**
+     * Returns the default port the controller client will be connected to.
+     *
+     * @deprecated Use {@link CommandContext#getDefaultControllerAddress()} instead.
+     *
+     * @return  the default port the controller client will be connected to.
+     */
+    @Deprecated
+    int getDefaultControllerPort();
+
+    /**
+     * The default address of the default controller to connect to.
+     *
+     * @return The default address.
+     */
+    ControllerAddress getDefaultControllerAddress();
 
     /**
      * Returns the host the controller client is connected to or

--- a/cli/src/main/java/org/jboss/as/cli/CommandContext.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContext.java
@@ -118,18 +118,27 @@ public interface CommandContext {
     ModelControllerClient getModelControllerClient();
 
     /**
-     * Connects the controller client using the host and the port.
-     * If the host is null, the default controller host will be used,
-     * which is localhost.
-     * If the port is less than zero, the default controller port will be used,
-     * which is 9999.
+     * Connects the controller client using the default controller definition.
      *
-     * @param protocol the protocol to connect with, either remote, http or https
-     * @param host the host to connect with
-     * @param port the port to connect on
-     * @throws CommandLineException  in case the attempt to connect failed
+     * The default controller will be identified as the default specified on starting the CLI will be used, if no controller was
+     * specified on start up then the default defined in the CLI configuration will be used, if no default is defined then a
+     * connection to http-remoting://localhost:9990 will be used instead.
+     *
+     * @throws CommandLineException in case the attempt to connect failed
      */
-    void connectController(String protocol, String host, int port) throws CommandLineException;
+    void connectController() throws CommandLineException;
+
+    /**
+     * Connects to the controller specified.
+     *
+     * If the controller is null then the default specified on starting the CLI will be used, if no controller was specified on
+     * start up then the default defined in the CLI configuration will be used, if no default is defined then a connection to
+     * http-remoting://localhost:9990 will be used instead.
+     *
+     * @param controller the controller to connect to
+     * @throws CommandLineException in case the attempt to connect failed
+     */
+    void connectController(String controller) throws CommandLineException;
 
     /**
      * Bind the controller to an existing, connected client.
@@ -137,36 +146,10 @@ public interface CommandContext {
     void bindClient(ModelControllerClient newClient);
 
     /**
-     * Connects the controller client using the default host and the port.
-     * It simply calls connectController(null, -1).
-     *
-     * @throws CommandLineException  in case the attempt to connect failed
-     */
-    void connectController() throws CommandLineException;
-
-    /**
      * Closes the previously established connection with the controller client.
      * If the connection hasn't been established, the method silently returns.
      */
     void disconnectController();
-
-    /**
-     * Returns the default host the controller client will be connected to
-     * in case the host argument isn't specified.
-     *
-     * @return  the default host the controller client will be connected to
-     * in case the host argument isn't specified.
-     */
-    String getDefaultControllerHost();
-
-    /**
-     * Returns the default port the controller client will be connected to
-     * in case the port argument isn't specified.
-     *
-     * @return  the default port the controller client will be connected to
-     * in case the port argument isn't specified.
-     */
-    int getDefaultControllerPort();
 
     /**
      * Returns the host the controller client is connected to or

--- a/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
@@ -65,4 +65,26 @@ public abstract class CommandContextFactory {
     public abstract CommandContext newCommandContext(String controller, String username, char[] password, InputStream consoleInput,
             OutputStream consoleOutput) throws CliInitializationException;
 
+    /**
+     * @deprecated Use {@link #newCommandContext(String, String, char[])} instead.
+     */
+    @Deprecated
+    public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
+            String username, char[] password) throws CliInitializationException;
+
+    /**
+     * @deprecated Use {@link #newCommandContext(String, int, String, char[], boolean, int)} instead.
+     */
+    @Deprecated
+    public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
+            String username, char[] password, boolean initConsole, final int connectionTimeout) throws CliInitializationException;
+
+    /**
+     * @deprecated Use {@link #newCommandContext(String, int, String, char[], InputStream, OutputStream)} instead.
+     */
+    @Deprecated
+    public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
+            String username, char[] password,
+            InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException;
+
 }

--- a/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/CommandContextFactory.java
@@ -54,16 +54,15 @@ public abstract class CommandContextFactory {
 
     public abstract CommandContext newCommandContext(String username, char[] password) throws CliInitializationException;
 
-    public abstract CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
-            String username, char[] password) throws CliInitializationException;
+    public abstract CommandContext newCommandContext(String controller, String username, char[] password) throws CliInitializationException;
 
-    public abstract CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
-            String username, char[] password, boolean initConsole, final int connectionTimeout) throws CliInitializationException;
+    public abstract CommandContext newCommandContext(String controller, String username, char[] password, boolean initConsole,
+            final int connectionTimeout) throws CliInitializationException;
 
-    public abstract CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
-            String username, char[] password, boolean disableLocalAuth, boolean initConsole, final int connectionTimeout) throws CliInitializationException;
+    public abstract CommandContext newCommandContext(String controller, String username, char[] password, boolean disableLocalAuth,
+            boolean initConsole, final int connectionTimeout) throws CliInitializationException;
 
-    public abstract CommandContext newCommandContext(String controllerHost, int controllerPort,
-            String username, char[] password,
-            InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException;
+    public abstract CommandContext newCommandContext(String controller, String username, char[] password, InputStream consoleInput,
+            OutputStream consoleOutput) throws CliInitializationException;
+
 }

--- a/cli/src/main/java/org/jboss/as/cli/ControllerAddress.java
+++ b/cli/src/main/java/org/jboss/as/cli/ControllerAddress.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli;
+
+/**
+ * A class used both by the {@link ControllerAddressResolver} and by the configuration to represent the address of a controller.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ControllerAddress {
+
+    private final String protocol;
+    private final String host;
+    private final int port;
+
+    public ControllerAddress(final String protocol, final String host, final int port) {
+        this.protocol = protocol;
+        this.host = host;
+        this.port = port;
+    }
+
+    public String getProtocol() {
+        return protocol;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+}

--- a/cli/src/main/java/org/jboss/as/cli/ControllerAddressResolver.java
+++ b/cli/src/main/java/org/jboss/as/cli/ControllerAddressResolver.java
@@ -87,6 +87,11 @@ public class ControllerAddressResolver {
     }
 
     private ControllerAddress convert(final String controller) throws CommandLineException {
+        ControllerAddress alias = config.getAliasedControllerAddress(controller);
+        if (alias != null) {
+            return alias;
+        }
+
         String protocol = null;
         String host = null;
         int port = -1;

--- a/cli/src/main/java/org/jboss/as/cli/ControllerAddressResolver.java
+++ b/cli/src/main/java/org/jboss/as/cli/ControllerAddressResolver.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli;
+
+/**
+ * Utility to resolve the address to use to connect to a controller based on a user supplied address, a default address from the
+ * command line, a default address from the configuration and a hard coded default address.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class ControllerAddressResolver {
+
+    private static final String DEFAULT_PROTOCOL = "http-remoting";
+
+    private final CliConfig config;
+    private final String defaultController;
+
+    private ControllerAddressResolver(final CliConfig config, final String defaultController) {
+        this.config = config;
+        this.defaultController = defaultController;
+    }
+
+    public static ControllerAddressResolver newInstance(final CliConfig config, final String defaultController) {
+        return new ControllerAddressResolver(config, defaultController);
+    }
+
+    public ControllerAddress resolveAddress(final String controller) throws CommandLineException {
+        if (controller != null) {
+            return convert(controller);
+        }
+
+        if (defaultController != null) {
+            return convert(defaultController);
+        }
+
+        return new ControllerAddress(config.getDefaultControllerProtocol(), config.getDefaultControllerHost(),
+                config.getDefaultControllerPort());
+    }
+
+    private ControllerAddress convert(final String controller) throws CommandLineException {
+        String protocol = DEFAULT_PROTOCOL;
+        String host = null;
+        int port = -1;
+
+        String parsing;
+        final int protocolEnd = controller.lastIndexOf("://");
+        if (protocolEnd == -1) {
+            parsing = controller;
+        } else {
+            parsing = controller.substring(protocolEnd + 3);
+            protocol = controller.substring(0, protocolEnd);
+        }
+
+        String portStr = null;
+        int colonIndex = parsing.lastIndexOf(':');
+        if (colonIndex < 0) {
+            // default port
+            host = parsing;
+        } else if (colonIndex == 0) {
+            // default host
+            portStr = parsing.substring(1).trim();
+        } else {
+            final boolean hasPort;
+            int closeBracket = parsing.lastIndexOf(']');
+            if (closeBracket != -1) {
+                // possible ip v6
+                if (closeBracket > colonIndex) {
+                    hasPort = false;
+                } else {
+                    hasPort = true;
+                }
+            } else {
+                // probably ip v4
+                hasPort = true;
+            }
+            if (hasPort) {
+                host = parsing.substring(0, colonIndex).trim();
+                portStr = parsing.substring(colonIndex + 1).trim();
+            } else {
+                host = parsing;
+            }
+        }
+
+        if (portStr != null) {
+            try {
+                port = Integer.parseInt(portStr);
+            } catch (NumberFormatException e) {
+                throw new CommandFormatException("The port must be a valid non-negative integer: '" + parsing + "'");
+            }
+            if (port < 0) {
+                throw new CommandFormatException("The port must be a valid non-negative integer: '" + parsing + "'");
+            }
+        }
+
+        return new ControllerAddress(protocol, host, port);
+    }
+
+    public static class ControllerAddress {
+
+        private final String protocol;
+        private final String host;
+        private final int port;
+
+        private ControllerAddress(final String protocol, final String host, final int port) {
+            this.protocol = protocol;
+            this.host = host;
+            this.port = port;
+        }
+
+        public String getProtocol() {
+            return protocol;
+        }
+
+        public String getHost() {
+            return host;
+        }
+
+        public int getPort() {
+            return port;
+        }
+
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/gui/ConnectDialog.java
+++ b/cli/src/main/java/org/jboss/as/cli/gui/ConnectDialog.java
@@ -66,12 +66,11 @@ import org.jboss.as.cli.CommandLineException;
  */
 public class ConnectDialog extends JInternalFrame {
 
+    static final String DEFAULT_REMOTE = "http-remoting://localhost:9990"; // TODO - Can this sync up with config somehow?
     // NOTE: CLI has no Message IDs assigned, hence Resources.getText(...);
     // This will probably require a i18n
-    static final String HINT_CONNECT = "<protocol>:<hostname>:<port> OR empty";
+    static final String HINT_CONNECT = "<protocol>://<hostname>:<port> OR empty";
     static final String HINT_CONNECT_BUTTON = "Connect to server CLI";
-    static final String DEFAULT_PROTOCOL = "http-remoting";
-    static final String DEFAULT_REMOTE = DEFAULT_PROTOCOL+":localhost:9990";
     static final String TEXT_CONNECT = "Connect";
     static final String TEXT_CANCEL = "Cancel";
     static final String TEXT_USERNAME = "Username: ";
@@ -167,24 +166,11 @@ public class ConnectDialog extends JInternalFrame {
                     return;
                 }
 
-                String protocol = DEFAULT_PROTOCOL;
-                String host = null;
-                int port = -1;
+                String controller = null;
                 String user = null;
                 String password = null;
                 if (tfURL.getText().length() > 0) {
-                    final String[] target = tfURL.getText().split(":");
-                    if (target.length >= 1) {
-                        protocol = target[0];
-                    }
-
-                    if (target.length >= 2) {
-                        host = target[1];
-                    }
-
-                    if (target.length >= 3) {
-                        port = Integer.parseInt(target[2]);
-                    }
+                    controller = tfURL.getText();
 
                     if (tfUserName.getText().length() > 0) {
                         user = tfUserName.getText();
@@ -199,7 +185,7 @@ public class ConnectDialog extends JInternalFrame {
                     } else {
                         cmdCtx = CommandContextFactory.getInstance().newCommandContext(user, password.toCharArray());
                     }
-                    cmdCtx.connectController(protocol, host, port);
+                    cmdCtx.connectController(controller);
                     plugin.init(cmdCtx);
                 } catch (CliInitializationException e) {
                     statusBar.setText(e.getMessage());
@@ -313,7 +299,13 @@ public class ConnectDialog extends JInternalFrame {
     }
 
     private class UrlDocumentListener implements DocumentListener{
-        private static final String REGEXP = "([A-Za-z\\-]+)|([A-Za-z\\-]+:[1-9A-Za-z]+)|([A-Za-z\\-]+:[1-9A-Za-z]+:\\d+)";
+
+        private static final String RX_PROTOCOL = "[A-Za-z\\-]+://";
+        private static final String RX_HOST = "[1-9A-Za-z\\.]+";
+        private static final String RX_PORT = ":\\d+";
+
+        private static final String REGEXP = "(" + RX_HOST + ")|(" + RX_HOST + RX_PORT + ")|(" + RX_PROTOCOL + RX_HOST + ")|(" + RX_PROTOCOL + RX_HOST + RX_PORT + ")";
+
         private final JTextField textField;
 
         public UrlDocumentListener(JTextField textField) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
@@ -60,68 +60,18 @@ public class ConnectHandler extends CommandHandlerWithHelp {
     @Override
     protected void doHandle(CommandContext ctx) throws CommandLineException {
 
-        int port = -1;
-        String host = null;
-        String protocol = "http-remoting";
+        String controller = null;
+
         final ParsedCommandLine parsedCmd = ctx.getParsedCommandLine();
         final List<String> args = parsedCmd.getOtherProperties();
 
-        if(!args.isEmpty()) {
-            if(args.size() != 1) {
+        if (!args.isEmpty()) {
+            if (args.size() != 1) {
                 throw new CommandFormatException("The command expects only one argument but got " + args);
             }
-            final String fullArg = args.get(0);
-            final String arg;
-            final int protocolEnd = fullArg.lastIndexOf("://");
-            if(protocolEnd == -1) {
-                arg = fullArg;
-            } else {
-                arg = fullArg.substring(protocolEnd + 3);
-                protocol = fullArg.substring(0, protocolEnd);
-            }
-
-            String portStr = null;
-            int colonIndex = arg.lastIndexOf(':');
-            if(colonIndex < 0) {
-                // default port
-                host = arg;
-            } else if(colonIndex == 0) {
-                // default host
-                portStr = arg.substring(1).trim();
-            } else {
-                final boolean hasPort;
-                int closeBracket = arg.lastIndexOf(']');
-                if (closeBracket != -1) {
-                    //possible ip v6
-                    if (closeBracket > colonIndex) {
-                        hasPort = false;
-                    } else {
-                        hasPort = true;
-                    }
-                } else {
-                    //probably ip v4
-                    hasPort = true;
-                }
-                if (hasPort) {
-                    host = arg.substring(0, colonIndex).trim();
-                    portStr = arg.substring(colonIndex + 1).trim();
-                } else {
-                    host = arg;
-                }
-            }
-
-            if(portStr != null) {
-                try {
-                    port = Integer.parseInt(portStr);
-                } catch(NumberFormatException e) {
-                    throw new CommandFormatException("The port must be a valid non-negative integer: '" + args + "'");
-                }
-                if(port < 0) {
-                    throw new CommandFormatException("The port must be a valid non-negative integer: '" + args + "'");
-                }
-            }
+            controller = args.get(0);
         }
 
-        ctx.connectController(protocol, host, port);
+        ctx.connectController(controller);
     }
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -35,7 +35,7 @@ import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
 
 import org.jboss.as.cli.CommandLineException;
-import org.jboss.as.cli.ControllerAddressResolver.ControllerAddress;
+import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.ModelControllerClientFactory.ConnectionCloseHandler;
 import org.jboss.as.controller.client.impl.AbstractModelControllerClient;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -35,6 +35,7 @@ import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
 
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.ControllerAddressResolver.ControllerAddress;
 import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.ModelControllerClientFactory.ConnectionCloseHandler;
 import org.jboss.as.controller.client.impl.AbstractModelControllerClient;
@@ -114,8 +115,8 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
     private final ProtocolChannelClient.Configuration channelConfig;
     private boolean closed;
 
-    CLIModelControllerClient(final String protocol, CallbackHandler handler, String hostName, int connectionTimeout,
-            final ConnectionCloseHandler closeHandler, int port, Map<String, String> saslOptions, SSLContext sslContext) throws IOException {
+    CLIModelControllerClient(final ControllerAddress address, CallbackHandler handler, int connectionTimeout,
+            final ConnectionCloseHandler closeHandler, Map<String, String> saslOptions, SSLContext sslContext) throws IOException {
         this.handler = handler;
         this.sslContext = sslContext;
         this.closeHandler = closeHandler;
@@ -135,7 +136,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
         this.saslOptions = saslOptions;
         channelConfig.setSaslOptions(saslOptions);
         try {
-            channelConfig.setUri(new URI(protocol +"://" + formatPossibleIpv6Address(hostName) +  ":" + port));
+            channelConfig.setUri(new URI(address.getProtocol(), null, address.getHost(), address.getPort(), null, null, null));
         } catch (URISyntaxException e) {
             throw new IOException("Failed to create URI" , e);
         }
@@ -256,19 +257,6 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
                 }
             }
         }
-    }
-
-    private static String formatPossibleIpv6Address(String address) {
-        if (address == null) {
-            return address;
-        }
-        if (!address.contains(":")) {
-            return address;
-        }
-        if (address.startsWith("[") && address.endsWith("]")) {
-            return address;
-        }
-        return "[" + address + "]";
     }
 
     private final class ChannelCloseHandler implements CloseHandler<Channel> {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -224,6 +224,18 @@ class CliConfigImpl implements CliConfig {
     }
 
     @Override
+    @Deprecated
+    public String getDefaultControllerHost() {
+        return getDefaultControllerAddress().getHost();
+    }
+
+    @Override
+    @Deprecated
+    public int getDefaultControllerPort() {
+        return getDefaultControllerAddress().getPort();
+    }
+
+    @Override
     public ControllerAddress getDefaultControllerAddress() {
         return defaultController;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -53,35 +53,33 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
     }
 
     @Override
-    public CommandContext newCommandContext(String controllerProtocol, String controllerHost,
-            int controllerPort, String username, char[] password)
+    public CommandContext newCommandContext(String controller, String username, char[] password)
             throws CliInitializationException {
-        return newCommandContext(controllerProtocol, controllerHost, controllerPort, username, password, false, -1);
+        return newCommandContext(controller, username, password, false, -1);
     }
 
     @Override
-    public CommandContext newCommandContext(String controllerProtocol, String controllerHost,
-            int controllerPort, String username, char[] password,
+    public CommandContext newCommandContext(String controller, String username, char[] password,
             boolean initConsole, final int connectionTimeout) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, username != null, initConsole, connectionTimeout);
+        final CommandContext ctx = new CommandContextImpl(controller, username, password, username != null, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }
 
     @Override
-    public CommandContext newCommandContext(String controllerHost, int controllerPort,
+    public CommandContext newCommandContext(String controller,
             String username, char[] password,
             InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerHost, controllerPort, username, password, username != null, consoleInput, consoleOutput);
+        final CommandContext ctx = new CommandContextImpl(controller, username, password, username != null, consoleInput, consoleOutput);
         addShutdownHook(ctx);
         return ctx;
     }
 
     @Override
-    public CommandContext newCommandContext(String controllerProtocol, String controllerHost, int controllerPort,
+    public CommandContext newCommandContext(String controller,
             String username, char[] password, boolean disableLocalAuth, boolean initConsole, int connectionTimeout)
             throws CliInitializationException {
-        final CommandContext ctx = new CommandContextImpl(controllerProtocol, controllerHost, controllerPort, username, password, disableLocalAuth || username != null, initConsole, connectionTimeout);
+        final CommandContext ctx = new CommandContextImpl(controller, username, password, disableLocalAuth || username != null, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextFactoryImpl.java
@@ -23,6 +23,8 @@ package org.jboss.as.cli.impl;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
@@ -82,6 +84,42 @@ public class CommandContextFactoryImpl extends CommandContextFactory {
         final CommandContext ctx = new CommandContextImpl(controller, username, password, disableLocalAuth || username != null, initConsole, connectionTimeout);
         addShutdownHook(ctx);
         return ctx;
+    }
+
+    @Override
+    @Deprecated
+    public CommandContext newCommandContext(String controllerHost, int controllerPort, String username, char[] password)
+            throws CliInitializationException {
+        try {
+            return newCommandContext(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2),
+                    username, password);
+        } catch (URISyntaxException e) {
+            throw new CliInitializationException("Unable to construct URI for connection.", e);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public CommandContext newCommandContext(String controllerHost, int controllerPort, String username, char[] password,
+            boolean initConsole, int connectionTimeout) throws CliInitializationException {
+        try {
+            return newCommandContext(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2),
+                    username, password, initConsole, connectionTimeout);
+        } catch (URISyntaxException e) {
+            throw new CliInitializationException("Unable to construct URI for connection.", e);
+        }
+    }
+
+    @Override
+    @Deprecated
+    public CommandContext newCommandContext(String controllerHost, int controllerPort, String username, char[] password,
+            InputStream consoleInput, OutputStream consoleOutput) throws CliInitializationException {
+        try {
+            return newCommandContext(new URI(null, null, controllerHost, controllerPort, null, null, null).toString().substring(2),
+                    username, password, consoleInput, consoleOutput);
+        } catch (URISyntaxException e) {
+            throw new CliInitializationException("Unable to construct URI for connection.", e);
+        }
     }
 
     protected void addShutdownHook(final CommandContext cmdCtx) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -75,7 +75,7 @@ import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.CommandLineException;
 import org.jboss.as.cli.CommandRegistry;
 import org.jboss.as.cli.ControllerAddressResolver;
-import org.jboss.as.cli.ControllerAddressResolver.ControllerAddress;
+import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.cli.OperationCommand;
 import org.jboss.as.cli.SSLConfig;
 import org.jboss.as.cli.Util;

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -29,6 +29,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.security.GeneralSecurityException;
 import java.security.KeyStore;
 import java.security.MessageDigest;
@@ -795,6 +797,16 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     }
 
     @Override
+    @Deprecated
+    public void connectController(String host, int port) throws CommandLineException {
+        try {
+            connectController(new URI(null, null, host, port, null, null, null).toString().substring(2));
+        } catch (URISyntaxException e) {
+            throw new CommandLineException("Unable to construct URI for connection.", e);
+        }
+    }
+
+    @Override
     public void bindClient(ModelControllerClient newClient) {
         initNewClient(newClient, null);
     }
@@ -964,6 +976,23 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             notifyListeners(CliEvent.DISCONNECTED);
         }
         promptConnectPart = null;
+    }
+
+    @Override
+    @Deprecated
+    public String getDefaultControllerHost() {
+        return config.getDefaultControllerHost();
+    }
+
+    @Override
+    @Deprecated
+    public int getDefaultControllerPort() {
+        return config.getDefaultControllerPort();
+    }
+
+    @Override
+    public ControllerAddress getDefaultControllerAddress() {
+        return config.getDefaultControllerAddress();
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -28,7 +28,7 @@ import java.util.Map;
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
 
-import org.jboss.as.cli.ControllerAddressResolver.ControllerAddress;
+import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
 
 /**

--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import javax.net.ssl.SSLContext;
 import javax.security.auth.callback.CallbackHandler;
 
+import org.jboss.as.cli.ControllerAddressResolver.ControllerAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
 
 /**
@@ -46,28 +47,28 @@ public interface ModelControllerClientFactory {
         void handleClose();
     }
 
-    ModelControllerClient getClient(String protocol, String hostName, int port, CallbackHandler handler,
+    ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
             boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
             ConnectionCloseHandler closeHandler) throws IOException;
 
     ModelControllerClientFactory DEFAULT = new ModelControllerClientFactory() {
         @Override
-        public ModelControllerClient getClient(String protocol, String hostName, int port, CallbackHandler handler,
+        public ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
                 boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
                 ConnectionCloseHandler closeHandler) throws IOException {
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
-            return ModelControllerClient.Factory.create(protocol, hostName, port, handler, sslContext, connectionTimeout, saslOptions);
+            return ModelControllerClient.Factory.create(address.getProtocol(), address.getHost(), address.getPort(), handler, sslContext, connectionTimeout, saslOptions);
         }
     };
 
     ModelControllerClientFactory CUSTOM = new ModelControllerClientFactory() {
 
         @Override
-        public ModelControllerClient getClient(String protocol, final String hostName, final int port,
+        public ModelControllerClient getClient(ControllerAddress address,
                 final CallbackHandler handler, boolean disableLocalAuth, final SSLContext sslContext,
                 final int connectionTimeout, final ConnectionCloseHandler closeHandler) throws IOException {
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
-            return new CLIModelControllerClient(protocol, handler, hostName, connectionTimeout, closeHandler, port, saslOptions, sslContext);
+            return new CLIModelControllerClient(address, handler, connectionTimeout, closeHandler, saslOptions, sslContext);
         }};
 
 }

--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -19,6 +19,9 @@
 package org.jboss.as.cli.scriptsupport;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
@@ -108,9 +111,30 @@ public class CLI {
      * @param username The user name for logging in.
      * @param password The password for logging in.
      */
+    public void connect(String controller, String username, char[] password) {
+        checkAlreadyConnected();
+        try {
+            ctx = CommandContextFactory.getInstance().newCommandContext(controller, username, password);
+            ctx.connectController();
+        } catch (CliInitializationException e) {
+            throw new IllegalStateException("Unable to initialize command context.", e);
+        } catch (CommandLineException e) {
+            throw new IllegalStateException("Unable to connect to controller.", e);
+        }
+    }
+
+    /**
+     * Connect to the server using a specified host and port.
+     *
+     * @param controllerHost The host name.
+     * @param controllerPort The port.
+     * @param username The user name for logging in.
+     * @param password The password for logging in.
+     */
     public void connect(String controllerHost, int controllerPort, String username, char[] password) {
         connect("http-remoting", controllerHost, controllerPort, username, password);
     }
+
     /**
      * Connect to the server using a specified host and port.
      * @param protocol The protocol
@@ -122,8 +146,10 @@ public class CLI {
     public void connect(String protocol, String controllerHost, int controllerPort, String username, char[] password) {
         checkAlreadyConnected();
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(protocol, controllerHost, controllerPort, username, password);
+            ctx = CommandContextFactory.getInstance().newCommandContext(new URI(protocol, null, controllerHost, controllerPort, null, null, null).toString(), username, password);
             ctx.connectController();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Unable to construct URI.", e);
         } catch (CliInitializationException e) {
             throw new IllegalStateException("Unable to initialize command context.", e);
         } catch (CommandLineException e) {

--- a/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
+++ b/cli/src/main/java/org/jboss/as/cli/scriptsupport/CLI.java
@@ -146,10 +146,8 @@ public class CLI {
     public void connect(String protocol, String controllerHost, int controllerPort, String username, char[] password) {
         checkAlreadyConnected();
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(new URI(protocol, null, controllerHost, controllerPort, null, null, null).toString(), username, password);
+            ctx = CommandContextFactory.getInstance().newCommandContext(constructUri(protocol, controllerHost, controllerPort), username, password);
             ctx.connectController();
-        } catch (URISyntaxException e) {
-            throw new IllegalStateException("Unable to construct URI.", e);
         } catch (CliInitializationException e) {
             throw new IllegalStateException("Unable to initialize command context.", e);
         } catch (CommandLineException e) {
@@ -192,6 +190,16 @@ public class CLI {
             }
         } catch (IOException ioe) {
             throw new IllegalStateException("Unable to send command " + cliCommand + " to server.", ioe);
+        }
+    }
+
+    private String constructUri(final String protocol, final String host, final int port) {
+        try {
+            URI uri = new URI(protocol, null, host, port, null, null, null);
+            // String the leading '//' if there is no protocol.
+            return protocol == null ? uri.toString().substring(2) : uri.toString();
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException("Unable to construct URI.", e);
         }
     }
 

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -53,6 +53,11 @@ public class MockCliConfig implements CliConfig {
     }
 
     @Override
+    public ControllerAddress getAliasedControllerAddress(String alias) {
+        return null;
+    }
+
+    @Override
     public boolean isHistoryEnabled() {
         return false;
     }

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -23,6 +23,7 @@ package org.jboss.as.cli.completion.mock;
 
 
 import org.jboss.as.cli.CliConfig;
+import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.cli.SSLConfig;
 
 /**
@@ -42,13 +43,13 @@ public class MockCliConfig implements CliConfig {
     }
 
     @Override
-    public String getDefaultControllerHost() {
-        return "localhost";
+    public boolean isUseLegacyOverride() {
+        return true;
     }
 
     @Override
-    public int getDefaultControllerPort() {
-        return 9990;
+    public ControllerAddress getDefaultControllerAddress() {
+        return new ControllerAddress("http-remoting", "localhost", 9990);
     }
 
     @Override

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCliConfig.java
@@ -43,6 +43,18 @@ public class MockCliConfig implements CliConfig {
     }
 
     @Override
+    @Deprecated
+    public String getDefaultControllerHost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    public int getDefaultControllerPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public boolean isUseLegacyOverride() {
         return true;
     }

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -31,6 +31,7 @@ import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandHistory;
 import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.cli.batch.BatchManager;
 import org.jboss.as.cli.batch.BatchedCommand;
 import org.jboss.as.cli.operation.OperationCandidatesProvider;
@@ -188,6 +189,12 @@ public class MockCommandContext implements CommandContext {
     }
 
     @Override
+    @Deprecated
+    public void connectController(String host, int port) throws CommandLineException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void bindClient(ModelControllerClient newClient) {
         throw new UnsupportedOperationException();
     }
@@ -196,6 +203,24 @@ public class MockCommandContext implements CommandContext {
     @Override
     public void disconnectController() {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    public String getDefaultControllerHost() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    @Deprecated
+    public int getDefaultControllerPort() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ControllerAddress getDefaultControllerAddress() {
+        // TODO Auto-generated method stub
+        return null;
     }
 
     @Override

--- a/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
+++ b/cli/src/test/java/org/jboss/as/cli/completion/mock/MockCommandContext.java
@@ -183,7 +183,7 @@ public class MockCommandContext implements CommandContext {
     }
 
     @Override
-    public void connectController(String protocol, String host, int port) {
+    public void connectController(String controller) {
         throw new UnsupportedOperationException();
     }
 
@@ -211,16 +211,6 @@ public class MockCommandContext implements CommandContext {
     @Override
     public CommandHistory getHistory() {
         throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public String getDefaultControllerHost() {
-        return null;
-    }
-
-    @Override
-    public int getDefaultControllerPort() {
-        return -1;
     }
 
     @Override
@@ -325,7 +315,7 @@ public class MockCommandContext implements CommandContext {
 
     @Override
     public void connectController() {
-        connectController(null, null, -1);
+        connectController(null);
     }
 
     @Override

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
@@ -37,6 +37,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -58,7 +59,7 @@ public class JdrRunner implements JdrReportCollector {
         this.env.setHost(host);
         this.env.setPort(port);
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(new URI(protocol, null, host, Integer.parseInt(port), null, null, null).toString(), null, null);
+            ctx = CommandContextFactory.getInstance().newCommandContext(constructUri(protocol, host, Integer.parseInt(port)), null, null);
             ctx.connectController();
             this.env.setClient(ctx.getModelControllerClient());
         }
@@ -168,5 +169,11 @@ public class JdrRunner implements JdrReportCollector {
 
     public void setServerName(String name) {
         this.env.setServerName(name);
+    }
+
+    private String constructUri(final String protocol, final String host, final int port) throws URISyntaxException {
+        URI uri = new URI(protocol, null, host, port, null, null, null);
+        // String the leading '//' if there is no protocol.
+        return protocol == null ? uri.toString().substring(2) : uri.toString();
     }
 }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
@@ -36,6 +36,7 @@ import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -57,7 +58,7 @@ public class JdrRunner implements JdrReportCollector {
         this.env.setHost(host);
         this.env.setPort(port);
         try {
-            ctx = CommandContextFactory.getInstance().newCommandContext(protocol, host, Integer.valueOf(port), null, null);
+            ctx = CommandContextFactory.getInstance().newCommandContext(new URI(protocol, null, host, Integer.parseInt(port), null, null, null).toString(), null, null);
             ctx.connectController();
             this.env.setClient(ctx.getModelControllerClient());
         }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.fail;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
@@ -47,19 +49,19 @@ public class CLITestUtil {
 
     public static CommandContext getCommandContext() throws CliInitializationException {
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext("http-remoting", serverAddr, serverPort, null, null);
+        return CommandContextFactory.getInstance().newCommandContext(convert("http-remoting", serverAddr , serverPort), null, null);
     }
 
     public static CommandContext getCommandContext(String address, int port, InputStream in, OutputStream out)
             throws CliInitializationException {
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext(address, port, null, null, in, out);
+        return CommandContextFactory.getInstance().newCommandContext(address + ":" + port, null, null, in, out);
     }
 
     public static CommandContext getCommandContext(OutputStream out) throws CliInitializationException {
         SecurityActions.setSystemProperty(JREADLINE_TERMINAL, JREADLINE_TEST_TERMINAL);
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext(serverAddr, serverPort, null, null, null, out);
+        return CommandContextFactory.getInstance().newCommandContext(convert(null, serverAddr , serverPort), null, null, null, out);
     }
 
     protected static void setJBossCliConfig() {
@@ -70,6 +72,14 @@ public class CLITestUtil {
                 fail("jboss.dist system property is not set");
             }
             SecurityActions.setSystemProperty(JBOSS_CLI_CONFIG, jbossDist + File.separator + "bin" + File.separator + "jboss-cli.xml");
+        }
+    }
+
+    private static String convert(final String protocol, final String host, final int port) throws CliInitializationException {
+        try {
+            return new URI(protocol, null, host, port, null, null, null).toString();
+        } catch (URISyntaxException e) {
+            throw new CliInitializationException("Unable to convert URI", e);
         }
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLITestUtil.java
@@ -49,7 +49,7 @@ public class CLITestUtil {
 
     public static CommandContext getCommandContext() throws CliInitializationException {
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext(convert("http-remoting", serverAddr , serverPort), null, null);
+        return CommandContextFactory.getInstance().newCommandContext(constructUri("http-remoting", serverAddr , serverPort), null, null);
     }
 
     public static CommandContext getCommandContext(String address, int port, InputStream in, OutputStream out)
@@ -61,7 +61,7 @@ public class CLITestUtil {
     public static CommandContext getCommandContext(OutputStream out) throws CliInitializationException {
         SecurityActions.setSystemProperty(JREADLINE_TERMINAL, JREADLINE_TEST_TERMINAL);
         setJBossCliConfig();
-        return CommandContextFactory.getInstance().newCommandContext(convert(null, serverAddr , serverPort), null, null, null, out);
+        return CommandContextFactory.getInstance().newCommandContext(constructUri(null, serverAddr , serverPort), null, null, null, out);
     }
 
     protected static void setJBossCliConfig() {
@@ -75,11 +75,14 @@ public class CLITestUtil {
         }
     }
 
-    private static String convert(final String protocol, final String host, final int port) throws CliInitializationException {
+    private static String constructUri(final String protocol, final String host, final int port) throws CliInitializationException {
         try {
-            return new URI(protocol, null, host, port, null, null, null).toString();
+            URI uri = new URI(protocol, null, host, port, null, null, null);
+            // String the leading '//' if there is no protocol.
+            return protocol == null ? uri.toString().substring(2) : uri.toString();
         } catch (URISyntaxException e) {
             throw new CliInitializationException("Unable to convert URI", e);
         }
     }
+
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIWrapper.java
@@ -25,6 +25,8 @@ package org.jboss.as.test.integration.management.util;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.jboss.as.cli.CliInitializationException;
 import org.jboss.as.cli.CommandContext;
@@ -116,9 +118,12 @@ public class CLIWrapper {
     public boolean sendConnect(String cliAddress) {
         String addr = cliAddress != null ? cliAddress : TestSuiteEnvironment.getServerAddress();
         try {
-            ctx.connectController("http-remoting", addr, TestSuiteEnvironment.getServerPort());
+            ctx.connectController(new URI("http-remoting", null, addr, TestSuiteEnvironment.getServerPort(), null, null, null).toString());
             return true;
         } catch (CommandLineException e) {
+            e.printStackTrace();
+            return false;
+        } catch (URISyntaxException e) {
             e.printStackTrace();
             return false;
         }


### PR DESCRIPTION
A dedicated attribute for the default protocol instead of using a part of the address of the default controller.
Legacy address handling mapping addresses with port 9999 to protocol remoting.
Protocol to port mappings for addresses with no port specified.
Alias definitions within the jboss-cli.xml configuration, allowing both overrides of addresses already in use and simplified aliases to remove the need to enter the full address.
Clean up of the associated schema to correctly reflect what can be used as a top level element in the configuration.
