### PR TITLE
Check attachment for LogContext.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingDeploymentUnitProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingDeploymentUnitProcessor.java
@@ -94,10 +94,12 @@ public class LoggingDeploymentUnitProcessor implements DeploymentUnitProcessor {
             try {
                 // Unregister the log context
                 WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
-                final LogContext logContext = LogContext.getLogContext();
+                LogContext logContext = context.removeAttachment(LOG_CONTEXT_KEY);
+                if (logContext == null) {
+                    logContext = LogContext.getLogContext();
+                }
                 LoggingExtension.CONTEXT_SELECTOR.unregisterLogContext(module.getClassLoader(), logContext);
                 LoggingLogger.ROOT_LOGGER.tracef("Removing LogContext '%s' from '%s'", logContext, module);
-                context.removeAttachment(LOG_CONTEXT_KEY);
             } finally {
                 WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
             }


### PR DESCRIPTION
@jamezp, @dmlloyd : btw, how do you expect the https://github.com/wildfly/wildfly/blob/master/logging/src/main/java/org/jboss/as/logging/LoggingDeploymentUnitProcessor.java#L97 to work?

Since, afaik, ClassLoaderLogContextSelector uses caller stack to match the classloader.
And since we register app's classloader against LogContextSelector, whereas cleanup is done in subsystem,
there is no way this will ever match -- hence leaking classloaders.

@ctomc ^^
