### PR TITLE
Security subsystem transformer fixes

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/TransformingProxyController.java
+++ b/controller/src/main/java/org/jboss/as/controller/TransformingProxyController.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+
 import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.registry.Resource;
@@ -146,7 +148,17 @@ public interface TransformingProxyController extends ProxyController {
 
         @Override
         public OperationTransformer.TransformedOperation transformOperation(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-            return transformers.transformOperation(context, operation);
+            //Some transformers don't propagate the headers, back them up here and add them again
+            ModelNode operationHeaders = operation.hasDefined(OPERATION_HEADERS) ? operation.get(OPERATION_HEADERS) : null;
+            OperationTransformer.TransformedOperation transformed = transformers.transformOperation(context, operation);
+
+            if (operationHeaders != null) {
+                ModelNode transformedOp = transformed.getTransformedOperation();
+                if (transformedOp != null && !transformedOp.hasDefined(OPERATION_HEADERS)) {
+                    transformedOp.get(OPERATION_HEADERS).set(operationHeaders);
+                }
+            }
+            return transformed;
         }
 
         @Override

--- a/controller/src/main/java/org/jboss/as/controller/transform/description/TransformationRule.java
+++ b/controller/src/main/java/org/jboss/as/controller/transform/description/TransformationRule.java
@@ -111,10 +111,6 @@ abstract class TransformationRule {
             super(context);
         }
 
-        protected TransformationContext getContext() {
-            return super.getContext();
-        }
-
         abstract void invokeNext(Resource resource) throws OperationFailedException;
 
     }
