### PR TITLE
WFLY-2468 WFLY-1469 WFLY-160 add support for runtime reloadable mail operations

### DIFF
--- a/build/src/main/resources/configuration/subsystems/mail.xml
+++ b/build/src/main/resources/configuration/subsystems/mail.xml
@@ -2,8 +2,8 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.mail</extension-module>
-   <subsystem xmlns="urn:jboss:domain:mail:1.1">
-       <mail-session jndi-name="java:jboss/mail/Default">
+   <subsystem xmlns="urn:jboss:domain:mail:2.0">
+       <mail-session name="default" jndi-name="java:jboss/mail/Default">
            <smtp-server outbound-socket-binding-ref="mail-smtp"/>
        </mail-session>
    </subsystem>

--- a/build/src/main/resources/docs/schema/wildfly-mail_2_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-mail_2_0.xsd
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:mail:2.0"
+           targetNamespace="urn:jboss:domain:mail:2.0"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+    <!-- The mail subsystem root element -->
+    <xs:element name="subsystem" type="mail-subsystemType"/>
+    <xs:complexType name="mail-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the mail subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="mail-session" type="mail-sessionType"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="mail-sessionType">
+        <xs:sequence>
+            <xs:element name="smtp-server" type="server-type" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="pop3-server" type="server-type" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="imap-server" type="server-type" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="custom-server" type="custom-server-type" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="jndi-name" use="required" type="xs:string"/>
+        <xs:attribute name="debug" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                       enables debuging of mail session
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="from" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                            sets mail.from attribute
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+    <xs:complexType name="server-type" mixed="true">
+        <xs:attribute name="outbound-socket-binding-ref" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Reference to the outbound-socket-binding element in the socket-binding-group that should
+                    be used for configuring the client socket used to communicate with the mail server.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of ssl for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tls" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of tls for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="username" type="xs:string" use="optional"/>
+        <xs:attribute name="password" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="property-type">
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="value" type="xs:string"/>
+    </xs:complexType>
+
+
+    <xs:complexType name="custom-server-type" mixed="true">
+        <xs:sequence>
+            <xs:element name="property" type="property-type" maxOccurs="unbounded" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="outbound-socket-binding-ref" use="required" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Reference to the outbound-socket-binding element in the socket-binding-group that should
+                    be used for configuring the client socket used to communicate with the mail server.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="ssl" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of ssl for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="tls" use="optional" type="xs:boolean">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    enables use of tls for this server configuration
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="username" type="xs:string" use="optional"/>
+        <xs:attribute name="password" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeMarshaller.java
@@ -76,4 +76,8 @@ public abstract class AttributeMarshaller {
     public void marshallAsElement(final AttributeDefinition attribute, final ModelNode resourceModel, final boolean marshallDefault, final XMLStreamWriter writer) throws XMLStreamException{
         throw ControllerMessages.MESSAGES.couldNotMarshalAttributeAsElement(attribute.getName());
     }
+
+    public boolean isMarshallableAsElement(){
+        return false;
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -39,6 +39,7 @@ public class PersistentResourceXMLDescription {
     protected final boolean useValueAsElementName;
     protected final boolean noAddOperation;
     protected final AdditionalOperationsGenerator additionalOperationsGenerator;
+    private boolean flushRequired = true;
 
     protected PersistentResourceXMLDescription(final PersistentResourceDefinition resourceDefinition, final String xmlElementName, final String xmlWrapperElement, final LinkedHashMap<String, AttributeDefinition> attributes, final List<PersistentResourceXMLDescription> children, final boolean useValueAsElementName, final boolean noAddOperation, final AdditionalOperationsGenerator additionalOperationsGenerator) {
         this.resourceDefinition = resourceDefinition;
@@ -85,6 +86,13 @@ public class PersistentResourceXMLDescription {
                 throw ParseUtils.unexpectedAttribute(reader, i);
             }
         }
+        for (AttributeDefinition attributeDefinition: attributes.values()){
+            if (attributeDefinition instanceof PropertiesAttributeDefinition){
+                PropertiesAttributeDefinition attribute = (PropertiesAttributeDefinition) attributeDefinition;
+                attribute.parse(reader,op);
+                flushRequired = false;
+            }
+        }
         if (wildcard && name == null) {
             throw MESSAGES.missingRequiredAttributes(new StringBuilder(NAME), reader.getLocation());
         }
@@ -117,7 +125,9 @@ public class PersistentResourceXMLDescription {
 
     public void parseChildren(final XMLExtendedStreamReader reader, PathAddress parentAddress, List<ModelNode> list) throws XMLStreamException {
         if (children.size() == 0) {
-            ParseUtils.requireNoContent(reader);
+            if (flushRequired){
+                ParseUtils.requireNoContent(reader);
+            }
         } else {
             Map<String, PersistentResourceXMLDescription> children = getChildrenMap();
             while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {

--- a/controller/src/main/java/org/jboss/as/controller/RestartParentWriteAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/RestartParentWriteAttributeHandler.java
@@ -24,6 +24,7 @@ package org.jboss.as.controller;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import java.util.Collection;
 import java.util.NoSuchElementException;
 
 import org.jboss.as.controller.operations.common.Util;
@@ -42,6 +43,11 @@ public abstract class RestartParentWriteAttributeHandler extends AbstractWriteAt
     private final String parentKeyName;
 
     public RestartParentWriteAttributeHandler(String parentKeyName, AttributeDefinition... definitions) {
+        super(definitions);
+        this.parentKeyName = parentKeyName;
+    }
+
+    public RestartParentWriteAttributeHandler(final String parentKeyName, final Collection<AttributeDefinition> definitions) {
         super(definitions);
         this.parentKeyName = parentKeyName;
     }

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailExtension.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailExtension.java
@@ -50,7 +50,6 @@ import org.jboss.as.controller.transform.description.TransformationDescriptionBu
 public class MailExtension implements Extension {
 
     public static final String SUBSYSTEM_NAME = "mail";
-    private final MailSubsystemParser parser = new MailSubsystemParser();
     private static final String RESOURCE_NAME = MailExtension.class.getPackage().getName() + ".LocalDescriptions";
     static PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);
     static PathElement MAIL_SESSION_PATH = PathElement.pathElement(MailSubsystemModel.MAIL_SESSION);
@@ -65,12 +64,13 @@ public class MailExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_1_0.getUriString(), parser);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_1_1.getUriString(), parser);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_1_0.getUriString(), MailSubsystemParser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_1_1.getUriString(), MailSubsystemParser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.MAIL_2_0.getUriString(), MailSubsystemParser2_0.INSTANCE);
     }
 
-    private static final int MANAGEMENT_API_MAJOR_VERSION = 1;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 3;
+    private static final int MANAGEMENT_API_MAJOR_VERSION = 2;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 0;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
 
@@ -81,21 +81,11 @@ public class MailExtension implements Extension {
 
         final ManagementResourceRegistration subsystemRegistration = subsystem.registerSubsystemModel(MailSubsystemResource.INSTANCE);
         subsystemRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
-        // /subsystem=mail/mail-session
-        ManagementResourceRegistration session = subsystemRegistration.registerSubModel(MailSessionDefinition.INSTANCE);
-        // /subsystem=mail/mail-session=java:/Mail/server=imap
-        session.registerSubModel(MailServerDefinition.INSTANCE_IMAP);
-        // /subsystem=mail/mail-session=java:/Mail/server=pop3
-        session.registerSubModel(MailServerDefinition.INSTANCE_POP3);
-        // /subsystem=mail/mail-session=java:/Mail/server=smtp
-        session.registerSubModel(MailServerDefinition.INSTANCE_SMTP);
-        // /subsystem=mail/mail-session=java:/Mail/custom=*
-        session.registerSubModel(MailServerDefinition.INSTANCE_CUSTOM);
 
         if (context.isRegisterTransformers()) {
             registerTransformers(subsystem);
         }
-        subsystem.registerXMLElementWriter(parser);
+        subsystem.registerXMLElementWriter(MailSubsystemParser2_0.INSTANCE);
     }
 
     private void registerTransformers(SubsystemRegistration subsystem) {

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser2_0.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser2_0.java
@@ -1,0 +1,97 @@
+/*
+ *
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2013, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
+ */
+
+package org.jboss.as.mail.extension;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import java.util.List;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * @author Tomaz Cerar (c) 2013 Red Hat Inc.
+ */
+public class MailSubsystemParser2_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+    protected static final MailSubsystemParser2_0 INSTANCE = new MailSubsystemParser2_0();
+    private static final PersistentResourceXMLDescription xmlDescription;
+
+    static {
+        xmlDescription = builder(MailSubsystemResource.INSTANCE)
+                .addChild(
+                        builder(MailSessionDefinition.INSTANCE)
+                                .addAttributes(MailSessionDefinition.INSTANCE.getAttributes())
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_SMTP)
+                                                .addAttributes(MailServerDefinition.INSTANCE_SMTP.getAttributes())
+                                                .setXmlElementName(MailSubsystemModel.SMTP_SERVER)
+
+                                )
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_POP3)
+                                                .addAttributes(MailServerDefinition.INSTANCE_SMTP.getAttributes())
+                                                .setXmlElementName(MailSubsystemModel.POP3_SERVER)
+                                )
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_IMAP)
+                                                .addAttributes(MailServerDefinition.INSTANCE_SMTP.getAttributes())
+                                                .setXmlElementName(MailSubsystemModel.IMAP_SERVER)
+                                )
+                                .addChild(
+                                        builder(MailServerDefinition.INSTANCE_CUSTOM)
+                                                .addAttributes(MailServerDefinition.INSTANCE_CUSTOM.getAttributes())
+                                                .setXmlElementName(MailSubsystemModel.CUSTOM_SERVER)
+                                )
+                )
+                .build();
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeContent(XMLExtendedStreamWriter writer, SubsystemMarshallingContext context) throws XMLStreamException {
+        ModelNode model = new ModelNode();
+        model.get(MailSubsystemResource.INSTANCE.getPathElement().getKeyValuePair()).set(context.getModelNode());//this is bit of workaround for SPRD to work properly
+        xmlDescription.persist(writer, model, Namespace.CURRENT.getUriString());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readElement(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
+        xmlDescription.parse(reader, PathAddress.EMPTY_ADDRESS, list);
+    }
+}

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemResource.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemResource.java
@@ -22,14 +22,20 @@
 
 package org.jboss.as.mail.extension;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
