### PR TITLE
WFLY-963: adds support for jndi modifications by modules/extensions, at ...

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/service/BinderService.java
+++ b/naming/src/main/java/org/jboss/as/naming/service/BinderService.java
@@ -22,15 +22,8 @@
 
 package org.jboss.as.naming.service;
 
-import static org.jboss.as.naming.NamingLogger.ROOT_LOGGER;
-
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
-
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.ServiceBasedNamingStore;
-import org.jboss.as.naming.deployment.JndiNamingDependencyProcessor;
-import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -38,6 +31,10 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.jboss.as.naming.NamingLogger.ROOT_LOGGER;
 
 /**
  * Service responsible for binding and unbinding a entry into a naming context.  This service can be used as a dependency for
@@ -52,18 +49,17 @@ public class BinderService implements Service<ManagedReferenceFactory> {
     private final String name;
     private final InjectedValue<ManagedReferenceFactory> managedReferenceFactory = new InjectedValue<ManagedReferenceFactory>();
     private final Object source;
-    private final AtomicInteger refcnt = new AtomicInteger(0);
-    private ServiceController<?> controller;
-    private final ServiceName deploymentServiceName;
+    private final AtomicInteger refcnt;
+    private volatile ServiceController<?> controller;
 
     /**
      * Construct new instance.
      *
      * @param name The JNDI name to use for binding. May be either an absolute or relative name
      * @param source
-     * @param deploymentServiceName the service name for the related deployment unit
+     * @param shared indicates if the bind may be shared among multiple deployments, if true the service tracks references indicated through acquire(), and automatically stops once all deployments unreference it through release()
      */