@@ -123,6 +119,7 @@ abstract class TransformationRule {
 
         private final TransformationContext delegate;
         private volatile boolean immutable;
+
         private TransformationContextWrapper(TransformationContext delegate) {
             this.delegate = delegate;
         }
@@ -156,7 +153,7 @@ abstract class TransformationRule {
         public Resource readResource(PathAddress address) {
             Resource resource = delegate.readResource(address);
             if (resource != null) {
-                return immutable ? new ProtectedModelResource(resource) : resource;
+                return immutable ? new ProtectedModelResource<Resource>(resource) : resource;
             }
             return null;
         }
@@ -165,7 +162,7 @@ abstract class TransformationRule {
         public Resource readResourceFromRoot(PathAddress address) {
             Resource resource = delegate.readResourceFromRoot(address);
             if (resource != null) {
-                return immutable ? new ProtectedModelResource(resource) : resource;
+                return immutable ? new ProtectedModelResource<Resource>(resource) : resource;
             }
             return null;
         }
@@ -253,11 +250,11 @@ abstract class TransformationRule {
    /**
     *  Implementation of resource that returns an unmodifiable model
     */
-   private static class ProtectedModelResource implements Resource {
+   private static class ProtectedModelResource<T extends Resource> implements Resource {
 
-       private Resource delegate;
+       protected T delegate;
 
-       ProtectedModelResource(Resource delegate){
+       ProtectedModelResource(T delegate){
            this.delegate = delegate;
        }
 
@@ -285,7 +282,7 @@ abstract class TransformationRule {
        public Resource getChild(PathElement element) {
            Resource resource = delegate.getChild(element);
            if (resource != null) {
-               return new ProtectedModelResource(resource);
+               return new ProtectedModelResource<Resource>(resource);
            }
            return null;
        }
@@ -294,7 +291,7 @@ abstract class TransformationRule {
        public Resource requireChild(PathElement element) {
            Resource resource = delegate.requireChild(element);
            if (resource != null) {
-               return new ProtectedModelResource(resource);
+               return new ProtectedModelResource<Resource>(resource);
            }
            return null;
        }
@@ -308,7 +305,7 @@ abstract class TransformationRule {
        public Resource navigate(PathAddress address) {
            Resource resource = delegate.navigate(address);
            if (resource != null) {
-               return new ProtectedModelResource(resource);
+               return new ProtectedModelResource<Resource>(resource);
            }
            return null;
        }
@@ -331,6 +328,7 @@ abstract class TransformationRule {
                for (ResourceEntry entry : children) {
                    protectedChildren.add(new ProtectedModelResourceEntry(entry));
                }
+               return protectedChildren;
            }
            return null;
        }
@@ -356,13 +354,12 @@ abstract class TransformationRule {
        }
 
        public Resource clone() {
-           return new ProtectedModelResource(delegate.clone());
+           return new ProtectedModelResource<Resource>(delegate.clone());
        }
    }
 
 
-    private static class ProtectedModelResourceEntry extends ProtectedModelResource implements ResourceEntry {
-        ResourceEntry delegate;
+    private static class ProtectedModelResourceEntry extends ProtectedModelResource<ResourceEntry> implements ResourceEntry {
 
         ProtectedModelResourceEntry(ResourceEntry delegate){
             super(delegate);

--- a/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/OperationTransformationTestCase.java
@@ -386,7 +386,6 @@ public class OperationTransformationTestCase {
         public boolean isSkipRuntimeIgnoreCheck() {
             return false;
         }
-
     }
 
 }

--- a/security/src/main/java/org/jboss/as/security/LegacySupport.java
+++ b/security/src/main/java/org/jboss/as/security/LegacySupport.java
@@ -423,16 +423,19 @@ class LegacySupport {
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
             Resource existing = context.readResource(PathAddress.EMPTY_ADDRESS);
             OperationStepHandler addHandler = context.getResourceRegistration().getSubModel(PathAddress.EMPTY_ADDRESS.append(newKeyName)).getOperationHandler(PathAddress.EMPTY_ADDRESS, "add");
-            List<ModelNode> modules = new ArrayList<ModelNode>(operation.get(VALUE).asList());
-            Collections.reverse(modules); //need to reverse it to make sure they are added in proper order
-            for (ModelNode module : modules) {
-                ModelNode addModuleOp = module.clone();
-                String code = addModuleOp.get(Constants.CODE).asString();
-                PathElement relativePath = PathElement.pathElement(newKeyName, code);
-                PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR)).append(relativePath);
-                addModuleOp.get(OP_ADDR).set(address.toModelNode());
-                addModuleOp.get(OP).set(ADD);
-                context.addStep(new ModelNode(), addModuleOp, addHandler, OperationContext.Stage.MODEL, true);
+            ModelNode value = operation.get(VALUE);
+            if (value.isDefined()) {
+                List<ModelNode> modules = new ArrayList<ModelNode>(value.asList());
+                Collections.reverse(modules); //need to reverse it to make sure they are added in proper order
+                for (ModelNode module : modules) {
+                    ModelNode addModuleOp = module.clone();
+                    String code = addModuleOp.get(Constants.CODE).asString();
+                    PathElement relativePath = PathElement.pathElement(newKeyName, code);
+                    PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR)).append(relativePath);
+                    addModuleOp.get(OP_ADDR).set(address.toModelNode());
+                    addModuleOp.get(OP).set(ADD);
+                    context.addStep(new ModelNode(), addModuleOp, addHandler, OperationContext.Stage.MODEL, true);
+                }
             }
             //remove on the end to make sure it is executed first
             for (Resource.ResourceEntry entry : existing.getChildren(newKeyName)) {

--- a/security/src/main/java/org/jboss/as/security/SecurityExtension.java
+++ b/security/src/main/java/org/jboss/as/security/SecurityExtension.java
@@ -174,6 +174,9 @@ public class SecurityExtension implements Extension {
         registerModuleTransformer(securityDomain, PATH_AUDIT_CLASSIC, providerModule);
         final ModulesToAttributeTransformer identityTrustModule = new ModulesToAttributeTransformer(Constants.TRUST_MODULE, Constants.TRUST_MODULES);
         registerModuleTransformer(securityDomain, PATH_IDENTITY_TRUST_CLASSIC, identityTrustModule);
+        final ModulesToAttributeTransformer aclModule = new ModulesToAttributeTransformer(Constants.ACL_MODULE, Constants.ACL_MODULES);
+        registerModuleTransformer(securityDomain, ACL_PATH, aclModule);
+
         final ModulesToAttributeTransformer authModule = new ModulesToAttributeTransformer(Constants.AUTH_MODULE, Constants.AUTH_MODULES);
         ResourceTransformationDescriptionBuilder jaspiReg = registerModuleTransformer(securityDomain, PATH_JASPI_AUTH, authModule);
 
@@ -210,6 +213,10 @@ public class SecurityExtension implements Extension {
         registerModuleTransformer(securityDomain, PATH_AUDIT_CLASSIC, providerModule);
         final AttributeToModulesTransformer identityTrustModule = new AttributeToModulesTransformer(Constants.TRUST_MODULES);
         registerModuleTransformer(securityDomain, PATH_IDENTITY_TRUST_CLASSIC, identityTrustModule);
+        final AttributeToModulesTransformer aclModule = new AttributeToModulesTransformer(Constants.ACL_MODULES);
+        ResourceTransformationDescriptionBuilder aclBuilder = registerModuleTransformer(securityDomain, ACL_PATH, aclModule);
+        //https://issues.jboss.org/browse/WFLY-2474 acl-module was wrongly called login-module in 7.2.0
+        aclBuilder.addChildRedirection(PathElement.pathElement(Constants.ACL_MODULE), PathElement.pathElement(Constants.LOGIN_MODULE));
 
         AttributeToModulesTransformer authModule = new AttributeToModulesTransformer(Constants.AUTH_MODULES);
         ResourceTransformationDescriptionBuilder jaspiReg = registerModuleTransformer(securityDomain, PATH_JASPI_AUTH, authModule);

--- a/security/src/main/java/org/jboss/as/security/SecurityExtension.java
+++ b/security/src/main/java/org/jboss/as/security/SecurityExtension.java
@@ -85,6 +85,7 @@ public class SecurityExtension implements Extension {
 
     private static final SecuritySubsystemParser PARSER = SecuritySubsystemParser.getInstance();
     static final PathElement ACL_PATH = PathElement.pathElement(Constants.ACL, Constants.CLASSIC);
+    static final PathElement PATH_IDENTITY_TRUST_CLASSIC = PathElement.pathElement(Constants.IDENTITY_TRUST, Constants.CLASSIC);
     static final PathElement PATH_JASPI_AUTH = PathElement.pathElement(Constants.AUTHENTICATION, Constants.JASPI);
     static final PathElement PATH_CLASSIC_AUTHENTICATION = PathElement.pathElement(Constants.AUTHENTICATION, Constants.CLASSIC);
     static final PathElement SECURITY_DOMAIN_PATH = PathElement.pathElement(Constants.SECURITY_DOMAIN);
@@ -171,6 +172,8 @@ public class SecurityExtension implements Extension {
         registerModuleTransformer(securityDomain, PATH_MAPPING_CLASSIC, mappingModule);
         final ModulesToAttributeTransformer providerModule = new ModulesToAttributeTransformer(Constants.PROVIDER_MODULE, Constants.PROVIDER_MODULES);
         registerModuleTransformer(securityDomain, PATH_AUDIT_CLASSIC, providerModule);
+        final ModulesToAttributeTransformer identityTrustModule = new ModulesToAttributeTransformer(Constants.TRUST_MODULE, Constants.TRUST_MODULES);
+        registerModuleTransformer(securityDomain, PATH_IDENTITY_TRUST_CLASSIC, identityTrustModule);
         final ModulesToAttributeTransformer authModule = new ModulesToAttributeTransformer(Constants.AUTH_MODULE, Constants.AUTH_MODULES);
         ResourceTransformationDescriptionBuilder jaspiReg = registerModuleTransformer(securityDomain, PATH_JASPI_AUTH, authModule);
 
@@ -205,6 +208,9 @@ public class SecurityExtension implements Extension {
         registerModuleTransformer(securityDomain, PATH_MAPPING_CLASSIC, mappingModule);
         AttributeToModulesTransformer providerModule = new AttributeToModulesTransformer(Constants.PROVIDER_MODULES);
         registerModuleTransformer(securityDomain, PATH_AUDIT_CLASSIC, providerModule);
+        final AttributeToModulesTransformer identityTrustModule = new AttributeToModulesTransformer(Constants.TRUST_MODULES);
+        registerModuleTransformer(securityDomain, PATH_IDENTITY_TRUST_CLASSIC, identityTrustModule);
+
         AttributeToModulesTransformer authModule = new AttributeToModulesTransformer(Constants.AUTH_MODULES);
         ResourceTransformationDescriptionBuilder jaspiReg = registerModuleTransformer(securityDomain, PATH_JASPI_AUTH, authModule);
 

--- a/security/src/main/java/org/jboss/as/security/SecuritySubsystemParser.java
+++ b/security/src/main/java/org/jboss/as/security/SecuritySubsystemParser.java
@@ -297,7 +297,7 @@ public class SecuritySubsystemParser implements XMLStreamConstants, XMLElementRe
     private void writeIdentityTrust(XMLExtendedStreamWriter writer, ModelNode modelNode) throws XMLStreamException {
         if (modelNode.isDefined() && modelNode.asInt() > 0) {
             writer.writeStartElement(Element.IDENTITY_TRUST.getLocalName());
-            writeLoginModule(writer, modelNode, Constants.TRUST_MODULE);
+            writeLoginModule(writer, modelNode, Constants.TRUST_MODULE, Element.TRUST_MODULE.getLocalName());
             writer.writeEndElement();
         }
     }

--- a/security/src/main/java/org/jboss/as/security/SecuritySubsystemParser.java
+++ b/security/src/main/java/org/jboss/as/security/SecuritySubsystemParser.java
@@ -65,6 +65,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
@@ -281,7 +282,7 @@ public class SecuritySubsystemParser implements XMLStreamConstants, XMLElementRe
     private void writeACL(XMLExtendedStreamWriter writer, ModelNode modelNode) throws XMLStreamException {
         if (modelNode.isDefined() && modelNode.asInt() > 0) {
             writer.writeStartElement(Element.ACL.getLocalName());
-            writeLoginModule(writer, modelNode, Constants.ACL_MODULE);
+            writeLoginModule(writer, modelNode, Constants.ACL_MODULE, Element.ACL_MODULE.getLocalName());
             writer.writeEndElement();
         }
     }

--- a/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
+++ b/security/src/main/resources/org/jboss/as/security/LocalDescriptions.properties
@@ -129,6 +129,7 @@ vault.vault-options=Security Vault options.
 policy-module=Policy module
 auth-module=Auth module
 login-module=Login module
+acl-module=ACL module
 mapping-module=List of modules that map principal, role, and credential information
 mapping-module.add=Adds a mapping configuration.
 mapping-module.remove=Removes a mapping configuration.

--- a/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
+++ b/security/src/test/java/org/jboss/as/security/SecurityDomainModelv12UnitTestCase.java
@@ -23,9 +23,13 @@
  */
 package org.jboss.as.security;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -36,7 +40,10 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.ReadResourceHandler;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
+import org.jboss.as.model.test.FailedOperationTransformationConfig.ChainedConfig;
+import org.jboss.as.model.test.FailedOperationTransformationConfig.NewAttributesConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.RejectExpressionsConfig;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
@@ -47,7 +54,10 @@ import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -56,6 +66,28 @@ import org.junit.Test;
  * </p>
  */
 public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTest {
+
+    private static String oldConfig;
+    @BeforeClass
+    public static void beforeClass() {
+        try {
+            File target = new File(SecurityDomainModelv11UnitTestCase.class.getProtectionDomain().getCodeSource().getLocation().toURI()).getParentFile();
+            File config = new File(target, "config");
+            config.mkdir();
+            oldConfig = System.setProperty("jboss.server.config.dir", config.getAbsolutePath());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        if (oldConfig != null) {
+            System.setProperty("jboss.server.config.dir", oldConfig);
+        } else {
+            System.clearProperty("jboss.server.config.dir");
+        }
+    }
 
     public SecurityDomainModelv12UnitTestCase() {
         super(SecurityExtension.SUBSYSTEM_NAME, new SecurityExtension());
@@ -139,17 +171,13 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
 
         builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-security:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, null)
                 .dontPersistXml();
 
         KernelServices mainServices = builder.build();
         Assert.assertTrue(mainServices.isSuccessfulBoot());
         Assert.assertTrue(mainServices.getLegacyServices(modelVersion).isSuccessfulBoot());
-//        ModelTestUtils.checkFailedTransformedBootOperations(
-//                mainServices,
-//                modelVersion,
-//                builder.parseXml(readResource("transformers.xml")),
-//                new FailedOperationTransformationConfig()
-//        );
+
         checkSubsystemModelTransformation(mainServices, modelVersion, new ModelFixer() {
             @Override
             public ModelNode fixModel(ModelNode modelNode) {
@@ -197,8 +225,8 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
                 //Here we should really use the main subsystem xml, but since the operation transformers read from the model,
                 //to create the composite add the framework needs beefing up to be able to correct the model as part of try/fail loop
                 //TODO use a custom RejectExpressionsConfig for that?
-                builder.parseXml(readResource("transformers.xml")),
-                getConfig_1_1_0()
+                builder.parseXml(readResource("securitysubsystemv12.xml")),
+                getConfig_1_1_0(mainServices)
         );
 
     }
@@ -208,7 +236,6 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource("transformers-noexpressions.xml");
 
-        //which is why we need to include the jboss-as-controller artifact.
         builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
                 .addMavenResourceURL("org.jboss.as:jboss-as-security:" + controllerVersion.getMavenGavVersion())
                 .dontPersistXml()
@@ -232,6 +259,10 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
             if (securityDomain.hasDefined(Constants.AUDIT)) {
                 securityDomain.get(Constants.AUDIT).require(Constants.CLASSIC);
                 testAddAndRemove_1_1_0(mainServices, version, mainModel, getSecurityDomainAddress(domainName).append(PathElement.pathElement(Constants.AUDIT, Constants.CLASSIC)), Constants.PROVIDER_MODULES, Constants.PROVIDER_MODULE);
+            }
+            if (securityDomain.hasDefined(Constants.ACL)) {
+                securityDomain.get(Constants.ACL).require(Constants.CLASSIC);
+                testAddAndRemove_1_1_0(mainServices, version, mainModel, getSecurityDomainAddress(domainName).append(PathElement.pathElement(Constants.ACL, Constants.CLASSIC)), Constants.ACL_MODULES, Constants.ACL_MODULE);
             }
             if (securityDomain.hasDefined(Constants.AUTHENTICATION))
             {
@@ -259,6 +290,8 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
                 testAddAndRemove_1_1_0(mainServices, version, mainModel, getSecurityDomainAddress(domainName).append(PathElement.pathElement(Constants.MAPPING, Constants.CLASSIC)), Constants.MAPPING_MODULES, Constants.MAPPING_MODULE);
             }
         }
+
+        testAddAndRemoveJaspi_1_1(mainServices, version);
     }
 
 
@@ -271,7 +304,6 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         final List<ModelNode> originalAttribute = getLegacyAttribute(legacyServices, parentAddress, attributeName);
         Assert.assertEquals(originalKeys.size(), originalAttribute.size());
 
-        // TODO Check that the attributes are similar
         checkSimilarEntries(originalAttribute, parentModel.get(resourceType));
 
         ModelNode add = Util.createAddOperation(parentAddress.append(PathElement.pathElement(resourceType, "new-added-by-test")));
@@ -283,16 +315,14 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         add.get("module-options", "password-stacking").set("useFirstPass");
 
         //We need to execute on the main server since its child resources will get used for the legacy service
-        ModelTestUtils.checkOutcome(mainServices.executeOperation(add));
-        ModelTestUtils.checkOutcome(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, add)));
+        executeOpsInBothControllers(mainServices, modelVersion, add);
 
         List<ModelNode> attributes = getLegacyAttribute(legacyServices, parentAddress, attributeName);
         Assert.assertEquals(originalKeys.size() + 1, attributes.size());
 
         //Remove the added attribute
         final ModelNode removeAdded = Util.createRemoveOperation(parentAddress.append(PathElement.pathElement(resourceType, "new-added-by-test")));
-        ModelTestUtils.checkOutcome(mainServices.executeOperation(removeAdded));
-        ModelTestUtils.checkOutcome(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, removeAdded)));
+        executeOpsInBothControllers(mainServices, modelVersion, removeAdded);
         attributes = getLegacyAttribute(legacyServices, parentAddress, attributeName);
         Assert.assertEquals(originalKeys.size(), attributes.size());
         checkSimilarEntries(attributes, parentModel.get(resourceType));
@@ -301,17 +331,285 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         int i = originalKeys.size();
         for (String childName : originalKeys) {
 
-            if (i-- == 1) {
-                //TODO Without this break there, a remove of the last xxx-module resource becomes a remove of the parent so we get failures
-                //when calling getLegacyAttribute() since the resource has been removed.
-                break;
-            }
-
             final ModelNode remove = Util.createRemoveOperation(parentAddress.append(PathElement.pathElement(resourceType, childName)));
             ModelTestUtils.checkOutcome(mainServices.executeOperation(remove));
             ModelTestUtils.checkOutcome(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, remove)));
-            attributes = getLegacyAttribute(legacyServices, parentAddress, attributeName);
-            Assert.assertEquals(i, attributes.size());
+            if (--i > 0) {
+                //There are still xxx-module so we work fine
+                legacyServices.executeForResult(Util.createOperation(ReadResourceHandler.DEFINITION, parentAddress));
+                attributes = getLegacyAttribute(legacyServices, parentAddress, attributeName);
+                Assert.assertEquals(i, attributes.size());
+            } else {
+                //Here the read-resource should fail since the resource no longer exists, removal of
+                //the last xxx-module resource becomes a remove of the parent
+                legacyServices.executeForFailure(Util.createOperation(ReadResourceHandler.DEFINITION, parentAddress));
+                //Remove the main resource
+                ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createRemoveOperation(parentAddress)));
+
+            }
+        }
+
+        //Now that the resource is removed try to add it again, we will also need to add it to the main services since the
+        //transformers use the model to decide what is sent across to the legacy controller
+        ModelNode addResource = parentModel.clone();
+
+        addResource.remove(resourceType);
+        addResource.get(OP).set(ADD);
+        addResource.get(OP_ADDR).set(parentAddress.toModelNode());
+
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(addResource));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, addResource)));
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, parentAddress));
+
+        //Remove the parent resource
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(parentAddress));
+
+        //Do the add again in the different way
+        addResource = parentModel.clone();
+        addResource.remove(attributeName);
+        List<Property> children = parentModel.clone().remove(resourceType).asPropertyList();
+        addResource.get(OP).set(ADD);
+        addResource.get(OP_ADDR).set(parentAddress.toModelNode());
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(addResource));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, addResource)));
+        for (Property childProp : children) {
+            ModelNode addChild = Util.createAddOperation(parentAddress.append(resourceType, childProp.getName()));
+            for (String key : childProp.getValue().keys()) {
+                addChild.get(key).set(childProp.getValue().get(key));
+            }
+            executeOpsInBothControllers(mainServices, modelVersion, addChild);
+        }
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, parentAddress));
+        attributes = getLegacyAttribute(legacyServices, parentAddress, attributeName);
+        Assert.assertEquals(originalKeys.size(), attributes.size());
+        checkSimilarEntries(attributes, parentModel.get(resourceType));
+
+
+        //Remove the parent resource
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(parentAddress));
+    }
+
+    private void testAddAndRemoveJaspi_1_1(KernelServices mainServices, ModelVersion modelVersion) throws Exception {
+        //Create the operations we will need a bit later - the 'jaspi-test' security domain should still be hanging round
+        final PathAddress securityDomainAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, SecurityExtension.SUBSYSTEM_NAME),
+                PathElement.pathElement(Constants.SECURITY_DOMAIN, "jaspi-test"));
+        final PathAddress jaspiAuth = securityDomainAddress.append(SecurityExtension.PATH_JASPI_AUTH);
+        final ModelNode addJaspiAuth = Util.createAddOperation(jaspiAuth);
+        addJaspiAuth.protect();
+
+        final PathAddress authModule = jaspiAuth.append(Constants.AUTH_MODULE, "org.jboss.Blah");
+        final ModelNode addAuthModule = Util.createAddOperation(authModule);
+        addAuthModule.get(Constants.CODE).set("org.jboss.Blah");
+        addAuthModule.get(Constants.FLAG).set("optional");
+        addAuthModule.protect();
+
+        final PathAddress loginModuleStack = jaspiAuth.append(Constants.LOGIN_MODULE_STACK, "test");
+        final ModelNode addLoginModuleStack = Util.createAddOperation(loginModuleStack);
+        addLoginModuleStack.protect();
+
+        final PathAddress loginModuleStackModule = loginModuleStack.append(Constants.LOGIN_MODULE, "UserRoles");
+        final ModelNode addLoginModuleStackModule = Util.createAddOperation(loginModuleStackModule);
+        addLoginModuleStackModule.get(Constants.CODE).set("UserRoles");
+        addLoginModuleStackModule.get(Constants.FLAG).set("required");
+        addLoginModuleStackModule.get(Constants.MODULE_OPTIONS).add("usersProperties", "testA");
+        addLoginModuleStackModule.get(Constants.MODULE_OPTIONS).add("rolesProperties", "testB");
+        addLoginModuleStackModule.protect();
+
+        //Try to add jaspi resources in the 'wrong' order which breaks the plain ModulesToAttributeTransformer  - this is the same order as the reject test has
+        executeOpsInBothControllers(mainServices, modelVersion, addJaspiAuth, addLoginModuleStack, addLoginModuleStackModule, addAuthModule);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+
+        //Do a remove by deleting the last child resources
+        //Remove the only jaspi login module - this should remove it in the legacy controller
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(loginModuleStackModule));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+        //Remove the only auth module - this should remove it in the legacy controller
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(authModule));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth))));
+        //Clean up the remaining stuff in the main controller
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createRemoveOperation(jaspiAuth)));
+
+        //Now add them in the 'right' order
+        executeOpsInBothControllers(mainServices, modelVersion, addJaspiAuth, addAuthModule, addLoginModuleStack, addLoginModuleStackModule);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+
+        //Remove the jaspi parent resource
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(jaspiAuth));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth))));
+
+        //Add them using the collapsed form
+        final ModelNode addJaspiAuthCollapsed = addJaspiAuth.clone();
+        ModelNode modules = new ModelNode();
+        modules.get(Constants.CODE).set("org.jboss.Blah");
+        modules.get(Constants.FLAG).set("optional");
+        addJaspiAuthCollapsed.get(Constants.AUTH_MODULES).add(modules);
+        addJaspiAuthCollapsed.protect();
+
+        final ModelNode addLoginStackCollapsed = addLoginModuleStack.clone();
+        modules = new ModelNode();
+        modules.get(Constants.CODE).set("UserRoles");
+        modules.get(Constants.FLAG).set("required");
+        modules.get(Constants.MODULE_OPTIONS).add("usersProperties", "testA");
+        modules.get(Constants.MODULE_OPTIONS).add("rolesProperties", "testB");
+        addLoginStackCollapsed.get(Constants.LOGIN_MODULES).add(modules);
+        addLoginStackCollapsed.protect();
+
+        executeOpsInBothControllers(mainServices, modelVersion, addJaspiAuthCollapsed, addLoginStackCollapsed);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+
+        //Add some more modules
+        final PathAddress authModule2 = jaspiAuth.append(Constants.AUTH_MODULE, "X");
+        final ModelNode addAuthModule2 = Util.createAddOperation(authModule2);
+        addAuthModule2.get(Constants.CODE).set("X");
+        addAuthModule2.get(Constants.FLAG).set("optional");
+        addAuthModule2.protect();
+        executeOpsInBothControllers(mainServices, modelVersion, addAuthModule2);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+        final PathAddress loginModuleStackModule2 = loginModuleStack.append(Constants.LOGIN_MODULE, "UserRoles2");
+        final ModelNode addLoginModuleStackModule2 = Util.createAddOperation(loginModuleStackModule2);
+        addLoginModuleStackModule2.get(Constants.CODE).set("UserRoles2");
+        addLoginModuleStackModule2.get(Constants.FLAG).set("required");
+        addLoginModuleStackModule2.get(Constants.MODULE_OPTIONS).add("usersProperties", "testA");
+        addLoginModuleStackModule2.get(Constants.MODULE_OPTIONS).add("rolesProperties", "testB");
+        addLoginModuleStackModule2.protect();
+        executeOpsInBothControllers(mainServices, modelVersion, addLoginModuleStackModule2);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+        //Now remove all the modules to see if this can work
+        //TODO - not sure how to solve the following:
+        //Removing the last module removes the parent resource in the legacy model. This is fine if you first remove all
+        //the login-modules which removes the stack (which is a child of authentication=jaspi) and then all auth-modules,
+        //which removes authentication=jaspi element. However, doing this the other way round will not work as expected,
+        //if you remove all auth-modules, authentication=jaspi will disappear taking withit all login module stacks and children
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(loginModuleStackModule));
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(loginModuleStackModule2));
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(authModule));
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+
+        executeOpsInBothControllers(mainServices, modelVersion, Util.createRemoveOperation(authModule2));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth))));
+
+        //cleanup the empty resources in the main controller
+        mainServices.executeOperation(Util.createRemoveOperation(loginModuleStack));
+        mainServices.executeOperation(Util.createRemoveOperation(jaspiAuth));
+
+
+        //Now add empty ones and use write-attribute to set the modules via the alias, and make sure this shows up in the legacy controller
+        executeOpsInBothControllers(mainServices, modelVersion, addJaspiAuth, addLoginModuleStack);
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth))));
+
+        //First do write-attribute in the 'right' order
+        modules = new ModelNode();
+        modules.get(Constants.CODE).set("org.jboss.Blah");
+        modules.get(Constants.FLAG).set("optional");
+        ModelNode temp = modules.clone();
+        modules.clear().add(temp.clone());
+        final ModelNode writeJaspiAuthAuthModules = Util.getWriteAttributeOperation(jaspiAuth, Constants.AUTH_MODULES, modules);
+        writeJaspiAuthAuthModules.protect();
+        executeOpsInBothControllers(mainServices, modelVersion, writeJaspiAuthAuthModules);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+
+        modules = new ModelNode();
+        modules.get(Constants.CODE).set("UserRoles");
+        modules.get(Constants.FLAG).set("required");
+        modules.get(Constants.MODULE_OPTIONS).add("usersProperties", "testA");
+        modules.get(Constants.MODULE_OPTIONS).add("rolesProperties", "testB");
+        temp = modules.clone();
+        modules.clear().add(temp.clone());
+        final ModelNode writeLoginModuleStackModules = Util.getWriteAttributeOperation(loginModuleStack, Constants.LOGIN_MODULES, modules);
+        writeLoginModuleStackModules.protect();
+        executeOpsInBothControllers(mainServices, modelVersion, writeLoginModuleStackModules);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+
+        //Add another one to each
+        final ModelNode writeJaspiAuthAuthModules2 = writeJaspiAuthAuthModules.clone();
+        modules = new ModelNode();
+        modules.get(Constants.CODE).set("org.jboss.Blah2");
+        modules.get(Constants.FLAG).set("optional");
+        writeJaspiAuthAuthModules2.get(Constants.VALUE).add(modules);
+        executeOpsInBothControllers(mainServices, modelVersion, writeJaspiAuthAuthModules2);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        final ModelNode writeLoginModuleStackModules2 = writeLoginModuleStackModules.clone();
+        modules = new ModelNode();
+        modules.get(Constants.CODE).set("UserRoles");
+        modules.get(Constants.FLAG).set("required");
+        modules.get(Constants.MODULE_OPTIONS).add("usersProperties", "testA");
+        modules.get(Constants.MODULE_OPTIONS).add("rolesProperties", "testB");
+        writeJaspiAuthAuthModules2.get(Constants.VALUE).add(modules);
+        executeOpsInBothControllers(mainServices, modelVersion, writeLoginModuleStackModules2);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+
+        //Remove by undefining the attribute
+        executeOpsInBothControllers(mainServices, modelVersion, Util.getUndefineAttributeOperation(loginModuleStack, Constants.LOGIN_MODULES));
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+        executeOpsInBothControllers(mainServices, modelVersion, Util.getUndefineAttributeOperation(jaspiAuth, Constants.AUTH_MODULES));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth))));
+
+        //cleanup the empty resources in the main controller
+        mainServices.executeOperation(Util.createRemoveOperation(loginModuleStack));
+        mainServices.executeOperation(Util.createRemoveOperation(jaspiAuth));
+
+        //Now add empty ones and do write-attribute in 'wrong' order
+        executeOpsInBothControllers(mainServices, modelVersion, addJaspiAuth, addLoginModuleStack);
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth))));
+        executeOpsInBothControllers(mainServices, modelVersion, writeLoginModuleStackModules);
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+        executeOpsInBothControllers(mainServices, modelVersion, writeJaspiAuthAuthModules);
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        compareModules(mainServices, modelVersion, loginModuleStack, Constants.LOGIN_MODULES, Constants.LOGIN_MODULE);
+
+        //Remove by writing an undefined attribute
+        executeOpsInBothControllers(mainServices, modelVersion, Util.getWriteAttributeOperation(loginModuleStack, Constants.LOGIN_MODULES, new ModelNode()));
+        compareModules(mainServices, modelVersion, jaspiAuth, Constants.AUTH_MODULES, Constants.AUTH_MODULE);
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, loginModuleStack))));
+        executeOpsInBothControllers(mainServices, modelVersion, Util.getWriteAttributeOperation(jaspiAuth, Constants.AUTH_MODULES, new ModelNode()));
+        ModelTestUtils.checkOutcome(mainServices.executeOperation(Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth)));
+        ModelTestUtils.checkFailed(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, Util.createOperation(ReadResourceHandler.DEFINITION, jaspiAuth))));
+
+        //cleanup the empty resources in the main controller
+        mainServices.executeOperation(Util.createRemoveOperation(loginModuleStack));
+        mainServices.executeOperation(Util.createRemoveOperation(jaspiAuth));
+    }
+
+    private void compareModules(KernelServices mainServices, ModelVersion modelVersion, PathAddress address, String attrName, String resourceType) throws Exception {
+        ModelNode parentModel = ModelTestUtils.getSubModel(mainServices.readWholeModel(false), address);
+        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
+        ModelNode attributes = ModelTestUtils.getSubModel(legacyServices.readWholeModel(), address);
+        checkSimilarEntries(attributes.get(attrName).asList(), parentModel.get(resourceType));
+    }
+
+    private void executeOpsInBothControllers(KernelServices mainServices, ModelVersion modelVersion, ModelNode...ops) throws Exception{
+        for (ModelNode op : ops) {
+            ModelTestUtils.checkOutcome(mainServices.executeOperation(op.clone()));
+            ModelTestUtils.checkOutcome(mainServices.executeOperation(modelVersion, mainServices.transformOperation(modelVersion, op.clone())));
         }
     }
 
