### PR TITLE
Use the right XNIO provider for Remoting

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
@@ -33,6 +33,5 @@
         <module name="org.jboss.marshalling" export="true"/>
         <module name="org.jboss.sasl" services="import"/>
         <module name="org.jboss.xnio" export="true"/>
-        <module name="org.jboss.xnio.nio" services="import"/>
     </dependencies>
 </module>

--- a/remoting/src/main/java/org/jboss/as/remoting/EndpointService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/EndpointService.java
@@ -37,6 +37,7 @@ import org.jboss.remoting3.remote.HttpUpgradeConnectionProviderFactory;
 import org.jboss.remoting3.remote.RemoteConnectionProviderFactory;
 import org.xnio.OptionMap;
 import org.xnio.Options;
+import org.xnio.Xnio;
 
 /**
  * An MSC service for Remoting endpoints.
@@ -70,7 +71,7 @@ public final class EndpointService implements Service<Endpoint> {
         final Endpoint endpoint;
         try {
             boolean ok = false;
-            endpoint = Remoting.createEndpoint(endpointName, optionMap);
+            endpoint = Remoting.createEndpoint(endpointName, Xnio.getInstance(), optionMap);
             try {
                 // Reuse the options for the remote connection factory for now
                 endpoint.addConnectionProvider(Protocol.REMOTE.toString(), new RemoteConnectionProviderFactory(), optionMap);


### PR DESCRIPTION
Fixes Remoting to let XNIO detect its own implementation.
