### PR TITLE
Prevent possible deadlocks relating to intermixing of parallel-capable a...

### DIFF
--- a/jpa/core/src/main/java/org/jboss/as/jpa/classloader/TempClassLoader.java
+++ b/jpa/core/src/main/java/org/jboss/as/jpa/classloader/TempClassLoader.java
@@ -49,6 +49,12 @@ public class TempClassLoader extends ConcurrentClassLoader {
     private final ClassLoader delegate;
     private static final String MANIFEST_MF = "META-INF" + File.separatorChar + "MANIFEST.MF";
 
+    static {
+        try {
+            ClassLoader.registerAsParallelCapable();
+        } catch (Throwable ignored) {}
+    }
+
     TempClassLoader(final ClassLoader delegate) {
         super(null);
         this.delegate = delegate;


### PR DESCRIPTION
...nd non-lockless class loaders

Minor, low-risk change.  No confirmed failure has been observed to date, but this way we can be sure.  The try/catch is so that the code can still run on JDK 6 in case we want to backport.