@@ -320,7 +618,7 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         for (ModelNode attr : attributes) {
             String code = attr.get(Constants.CODE).asString();
             ModelNode resource = parentResource.get(code);
-            Assert.assertEquals(attr, resource);
+            ModelTestUtils.compare(attr, resource, true);
         }
     }
 
@@ -345,14 +643,91 @@ public class SecurityDomainModelv12UnitTestCase extends AbstractSubsystemBaseTes
         return add;
     }
 
-    private FailedOperationTransformationConfig getConfig_1_1_0() {
+    private FailedOperationTransformationConfig getConfig_1_1_0(KernelServices mainServices) {
         PathAddress subsystemAddress = PathAddress.pathAddress(SecurityExtension.PATH_SUBSYSTEM);
         PathAddress securityDomain = subsystemAddress.append(SecurityExtension.SECURITY_DOMAIN_PATH);
-        return new FailedOperationTransformationConfig()
-                .addFailedAttribute(subsystemAddress, new RejectExpressionsConfig(SecuritySubsystemRootResourceDefinition.DEEP_COPY_SUBJECT_MODE))
-                .addFailedAttribute(securityDomain, new RejectExpressionsConfig(SecurityDomainResourceDefinition.CACHE_TYPE))
-                .addFailedAttribute(securityDomain.append(SecurityExtension.JSSE_PATH), new RejectExpressionsConfig(JSSEResourceDefinition.ADDITIONAL_PROPERTIES))
-                .addFailedAttribute(subsystemAddress.append(SecurityExtension.VAULT_PATH), new RejectExpressionsConfig(VaultResourceDefinition.OPTIONS))
-                ;
+        PathAddress securityDomainOther = subsystemAddress.append(PathElement.pathElement(SecurityExtension.SECURITY_DOMAIN_PATH.getKey(), "other"));
+
+        FailedOperationTransformationConfig config = new FailedOperationTransformationConfig();
+
+        config.addFailedAttribute(subsystemAddress, new RejectExpressionsConfig(SecuritySubsystemRootResourceDefinition.DEEP_COPY_SUBJECT_MODE));
+        config.addFailedAttribute(securityDomain, new RejectExpressionsConfig(SecurityDomainResourceDefinition.CACHE_TYPE));
+        config.addFailedAttribute(securityDomainOther.append(SecurityExtension.JSSE_PATH), new RejectExpressionsConfig(JSSEResourceDefinition.ADDITIONAL_PROPERTIES));
+        config.addFailedAttribute(subsystemAddress.append(SecurityExtension.VAULT_PATH), new RejectExpressionsConfig(VaultResourceDefinition.OPTIONS));
+
+        PathAddress securityDomainOtherClassicAuthentication = securityDomainOther.append(SecurityExtension.PATH_CLASSIC_AUTHENTICATION);
+
+        PathAddress securityDomainOtherClassicAuthenticationLoginRemoting = securityDomainOtherClassicAuthentication.append(PathElement.pathElement(Constants.LOGIN_MODULE, "Remoting"));
+        config.addFailedAttribute(securityDomainOtherClassicAuthenticationLoginRemoting,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherClassicAuthenticationLoginRemoting, Constants.FLAG, Constants.MODULE_OPTIONS));
+
+        PathAddress securityDomainOtherJaspiAuthentication = securityDomainOtherClassicAuthentication.append(PathElement.pathElement(Constants.LOGIN_MODULE, "lm"));
+        config.addFailedAttribute(securityDomainOtherJaspiAuthentication,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherJaspiAuthentication, Constants.FLAG, Constants.MODULE_OPTIONS));
+
+        PathAddress securityDomainOtherClassicAuthenticationLoginRealmUsersRoles = securityDomainOtherClassicAuthentication.append(PathElement.pathElement(Constants.LOGIN_MODULE, "RealmUsersRoles"));
+        config.addFailedAttribute(securityDomainOtherClassicAuthenticationLoginRealmUsersRoles,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherClassicAuthenticationLoginRealmUsersRoles, Constants.MODULE_OPTIONS));
+
+        PathAddress securityDomainOtherClassicAuthorizationPolicyDenyAll = securityDomainOther.append(SecurityExtension.PATH_AUTHORIZATION_CLASSIC, PathElement.pathElement(Constants.POLICY_MODULE, "DenyAll"));
+        config.addFailedAttribute(securityDomainOtherClassicAuthorizationPolicyDenyAll,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherClassicAuthorizationPolicyDenyAll, Constants.FLAG, Constants.MODULE_OPTIONS));
+
+        PathAddress securityDomainOtherClassicAcl = securityDomainOther.append(SecurityExtension.ACL_PATH, PathElement.pathElement(Constants.ACL_MODULE, "acl"));
+        config.addFailedAttribute(securityDomainOtherClassicAcl,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherClassicAcl, Constants.FLAG, Constants.MODULE_OPTIONS));
+
+        PathAddress securityDomainOtherMappingClassicMapping = securityDomainOther.append(SecurityExtension.PATH_MAPPING_CLASSIC, PathElement.pathElement(Constants.MAPPING_MODULE, "test"));
+        config.addFailedAttribute(securityDomainOtherMappingClassicMapping,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherMappingClassicMapping, Constants.TYPE, Constants.MODULE_OPTIONS));
+
+        PathAddress securityDomainOtherAudit = securityDomainOther.append(SecurityExtension.PATH_AUDIT_CLASSIC, PathElement.pathElement(Constants.PROVIDER_MODULE, "customModule"));
+        config.addFailedAttribute(securityDomainOtherAudit,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherAudit, Constants.MODULE_OPTIONS));
+
+        PathAddress securityDomainOtherIdentity = securityDomainOther.append(SecurityExtension.PATH_IDENTITY_TRUST_CLASSIC, PathElement.pathElement(Constants.TRUST_MODULE, "IdentityThingy"));
+        config.addFailedAttribute(securityDomainOtherIdentity,
+                createCorrectModelRejectExpressionsConfig(mainServices, securityDomainOtherIdentity, Constants.FLAG, Constants.MODULE_OPTIONS));
+
+        PathAddress jaspiAuthenticationAuthModule = subsystemAddress.append(
+                PathElement.pathElement(Constants.SECURITY_DOMAIN, "jaspi-test"),SecurityExtension.PATH_JASPI_AUTH, PathElement.pathElement(Constants.AUTH_MODULE, "org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule"));
+        config.addFailedAttribute(jaspiAuthenticationAuthModule,
+                ChainedConfig.createBuilder(Constants.FLAG, Constants.MODULE_OPTIONS, Constants.MODULE)
+                    .addConfig(new CorrectModelConfig(mainServices, jaspiAuthenticationAuthModule, Constants.FLAG))
+                    .addConfig(new CorrectModelConfig(mainServices, jaspiAuthenticationAuthModule, Constants.MODULE_OPTIONS))
+                    .addConfig(new NewAttributesConfig(Constants.MODULE))
+                    .build());
+
+        return config;
+    }
+
+    private ChainedConfig createCorrectModelRejectExpressionsConfig(KernelServices kernelServices, PathAddress address, String...attributes) {
+        ChainedConfig.Builder builder = ChainedConfig.createBuilder(attributes);
+        for (String attr : attributes) {
+            builder.addConfig(new CorrectModelConfig(kernelServices, address, attr));
+        }
+        return builder.build();
+    }
+
+    private class CorrectModelConfig extends RejectExpressionsConfig {
+        private final KernelServices mainServices;
+        private final PathAddress address;
+        private final String attribute;
+
+        public CorrectModelConfig(KernelServices mainServices, PathAddress address, String attribute) {
+            super(attribute);
+            this.mainServices = mainServices;
+            this.address = address;
+            this.attribute = attribute;
+        }
+        @Override
+        protected ModelNode correctValue(ModelNode toResolve, boolean isWriteAttribute) {
+            ModelNode resolved = super.correctValue(toResolve, isWriteAttribute);
+
+            //Update the value in the model, the transformer uses the child resource to create the attribute in the parent resource
+            ModelNode write = Util.getWriteAttributeOperation(address, attribute, resolved);
+            ModelTestUtils.checkOutcome(mainServices.executeOperation(write));
+            return resolved;
+        }
     }
 }

