### PR TITLE
WFLY-2502 Naming context read-only during RA stop

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
@@ -120,12 +120,14 @@ public final class ResourceAdapterActivatorService extends AbstractResourceAdapt
         } catch (Throwable e) {
             // To clean up we need to invoke blocking behavior, so do that in another thread
             // and let this MSC thread return
-            cleanupStartAsync(context, deploymentName, e);
+            String raName = deploymentName;
+            ServiceName raServiceName = ConnectorServices.getResourceAdapterServiceName(raName);
+            cleanupStartAsync(context, deploymentName, raServiceName, e);
             return;
         }
-
         String raName = deploymentMD.getDeploymentName();
         ServiceName raServiceName = ConnectorServices.getResourceAdapterServiceName(raName);
+
 
         value = new ResourceAdapterDeployment(deploymentMD, raName, raServiceName);
         registry.getValue().registerResourceAdapterDeployment(value);

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/ResourceAdapterXmlDeploymentService.java
@@ -112,7 +112,7 @@ public final class ResourceAdapterXmlDeploymentService extends AbstractResourceA
             } catch (Throwable t) {
                 // To clean up we need to invoke blocking behavior, so do that in another thread
                 // and let this MSC thread return
-                cleanupStartAsync(context, raName, t);
+                cleanupStartAsync(context, raName, deploymentServiceName, t);
                 return;
             }
             String id = ((ModifiableResourceAdapter) raxml).getId();

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/AbstractComplexSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/AbstractComplexSubsystemTestCase.java
@@ -22,7 +22,6 @@
 package org.jboss.as.connector.subsystems.complextestcases;
 
 
-import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/ParseUtils.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/ParseUtils.java
@@ -1,24 +1,24 @@
 /*
-* JBoss, Home of Professional Open Source.
-* Copyright 2011, Red Hat Middleware LLC, and individual contributors
-* as indicated by the @author tags. See the copyright.txt file in the
-* distribution for a full listing of individual contributors.
-*
-* This is free software; you can redistribute it and/or modify it
-* under the terms of the GNU Lesser General Public License as
-* published by the Free Software Foundation; either version 2.1 of
-* the License, or (at your option) any later version.
-*
-* This software is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-* Lesser General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public
-* License along with this software; if not, write to the Free
-* Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-* 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-*/
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
 package org.jboss.as.connector.subsystems.complextestcases;
 
 import java.util.Enumeration;
