### PR TITLE
WFLY-2472. Remove default-context-propagation property from jboss-as-xts_1_0.xsd

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-xts_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-xts_1_0.xsd
@@ -44,7 +44,6 @@
         </xs:annotation>
         <xs:all>
             <xs:element name="xts-environment" type="xts-environment" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="default-context-propagation" type="default-context-propagation" minOccurs="0" maxOccurs="1"/>
         </xs:all>
     </xs:complexType>
 
@@ -64,23 +63,6 @@
             </xs:documentation>
         </xs:annotation>
         <xs:attribute name="url" type="xs:string" use="optional" />
-    </xs:complexType>
-
-    <xs:complexType name="default-context-propagation">
-        <xs:annotation>
-            <xs:documentation>
-            <![CDATA[
-                'enabled' states whether to automatically propagate transactional context.
-                When set to 'true', Web Service clients will automatically propagate a WS-AT
-                transactional context if a JTA or WS-AT transaction is running when the call is made.
-                Similarly, a WS-BA transactional context will be propagated if a WS-BA transaction
-                is running when the call is made. This behavior can be overridden on a per client
-                basis using the org.jboss.jbossts.txbridge.outbound.JTAOverWSATFeature and
-                com.arjuna.mw.wst11.client.WSTXFeature features.
-            ]]>
-            </xs:documentation>
-        </xs:annotation>
-        <xs:attribute name="enabled" type="xs:boolean" use="optional" />
     </xs:complexType>
 
 </xs:schema>

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemParser.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemParser.java
@@ -27,6 +27,7 @@ import static org.jboss.as.xts.XTSSubsystemDefinition.DEFAULT_CONTEXT_PROPAGATIO
 import static org.jboss.as.xts.XTSSubsystemDefinition.ENVIRONMENT_URL;
 import static org.jboss.as.xts.XTSSubsystemDefinition.HOST_NAME;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 
@@ -64,11 +65,12 @@ class XTSSubsystemParser implements XMLStreamConstants, XMLElementReader<List<Mo
         list.add(subsystem);
 
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
+        final List<Element> expected = getExpectedElements(reader);
 
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
 
-            if (!encountered.add(element)) {
+            if (!expected.contains(element) || !encountered.add(element)) {
                 throw ParseUtils.unexpectedElement(reader);
             }
 
@@ -201,5 +203,20 @@ class XTSSubsystemParser implements XMLStreamConstants, XMLElementReader<List<Mo
 
         // Handle elements
         ParseUtils.requireNoContent(reader);
+    }
+
+    private List<Element> getExpectedElements(final XMLExtendedStreamReader reader) {
+        final Namespace namespace = Namespace.forUri(reader.getNamespaceURI());
+        final List<Element> elements = new ArrayList<>();
+
+        if (Namespace.XTS_1_0.equals(namespace)) {
+            elements.add(Element.XTS_ENVIRONMENT);
+        } else if (Namespace.XTS_2_0.equals(namespace)) {
+            elements.add(Element.XTS_ENVIRONMENT);
+            elements.add(Element.HOST);
+            elements.add(Element.DEFAULT_CONTEXT_PROPAGATION);
+        }
+
+        return elements;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2472