--- a/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
@@ -44,6 +44,11 @@
                  <module-option name="a" value="${test.prop:c}"/>
                </policy-module>
 			</authorization>
+         <acl>
+			   <acl-module name="acl" code="AclThingy" flag="${test.prop:required}" module="test">
+			        <module-option name="d" value="r"/>
+			   </acl-module>
+         </acl>
 			<mapping>
 			  <mapping-module name="test" code="SimpleRoles" type="${test.prop:role}" module="test-mapping">
                  <module-option name="d" value="e"/>
@@ -80,7 +85,7 @@
                   cipher-suites="${test.prop:aaa,bbb,ccc}"
                   protocols="${test.prop:one,two,three}">
                 <property name="name" value="${some.prop:default}"/>
-            </jsse>
+         </jsse>
 		</security-domain>
         <security-domain name="jaspi-test" cache-type="default">
             <authentication-jaspi>

--- a/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
@@ -26,8 +26,8 @@
 	<security-domains>
 		<security-domain name="other" cache-type="default">
              <authentication>
-                <login-module code="Remoting" flag="optional">
-                  <module-option name="password-stacking" value="useFirstPass"/>
+                <login-module code="Remoting" flag="${test.prop:optional}" module="test-authentication">
+                  <module-option name="password-stacking" value="${test.prop:useFirstPass}"/>
                 </login-module>
                  <login-module code="Duplicate" flag="optional" />
                  <login-module name="duplicate-module" code="Duplicate" flag="optional" />
