### PR TITLE
WFLY-2491 Upgrade JGroups to 3.4.1.Final

### DIFF
--- a/clustering/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/src/main/resources/jgroups-defaults.xml
@@ -28,10 +28,11 @@
         ucast_send_buf_size="640000"
         mcast_recv_buf_size="25000000"
         mcast_send_buf_size="640000"
-        max_bundle_size="64000"
+        max_bundle_size="31k"
         max_bundle_timeout="30"
         ip_ttl="2"
-        
+        bundler_type="old"
+
         thread_pool.enabled="true"
         thread_pool.min_threads="20"
         thread_pool.max_threads="300"
@@ -45,14 +46,23 @@
         oob_thread_pool.max_threads="300"
         oob_thread_pool.keep_alive_time="1000"
         oob_thread_pool.queue_enabled="false"
-        oob_thread_pool.rejection_policy="discard"/>
+        oob_thread_pool.rejection_policy="discard"
+
+        internal_thread_pool.enabled="true"
+        internal_thread_pool.min_threads="1"
+        internal_thread_pool.max_threads="10"
+        internal_thread_pool.keep_alive_time="60000"
+        internal_thread_pool.queue_enabled="true"
+        internal_thread_pool.queue_max_size="100"
+        internal_thread_pool.rejection_policy="discard"/>
     <TCP
         recv_buf_size="20000000"
         send_buf_size="640000"
-        max_bundle_size="64000"
+        max_bundle_size="31k"
         max_bundle_timeout="30"
         use_send_queues="false"
         sock_conn_timeout="300"
+        bundler_type="old"
 
         thread_pool.enabled="true"
         thread_pool.min_threads="20"
@@ -67,14 +77,22 @@
         oob_thread_pool.max_threads="200"
         oob_thread_pool.keep_alive_time="1000"
         oob_thread_pool.queue_enabled="false"
-        oob_thread_pool.rejection_policy="discard"/>
+        oob_thread_pool.rejection_policy="discard"
+
+        internal_thread_pool.enabled="true"
+        internal_thread_pool.min_threads="1"
+        internal_thread_pool.max_threads="10"
+        internal_thread_pool.keep_alive_time="60000"
+        internal_thread_pool.queue_enabled="true"
+        internal_thread_pool.queue_max_size="100"
+        internal_thread_pool.rejection_policy="discard"/>
     <PING timeout="2000" num_initial_members="3"/>
     <MPING timeout="3000" num_initial_members="3" ip_ttl="2"/>
     <MERGE2 max_interval="100000" min_interval="20000"/>
     <MERGE3 max_interval="100000" min_interval="20000"/>
     <FD_SOCK/>
     <FD timeout="6000" max_tries="5"/>
-    <FD_ALL timeout="15000"/>
+    <FD_ALL timeout="15000" interval="3000"/>
     <VERIFY_SUSPECT timeout="1500"/>
     <BARRIER/>
     <pbcast.NAKACK use_mcast_xmit="true"
@@ -105,9 +123,9 @@
         view_bundling="true"
         view_ack_collection_timeout="5000"
         resume_task_timeout="7500"/>
-    <UFC max_credits="2000000"/>
-    <MFC max_credits="2000000"/>
-    <FRAG2 frag_size="60000"/>
+    <UFC max_credits="1m" min_threshold="0.40"/>
+    <MFC max_credits="1m" min_threshold="0.40"/>
+    <FRAG2 frag_size="30k"/>
     <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false"/>
     <pbcast.STATE_TRANSFER/>
     <pbcast.FLUSH timeout="0" start_flush_timeout="10000"/>

--- a/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTest.java
+++ b/clustering/jgroups/src/test/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemTest.java
@@ -129,7 +129,7 @@ public class JGroupsSubsystemTest extends AbstractSubsystemBaseTest {
             ModelNode protocol = new ModelNode();
             protocol.get(ModelKeys.TYPE).set(protocolList[i]) ;
             protocol.get("socket-binding").set("jgroups-udp");
-            System.out.println("adding protovcol = " + protocol.toString());
+            System.out.println("adding protocol = " + protocol.toString());
             protocols.add(protocol);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <version.org.jboss.xnio>3.1.0.CR7</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
-        <version.org.jgroups>3.4.0.Final</version.org.jgroups>
+        <version.org.jgroups>3.4.1.Final</version.org.jgroups>
         <version.org.jipijapa>1.0.0.CR2</version.org.jipijapa>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.mockito>1.9.5</version.org.mockito>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2491

Add protocol stack tweaks based on Infinispan configs.
Revert to old bundler until performance issues with new bundler are solved.
