### PR TITLE
[WFLY-2415] Make legacy xml use statistics=true, which is the actual leg...

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_0.java
@@ -98,6 +98,7 @@ public final class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<
     private void parseContainer(XMLExtendedStreamReader reader, ModelNode subsystemAddress, List<ModelNode> operations) throws XMLStreamException {
 
         ModelNode container = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        container.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         String name = null;
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -290,6 +291,7 @@ public final class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         // set the cache mode to local
@@ -326,6 +328,7 @@ public final class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -387,6 +390,7 @@ public final class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -429,6 +433,7 @@ public final class InfinispanSubsystemXMLReader_1_0 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_1.java
@@ -97,6 +97,7 @@ public final class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<
     private void parseContainer(XMLExtendedStreamReader reader, ModelNode subsystemAddress, List<ModelNode> operations) throws XMLStreamException {
 
         ModelNode container = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        container.get(CacheContainerResourceDefinition.STATISTICS.getName()).set(true);
         String name = null;
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -283,6 +284,7 @@ public final class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         // set the cache mode to local
@@ -319,6 +321,7 @@ public final class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -380,6 +383,7 @@ public final class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -422,6 +426,7 @@ public final class InfinispanSubsystemXMLReader_1_1 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_2.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_2.java
@@ -97,6 +97,7 @@ public final class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<
     private void parseContainer(XMLExtendedStreamReader reader, ModelNode subsystemAddress, List<ModelNode> operations) throws XMLStreamException {
 
         ModelNode container = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        container.get(CacheContainerResourceDefinition.STATISTICS.getName()).set(true);
         String name = null;
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -291,6 +292,7 @@ public final class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         // set the cache mode to local
@@ -327,6 +329,7 @@ public final class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -388,6 +391,7 @@ public final class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -430,6 +434,7 @@ public final class InfinispanSubsystemXMLReader_1_2 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_3.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_3.java
@@ -81,6 +81,7 @@ public final class InfinispanSubsystemXMLReader_1_3 implements XMLElementReader<
     private void parseContainer(XMLExtendedStreamReader reader, PathAddress subsystemAddress, List<ModelNode> operations) throws XMLStreamException {
 
         ModelNode container = Util.getEmptyOperation(ADD, null);
+        container.get(CacheContainerResourceDefinition.STATISTICS.getName()).set(true);
         String name = null;
         final Set<Attribute> required = EnumSet.of(Attribute.NAME);
 
@@ -274,6 +275,7 @@ public final class InfinispanSubsystemXMLReader_1_3 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         // NOTE: this list is used to avoid lost attribute updates to the cache
         // object once it has been added to the operations list
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
@@ -311,6 +313,7 @@ public final class InfinispanSubsystemXMLReader_1_3 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -372,6 +375,7 @@ public final class InfinispanSubsystemXMLReader_1_3 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -414,6 +418,7 @@ public final class InfinispanSubsystemXMLReader_1_3 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_4.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader_1_4.java
@@ -82,6 +82,7 @@ public final class InfinispanSubsystemXMLReader_1_4 implements XMLElementReader<
     private void parseContainer(XMLExtendedStreamReader reader, PathAddress subsystemAddress, List<ModelNode> operations) throws XMLStreamException {
 
         ModelNode container = Util.getEmptyOperation(ADD, null);
+        container.get(CacheContainerResourceDefinition.STATISTICS.getName()).set(true);
         String name = null;
         final Set<Attribute> required = EnumSet.of(Attribute.NAME);
 
@@ -271,6 +272,7 @@ public final class InfinispanSubsystemXMLReader_1_4 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
 
         // set the cache mode to local
         // cache.get(ModelKeys.MODE).set(Configuration.CacheMode.LOCAL.name());
@@ -307,6 +309,7 @@ public final class InfinispanSubsystemXMLReader_1_4 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -361,6 +364,7 @@ public final class InfinispanSubsystemXMLReader_1_4 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
@@ -399,6 +403,7 @@ public final class InfinispanSubsystemXMLReader_1_4 implements XMLElementReader<
 
         // ModelNode for the cache add operation
         ModelNode cache = Util.getEmptyOperation(ModelDescriptionConstants.ADD, null);
+        cache.get(CacheResourceDefinition.STATISTICS.getName()).set(true);
         List<ModelNode> additionalConfigurationOperations = new ArrayList<ModelNode>();
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemTestCase.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.ModelDescriptionValidator.ValidationConfiguration;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -122,6 +123,29 @@ public class InfinispanSubsystemTestCase extends ClusteringSubsystemTest {
        // System.out.println("model = " + model.asString());
 
        Assert.assertTrue(model.get(SUBSYSTEM).hasDefined(getMainSubsystemName()));
+
+       checkLegacyParserStatisticsTrue(model.get(SUBSYSTEM, mainSubsystemName));
+    }
+
+    private void checkLegacyParserStatisticsTrue(ModelNode subsystem) {
+        if (xmlFile.endsWith("1_0.xml") || xmlFile.endsWith("1_1.xml") || xmlFile.endsWith("1_2.xml") || xmlFile.endsWith("1_3.xml") || xmlFile.endsWith("1_4.xml")) {
+            for (Property containerProp : subsystem.get(CacheContainerResourceDefinition.CONTAINER_PATH.getKey()).asPropertyList()) {
+                Assert.assertTrue("cache-container=" + containerProp.getName(),
+                        containerProp.getValue().get(CacheContainerResourceDefinition.STATISTICS.getName()).asBoolean());
+
+                for (String key : containerProp.getValue().keys()) {
+                    if (key.endsWith("-cache") && !key.equals("default-cache")) {
+                        ModelNode caches = containerProp.getValue().get(key);
+                        if (caches.isDefined()) {
+                            for (Property cacheProp : caches.asPropertyList()) {
+                                Assert.assertTrue("cache-container=" + containerProp.getName() + "," + key + "=" + cacheProp.getName(),
+                                        containerProp.getValue().get(CacheResourceDefinition.STATISTICS.getName()).asBoolean());
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
...acy behaviour

This is a followup to https://github.com/wildfly/wildfly/pull/5415. The model has default=false for the new statistics attribute, so parsing old configuration get the opposite behaviour of what used to be the case. This commit sets the statistics attribute to true in the old parsers.