@@ -40,37 +40,56 @@
                 </login-module>
               </authentication>
 			<authorization>
-			   <policy-module code="DenyAll" flag="required">
-                 <module-option name="a" value="c"/>
+			   <policy-module code="DenyAll" flag="${test.prop:required}" module="test-auth">
+                 <module-option name="a" value="${test.prop:c}"/>
                </policy-module>
 			</authorization>
 			<mapping>
-			  <mapping-module code="SimpleRoles" type="role">
+			  <mapping-module name="test" code="SimpleRoles" type="${test.prop:role}" module="test-mapping">
                  <module-option name="d" value="e"/>
-              </mapping-module>
-            </mapping>
-            <audit>
+           </mapping-module>
+         </mapping>
+         <audit>
                  <provider-module code="customModule">
-                   <module-option name="d" value="r"/>
+                   <module-option name="d" value="${test.prop:r}"/>
                  </provider-module>
-            </audit> 
-			<jsse truststore-url="keystore.jks"
-                  truststore-password="rmi+ssl"
-                  keystore-url="clientcert.jks"
-                  keystore-password="changeit">
+         </audit>
+			<jsse truststore-url="${test.prop:keystore.jks}"
+                  truststore-password="${test.prop:rmi+ssl}"
+                  truststore-type="${test.prop:jks}"
+                  truststore-provider="${test.prop:truststore.jks}"
+                  truststore-provider-argument="${test.prop:trust-arg}"
+                  trust-manager-factory-algorithm="${test.prop:JKS}"
+                  trust-manager-factory-provider="${test.prop:JKS-provider}"
+                  keystore-url="${test.prop:clientcert.jks}"
+                  keystore-password="${test.prop:changeit}"
+                  keystore-type="${test.prop:jks2}"
+                  keystore-provider="${test.prop:keystore.jks}"
+                  keystore-provider-argument="${test.prop:key-arg}"
+                  key-manager-factory-algorithm="${test.prop:JKS}"
+                  key-manager-factory-provider="${test.prop:JKS-provider}"
+                  client-alias="${test.prop:client-alias"
+                  server-alias="${test.prop:server-alias"
+                  service-auth-token="${test.prop:server-auth-token"
+                  client-auth="${test.prop:true}"
+                  cipher-suites="${test.prop:aaa,bbb,ccc}"
+                  protocols="${test.prop:one,two,three}">
                 <property name="name" value="${some.prop:default}"/>
             </jsse>
 		</security-domain>
         <security-domain name="jaspi-test" cache-type="default">
             <authentication-jaspi>
                 <login-module-stack name="lm-stack">