-import org.jboss.as.controller.SimpleResourceDefinition;
 
 /**
  * @author Tomaz Cerar
  * @created 19.12.11 20:04
  */
-class MailSubsystemResource extends SimpleResourceDefinition {
+class MailSubsystemResource extends PersistentResourceDefinition {
     public static final MailSubsystemResource INSTANCE = new MailSubsystemResource();
 
     private MailSubsystemResource() {
@@ -37,5 +43,15 @@ class MailSubsystemResource extends SimpleResourceDefinition {
                 MailExtension.getResourceDescriptionResolver(),
                 MailSubsystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    protected List<? extends PersistentResourceDefinition> getChildren() {
+        return Arrays.asList(MailSessionDefinition.INSTANCE);
     }
 }

--- a/mail/src/main/java/org/jboss/as/mail/extension/Namespace.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/Namespace.java
@@ -33,12 +33,13 @@ enum Namespace {
     UNKNOWN(null),
 
     MAIL_1_0("urn:jboss:domain:mail:1.0"),
-    MAIL_1_1("urn:jboss:domain:mail:1.1");
+    MAIL_1_1("urn:jboss:domain:mail:1.1"),
+    MAIL_2_0("urn:jboss:domain:mail:2.0");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = MAIL_1_1;
+    public static final Namespace CURRENT = MAIL_2_0;
 
     private final String name;
 

--- a/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem10TestCase.java
+++ b/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem10TestCase.java
@@ -15,12 +15,20 @@ import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.extension.ExtensionRegistry;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.naming.service.NamingService;
+import org.jboss.as.naming.service.NamingStoreService;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.ControllerInitializer;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceTarget;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -102,6 +110,19 @@ public class MailSubsystem10TestCase extends AbstractSubsystemBaseTest {
             // and socket-binding-group stuff we depend on TODO something less hacky
             ci.addSocketBinding("make-framework-happy", 59999);
             return ci;
+        }
+
+        @Override
+        protected void addExtraServices(ServiceTarget target) {
+            super.addExtraServices(target);
+            target.addService(ContextNames.JAVA_CONTEXT_SERVICE_NAME, new NamingStoreService())
+                            .setInitialMode(ServiceController.Mode.ACTIVE)
+                            .install();
+            target.addService(ContextNames.JBOSS_CONTEXT_SERVICE_NAME, new NamingStoreService())
+                            .setInitialMode(ServiceController.Mode.ACTIVE)
+                            .install();
+
+
         }
     }
 }

--- a/mail/src/test/resources/org/jboss/as/mail/extension/subsystem_2_0.xml
+++ b/mail/src/test/resources/org/jboss/as/mail/extension/subsystem_2_0.xml
@@ -1,0 +1,48 @@
+<!--
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
+  -->
+
+<subsystem xmlns="urn:jboss:domain:mail:2.0">
+    <mail-session name="defaultMail" jndi-name="java:/Mail" from="user dot name at domain dot tld">
+        <smtp-server outbound-socket-binding-ref="mail-smtp" tls="true" username="${exp.name:nobody}" password="${exp.password:pass}" />
+        <pop3-server outbound-socket-binding-ref="mail-pop3"/>
+        <imap-server outbound-socket-binding-ref="mail-imap" username="${exp.name:nobody}" password="${exp.password:pass}" />
+    </mail-session>
+    <mail-session name="default2" debug="true" jndi-name="java:jboss/mail/Default">
+        <smtp-server outbound-socket-binding-ref="mail-smtp"/>
+    </mail-session>
+    <mail-session name="custom" debug="true" jndi-name="java:jboss/mail/Custom">
+        <custom-server name="smtp" username="username" password="password">
+            <property name="host" value="mail.example.com"/>
+        </custom-server>
+        <custom-server name="pop3" outbound-socket-binding-ref="mail-pop3">
+            <property name="custom_prop" value="some-custom-prop-value"/>
+            <property name="some.fully.qualified.property" value="fully-qualified-prop-name"/>
+        </custom-server>
+    </mail-session>
+    <mail-session name="custom2" debug="true" jndi-name="java:jboss/mail/Custom2">
+        <custom-server name="pop3" outbound-socket-binding-ref="mail-pop3">
+            <property name="custom_prop" value="some-custom-prop-value"/>
+        </custom-server>
+    </mail-session>
+</subsystem>

--- a/security/src/main/java/org/jboss/as/security/MappingModuleDefinition.java
+++ b/security/src/main/java/org/jboss/as/security/MappingModuleDefinition.java
@@ -82,7 +82,7 @@ public class MappingModuleDefinition extends SimpleResourceDefinition {
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         super.registerAttributes(resourceRegistration);
-        SecurityDomainReloadWriteHandler writeHandler = new SecurityDomainReloadWriteHandler(ATTRIBUTES);
+        SecurityDomainReloadWriteHandler writeHandler = new SecurityDomainReloadWriteHandler(getAttributes());
         for (AttributeDefinition attr : getAttributes()) {
             resourceRegistration.registerReadWriteAttribute(attr, null, writeHandler);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/EjbSecurityDomainSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/EjbSecurityDomainSetup.java
@@ -94,7 +94,6 @@ public class EjbSecurityDomainSetup extends AbstractSecurityDomainSetup {
             loginModule.get(FLAG).set("required");
             loginModule.get(Constants.MODULE_OPTIONS).add("password-stacking", "useFirstPass");
             loginModule.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
-            loginModule.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
             steps.add(loginModule);
         }
 

--- a/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ApplicationTypeTestCase.java
+++ b/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/ApplicationTypeTestCase.java
@@ -140,7 +140,7 @@ public class ApplicationTypeTestCase extends AbstractRbacTestCase {
     private void testMailSession(boolean canWrite, ModelControllerClient client) throws IOException {
         ModelNode operation = Util.createOperation(WRITE_ATTRIBUTE_OPERATION, pathAddress(
                 pathElement(SUBSYSTEM, "mail"),
-                pathElement("mail-session", "java:jboss/mail/Default")
+                pathElement("mail-session", "default")
         ));
         operation.get(NAME).set("jndi-name");
         operation.get(VALUE).set("java:jboss/mail/Default_XXX");

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
@@ -193,6 +193,7 @@ public class UndertowSubsystemParser_1_0 implements XMLStreamConstants, XMLEleme
                                 )
 
                 )
+                //todo why do we really need this?
                 .setAdditionalOperationsGenerator(new PersistentResourceXMLDescription.AdditionalOperationsGenerator() {
                     @Override
                     public void additionalOperations(final PathAddress address, final ModelNode addOperation, final List<ModelNode> operations) {


### PR DESCRIPTION
mail subsystem changes:
- new model version 2.0
- new parser version 2.0 & xsd
- better runtime operation tests
- all operations are runtime executable now
- update XSD & default confguration

WFLY-2468 MappingModuleDefinition is incorrectly constructing the write-attribute handler