@@ -37,13 +37,13 @@ public class ParseUtils {
      * @param indiName
      */
     public static  Properties commonDsProperties(String jndiName){
-    	Properties params=new Properties();
-    	//attributes
-    	params.put("use-java-context","true");
+        Properties params=new Properties();
+        //attributes
+        params.put("use-java-context","true");
         params.put("spy","false");
         params.put("use-ccm","true");
-    	params.put("jndi-name", jndiName);
-    	//common elements
+        params.put("jndi-name", jndiName);
+        //common elements
         params.put("driver-name","h2");
         params.put("new-connection-sql","select 1");
         params.put("transaction-isolation","TRANSACTION_READ_COMMITTED");
@@ -81,15 +81,15 @@ public class ParseUtils {
         params.put("prepared-statements-cache-size","30");
         params.put("share-prepared-statements","true");
 
-    	return params;
+        return params;
     }
     /**
      * Returns properties for complex XA datasource
      * @param indiName
      */
     public static  Properties xaDsProperties(String jndiName){
-    	Properties params=commonDsProperties(jndiName);
-    	//attributes
+        Properties params=commonDsProperties(jndiName);
+        //attributes
 
         //common
         params.put("xa-datasource-class","org.jboss.as.connector.subsystems.datasources.ModifiableXaDataSource");
@@ -108,14 +108,14 @@ public class ParseUtils {
         params.put("recovery-password","sa");
 
 
-    	return params;
+        return params;
     }
     /**
      * Returns properties for non XA datasource
      * @param jndiName
      */
     public static Properties nonXaDsProperties(String jndiName){
-    	Properties params=commonDsProperties(jndiName);    	//attributes
+        Properties params=commonDsProperties(jndiName); //attributes
         params.put("jta","false");
         //common
         params.put("driver-class","org.hsqldb.jdbcDriver");
@@ -129,25 +129,25 @@ public class ParseUtils {
 
      */
     public static  Properties raCommonProperties(){
-    	Properties params=new Properties();
-    	 params.put("archive","some.rar");
-         params.put("transaction-support","XATransaction");
-         params.put("bootstrap-context","someContext");
+        Properties params=new Properties();
+        params.put("archive","some.rar");
+        params.put("transaction-support","XATransaction");
+        params.put("bootstrap-context","someContext");
 
-    	return params;
+        return params;
     }
     /**
      * Returns properties for RA connection-definition element
 
      */
     public static  Properties raConnectionProperties(){
-    	Properties params=new Properties();
-    	//attributes
-    	params.put("use-java-context","false");
+        Properties params=new Properties();
+        //attributes
+        params.put("use-java-context","false");
         params.put("class-name","Class1");
         params.put("use-ccm","true");
-    	params.put("jndi-name", "java:jboss/name1");
-    	params.put("enabled","false");
+        params.put("jndi-name", "java:jboss/name1");
+        params.put("enabled","false");
         //pool
         params.put("min-pool-size","1");
         params.put("max-pool-size","5");
@@ -178,21 +178,21 @@ public class ParseUtils {
         params.put("recovery-username","sa");
         params.put("recovery-password","sa-pass");
 
-    	return params;
+        return params;
     }
     /**
      * Returns properties for RA admin-object element
 
      */
     public static  Properties raAdminProperties(){
-    	Properties params=new Properties();
-    	//attributes
-    	params.put("use-java-context","false");
+        Properties params=new Properties();
+        //attributes
+        params.put("use-java-context","false");
         params.put("class-name","Class3");
-    	params.put("jndi-name", "java:jboss/Name3");
-    	params.put("enabled","true");
+        params.put("jndi-name", "java:jboss/Name3");
+        params.put("enabled","true");
 
-    	return params;
+        return params;
     }
 
     /**
@@ -201,12 +201,12 @@ public class ParseUtils {
      * @param params
      */
     public static void setOperationParams(ModelNode operation,Properties params){
-    	String str;
-    	Enumeration e = params.propertyNames();
+        String str;
+        Enumeration<?> e = params.propertyNames();
 
         while (e.hasMoreElements()) {
-        	str=(String)e.nextElement();
-        	operation.get(str).set(params.getProperty(str));
+            str=(String)e.nextElement();
+            operation.get(str).set(params.getProperty(str));
         }
     }
     /**
@@ -214,13 +214,13 @@ public class ParseUtils {
      * TODO: not implemented jet in DMR
      */
     public static void addExtensionProperties(ModelNode operation){
-    	/*
+        /*
 
         operation.get("reauth-plugin-properties","Property").set("A");
         operation.get("valid-connection-checker-properties","Property").set("B");
         operation.get("stale-connect,roperties","Property").set("C");
         operation.get("exception-sorter-properties","Property").set("D");
-       */
+         */
         /*final ModelNode sourcePropertiesAddress = address.clone();
         sourcePropertiesAddress.add("reauth-plugin-properties", "Property");
         sourcePropertiesAddress.protect();
@@ -238,24 +238,24 @@ public class ParseUtils {
      * @param params
      */
     public static void checkModelParams(ModelNode node, Properties params){
-    	String str;
+        String str;
 
         StringBuffer sb = new StringBuffer();
         String par,child;
         Enumeration<?> e = params.propertyNames();
 
         while (e.hasMoreElements()) {
-        	str=(String)e.nextElement();
-        	par=params.getProperty(str);
-        	if (node.get(str) == null) {
-        	    sb.append("Parameter <"+str+"> is not set, but must be set to '"+par+"' \n");
-        	}
-        	else{
-        		child= node.get(str).asString();
-        		if (!child.equals(par)) {
-        		    sb.append("Parameter <"+str+"> is set to '"+child+"', but must be set to '"+par+"' \n");
-        		}
-        	}
+            str=(String)e.nextElement();
+            par=params.getProperty(str);
+            if (node.get(str) == null) {
+                sb.append("Parameter <"+str+"> is not set, but must be set to '"+par+"' \n");
+            }
+            else{
+                child= node.get(str).asString();
+                if (!child.equals(par)) {
+                    sb.append("Parameter <"+str+"> is set to '"+child+"', but must be set to '"+par+"' \n");
+                }
+            }
         }
         if (sb.length()>0) Assert.fail("There are parsing errors:\n"+sb.toString()+"Parsed configuration:\n"+node);
     }

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/datasource.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/datasource.xml
@@ -55,12 +55,12 @@
                         </password>
                         <reauth-plugin class-name="someClass1">
                         <config-property name="name">Property1</config-property>
-			</reauth-plugin>
+            </reauth-plugin>
                     </security>
                     <validation>
                         <valid-connection-checker class-name="someClass2">
                         <config-property name="name">Property2</config-property>
-			</valid-connection-checker>
+            </valid-connection-checker>
                         <check-valid-connection-sql>
                             select 1
                         </check-valid-connection-sql>
@@ -78,15 +78,15 @@
                         </use-fast-fail>
                         <stale-connection-checker class-name="someClass3">
                         <config-property name="name">Property3</config-property>
-			</stale-connection-checker>
+            </stale-connection-checker>
                         <exception-sorter class-name="someClass4">
                         <config-property name="name">Property4</config-property>
-			</exception-sorter>
+            </exception-sorter>
                     </validation>
                     <timeout>
-			<blocking-timeout-millis>20000</blocking-timeout-millis>
-			<idle-timeout-minutes>4</idle-timeout-minutes>
-			<set-tx-query-timeout/>
+            <blocking-timeout-millis>20000</blocking-timeout-millis>
+            <idle-timeout-minutes>4</idle-timeout-minutes>
+            <set-tx-query-timeout/>
                         <query-timeout>
                             120
                         </query-timeout>
@@ -104,7 +104,7 @@
                         <prepared-statement-cache-size>
                             30
                         </prepared-statement-cache-size>
-			<share-prepared-statements/>
+            <share-prepared-statements/>
                         <track-statements>nowarn</track-statements>
                     </statement>
                 </datasource>
@@ -149,8 +149,8 @@
                         <is-same-rm-override>
                             true
                         </is-same-rm-override>
-			<interleaving/>
-			<no-tx-separate-pools/>
+            <interleaving/>
+            <no-tx-separate-pools/>
                         <pad-xid>
                             true
                         </pad-xid>
@@ -167,7 +167,7 @@
                         </password>
                         <reauth-plugin class-name="someClass1">
                         <config-property name="name">Property1</config-property>
-			</reauth-plugin>
+            </reauth-plugin>
                     </security>
                     <recovery no-recovery="false">
                         <recover-credential>
@@ -181,12 +181,12 @@
                         <recover-plugin class-name="someClass5">
                         <config-property name="name">Property5</config-property>
                         <config-property name="name1">Property6</config-property>
-			</recover-plugin>
+            </recover-plugin>
                     </recovery>
                     <validation>
                         <valid-connection-checker class-name="someClass2">
                         <config-property name="name">Property2</config-property>
-			</valid-connection-checker>
+            </valid-connection-checker>
                         <check-valid-connection-sql>
                             select 1
                         </check-valid-connection-sql>
@@ -204,15 +204,15 @@
                         </use-fast-fail>
                         <stale-connection-checker class-name="someClass3">
                         <config-property name="name">Property3</config-property>
-			</stale-connection-checker>
+            </stale-connection-checker>
                         <exception-sorter class-name="someClass4">
                         <config-property name="name">Property4</config-property>
-			</exception-sorter>
+            </exception-sorter>
                     </validation>
                     <timeout>
-			<blocking-timeout-millis>20000</blocking-timeout-millis>
-			<idle-timeout-minutes>4</idle-timeout-minutes>
-			<set-tx-query-timeout/>
+            <blocking-timeout-millis>20000</blocking-timeout-millis>
+            <idle-timeout-minutes>4</idle-timeout-minutes>
+            <set-tx-query-timeout/>
                         <query-timeout>
                             120
                         </query-timeout>
@@ -233,10 +233,10 @@
                         <prepared-statement-cache-size>
                             30
                         </prepared-statement-cache-size>
-			<share-prepared-statements/>
-			<track-statements>nowarn</track-statements>
+            <share-prepared-statements/>
+            <track-statements>nowarn</track-statements>
                     </statement>
-		  </xa-datasource>
+          </xa-datasource>
                 <drivers>
                     <driver name="h2" module="com.h2database.h2">
                         <xa-datasource-class>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/jca.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/jca.xml
@@ -17,7 +17,7 @@
                 </long-running-threads>
             </default-workmanager>
             <workmanager name="wm">
-            	<short-running-threads allow-core-timeout="false">
+                <short-running-threads allow-core-timeout="false">
                     <core-threads count="5"/>
                     <queue-length count="5"/>
                     <max-threads count="50"/>
@@ -32,7 +32,7 @@
                 </long-running-threads>
             </workmanager>
             <workmanager name="wm1">
-            	<short-running-threads allow-core-timeout="false">
+                <short-running-threads allow-core-timeout="false">
                     <core-threads count="5"/>
                     <queue-length count="5"/>
                     <max-threads count="50"/>
@@ -47,8 +47,8 @@
                 </long-running-threads>
             </workmanager>
             <bootstrap-contexts>
-            	<bootstrap-context name="bc" workmanager="wm"/>
-            	<bootstrap-context name="bc1" workmanager="wm1"/>
+                <bootstrap-context name="bc" workmanager="wm"/>
+                <bootstrap-context name="bc1" workmanager="wm1"/>
             </bootstrap-contexts>
             <cached-connection-manager debug="true" error="false"/>
         </subsystem>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra.xml
@@ -2,71 +2,71 @@
             <resource-adapters>
                 <resource-adapter id="myRA">
                     <archive>some.rar</archive>
-		    <bootstrap-context>someContext</bootstrap-context>
+            <bootstrap-context>someContext</bootstrap-context>
 
-		    <bean-validation-groups>
-		      <bean-validation-group>Class0</bean-validation-group>
-		      <bean-validation-group>Class00</bean-validation-group>
-		    </bean-validation-groups>
-		    <transaction-support>XATransaction</transaction-support>
-		    <config-property name="Property">A</config-property>
+            <bean-validation-groups>
+              <bean-validation-group>Class0</bean-validation-group>
+              <bean-validation-group>Class00</bean-validation-group>
+            </bean-validation-groups>
+            <transaction-support>XATransaction</transaction-support>
+            <config-property name="Property">A</config-property>
                     <connection-definitions>
                         <connection-definition
                                 class-name="Class1"
                                 jndi-name="java:jboss/name1"
                                 pool-name="Pool1"
-				use-ccm="true"
-				use-java-context="false"
-				enabled="false">
+                use-ccm="true"
+                use-java-context="false"
+                enabled="false">
                             <config-property name="Property">B</config-property>
-			    <xa-pool>
-			      <min-pool-size>1</min-pool-size>
-			      <max-pool-size>5</max-pool-size>
-			      <prefill>true</prefill>
-			       <use-strict-min>true</use-strict-min>
-			       <flush-strategy>IdleConnections</flush-strategy>
-			       <is-same-rm-override>true</is-same-rm-override>
-			       <interleaving/>
-			       <no-tx-separate-pools/>
-				 <pad-xid>true</pad-xid>
-				<wrap-xa-resource>true</wrap-xa-resource>
-			    </xa-pool>
-			    <security>
-			      <application/>
-			    </security>
-			   <timeout>
-			      <blocking-timeout-millis>5000</blocking-timeout-millis>
-			      <idle-timeout-minutes>4</idle-timeout-minutes>
-			      <allocation-retry>2</allocation-retry>
-			      <allocation-retry-wait-millis>3000</allocation-retry-wait-millis>
-			      <xa-resource-timeout>300</xa-resource-timeout>
-			    </timeout>
-			     <validation>
-			      <background-validation>true</background-validation>
-			      <background-validation-millis>5000</background-validation-millis>
-			      <use-fast-fail>true</use-fast-fail>
-			    </validation>
-			  <recovery no-recovery="false">
-			    <recover-credential>
-			      <user-name>sa</user-name>
-			       <password>sa-pass</password>
-			        <security-domain>HsqlDbRealm</security-domain>
-			     </recover-credential>
-			        <recover-plugin class-name="someClass2">
-				<config-property name="Property">C</config-property>
-			      </recover-plugin>
-			    </recovery>
+                <xa-pool>
+                  <min-pool-size>1</min-pool-size>
+                  <max-pool-size>5</max-pool-size>
+                  <prefill>true</prefill>
+                   <use-strict-min>true</use-strict-min>
+                   <flush-strategy>IdleConnections</flush-strategy>
+                   <is-same-rm-override>true</is-same-rm-override>
+                   <interleaving/>
+                   <no-tx-separate-pools/>
+                 <pad-xid>true</pad-xid>
+                <wrap-xa-resource>true</wrap-xa-resource>
+                </xa-pool>
+                <security>
+                  <application/>
+                </security>
+               <timeout>
+                  <blocking-timeout-millis>5000</blocking-timeout-millis>
+                  <idle-timeout-minutes>4</idle-timeout-minutes>
+                  <allocation-retry>2</allocation-retry>
+                  <allocation-retry-wait-millis>3000</allocation-retry-wait-millis>
+                  <xa-resource-timeout>300</xa-resource-timeout>
+                </timeout>
+                 <validation>
+                  <background-validation>true</background-validation>
+                  <background-validation-millis>5000</background-validation-millis>
+                  <use-fast-fail>true</use-fast-fail>
+                </validation>
+              <recovery no-recovery="false">
+                <recover-credential>
+                  <user-name>sa</user-name>
+                   <password>sa-pass</password>
+                    <security-domain>HsqlDbRealm</security-domain>
+                 </recover-credential>
+                    <recover-plugin class-name="someClass2">
+                <config-property name="Property">C</config-property>
+                  </recover-plugin>
+                </recovery>
 
-		      </connection-definition>
+              </connection-definition>
                     </connection-definitions>
 
                     <admin-objects>
                         <admin-object
                                 class-name="Class3"
                                 jndi-name="java:jboss/Name3"
-				pool-name="Pool2"
-				use-java-context="false"
-				enabled="true">
+                pool-name="Pool2"
+                use-java-context="false"
+                enabled="true">
                             <config-property name="Property">D</config-property>
                         </admin-object>
                     </admin-objects>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra2.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/ra2.xml
@@ -4,11 +4,11 @@
    <archive>multiple.rar</archive>
       <transaction-support>NoTransaction</transaction-support>
         <connection-definitions>
-        	<connection-definition  class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name1"  pool-name="Pool1">    </connection-definition>
-		    <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name2"  pool-name="Pool2"> </connection-definition>
-		</connection-definitions>
+            <connection-definition  class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name1"  pool-name="Pool1">    </connection-definition>
+            <connection-definition class-name="org.jboss.as.test.smoke.deployment.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name2"  pool-name="Pool2"> </connection-definition>
+        </connection-definitions>
         <admin-objects>
-          <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl"  jndi-name="java:jboss/Name3"	pool-name="Pool3">  </admin-object>
+          <admin-object class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl"  jndi-name="java:jboss/Name3"    pool-name="Pool3">  </admin-object>
           <admin-object  class-name="org.jboss.as.test.smoke.deployment.rar.MultipleAdminObject1Impl" jndi-name="java:jboss/Name4" pool-name="Pool4"> </admin-object>
          </admin-objects>
     </resource-adapter>

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasource.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/datasources/datasource.xml
@@ -55,12 +55,12 @@
                         </password>
                         <reauth-plugin class-name="someClass1">
                         <config-property name="name">Property1</config-property>
-			</reauth-plugin>
+            </reauth-plugin>
                     </security>
                     <validation>
                         <valid-connection-checker class-name="someClass2">
                         <config-property name="name">Property2</config-property>
-			</valid-connection-checker>
+            </valid-connection-checker>
                         <check-valid-connection-sql>
                             select 1
                         </check-valid-connection-sql>
@@ -78,15 +78,15 @@
                         </use-fast-fail>
                         <stale-connection-checker class-name="someClass3">
                         <config-property name="name">Property3</config-property>
-			</stale-connection-checker>
+            </stale-connection-checker>
                         <exception-sorter class-name="someClass4">
                         <config-property name="name">Property4</config-property>
-			</exception-sorter>
+            </exception-sorter>
                     </validation>
                     <timeout>
-			<blocking-timeout-millis>20000</blocking-timeout-millis>
-			<idle-timeout-minutes>4</idle-timeout-minutes>
-			<set-tx-query-timeout/>
+            <blocking-timeout-millis>20000</blocking-timeout-millis>
+            <idle-timeout-minutes>4</idle-timeout-minutes>
+            <set-tx-query-timeout/>
                         <query-timeout>
                             120
                         </query-timeout>
@@ -104,7 +104,7 @@
                         <prepared-statement-cache-size>
                             30
                         </prepared-statement-cache-size>
-			<share-prepared-statements/>
+            <share-prepared-statements/>
                         <track-statements>nowarn</track-statements>
                     </statement>
                 </datasource>
@@ -149,8 +149,8 @@
                         <is-same-rm-override>
                             true
                         </is-same-rm-override>
-			<interleaving/>
-			<no-tx-separate-pools/>
+            <interleaving/>
+            <no-tx-separate-pools/>
                         <pad-xid>
                             true
                         </pad-xid>
@@ -167,7 +167,7 @@
                         </password>
                         <reauth-plugin class-name="someClass1">
                         <config-property name="name">Property1</config-property>
-			</reauth-plugin>
+            </reauth-plugin>
                     </security>
                     <recovery no-recovery="false">
                         <recover-credential>
@@ -181,12 +181,12 @@
                         <recover-plugin class-name="someClass5">
                         <config-property name="name">Property5</config-property>
                         <config-property name="name1">Property6</config-property>
-			</recover-plugin>
+            </recover-plugin>
                     </recovery>
                     <validation>
                         <valid-connection-checker class-name="someClass2">
                         <config-property name="name">Property2</config-property>
-			</valid-connection-checker>
+            </valid-connection-checker>
                         <check-valid-connection-sql>
                             select 1
                         </check-valid-connection-sql>
@@ -204,15 +204,15 @@
                         </use-fast-fail>
                         <stale-connection-checker class-name="someClass3">
                         <config-property name="name">Property3</config-property>
-			</stale-connection-checker>
+            </stale-connection-checker>
                         <exception-sorter class-name="someClass4">
                         <config-property name="name">Property4</config-property>
-			</exception-sorter>
+            </exception-sorter>
                     </validation>
                     <timeout>
-			<blocking-timeout-millis>20000</blocking-timeout-millis>
-			<idle-timeout-minutes>4</idle-timeout-minutes>
-			<set-tx-query-timeout/>
+            <blocking-timeout-millis>20000</blocking-timeout-millis>
+            <idle-timeout-minutes>4</idle-timeout-minutes>
+            <set-tx-query-timeout/>
                         <query-timeout>
                             120
                         </query-timeout>
@@ -233,10 +233,10 @@
                         <prepared-statement-cache-size>
                             30
                         </prepared-statement-cache-size>
-			<share-prepared-statements/>
-			<track-statements>nowarn</track-statements>
+            <share-prepared-statements/>
+            <track-statements>nowarn</track-statements>
                     </statement>
-		  </xa-datasource>
+          </xa-datasource>
                 <drivers>
                     <driver name="h2" module="com.h2database.h2">
                         <xa-datasource-class>

--- a/connector/src/test/resources/ra16annoactiv.rar/META-INF/ra.xml
+++ b/connector/src/test/resources/ra16annoactiv.rar/META-INF/ra.xml
@@ -25,12 +25,12 @@
             <connection-impl-class>org.jboss.jca.test.deployers.spec.rars.TestConnection</connection-impl-class>
          </connection-definition>
          <!-- overwrite -->
-     
+
          <transaction-support>LocalTransaction</transaction-support>
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <inbound-resourceadapter>
-         <messageadapter>        
+         <messageadapter>
             <messagelistener>
                <messagelistener-type>org.jboss.jca.test.deployers.spec.rars.MessageListener</messagelistener-type>
                <activationspec>

--- a/connector/src/test/resources/ra16annoadminobj.rar/META-INF/ra.xml
+++ b/connector/src/test/resources/ra16annoadminobj.rar/META-INF/ra.xml
@@ -20,7 +20,7 @@
          <config-property-type>java.lang.String</config-property-type>
          <config-property-value>JEFF</config-property-value>
       </config-property>
-      
+
       <outbound-resourceadapter>
          <connection-definition>
             <managedconnectionfactory-class>org.jboss.jca.test.deployers.spec.rars.ra16annoadminobj.TestManagedConnectionFactory</managedconnectionfactory-class>
@@ -30,19 +30,19 @@
              <config-property-type>java.lang.String</config-property-type>
              <config-property-value>JEFF</config-property-value>
           </config-property>
-          
+
             <connectionfactory-interface>javax.resource.spi.ManagedConnection</connectionfactory-interface>
             <connectionfactory-impl-class>org.jboss.jca.test.deployers.spec.rars.ra16annoadminobj.TestManagedConnection</connectionfactory-impl-class>
             <connection-interface>org.jboss.jca.test.deployers.spec.rars.TestConnectionInterface</connection-interface>
             <connection-impl-class>org.jboss.jca.test.deployers.spec.rars.TestConnection</connection-impl-class>
          </connection-definition>
          <!-- overwrite -->
-     
+
          <transaction-support>LocalTransaction</transaction-support>
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <inbound-resourceadapter>
-         <messageadapter>        
+         <messageadapter>
             <messagelistener>
                <messagelistener-type>org.jboss.jca.test.deployers.spec.rars.MessageListener</messagelistener-type>
                <activationspec>

--- a/connector/src/test/resources/ra16annoauthmech.rar/META-INF/ra.xml
+++ b/connector/src/test/resources/ra16annoauthmech.rar/META-INF/ra.xml
@@ -20,7 +20,7 @@
          <config-property-type>java.lang.String</config-property-type>
          <config-property-value>JEFF</config-property-value>
       </config-property>
-      
+
       <outbound-resourceadapter>
          <connection-definition>
             <managedconnectionfactory-class>org.jboss.jca.test.deployers.spec.rars.ra16annoauthmech.TestManagedConnectionFactory</managedconnectionfactory-class>
@@ -30,19 +30,19 @@
              <config-property-type>java.lang.String</config-property-type>
              <config-property-value>JEFF</config-property-value>
           </config-property>
-          
+
             <connectionfactory-interface>javax.resource.spi.ManagedConnection</connectionfactory-interface>
             <connectionfactory-impl-class>org.jboss.jca.test.deployers.spec.rars.ra16annoauthmech.TestManagedConnection</connectionfactory-impl-class>
             <connection-interface>org.jboss.jca.test.deployers.spec.rars.TestConnectionInterface</connection-interface>
             <connection-impl-class>org.jboss.jca.test.deployers.spec.rars.TestConnection</connection-impl-class>
          </connection-definition>
          <!-- overwrite -->
-     
+
          <transaction-support>LocalTransaction</transaction-support>
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <inbound-resourceadapter>
-         <messageadapter>        
+         <messageadapter>
             <messagelistener>
                <messagelistener-type>org.jboss.jca.test.deployers.spec.rars.MessageListener</messagelistener-type>
                <activationspec>

--- a/connector/src/test/resources/ra16annoconfprop.rar/META-INF/ra.xml
+++ b/connector/src/test/resources/ra16annoconfprop.rar/META-INF/ra.xml
@@ -20,7 +20,7 @@
          <config-property-type>java.lang.String</config-property-type>
          <config-property-value>JEFF</config-property-value>
       </config-property>
-      
+
       <outbound-resourceadapter>
          <connection-definition>
             <managedconnectionfactory-class>org.jboss.jca.test.deployers.spec.rars.ra16annoconfprop.TestManagedConnectionFactory</managedconnectionfactory-class>
@@ -30,19 +30,19 @@
              <config-property-type>java.lang.String</config-property-type>
              <config-property-value>JEFF</config-property-value>
           </config-property>
-          
+
             <connectionfactory-interface>javax.resource.spi.ManagedConnection</connectionfactory-interface>
             <connectionfactory-impl-class>org.jboss.jca.test.deployers.spec.rars.ra16annoconfprop.TestManagedConnection</connectionfactory-impl-class>
             <connection-interface>org.jboss.jca.test.deployers.spec.rars.TestConnectionInterface</connection-interface>
             <connection-impl-class>org.jboss.jca.test.deployers.spec.rars.TestConnection</connection-impl-class>
          </connection-definition>
          <!-- overwrite -->
-     
+
          <transaction-support>LocalTransaction</transaction-support>
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <inbound-resourceadapter>
-         <messageadapter>        
+         <messageadapter>
             <messagelistener>
                <messagelistener-type>org.jboss.jca.test.deployers.spec.rars.MessageListener</messagelistener-type>
                <activationspec>

--- a/connector/src/test/resources/ra16annoconndef.rar/META-INF/ra.xml
+++ b/connector/src/test/resources/ra16annoconndef.rar/META-INF/ra.xml
@@ -20,7 +20,7 @@
          <config-property-type>java.lang.String</config-property-type>
          <config-property-value>JEFF</config-property-value>
       </config-property>
-      
+
       <outbound-resourceadapter>
          <connection-definition>
             <managedconnectionfactory-class>org.jboss.jca.test.deployers.spec.rars.ra16annoconndef.TestManagedConnectionFactory</managedconnectionfactory-class>
@@ -30,19 +30,19 @@
              <config-property-type>java.lang.String</config-property-type>
              <config-property-value>JEFF</config-property-value>
           </config-property>
-          
+
             <connectionfactory-interface>javax.resource.spi.ManagedConnection</connectionfactory-interface>
             <connectionfactory-impl-class>org.jboss.jca.test.deployers.spec.rars.ra16annoconndef.TestManagedConnection</connectionfactory-impl-class>
             <connection-interface>org.jboss.jca.test.deployers.spec.rars.TestConnectionInterface</connection-interface>
             <connection-impl-class>org.jboss.jca.test.deployers.spec.rars.TestConnection</connection-impl-class>
          </connection-definition>
-         <!-- overwrite 
+         <!-- overwrite
          <transaction-support>LocalTransaction</transaction-support>
          -->
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <inbound-resourceadapter>
-         <messageadapter>        
+         <messageadapter>
             <messagelistener>
                <messagelistener-type>org.jboss.jca.test.deployers.spec.rars.MessageListener</messagelistener-type>
                <activationspec>

--- a/connector/src/test/resources/ra16annoconndefs.rar/META-INF/ra.xml
+++ b/connector/src/test/resources/ra16annoconndefs.rar/META-INF/ra.xml
@@ -20,7 +20,7 @@
          <config-property-type>java.lang.String</config-property-type>
          <config-property-value>JEFF</config-property-value>
       </config-property>
-      
+
       <outbound-resourceadapter>
          <connection-definition>
             <managedconnectionfactory-class>org.jboss.jca.test.deployers.spec.rars.ra16annoconndefs.TestManagedConnectionFactory</managedconnectionfactory-class>
@@ -30,20 +30,20 @@
              <config-property-type>java.lang.String</config-property-type>
              <config-property-value>JEFF</config-property-value>
           </config-property>
-          
+
             <connectionfactory-interface>javax.resource.spi.ManagedConnection</connectionfactory-interface>
             <connectionfactory-impl-class>org.jboss.jca.test.deployers.spec.rars.ra16annoconndefs.TestManagedConnection</connectionfactory-impl-class>
             <connection-interface>org.jboss.jca.test.deployers.spec.rars.TestConnectionInterface</connection-interface>
             <connection-impl-class>org.jboss.jca.test.deployers.spec.rars.TestConnection</connection-impl-class>
          </connection-definition>
-         <!-- overwrite 
-     
+         <!-- overwrite
+
          <transaction-support>LocalTransaction</transaction-support>
          -->
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <inbound-resourceadapter>
-         <messageadapter>        
+         <messageadapter>
             <messagelistener>
                <messagelistener-type>org.jboss.jca.test.deployers.spec.rars.MessageListener</messagelistener-type>
                <activationspec>

--- a/connector/src/test/resources/ra16inoutanno.rar/META-INF/ra.xml
+++ b/connector/src/test/resources/ra16inoutanno.rar/META-INF/ra.xml
@@ -14,13 +14,13 @@
 
    <resourceadapter>
       <resourceadapter-class>org.jboss.jca.test.deployers.spec.rars.ra16inoutanno.TestResourceAdapter</resourceadapter-class>
-      
+
       <config-property>
          <config-property-name>myStringProperty</config-property-name>
          <config-property-type>java.lang.String</config-property-type>
          <config-property-value>JEFF</config-property-value>
       </config-property>
-      
+
       <outbound-resourceadapter>
          <connection-definition>
             <managedconnectionfactory-class>org.jboss.jca.test.deployers.spec.rars.ra16inoutanno.TestManagedConnectionFactory</managedconnectionfactory-class>
@@ -35,7 +35,7 @@
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <inbound-resourceadapter>
-         <messageadapter>        
+         <messageadapter>
             <messagelistener>
                <messagelistener-type>org.jboss.jca.test.deployers.spec.rars.MessageListener</messagelistener-type>
                <activationspec>


### PR DESCRIPTION
When the `ResourceAdapter#stop()` method is invoked on an annotation
based 1.6 JCR resource adapter the naming context is read only. The
method can be invoked in two cases. Either a normal undeployment or
a clean up after a failed deployment.
- `AbstractResourceAdapterDeploymentService#stopAsync` pushes the owner
- `AbstractResourceAdapterDeploymentService#unregisterAll` catches any
  error that `ResourceAdapter#stop` may throw and logs it
- `AbstractResourceAdapterDeploymentService#cleanupStartAsync` also
  pushes the owner

Issue: WFLY-2502
https://issues.jboss.org/browse/WFLY-2502