-                    <login-module code="UsersRoles" flag="required">
+                    <login-module name="lm" code="UsersRoles" flag="required" module="test-jaspi">
                         <module-option name="usersProperties" value="${jboss.server.config.dir:}/application-users.properties"/>
                         <module-option name="rolesProperties" value="${jboss.server.config.dir:}/application-roles.properties"/>
                     </login-module>
                 </login-module-stack>
                 <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"
-                             flag="optional"/>
+                             flag="${test.prop:optional}" module="test-jaspi">
+                   <module-option name="x" value="${test.prop:y}"/>
+                   <module-option name="p" value="${test.prop:r}"/>
+                </auth-module>
             </authentication-jaspi>
         </security-domain>
         <security-domain name="ordering" cache-type="default">

--- a/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
@@ -54,6 +54,11 @@
                    <module-option name="d" value="${test.prop:r}"/>
                  </provider-module>
          </audit>
+         <identity-trust>
+             <trust-module code="IdentityThingy" flag="${test.prop:required}" module="test-identity">
+                 <module-option name="d" value="r"/>
+             </trust-module>
+         </identity-trust>
 			<jsse truststore-url="${test.prop:keystore.jks}"
                   truststore-password="${test.prop:rmi+ssl}"
                   truststore-type="${test.prop:jks}"

--- a/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
+++ b/security/src/test/resources/org/jboss/as/security/securitysubsystemv12.xml
@@ -23,8 +23,8 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:security:1.2">
-	<security-domains>
-		<security-domain name="other" cache-type="default">
+   <security-domains>
+      <security-domain name="other" cache-type="default">
              <authentication>
                 <login-module code="Remoting" flag="${test.prop:optional}" module="test-authentication">
                   <module-option name="password-stacking" value="${test.prop:useFirstPass}"/>
@@ -39,19 +39,19 @@
                   <module-option name="password-stacking" value="useFirstPass"/>
                 </login-module>
               </authentication>
-			<authorization>
-			   <policy-module code="DenyAll" flag="${test.prop:required}" module="test-auth">
+         <authorization>
+            <policy-module code="DenyAll" flag="${test.prop:required}" module="test-auth">
                  <module-option name="a" value="${test.prop:c}"/>
                </policy-module>
