### PR TITLE
Fixes an issue with channel lifecycle that causes WFLY-2458

### DIFF
--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/MuxChannel.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/MuxChannel.java
@@ -58,4 +58,22 @@ public class MuxChannel extends JChannel {
             super.setUpHandler(handler);
         }
     }
+
+    /**
+     * Hack to workaround ISPN-3697.
+     * {@link #close} will be a no-op
+     * Channel will actually be closed via {@link #destroy()} called when the channel service is stopped..
+     */
+    @Override
+    public void close() {
+        // Hide
+    }
+
+    /**
+     * Hack to workaround ISPN-3697.
+     * Introduce new method that effectively closes the channel.
+     */
+    public void destroy() {
+        super.close();
+    }
 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
@@ -25,6 +25,7 @@ import static org.jboss.as.clustering.jgroups.JGroupsLogger.ROOT_LOGGER;
 
 import org.jboss.as.clustering.jgroups.ChannelFactory;
 import org.jboss.as.clustering.jgroups.JGroupsMessages;
+import org.jboss.as.clustering.jgroups.MuxChannel;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
@@ -84,6 +85,8 @@ public class ChannelService implements Service<Channel>, ChannelListener {
     public void stop(StopContext context) {
         if (this.channel != null) {
             this.channel.removeChannelListener(this);
+            // Fixes WFLY-2458 using a hack to workaround ISPN-3697.
+            ((MuxChannel) this.channel).destroy();
         }
         this.channel = null;
     }


### PR DESCRIPTION
Adds a hack to workaround ISPN-3697.
