### PR TITLE
Fixed init script for Ubuntu 13.10

### DIFF
--- a/build/src/main/resources/bin/init.d/wildfly-init-debian.sh
+++ b/build/src/main/resources/bin/init.d/wildfly-init-debian.sh
@@ -48,6 +48,15 @@ if [ -n "$JAVA_HOME" ]; then
 	export JAVA_HOME
 fi
 
+# Setup the JVM
+if [ "x$JAVA" = "x" ]; then
+	if [ "x$JAVA_HOME" != "x" ]; then
+		JAVA="$JAVA_HOME/bin/java"
+	else
+		JAVA="java"
+	fi
+fi
+
 # Location of wildfly
 if [ -z "$JBOSS_HOME" ]; then
 	JBOSS_HOME=/opt/wildfly
@@ -132,7 +141,7 @@ export LAUNCH_JBOSS_IN_BACKGROUND
 
 # Helper function to check status of wildfly service
 check_status() {
-	pidofproc -p $JBOSS_PIDFILE $JAVA_HOME/bin/java >/dev/null 2>&1
+	pidofproc -p $JBOSS_PIDFILE $JAVA >/dev/null 2>&1
 }
 
 case "$1" in

--- a/build/src/main/resources/bin/init.d/wildfly-init-debian.sh
+++ b/build/src/main/resources/bin/init.d/wildfly-init-debian.sh
@@ -132,7 +132,7 @@ export LAUNCH_JBOSS_IN_BACKGROUND
 
 # Helper function to check status of wildfly service
 check_status() {
-	pidofproc -p $JBOSS_PIDFILE >/dev/null 2>&1
+	pidofproc -p $JBOSS_PIDFILE $JAVA_HOME/bin/java >/dev/null 2>&1
 }
 
 case "$1" in


### PR DESCRIPTION
In Ubuntu 13.10 they changed /lib/lsb/init-functions making /full/path/to/executable as required parameter of pidofproc. As result this init script stopped working for Ubuntu 13.10. Why did they do that? I suppose because man page for pidofproc specifies this parameter as required. Will my change affect existing distributions? I've checked init-functions for Debian Wheezy and Ubuntu 12.04, they silently ignore all parameters except pidfile. Why path to executable is java, why not $JBOSS_SCRIPT? Because man page for pidofproc says that pid should correspond to executable, and pid corresponds to java process. Although current implementation in Ubuntu 13.10 doesn't check it (indeed any additional parameter would resolve this issue). Testing done: Manually checked that after modification the init script can start and stop service in Debian Wheezy, Ubuntu 12.04, 13.10 and there're no pending abandoned wildfly processes.