-			</authorization>
+         </authorization>
          <acl>
-			   <acl-module name="acl" code="AclThingy" flag="${test.prop:required}" module="test">
-			        <module-option name="d" value="r"/>
-			   </acl-module>
+            <acl-module name="acl" code="AclThingy" flag="${test.prop:required}" module="test">
+                 <module-option name="d" value="${test.prop:r}"/>
+            </acl-module>
          </acl>
-			<mapping>
-			  <mapping-module name="test" code="SimpleRoles" type="${test.prop:role}" module="test-mapping">
-                 <module-option name="d" value="e"/>
+         <mapping>
+           <mapping-module name="test" code="SimpleRoles" type="${test.prop:role}" module="test-mapping">
+                 <module-option name="d" value="${test.prop:e}"/>
            </mapping-module>
          </mapping>
          <audit>
@@ -61,10 +61,10 @@
          </audit>
          <identity-trust>
              <trust-module code="IdentityThingy" flag="${test.prop:required}" module="test-identity">
-                 <module-option name="d" value="r"/>
+                 <module-option name="d" value="${test.prop:r}"/>
              </trust-module>
          </identity-trust>
-			<jsse truststore-url="${test.prop:keystore.jks}"
+         <jsse truststore-url="${test.prop:keystore.jks}"
                   truststore-password="${test.prop:rmi+ssl}"
                   truststore-type="${test.prop:jks}"
                   truststore-provider="${test.prop:truststore.jks}"
@@ -86,7 +86,7 @@
                   protocols="${test.prop:one,two,three}">
                 <property name="name" value="${some.prop:default}"/>
          </jsse>
-		</security-domain>
+      </security-domain>
         <security-domain name="jaspi-test" cache-type="default">
             <authentication-jaspi>
                 <login-module-stack name="lm-stack">
@@ -133,8 +133,8 @@
             <jsse server-alias="silent.planet" />
         </security-domain>
     </security-domains>
-	<vault code="somevault">
-	  <vault-option name="xyz" value="zxc"/>
-	  <vault-option name="abc" value="def"/>
+   <vault code="somevault">
+     <vault-option name="xyz" value="zxc"/>
+     <vault-option name="abc" value="def"/>
     </vault>
 </subsystem>

--- a/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
@@ -26,7 +26,7 @@
     <security-domains>
         <security-domain name="other" cache-type="default">
             <authentication>
-                <login-module code="Remoting" flag="optional">
+                <login-module code="Remoting" flag="optional" module="test-authentication">
                     <module-option name="password-stacking" value="useFirstPass"/>
                 </login-module>
                 <login-module code="Duplicate" flag="optional"/>
@@ -39,12 +39,12 @@
                 </login-module>
             </authentication>
             <authorization>
-                <policy-module code="DenyAll" flag="required">
+                <policy-module code="DenyAll" flag="required" module="test-auth">
                     <module-option name="a" value="c"/>
                 </policy-module>
             </authorization>
             <mapping>
-                <mapping-module code="SimpleRoles" type="role">
+                <mapping-module code="SimpleRoles" type="role" module="test-mapping">
                     <module-option name="d" value="e"/>
                 </mapping-module>
             </mapping>
@@ -53,17 +53,35 @@
                     <module-option name="d" value="r"/>
                 </provider-module>
             </audit>
-            <jsse truststore-url="keystore.jks"
-                  truststore-password="rmi+ssl"
-                  keystore-url="clientcert.jks"
-                  keystore-password="changeit" />
+            <jsse  truststore-url="${test.prop:keystore.jks}"
+                  truststore-password="${test.prop:rmi+ssl}"
+                  truststore-type="${test.prop:jks}"
+                  truststore-provider="${test.prop:truststore.jks}"
+                  truststore-provider-argument="${test.prop:trust-arg}"
+                  trust-manager-factory-algorithm="${test.prop:JKS}"
+                  trust-manager-factory-provider="${test.prop:JKS-provider}"
+                  keystore-url="${test.prop:clientcert.jks}"
+                  keystore-password="${test.prop:changeit}"
+                  keystore-type="${test.prop:jks2}"
+                  keystore-provider="${test.prop:keystore.jks}"
+                  keystore-provider-argument="${test.prop:key-arg}"
+                  key-manager-factory-algorithm="${test.prop:JKS}"
+                  key-manager-factory-provider="${test.prop:JKS-provider}"
+                  client-alias="${test.prop:client-alias"
+                  server-alias="${test.prop:server-alias"
+                  service-auth-token="${test.prop:server-auth-token"
+                  client-auth="${test.prop:true}"
+                  cipher-suites="${test.prop:aaa,bbb,ccc}"
+                  protocols="${test.prop:one,two,three}">
+                <property name="name" value="default" />
+            </jsse>
         </security-domain>
         <security-domain name="jaspi-test" cache-type="default">
             <authentication-jaspi>
                 <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"
                              flag="optional"/>
                 <login-module-stack name="lm-stack">
-                    <login-module code="UsersRoles" flag="required">
+                    <login-module code="UsersRoles" flag="required" module="test-jaspi">
                         <module-option name="usersProperties" value="${jboss.server.config.dir:}/application-users.properties"/>
                         <module-option name="rolesProperties" value="${jboss.server.config.dir:}/application-roles.properties"/>
                     </login-module>

--- a/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
@@ -32,8 +32,8 @@
                 <login-module code="Duplicate" flag="optional"/>
                 <login-module code="Anon" flag="optional"/>
                 <login-module code="RealmUsersRoles" flag="required">
-                    <module-option name="usersProperties" value="${jboss.server.config.dir}/application-users.properties"/>
-                    <module-option name="rolesProperties" value="${jboss.server.config.dir}/application-roles.properties"/>
+                    <module-option name="usersProperties" value="/home/place/application-users.properties"/>
+                    <module-option name="rolesProperties" value="/home/place/application-roles.properties"/>
                     <module-option name="realm" value="ApplicationRealm"/>
                     <module-option name="password-stacking" value="useFirstPass"/>
                 </login-module>
@@ -98,6 +98,7 @@
                 </login-module-stack>
             </authentication-jaspi>
         </security-domain>
+        
         <security-domain name="ordering" cache-type="default">
             <authentication>
                 <login-module code="Remoting" flag="optional">
@@ -120,6 +121,7 @@
                 <policy-module code="Delegating" flag="required"/>
             </authorization>
         </security-domain>
+        
         <security-domain name="jboss-ejb-policy" cache-type="default">
             <authorization>
                 <policy-module code="Delegating" flag="required"/>

--- a/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
@@ -53,6 +53,11 @@
                     <module-option name="d" value="r"/>
                 </provider-module>
             </audit>
+            <identity-trust>
+               <trust-module code="IdentityThingy" flag="required" module="test-identity">
+                 <module-option name="d" value="r"/>
+               </trust-module>
+            </identity-trust>
             <jsse  truststore-url="${test.prop:keystore.jks}"
                   truststore-password="${test.prop:rmi+ssl}"
                   truststore-type="${test.prop:jks}"

--- a/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers-noexpressions.xml
@@ -43,6 +43,11 @@
                     <module-option name="a" value="c"/>
                 </policy-module>
             </authorization>
+            <acl>
+               <acl-module code="AclThingy" flag="required" module="test">
+                 <module-option name="d" value="r"/>
+               </acl-module>
+            </acl>
             <mapping>
                 <mapping-module code="SimpleRoles" type="role" module="test-mapping">
                     <module-option name="d" value="e"/>

--- a/security/src/test/resources/org/jboss/as/security/transformers.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers.xml
@@ -54,6 +54,11 @@
                     <module-option name="d" value="r"/>
                 </provider-module>
             </audit>
+         <identity-trust>
+             <trust-module code="IdentityThingy" flag="required" module="test-identity">
+                 <module-option name="d" value="r"/>
+             </trust-module>
+         </identity-trust>
          <jsse truststore-url="jks"
                   truststore-password="rmi+ssl"
                   truststore-type="jks"

--- a/security/src/test/resources/org/jboss/as/security/transformers.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers.xml
@@ -26,7 +26,7 @@
     <security-domains>
         <security-domain name="other" cache-type="default">
             <authentication>