-    public BinderService(final String name, Object source, ServiceName deploymentServiceName) {
+    public BinderService(final String name, Object source, boolean shared) {
         if (name.startsWith("java:")) {
             //this is an absolute reference
             this.name = name.substring(name.indexOf('/') + 1);
@@ -71,7 +67,7 @@ public class BinderService implements Service<ManagedReferenceFactory> {
             this.name = name;
         }
         this.source = source;
-        this.deploymentServiceName = deploymentServiceName;
+        refcnt = shared ? new AtomicInteger(0) : null;
     }
 
     /**
@@ -80,11 +76,11 @@ public class BinderService implements Service<ManagedReferenceFactory> {
      * @param name The JNDI name to use for binding. May be either an absolute or relative name
      */
     public BinderService(final String name, Object source) {
-        this(name,source,null);
+        this(name, source, false);
     }
 
     public BinderService(final String name) {
-        this(name, null, null);
+        this(name, null, false);
     }
 
     public Object getSource() {
@@ -92,13 +88,20 @@ public class BinderService implements Service<ManagedReferenceFactory> {
     }
 
     public void acquire() {
-        refcnt.incrementAndGet();
+        if (refcnt != null) {
+            refcnt.incrementAndGet();
+        }
     }
 
     public void release() {
-        if (refcnt.decrementAndGet() <= 0 && controller != null) {
+        if (refcnt != null && refcnt.decrementAndGet() <= 0 && controller != null) {
             controller.setMode(ServiceController.Mode.REMOVE);
         }
+    }
+
+    public ServiceName getServiceName() {
+        final ServiceController<?> serviceController = this.controller;
+        return serviceController != null ? serviceController.getName() : null;
     }
 
     /**
@@ -107,17 +110,11 @@ public class BinderService implements Service<ManagedReferenceFactory> {
      * @param context The start context
      * @throws StartException If the entity can not be bound
      */
-    public synchronized void start(StartContext context) throws StartException {
+    public void start(StartContext context) throws StartException {
         final ServiceBasedNamingStore namingStore = namingStoreValue.getValue();
-        ServiceController<?> controller = context.getController();
-        this.controller = controller;
+        controller = context.getController();
         namingStore.add(controller.getName());
         ROOT_LOGGER.tracef("Bound resource %s into naming store %s (service name %s)", name, namingStore, controller.getName());
-        if(deploymentServiceName != null) {
-            // add this controller service name to the related deployment runtime bindings management service, which if stop will release this service too, thus removing the bind
-            final Set<ServiceName> duBindingReferences = (Set<ServiceName>) controller.getServiceContainer().getService(JndiNamingDependencyProcessor.serviceName(deploymentServiceName)).getValue();
-            duBindingReferences.add(controller.getName());
-        }
     }
 
     /**
@@ -125,17 +122,10 @@ public class BinderService implements Service<ManagedReferenceFactory> {
      *
      * @param context The stop context
      */
-    public synchronized void stop(StopContext context) {
+    public void stop(StopContext context) {
         final ServiceBasedNamingStore namingStore = namingStoreValue.getValue();
-        namingStore.remove(context.getController().getName());
-        if(deploymentServiceName != null) {
-            // remove the service name from the related deployment runtime bindings management service,
-            final Set<ServiceName> duBindingReferences = (Set<ServiceName>) controller.getServiceContainer().getService(JndiNamingDependencyProcessor.serviceName(deploymentServiceName)).getValue();
-            if(duBindingReferences != null) {
-                // the set is null if the binder service was stopped by the deployment unit undeploy
-                duBindingReferences.remove(controller.getName());
-            }
-        }
+        namingStore.remove(controller.getName());
+        ROOT_LOGGER.tracef("Unbound resource %s into naming store %s (service name %s)", name, namingStore, context.getController().getName());
     }
 
     /**
@@ -144,7 +134,7 @@ public class BinderService implements Service<ManagedReferenceFactory> {
      * @return The value of the named entry
      * @throws IllegalStateException
      */
-    public synchronized ManagedReferenceFactory getValue() throws IllegalStateException {
+    public ManagedReferenceFactory getValue() throws IllegalStateException {
         return managedReferenceFactory.getValue();
     }
 
@@ -153,7 +143,7 @@ public class BinderService implements Service<ManagedReferenceFactory> {
      *
      * @return the injector
      */
-    public Injector<ManagedReferenceFactory> getManagedObjectInjector() {
+    public InjectedValue<ManagedReferenceFactory> getManagedObjectInjector() {
         return managedReferenceFactory;
     }
 
@@ -162,12 +152,13 @@ public class BinderService implements Service<ManagedReferenceFactory> {
      *
      * @return the injector
      */
-    public Injector<ServiceBasedNamingStore> getNamingStoreInjector() {
+    public InjectedValue<ServiceBasedNamingStore> getNamingStoreInjector() {
         return namingStoreValue;
     }
 
     @Override
     public String toString() {
-        return "BinderService[name=" + name + ",source=" + source + ",deployment=" + deploymentServiceName +"]";
+        return "BinderService[name=" + name + ", source=" + source + ", refcnt=" + (refcnt != null ? refcnt.get() : "n/a") +"]";
     }
+
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/BeanOne.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/BeanOne.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.naming.shared;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.naming.InitialContext;
+
+/**
+ * @author Eduardo Martins
+ */
+@Startup
+@Singleton
+public class BeanOne {
+
+    @EJB(lookup = "java:global/TEST_RESULTS_BEAN_JAR_NAME/TestResultsBean!org.jboss.as.test.integration.naming.shared.TestResults")
+    private TestResults testResults;
+
+    @PostConstruct
+    public void postConstruct() {
+        try {
+            new InitialContext().lookup(TestResults.SHARED_BINDING_NAME_ONE);
+            new InitialContext().rebind(TestResults.SHARED_BINDING_NAME_TWO,"");
+            testResults.setPostContructOne(true);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            testResults.setPostContructOne(false);
+        }
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        try {
+            new InitialContext().lookup(TestResults.SHARED_BINDING_NAME_ONE);
+            new InitialContext().lookup(TestResults.SHARED_BINDING_NAME_TWO);
+            testResults.setPreDestroyOne(true);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            testResults.setPreDestroyOne(false);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/BeanTwo.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/BeanTwo.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.naming.shared;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import javax.naming.InitialContext;
+
+/**
+ * @author Eduardo Martins
+ */
+@Startup
+@Singleton
+public class BeanTwo {
+
+    @EJB(lookup = "java:global/TEST_RESULTS_BEAN_JAR_NAME/TestResultsBean!org.jboss.as.test.integration.naming.shared.TestResults")
+    private TestResults testResults;
+
+    @PostConstruct
+    public void postConstruct() {
+        try {
+            new InitialContext().lookup(TestResults.SHARED_BINDING_NAME_ONE);
+            new InitialContext().rebind(TestResults.SHARED_BINDING_NAME_TWO,"");
+            testResults.setPostContructTwo(true);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            testResults.setPostContructTwo(false);
+        }
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        try {
+            new InitialContext().lookup(TestResults.SHARED_BINDING_NAME_ONE);
+            new InitialContext().lookup(TestResults.SHARED_BINDING_NAME_TWO);
+            testResults.setPreDestroyTwo(true);
+        } catch (Throwable e) {
+            e.printStackTrace();
+            testResults.setPreDestroyTwo(false);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/SharedBindingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/SharedBindingTestCase.java
@@ -1,0 +1,107 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.naming.shared;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A test case which verifies proper release of shared binds, i.e., automated unbind only after every deployment that shares the bind is undeployed.
+ * @author Eduardo Martins
+ */
+@RunWith(Arquillian.class)
+public class SharedBindingTestCase {
+
+    private static final String BEAN_ONE_JAR_NAME = "BEAN_ONE";
+    private static final String BEAN_TWO_JAR_NAME = "BEAN_TWO";
+    private static final String TEST_RESULTS_BEAN_JAR_NAME = "TEST_RESULTS_BEAN_JAR_NAME";
+
+    @ArquillianResource
+    public Deployer deployer;
+
+    @Deployment(name = BEAN_ONE_JAR_NAME, managed = false)
+    public static Archive<?> deployOne() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, BEAN_ONE_JAR_NAME +".jar");
+        jar.addClasses(BeanOne.class, TestResults.class);
+        jar.addAsManifestResource(SharedBindingTestCase.class.getPackage(), "ejb-jar-one.xml", "ejb-jar.xml");
+        return jar;
+    }
+
+    @Deployment(name = BEAN_TWO_JAR_NAME, managed = false)
+    public static Archive<?> deployTwo() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, BEAN_TWO_JAR_NAME +".jar");
+        jar.addClasses(BeanTwo.class, TestResults.class);
+        jar.addAsManifestResource(SharedBindingTestCase.class.getPackage(), "ejb-jar-two.xml", "ejb-jar.xml");
+        return jar;
+    }
+
+    @Deployment
+    public static Archive<?> deployThree() {
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, TEST_RESULTS_BEAN_JAR_NAME +".jar");
+        jar.addClasses(TestResultsBean.class, TestResults.class);
+        return jar;
+    }
+
+    @ArquillianResource
+    private InitialContext initialContext;
+
+    @Test
+    public void test() throws NamingException, InterruptedException {
+        // deploy bean one and two
+        deployer.deploy(BEAN_ONE_JAR_NAME);
+        boolean undeployedBeanOne = false;
+        try {
+            try {
+                deployer.deploy(BEAN_TWO_JAR_NAME);
+                // undeploy bean one first
+                deployer.undeploy(BEAN_ONE_JAR_NAME);
+                undeployedBeanOne = true;
+            } finally {
+                deployer.undeploy(BEAN_TWO_JAR_NAME);
+            }
+        } finally {
+            if(!undeployedBeanOne) {
+                deployer.undeploy(BEAN_ONE_JAR_NAME);
+            }
+        }
+        // lookup bean three and assert test results
+        final TestResults testResults = (TestResults) initialContext.lookup("java:global/"+ TEST_RESULTS_BEAN_JAR_NAME +"/"+TestResultsBean.class.getSimpleName()+"!"+TestResults.class.getName());
+        testResults.await(5, TimeUnit.SECONDS);
+        Assert.assertTrue(testResults.isPostContructOne());
+        Assert.assertTrue(testResults.isPostContructTwo());
+        Assert.assertTrue(testResults.isPreDestroyOne());
+        Assert.assertTrue(testResults.isPreDestroyTwo());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/TestResults.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/TestResults.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.naming.shared;
+
+import javax.ejb.Remote;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Eduardo Martins
+ */
+@Remote
+public interface TestResults {
+
+    final String SHARED_BINDING_NAME_ONE = "java:global/sharedbinds/one";
+    final String SHARED_BINDING_NAME_TWO = "java:global/sharedbinds/two";
+
+    boolean isPostContructOne();
+
+    void setPostContructOne(boolean postContructOne);
+
+    boolean isPostContructTwo();
+
+    void setPostContructTwo(boolean postContructTwo);
+
+    boolean isPreDestroyOne();
+
+    void setPreDestroyOne(boolean preDestroyOne);
+
+    boolean isPreDestroyTwo();
+
+    void setPreDestroyTwo(boolean preDestroyTwo);
+
+    void await(long timeout, TimeUnit timeUnit) throws InterruptedException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/TestResultsBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/TestResultsBean.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.naming.shared;
+
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * @author Eduardo Martins
+ */
+@Startup
+@Singleton
+public class TestResultsBean implements TestResults {
+
+    private final CountDownLatch latch = new CountDownLatch(4);
+
+    private boolean postContructOne;
+    private boolean postContructTwo;
+    private boolean preDestroyOne;
+    private boolean preDestroyTwo;
+
+    public boolean isPostContructOne() {
+        return postContructOne;
+    }
+
+    public void setPostContructOne(boolean postContructOne) {
+        this.postContructOne = postContructOne;
+        latch.countDown();
+    }
+
+    public boolean isPostContructTwo() {
+        return postContructTwo;
+    }
+
+    public void setPostContructTwo(boolean postContructTwo) {
+        this.postContructTwo = postContructTwo;
+        latch.countDown();
+    }
+
+    public boolean isPreDestroyOne() {
+        return preDestroyOne;
+    }
+
+    public void setPreDestroyOne(boolean preDestroyOne) {
+        this.preDestroyOne = preDestroyOne;
+        latch.countDown();
+    }
+
+    public boolean isPreDestroyTwo() {
+        return preDestroyTwo;
+    }
+
+    public void setPreDestroyTwo(boolean preDestroyTwo) {
+        this.preDestroyTwo = preDestroyTwo;
+        latch.countDown();
+    }
+
+    public void await(long timeout, TimeUnit timeUnit) throws InterruptedException {
+        latch.await(timeout, timeUnit);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-one.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-one.xml
@@ -1,0 +1,37 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd"
+         version="3.2">    
+    <enterprise-beans>
+        <session>
+            <ejb-name>BeanOne</ejb-name>
+            <env-entry>
+                <env-entry-name>java:global/sharedbinds/one</env-entry-name>
+                <env-entry-type>java.lang.Integer</env-entry-type>
+                <env-entry-value>1</env-entry-value>
+            </env-entry>
+        </session>        
+    </enterprise-beans>
+</ejb-jar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-two.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-two.xml
@@ -1,0 +1,37 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd"
+         version="3.2">
+    <enterprise-beans>
+        <session>
+            <ejb-name>BeanTwo</ejb-name>
+            <env-entry>
+                <env-entry-name>java:global/sharedbinds/one</env-entry-name>
+                <env-entry-type>java.lang.Integer</env-entry-type>
+                <env-entry-value>1</env-entry-value>
+            </env-entry>
+        </session>
+    </enterprise-beans>
+</ejb-jar>


### PR DESCRIPTION
...the writable service based naming store. The only change in the API is that now the owner may in alternative be a service target. In such case new binder services are installed in the provided service target, which was the old behaviour, which works fine for modules/extensions. 

The PR also improves the management of references/owners of binder services, and fixes the naming store logic for rebind and unbind operations. A new integration test is also provided to ensure that shared bindings are handled correctly.
