### PR TITLE
[WFLY-364] rollback-on-rutime-failure for deployments

### DIFF
--- a/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
+++ b/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.deployment-scanner</extension-module>
-   <subsystem xmlns="urn:jboss:domain:deployment-scanner:1.2">
+   <subsystem xmlns="urn:jboss:domain:deployment-scanner:2.0">
        <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
    </subsystem>
 </config>

--- a/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
+++ b/build/src/main/resources/configuration/subsystems/deployment-scanner.xml
@@ -3,6 +3,6 @@
 <config>
    <extension-module>org.jboss.as.deployment-scanner</extension-module>
    <subsystem xmlns="urn:jboss:domain:deployment-scanner:1.2">
-       <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000"/>
+       <deployment-scanner path="deployments" relative-to="jboss.server.base.dir" scan-interval="5000" runtime-failure-causes-rollback="${jboss.deployment.scanner.rollback.on.failure:false}"/>
    </subsystem>
 </config>

--- a/build/src/main/resources/docs/schema/jboss-as-deployment-scanner_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-deployment-scanner_2_0.xsd
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<xs:schema xmlns="urn:jboss:domain:deployment-scanner:1.2" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:jboss:domain:deployment-scanner:1.2" version="1.2">
+<xs:schema xmlns="urn:jboss:domain:deployment-scanner:2.0" xmlns:xs="http://www.w3.org/2001/XMLSchema" attributeFormDefault="unqualified" elementFormDefault="qualified" targetNamespace="urn:jboss:domain:deployment-scanner:2.0" version="2.0">
 
     <!-- The threads subsystem root element -->
     <xs:element name="subsystem" type="subsystem"/>

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerExtension.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerExtension.java
@@ -46,9 +46,9 @@ public class DeploymentScannerExtension implements Extension {
     static final String DEFAULT_SCANNER_NAME = "default"; // we actually need a scanner name to make it addressable
     private static final String RESOURCE_NAME = DeploymentScannerExtension.class.getPackage().getName() + ".LocalDescriptions";
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 2;
     private static final int MANAGEMENT_API_MINOR_VERSION = 0;
-    private static final int MANAGEMENT_API_MICRO_VERSION = 1;
+    private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
     static ResourceDescriptionResolver getResourceDescriptionResolver(final String keyPrefix) {
         return new StandardResourceDescriptionResolver(keyPrefix, RESOURCE_NAME, DeploymentScannerExtension.class.getClassLoader(), true, false);
@@ -67,7 +67,7 @@ public class DeploymentScannerExtension implements Extension {
 
         final SubsystemRegistration subsystem = context.registerSubsystem(CommonAttributes.DEPLOYMENT_SCANNER, MANAGEMENT_API_MAJOR_VERSION,
                 MANAGEMENT_API_MINOR_VERSION, MANAGEMENT_API_MICRO_VERSION);
-        subsystem.registerXMLElementWriter(DeploymentScannerParser_1_2.INSTANCE);
+        subsystem.registerXMLElementWriter(DeploymentScannerParser_2_0.INSTANCE);
 
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(new DeploymentScannerSubsystemDefinition());
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
@@ -88,7 +88,7 @@ public class DeploymentScannerExtension implements Extension {
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DEPLOYMENT_SCANNER_1_0.getUriString(), DeploymentScannerParser_1_0.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DEPLOYMENT_SCANNER_1_1.getUriString(), DeploymentScannerParser_1_1.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DEPLOYMENT_SCANNER_1_2.getUriString(), DeploymentScannerParser_1_2.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.DEPLOYMENT_SCANNER_2_0.getUriString(), DeploymentScannerParser_2_0.INSTANCE);
 
     }
 

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerParser_1_1.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerParser_1_1.java
@@ -106,6 +106,7 @@ class DeploymentScannerParser_1_1 implements XMLStreamConstants, XMLElementReade
         // elements
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             switch (Namespace.forUri(reader.getNamespaceURI())) {
+                case DEPLOYMENT_SCANNER_1_0:
                 case DEPLOYMENT_SCANNER_1_1: {
                     final Element element = Element.forName(reader.getLocalName());
                     switch (element) {

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerParser_2_0.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerParser_2_0.java
@@ -47,9 +47,9 @@ import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 /**
  */
-class DeploymentScannerParser_1_2 implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+class DeploymentScannerParser_2_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
 
-    public static final DeploymentScannerParser_1_2 INSTANCE = new DeploymentScannerParser_1_2();
+    public static final DeploymentScannerParser_2_0 INSTANCE = new DeploymentScannerParser_2_0();
 
     /**
      * {@inheritDoc}
@@ -109,7 +109,7 @@ class DeploymentScannerParser_1_2 implements XMLStreamConstants, XMLElementReade
             switch (Namespace.forUri(reader.getNamespaceURI())) {
                 case DEPLOYMENT_SCANNER_1_0:
                 case DEPLOYMENT_SCANNER_1_1:
-                case DEPLOYMENT_SCANNER_1_2: {
+                case DEPLOYMENT_SCANNER_2_0: {
                     final Element element = Element.forName(reader.getLocalName());
                     switch (element) {
                         case DEPLOYMENT_SCANNER: {

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/Namespace.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/Namespace.java
@@ -33,13 +33,13 @@ UNKNOWN(null),
 
     DEPLOYMENT_SCANNER_1_0("urn:jboss:domain:deployment-scanner:1.0"),
     DEPLOYMENT_SCANNER_1_1("urn:jboss:domain:deployment-scanner:1.1"),
-    DEPLOYMENT_SCANNER_1_2("urn:jboss:domain:deployment-scanner:1.2"),
+    DEPLOYMENT_SCANNER_2_0("urn:jboss:domain:deployment-scanner:2.0"),
     ;
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = DEPLOYMENT_SCANNER_1_2;
+    public static final Namespace CURRENT = DEPLOYMENT_SCANNER_2_0;
 
     private final String name;
 

--- a/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/DeploymentScannerParsingTestCase.java
+++ b/deployment-scanner/src/test/java/org/jboss/as/server/deployment/scanner/DeploymentScannerParsingTestCase.java
@@ -12,7 +12,7 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 
 public class DeploymentScannerParsingTestCase extends AbstractSubsystemBaseTest {
     private static final String SUBSYSTEM_XML =
-            "<subsystem xmlns=\"urn:jboss:domain:deployment-scanner:1.2\">\n" +
+            "<subsystem xmlns=\"urn:jboss:domain:deployment-scanner:2.0\">\n" +
             "    <deployment-scanner name=\"myScanner\" path=\"deployments_${custom.system.property:test}\" " +
                    "relative-to=\"jboss.server.base.dir\" scan-enabled=\"false\" scan-interval=\"5000\" " +
                    "auto-deploy-xml=\"true\" deployment-timeout=\"60\"/>\n" +

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/DeploymentOperationsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/DeploymentOperationsTestCase.java
@@ -107,7 +107,11 @@ public class DeploymentOperationsTestCase extends ContainerResourceMgmtTestBase 
         composite.get(OP).set(COMPOSITE);
         composite.get(OPERATION_HEADERS).get(ROLLBACK_ON_RUNTIME_FAILURE).set(false);
 
-        final ModelNode steps = composite.get(STEPS).setEmptyList();
+        final ModelNode nested = composite.get(STEPS).setEmptyList().add();
+        nested.get(OP).set(COMPOSITE);
+        nested.get(OP_ADDR).setEmptyList();
+
+        final ModelNode steps = nested.get(STEPS).setEmptyList();
 
         final ModelNode deployOne = steps.add();
         deployOne.get(OP).set(ADD);
@@ -129,7 +133,10 @@ public class DeploymentOperationsTestCase extends ContainerResourceMgmtTestBase 
         final ModelControllerClient client = getModelControllerClient();
         try {
             // Deploy
-            final ModelNode result = client.execute(operation);
+            final ModelNode overallResult = client.execute(operation);
+            Assert.assertTrue(overallResult.asString(), SUCCESS.equals(overallResult.get(OUTCOME).asString()));
+
+            final ModelNode result = overallResult.get(RESULT, "step-1");
             Assert.assertTrue(result.asString(), SUCCESS.equals(result.get(OUTCOME).asString()));
 
             final ModelNode step1 = result.get(RESULT, "step-1");

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -211,6 +211,7 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${jboss.https.port:8443}", "8443");
         result = result.replace("${jboss.remoting.port:4447}", "4447");
         result = result.replace("${jboss.ajp.port:8009}", "8009");
+        result = result.replace("${jboss.deployment.scanner.rollback.on.failure:false}", "false");
         return result;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-364

Missing from the original PR: Added a system property to the deployment-scanner configuration and made the tests more reliable. Also Darran pointed out that there could be a version conflict with EAP, so i bumped the schema and subsystem versions.