-                <login-module code="Remoting" flag="optional">
+                <login-module code="Remoting" flag="optional" module="test-authentication">
                     <module-option name="password-stacking" value="useFirstPass"/>
                 </login-module>
                 <login-module code="Duplicate" flag="optional"/>
@@ -40,12 +40,12 @@
                 </login-module>
             </authentication>
             <authorization>
-                <policy-module code="DenyAll" flag="required">
+                <policy-module code="DenyAll" flag="required" module="test-auth">
                     <module-option name="a" value="c"/>
                 </policy-module>
             </authorization>
             <mapping>
-                <mapping-module code="SimpleRoles" type="role">
+                <mapping-module code="SimpleRoles" type="role" module="test-mapping">
                     <module-option name="d" value="e"/>
                 </mapping-module>
             </mapping>
@@ -54,17 +54,35 @@
                     <module-option name="d" value="r"/>
                 </provider-module>
             </audit>
-            <jsse truststore-url="keystore.jks"
+         <jsse truststore-url="jks"
                   truststore-password="rmi+ssl"
+                  truststore-type="jks"
+                  truststore-provider="truststore.jks"
+                  truststore-provider-argument="trust-arg"
+                  trust-manager-factory-algorithm="JKS"
+                  trust-manager-factory-provider="JKS-provider"
                   keystore-url="clientcert.jks"
-                  keystore-password="changeit">
+                  keystore-password="changeit"
+                  keystore-type="jks2"
+                  keystore-provider="keystore.jks"
+                  keystore-provider-argument="key-arg"
+                  key-manager-factory-algorithm="JKS"
+                  key-manager-factory-provider="JKS-provider"
+                  client-alias="client-alias"
+                  server-alias="server-alias"
+                  service-auth-token="server-auth-token"
+                  client-auth="true"
+                  cipher-suites="aaa,bbb,ccc"
+                  protocols="one,two,three">
                 <property name="name" value="${some.prop:default}"/>
             </jsse>
         </security-domain>
         <security-domain name="jaspi-test" cache-type="default">
             <authentication-jaspi>
                 <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"
-                             flag="optional"/>
+                             flag="optional">
+                   <module-option name="x" value="y"/>
+                </auth-module>
                 <login-module-stack name="lm-stack">
                     <login-module code="UsersRoles" flag="required">
                         <module-option name="usersProperties" value="${jboss.server.config.dir:}/application-users.properties"/>

--- a/security/src/test/resources/org/jboss/as/security/transformers.xml
+++ b/security/src/test/resources/org/jboss/as/security/transformers.xml
@@ -44,6 +44,11 @@
                     <module-option name="a" value="c"/>
                 </policy-module>
             </authorization>
+            <acl>
+               <acl-module code="AclThingy" flag="required" module="test">
+                   <module-option name="d" value="r"/>
+               </acl-module>
+            </acl>
             <mapping>
                 <mapping-module code="SimpleRoles" type="role" module="test-mapping">
                     <module-option name="d" value="e"/>

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -53,6 +53,11 @@
     -->
 
     <dependencies>
+       <dependency>
+         <groupId>org.wildfly</groupId>
+         <artifactId>wildfly-model-test</artifactId>
+         <scope>test</scope>
+       </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_2_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_2_Final_TestCase.java
@@ -35,4 +35,9 @@ public class SimpleMixedDomain_7_1_2_Final_TestCase extends SimpleMixedDomainTes
     public static void beforeClass() {
         MixedDomainTestSuite.getSupport(MixedDomain_7_1_2_Final_TestSuite.class);
     }
+
+    @Override
+    protected String getProfile() {
+        return "full-ha-7.1.x";
+    }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_3_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_1_3_Final_TestCase.java
@@ -35,4 +35,9 @@ public class SimpleMixedDomain_7_1_3_Final_TestCase extends SimpleMixedDomainTes
     public static void beforeClass() {
         MixedDomainTestSuite.getSupport(MixedDomain_7_1_3_Final_TestSuite.class);
     }
+
+    @Override
+    protected String getProfile() {
+        return "full-ha-7.1.x";
+    }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_2_0_Final_TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomain_7_2_0_Final_TestCase.java
@@ -35,4 +35,9 @@ public class SimpleMixedDomain_7_2_0_Final_TestCase extends SimpleMixedDomainTes
     public static void beforeClass() {
         MixedDomainTestSuite.getSupport(MixedDomain_7_2_0_Final_TestSuite.class);
     }
+
+    @Override
+    protected String getProfile() {
+        return "full-ha-7.2.x";
+    }
 }

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -459,6 +459,24 @@
                             <policy-module code="Delegating" flag="required"/>
                         </authorization>
                     </security-domain>
+                    <!-- An extra security domain to test that the security transformers work -->
+                    <security-domain name="jaspi-test" cache-type="default">
+                         <authentication-jaspi>
+                            <login-module-stack name="lm-stack">
+                                <login-module name="lm" code="UsersRoles" flag="required" module="test-jaspi">
+                                    <module-option name="usersProperties" value="${jboss.server.config.dir:}/application-users.properties"/>
+                                    <module-option name="rolesProperties" value="${jboss.server.config.dir:}/application-roles.properties"/>
+                                </login-module>
+                            </login-module-stack>
+                            <!-- 
+                                For 7.1.x and 7.2.x this class needs to be org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule, in WildFly
+                                the class is org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule
+                             -->
+                            <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"
+                                         flag="${test.prop:optional}">
+                            </auth-module>
+                        </authentication-jaspi>
+                    </security-domain>
                 </security-domains>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
@@ -951,6 +969,29 @@
                             <policy-module code="Delegating" flag="required"/>
                         </authorization>
                     </security-domain>
+                    <!-- An extra security domain to test that the security transformers work -->
+                    <security-domain name="jaspi-test" cache-type="default">
+                         <authentication-jaspi>
+                            <login-module-stack name="lm-stack">
+                                <login-module name="lm" code="UsersRoles" flag="required" module="test-jaspi">
+                                <!-- System properties are rejected, just hardcode the paths 
+                                    <module-option name="usersProperties" value="${jboss.server.config.dir:}/application-users.properties"/>
+                                    <module-option name="rolesProperties" value="${jboss.server.config.dir:}/application-roles.properties"/>
+                                 -->
+                                    <module-option name="usersProperties" value="/application-users.properties"/>
+                                    <module-option name="rolesProperties" value="/application-roles.properties"/>
+                                </login-module>
+                            </login-module-stack>
+                            <!-- 
+                                For 7.1.x and 7.2.x this class needs to be org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule, in WildFly
+                                the class is org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule. Also the 'module' attribue is
+                                not supported
+                             -->
+                            <auth-module code="org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule" login-module-stack-ref="lm-stack"
+                                         flag="optional">
+                            </auth-module>
+                        </authentication-jaspi>
+                    </security-domain>                    
                 </security-domains>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
@@ -1417,6 +1458,24 @@
                         <authorization>
                             <policy-module code="Delegating" flag="required"/>
                         </authorization>
+                    </security-domain>
+                    <security-domain name="jaspi-test" cache-type="default">
+                         <authentication-jaspi>
+                            <login-module-stack name="lm-stack">
+                                <login-module name="lm" code="UsersRoles" flag="required" module="test-jaspi">
+                                    <module-option name="usersProperties" value="${jboss.server.config.dir:}/application-users.properties"/>
+                                    <module-option name="rolesProperties" value="${jboss.server.config.dir:}/application-roles.properties"/>
+                                </login-module>
+                            </login-module-stack>
+                            <!-- 
+                                For 7.1.x and 7.2.x this class needs to be org.jboss.as.web.security.jaspi.modules.HTTPBasicServerAuthModule, in WildFly
+                                the class is org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule. Also the 'module' attribue is
+                                not supported
+                             -->
+                            <auth-module code="org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule" login-module-stack-ref="lm-stack"
+                                         flag="${test.prop:optional}">
+                            </auth-module>
+                        </authentication-jaspi>
                     </security-domain>
                 </security-domains>
             </subsystem>


### PR DESCRIPTION
Adds missing transformers, fixes marshalling of some attributes, and makes the security subsystem transformers stateless.

https://issues.jboss.org/browse/WFLY-2474
https://issues.jboss.org/browse/WFLY-2475
https://issues.jboss.org/browse/WFLY-2476
https://issues.jboss.org/browse/WFLY-2530
