### PR TITLE
[WFLY-2511] NPE when HornetQ control resource does not exist

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
@@ -129,6 +129,10 @@ public class HornetQServerControlWriteHandler extends AbstractWriteAttributeHand
 
     private void applyOperationToHornetQService(final OperationContext context, ModelNode operation, String attributeName, ServiceController<?> hqService) {
         HornetQServerControl serverControl = HornetQServer.class.cast(hqService.getValue()).getHornetQServerControl();
+        if (serverControl == null) {
+            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
+            return;
+        }
         try {
             if (attributeName.equals(CommonAttributes.FAILOVER_ON_SHUTDOWN.getName()))  {
                 serverControl.setFailoverOnServerShutdown(CommonAttributes.FAILOVER_ON_SHUTDOWN.resolveModelAttribute(context, operation).asBoolean());

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueDefinition.java
@@ -167,6 +167,12 @@ public class QueueDefinition extends SimpleResourceDefinition {
      */
     static boolean forwardToRuntimeQueue(OperationContext context, ModelNode operation, OperationStepHandler handler) {
         PathAddress address = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
+
+        // do not forward if the current operation is for a runtime-queue already:
+        if (RUNTIME_QUEUE.equals(address.getLastElement().getKey())) {
+            return false;
+        }
+
         String queueName = address.getLastElement().getValue();
 
         PathAddress hornetQPathAddress = MessagingServices.getHornetQServerPathAddress(address);

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
@@ -105,6 +105,11 @@ public class QueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
         HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
         QueueControl control = QueueControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.CORE_QUEUE + queueName));
 
+        if (control == null) {
+            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
+            return;
+        }
+
         if (MESSAGE_COUNT.getName().equals(attributeName)) {
             context.getResult().set(control.getMessageCount());
         } else if (SCHEDULED_COUNT.getName().equals(attributeName)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/AbstractAddJndiHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/AbstractAddJndiHandler.java
@@ -86,7 +86,7 @@ public abstract class AbstractAddJndiHandler implements OperationStepHandler {
                         HornetQServer hqServer = HornetQServer.class.cast(hqService.getValue());
                         String resourceName = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
                         String jndiName = JNDI_BINDING.resolveModelAttribute(context, operation).asString();
-                        addJndiNameToControl(jndiName, resourceName, hqServer, context);
+                        addJndiNameToControl(jndiName, resourceName, hqServer, context, operation);
                     } // else the subsystem isn't started yet
 
                     if (!context.hasFailureDescription()) {
@@ -105,5 +105,5 @@ public abstract class AbstractAddJndiHandler implements OperationStepHandler {
         context.stepCompleted();
     }
 
-    protected abstract void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context);
+    protected abstract void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context, ModelNode operation);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAddJndiHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAddJndiHandler.java
@@ -27,6 +27,8 @@ import org.hornetq.api.jms.management.ConnectionFactoryControl;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.management.ManagementService;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.messaging.ManagementUtil;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Handler for "add-jndi" operation on a connection factory resource.
@@ -41,9 +43,14 @@ public class ConnectionFactoryAddJndiHandler extends AbstractAddJndiHandler {
     }
 
     @Override
-    protected void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context) {
+    protected void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context, ModelNode operation) {
         ManagementService mgmt = server.getManagementService();
         ConnectionFactoryControl control = ConnectionFactoryControl.class.cast(mgmt.getResource(ResourceNames.JMS_CONNECTION_FACTORY + resourceName));
+        if (control == null) {
+            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
+            return;
+        }
+
         try {
             control.addJNDI(toAdd);
         } catch (RuntimeException e) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueAddJndiHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueAddJndiHandler.java
@@ -27,6 +27,8 @@ import org.hornetq.api.jms.management.JMSQueueControl;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.management.ManagementService;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.messaging.ManagementUtil;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Handler for "add-jndi" operation on a JMS queue resource.
@@ -41,9 +43,15 @@ public class JMSQueueAddJndiHandler extends AbstractAddJndiHandler {
     }
 
     @Override
-    protected void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context) {
+    protected void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context, ModelNode operation) {
         ManagementService mgmt = server.getManagementService();
         JMSQueueControl control = JMSQueueControl.class.cast(mgmt.getResource(ResourceNames.JMS_QUEUE + resourceName));
+
+        if (control == null) {
+            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
+            return;
+        }
+
         try {
             control.addJNDI(toAdd);
         } catch (RuntimeException e) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAddJndiHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAddJndiHandler.java
@@ -27,6 +27,8 @@ import org.hornetq.api.jms.management.TopicControl;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.management.ManagementService;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.messaging.ManagementUtil;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Handler for "add-jndi" operation on a JMS topic resource.
@@ -41,9 +43,14 @@ public class JMSTopicAddJndiHandler extends AbstractAddJndiHandler {
     }
 
     @Override
-    protected void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context) {
+    protected void addJndiNameToControl(String toAdd, String resourceName, HornetQServer server, OperationContext context, ModelNode operation) {
         ManagementService mgmt = server.getManagementService();
         TopicControl control = TopicControl.class.cast(mgmt.getResource(ResourceNames.JMS_TOPIC + resourceName));
+        if (control == null) {
+            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
+            return;
+        }
+
         try {
             control.addJNDI(toAdd);
         } catch (RuntimeException e) {


### PR DESCRIPTION
guard against using a HornetQ control resource that does not exist and
rollback the operation with a meaningful message instead of throwing a
NPE

fix a potential infinite loop if a queue does not exist by preventing
forwarding an operation to a runtime-queue if the operation is _already_
for a runtime-queue
