### PR TITLE
[WFLY-2516] Exclude java.xml.crypto classes from Santuario module exports

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
@@ -23,6 +23,11 @@
   -->
 
 <module xmlns="urn:jboss:module:1.1" name="org.apache.santuario.xmlsec">
+
+    <exports>
+        <exclude path="javax/**"/>
+    </exports>
+
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/bindings/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/bindings/main/module.xml
@@ -41,11 +41,7 @@
         <module name="org.picketbox" />
         <module name="javax.xml.ws.api" />
         <module name="org.apache.log4j" />
-        <module name="org.apache.santuario.xmlsec">
-            <imports>
-                <exclude path="javax/*" />
-            </imports>
-        </module>
+        <module name="org.apache.santuario.xmlsec"/>
         <module name="javax.api" />
         <module name="org.jboss.ws.api" />
         <module name="org.jboss.ws.spi" />

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
@@ -41,11 +41,7 @@
         <module name="org.picketbox" />
         <module name="javax.xml.ws.api" />
         <module name="org.apache.log4j" />
-        <module name="org.apache.santuario.xmlsec">
-            <imports>
-                <exclude path="javax/*" />
-            </imports>
-        </module>
+        <module name="org.apache.santuario.xmlsec"/>
         <module name="javax.api" />
         <module name="org.jboss.ws.api" />
         <module name="org.jboss.ws.spi" />


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2516
