### PR TITLE
[WFLY-2444] Include filtering data in responses to wildcard requests

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -538,6 +538,11 @@ final class OperationContextImpl extends AbstractOperationContext {
         OperationId opId = new OperationId(operation);
         AuthorizationResult authResult = authorize(opId, operation, false, READ_CONFIG);
         if (authResult.getDecision() == AuthorizationResult.Decision.DENY) {
+            // See if the problem was addressability
+            AuthorizationResult addressResult = authorize(opId, operation, false, ADDRESS);
+            if (addressResult.getDecision() == AuthorizationResult.Decision.DENY) {
+                throw ControllerMessages.MESSAGES.managementResourceNotFound(activeStep.address);
+            }
             throw ControllerMessages.MESSAGES.unauthorized(activeStep.operationId.name, activeStep.address, authResult.getExplanation());
         }
         Resource model = this.model;

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadAttributeHandler.java
@@ -72,7 +72,6 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
     public static final OperationStepHandler INSTANCE = new ReadAttributeHandler();
 
     private final ParametersValidator validator = new ParametersValidator();
-    private final FilteredData filteredData;
     private final OperationStepHandler overrideHandler;
 
     public ReadAttributeHandler() {
@@ -80,15 +79,15 @@ public class ReadAttributeHandler extends GlobalOperationHandlers.AbstractMultiT
     }
 
     ReadAttributeHandler(FilteredData filteredData, OperationStepHandler overrideHandler) {
+        super(filteredData);
         validator.registerValidator(GlobalOperationAttributes.NAME.getName(), new StringLengthValidator(1));
         validator.registerValidator(GlobalOperationAttributes.INCLUDE_DEFAULTS.getName(), new ModelTypeValidator(ModelType.BOOLEAN, true));
         assert overrideHandler == null || filteredData != null : "overrideHandler only supported with filteredData";
-        this.filteredData = filteredData;
         this.overrideHandler = overrideHandler;
     }
 
     @Override
-    void doExecute(OperationContext context, ModelNode operation) throws OperationFailedException {
+    void doExecute(OperationContext context, ModelNode operation, FilteredData filteredData) throws OperationFailedException {
 
         // Add a step to authorize the attribute read once we determine the value below
         context.addStep(operation, new AuthorizeAttributeReadHandler(filteredData), OperationContext.Stage.MODEL, true);

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -115,7 +115,6 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         }
     };
 
-    private final FilteredData filteredData;
     private final OperationStepHandler overrideHandler;
 
     public ReadResourceHandler() {
@@ -123,6 +122,7 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
     }
 
     ReadResourceHandler(final FilteredData filteredData, OperationStepHandler overrideHandler) {
+        super(filteredData);
         //todo use AD for validation
         validator.registerValidator(ModelDescriptionConstants.RECURSIVE, new ModelTypeValidator(ModelType.BOOLEAN, true));
         validator.registerValidator(ModelDescriptionConstants.RECURSIVE_DEPTH, new ModelTypeValidator(ModelType.INT, true));
@@ -130,14 +130,14 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         validator.registerValidator(ModelDescriptionConstants.PROXIES, new ModelTypeValidator(ModelType.BOOLEAN, true));
         validator.registerValidator(ModelDescriptionConstants.INCLUDE_DEFAULTS, new ModelTypeValidator(ModelType.BOOLEAN, true));
         validator.registerValidator(ModelDescriptionConstants.ATTRIBUTES_ONLY, new ModelTypeValidator(ModelType.BOOLEAN, true));
-        this.filteredData = filteredData;
         this.overrideHandler = overrideHandler;
     }
 
 
 
     @Override
-    void doExecute(OperationContext context, ModelNode operation) throws OperationFailedException {
+    void doExecute(OperationContext context, ModelNode operation, FilteredData filteredData) throws OperationFailedException {
+
         if (filteredData == null) {
             doExecuteInternal(context, operation);
         } else {
@@ -191,7 +191,7 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         // Child resources recursively read
         final Map<PathElement, ModelNode> childResources = recursive ? new LinkedHashMap<PathElement, ModelNode>() : Collections.<PathElement, ModelNode>emptyMap();
 
-        final FilteredData localFilteredData = filteredData == null ? new FilteredData(address) : filteredData;
+        final FilteredData localFilteredData = getFilteredData() == null ? new FilteredData(address) : getFilteredData();
 
         // We're going to add a bunch of steps that should immediately follow this one. We are going to add them
         // in reverse order of how they should execute, as that is the way adding a Stage.IMMEDIATE step works

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/DetailedOperationsTestCase.java
@@ -113,7 +113,7 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         StandardRole role = StandardRole.MONITOR;
 
         permitted(READ_CONFIG_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_OPERATION, ACCESS_AUDIT_ADDR, role);
 
@@ -133,12 +133,12 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         denied(WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_READ_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
@@ -178,7 +178,7 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         StandardRole role = StandardRole.OPERATOR;
 
         permitted(READ_CONFIG_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_OPERATION, ACCESS_AUDIT_ADDR, role);
 
@@ -198,12 +198,12 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         denied(WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_READ_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         permitted(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
@@ -243,7 +243,7 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         StandardRole role = StandardRole.MAINTAINER;
 
         permitted(READ_CONFIG_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_OPERATION, ACCESS_AUDIT_ADDR, role);
 
@@ -263,12 +263,12 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         denied(WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_READ_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         permitted(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
@@ -308,7 +308,7 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         StandardRole role = StandardRole.DEPLOYER;
 
         permitted(READ_CONFIG_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_OPERATION, ACCESS_AUDIT_ADDR, role);
 
@@ -328,12 +328,12 @@ public class DetailedOperationsTestCase extends AbstractRbacTestBase {
         denied(WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_READ_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_READ_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 
         denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO), role);
-        denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
+        noAddress(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(SENSITIVE_CONSTRAINED_RESOURCE, FOO), role);
         permitted(READ_CONFIG_WRITE_RUNTIME_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, FOO), role);
         denied(READ_CONFIG_WRITE_RUNTIME_OPERATION, ACCESS_AUDIT_ADDR, role);
 


### PR DESCRIPTION
also... 

[WFLY-2572] OperationContext.readResourceFromRoot should throw NoSuchResourceException even when the user doesn't have 'address' perms
