### PR TITLE
[WFLY-2595] Rewrite the logging DUP's. Ensure the undeploy unregisters the log contexts so class loaders and log contexts aren't leaked.

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -48,10 +48,9 @@ import org.jboss.as.controller.services.path.ResolvePathHandler;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.TransformationDescription;
 import org.jboss.as.controller.transform.description.TransformationDescriptionBuilder;
+import org.jboss.as.logging.logmanager.WildFlyLogContextSelector;
 import org.jboss.as.logging.stdio.LogContextStdioContextSelector;
-import org.jboss.logmanager.ClassLoaderLogContextSelector;
 import org.jboss.logmanager.LogContext;
-import org.jboss.logmanager.ThreadLocalLogContextSelector;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.modules.ModuleLoader;
@@ -69,9 +68,7 @@ public class LoggingExtension implements Extension {
 
     static final PathElement LOGGING_PROFILE_PATH = PathElement.pathElement(CommonAttributes.LOGGING_PROFILE);
 
-    static final ClassLoaderLogContextSelector CONTEXT_SELECTOR = new ClassLoaderLogContextSelector();
-
-    static final ThreadLocalLogContextSelector THREAD_LOCAL_CONTEXT_SELECTOR = new ThreadLocalLogContextSelector(CONTEXT_SELECTOR);
+    static final WildFlyLogContextSelector CONTEXT_SELECTOR = WildFlyLogContextSelector.Factory.create();
 
     static final GenericSubsystemDescribeHandler DESCRIBE_HANDLER = GenericSubsystemDescribeHandler.create(LoggingChildResourceComparator.INSTANCE);
 
@@ -105,7 +102,7 @@ public class LoggingExtension implements Extension {
         if (!java.util.logging.LogManager.getLogManager().getClass().getName().equals(org.jboss.logmanager.LogManager.class.getName())) {
             throw LoggingMessages.MESSAGES.extensionNotInitialized();
         }
-        LogContext.setLogContextSelector(THREAD_LOCAL_CONTEXT_SELECTOR);
+        LogContext.setLogContextSelector(CONTEXT_SELECTOR);
         // Install STDIO context selector
         StdioContext.setStdioContextSelector(new LogContextStdioContextSelector(StdioContext.getStdioContext()));
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
@@ -37,6 +37,7 @@ import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Transform;
 import org.jboss.logging.annotations.Transform.TransformType;
 import org.jboss.logmanager.Configurator;
+import org.jboss.logmanager.LogContext;
 
 /**
  * This module is using message IDs in the range 11500-11599.
@@ -163,4 +164,15 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 11512, value = "A configurator class, '%s', is not a known configurator and will be replaced.")
     void replacingConfigurator(@Transform(TransformType.GET_CLASS) Configurator c);
+
+    /**
+     * Logs an error message indicating the {@link org.jboss.logmanager.LogContext log context} associated with the
+     * deployment could not be removed from the {@link org.jboss.logmanager.LogContextSelector log context selector}.
+     *
+     * @param logContext     the log context that could not be removed
+     * @param deploymentName the name of the deployment
+     */
+    @LogMessage(level = ERROR)
+    @Message(id = 11513, value = "The log context (%s) could not be removed for deployment %s")
+    void logContextNotRemoved(LogContext logContext, String deploymentName);
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingProfileContextSelector.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingProfileContextSelector.java
@@ -30,7 +30,7 @@ import org.jboss.util.collection.ConcurrentSkipListMap;
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-final class LoggingProfileContextSelector {
+public final class LoggingProfileContextSelector {
     private static final LoggingProfileContextSelector INSTANCE = new LoggingProfileContextSelector();
 
     private final ConcurrentMap<String, LogContext> profileContexts = new ConcurrentSkipListMap<String, LogContext>();
@@ -50,7 +50,7 @@ final class LoggingProfileContextSelector {
      *
      * @return the log context that was found or a new log context
      */
-    public LogContext getOrCreate(final String loggingProfile) {
+    protected LogContext getOrCreate(final String loggingProfile) {
         LogContext result = profileContexts.get(loggingProfile);
         if (result == null) {
             result = LogContext.create();

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -33,6 +33,8 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.logging.deployments.LoggingConfigDeploymentProcessor;
+import org.jboss.as.logging.deployments.LoggingProfileDeploymentProcessor;
 import org.jboss.as.logging.logmanager.ConfigurationPersistence;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
@@ -62,7 +64,8 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
         context.addStep(new AbstractDeploymentChainStep() {
             @Override
             protected void execute(final DeploymentProcessorTarget processorTarget) {
-                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG, LoggingDeploymentUnitProcessor.INSTANCE);
+                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG, new LoggingConfigDeploymentProcessor(LoggingExtension.CONTEXT_SELECTOR));
+                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_PROFILE, new LoggingProfileDeploymentProcessor(LoggingExtension.CONTEXT_SELECTOR));
             }
         }, Stage.RUNTIME);
 

--- a/logging/src/main/java/org/jboss/as/logging/deployments/AbstractLoggingDeploymentProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/AbstractLoggingDeploymentProcessor.java
@@ -1,0 +1,166 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments;
+
+import java.io.Closeable;
+import java.security.PrivilegedAction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.logging.LoggingLogger;
+import org.jboss.as.logging.logmanager.WildFlyLogContextSelector;
+import org.jboss.as.server.deployment.AttachmentKey;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.SubDeploymentMarker;
+import org.jboss.as.server.deployment.module.ResourceRoot;
+import org.jboss.logmanager.LogContext;
+import org.jboss.modules.Module;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class AbstractLoggingDeploymentProcessor implements DeploymentUnitProcessor {
+
+    public static final AttachmentKey<LogContext> LOG_CONTEXT_KEY = AttachmentKey.create(LogContext.class);
+
+    protected final WildFlyLogContextSelector logContextSelector;
+
+    protected AbstractLoggingDeploymentProcessor(final WildFlyLogContextSelector logContextSelector) {
+        this.logContextSelector = logContextSelector;
+    }
+
+    @Override
+    public final void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        // If the log context is already defined, skip the rest of the processing
+        if (!hasRegisteredLogContext(deploymentUnit)) {
+            if (deploymentUnit.hasAttachment(Attachments.MODULE) && deploymentUnit.hasAttachment(Attachments.DEPLOYMENT_ROOT)) {
+                // don't process sub-deployments as they are processed by processing methods
+                final ResourceRoot root = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
+                if (SubDeploymentMarker.isSubDeployment(root)) return;
+                processDeployment(phaseContext, deploymentUnit, root);
+            }
+        }
+    }
+
+    @Override
+    public final void undeploy(final DeploymentUnit context) {
+        // OSGi bundles deployments may not have a module attached
+        if (hasRegisteredLogContext(context) && context.hasAttachment(Attachments.MODULE)) {
+            // don't process sub-deployments as they are processed by processing methods
+            final ResourceRoot root = context.getAttachment(Attachments.DEPLOYMENT_ROOT);
+            if (SubDeploymentMarker.isSubDeployment(root)) return;
+            // Remove any log context selector references
+            final Module module = context.getAttachment(Attachments.MODULE);
+            unregisterLogContext(context, module);
+            // Unregister all sub-deployments
+            final List<DeploymentUnit> subDeployments = getSubDeployments(context);
+            for (DeploymentUnit subDeployment : subDeployments) {
+                final Module subDeploymentModule = subDeployment.getAttachment(Attachments.MODULE);
+                unregisterLogContext(subDeployment, subDeploymentModule);
+            }
+        }
+    }
+
+    /**
+     * Processes the deployment.
+     *
+     * @param phaseContext   the phase context
+     * @param deploymentUnit the deployment unit
+     * @param root           the root resource
+     *
+     * @throws DeploymentUnitProcessingException if an error occurs during processing
+     */
+    protected abstract void processDeployment(DeploymentPhaseContext phaseContext, DeploymentUnit deploymentUnit, ResourceRoot root) throws DeploymentUnitProcessingException;
+
+    protected void registerLogContext(final DeploymentUnit deploymentUnit, final Module module, final LogContext logContext) {
+        LoggingLogger.ROOT_LOGGER.tracef("Registering LogContext %s for deployment %s", logContext, deploymentUnit.getName());
+        if (WildFlySecurityManager.isChecking()) {
+            WildFlySecurityManager.doChecked(new PrivilegedAction<Object>() {
+                @Override
+                public Object run() {
+                    logContextSelector.registerLogContext(module.getClassLoader(), logContext);
+                    return null;
+                }
+            });
+        } else {
+            logContextSelector.registerLogContext(module.getClassLoader(), logContext);
+        }
+        // Add the log context to the sub-deployment unit for later removal
+        deploymentUnit.putAttachment(LOG_CONTEXT_KEY, logContext);
+    }
+
+    protected void unregisterLogContext(final DeploymentUnit deploymentUnit, final Module module) {
+        final LogContext logContext = deploymentUnit.removeAttachment(LOG_CONTEXT_KEY);
+        final boolean success;
+        if (WildFlySecurityManager.isChecking()) {
+            success = WildFlySecurityManager.doChecked(new PrivilegedAction<Boolean>() {
+                @Override
+                public Boolean run() {
+                    return logContextSelector.unregisterLogContext(module.getClassLoader(), logContext);
+                }
+            });
+        } else {
+            success = logContextSelector.unregisterLogContext(module.getClassLoader(), logContext);
+        }
+        if (success) {
+            LoggingLogger.ROOT_LOGGER.tracef("Removed LogContext '%s' from '%s'", logContext, module);
+        } else {
+            LoggingLogger.ROOT_LOGGER.logContextNotRemoved(logContext, deploymentUnit.getName());
+        }
+    }
+
+    protected static List<DeploymentUnit> getSubDeployments(final DeploymentUnit deploymentUnit) {
+        if (deploymentUnit.hasAttachment(Attachments.SUB_DEPLOYMENTS)) {
+            final List<DeploymentUnit> result = new ArrayList<DeploymentUnit>();
+            result.addAll(deploymentUnit.getAttachmentList(Attachments.SUB_DEPLOYMENTS));
+            return result;
+        }
+        return Collections.emptyList();
+    }
+
+    protected static void safeClose(final Closeable closable) {
+        if (closable != null) try {
+            closable.close();
+        } catch (Exception e) {
+            // no-op
+        }
+    }
+
+    /**
+     * Checks the deployment to see if it has a registered {@link org.jboss.logmanager.LogContext log context}.
+     *
+     * @param deploymentUnit the deployment unit to check
+     *
+     * @return {@code true} if the deployment unit has a log context, otherwise {@code false}
+     */
+    public static boolean hasRegisteredLogContext(final DeploymentUnit deploymentUnit) {
+        return deploymentUnit.hasAttachment(LOG_CONTEXT_KEY);
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/deployments/LoggingProfileDeploymentProcessor.java
+++ b/logging/src/main/java/org/jboss/as/logging/deployments/LoggingProfileDeploymentProcessor.java
@@ -1,0 +1,111 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.deployments;
+
+import java.util.List;
+import java.util.jar.Manifest;
+
+import org.jboss.as.logging.LoggingLogger;
+import org.jboss.as.logging.LoggingProfileContextSelector;
+import org.jboss.as.logging.logmanager.WildFlyLogContextSelector;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ResourceRoot;
+import org.jboss.logmanager.LogContext;
+import org.jboss.modules.Module;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class LoggingProfileDeploymentProcessor extends AbstractLoggingDeploymentProcessor implements DeploymentUnitProcessor {
+
+    private static final String LOGGING_PROFILE = "Logging-Profile";
+
+    public LoggingProfileDeploymentProcessor(final WildFlyLogContextSelector logContextSelector) {
+        super(logContextSelector);
+    }
+
+    @Override
+    protected void processDeployment(final DeploymentPhaseContext phaseContext, final DeploymentUnit deploymentUnit, final ResourceRoot root) throws DeploymentUnitProcessingException {
+        final List<DeploymentUnit> subDeployments = getSubDeployments(deploymentUnit);
+        final String loggingProfile = findLoggingProfile(root);
+        if (loggingProfile != null) {
+            // Get the profile logging context
+            final LoggingProfileContextSelector loggingProfileContext = LoggingProfileContextSelector.getInstance();
+            if (loggingProfileContext.exists(loggingProfile)) {
+                // Get the module
+                final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+                final LogContext logContext = loggingProfileContext.get(loggingProfile);
+                LoggingLogger.ROOT_LOGGER.tracef("Registering log context '%s' on '%s' for profile '%s'", logContext, root, loggingProfile);
+                registerLogContext(deploymentUnit, module, logContext);
+                // Process sub-deployments
+                for (DeploymentUnit subDeployment : subDeployments) {
+                    // A sub-deployment must have a module to process
+                    if (subDeployment.hasAttachment(Attachments.MODULE)) {
+                        // Set the result to true if a logging profile was found
+                        if (subDeployment.hasAttachment(Attachments.DEPLOYMENT_ROOT)) {
+                            processDeployment(phaseContext, subDeployment, subDeployment.getAttachment(Attachments.DEPLOYMENT_ROOT));
+                        }
+                        if (!hasRegisteredLogContext(subDeployment)) {
+                            final Module subDeploymentModule = subDeployment.getAttachment(Attachments.MODULE);
+                            LoggingLogger.ROOT_LOGGER.tracef("Registering log context '%s' on '%s' for profile '%s'", logContext, subDeployment.getAttachment(Attachments.DEPLOYMENT_ROOT), loggingProfile);
+                            registerLogContext(subDeployment, subDeploymentModule, logContext);
+                        }
+                    }
+                }
+            } else {
+                LoggingLogger.ROOT_LOGGER.loggingProfileNotFound(loggingProfile, root);
+            }
+        } else {
+            // No logging profile found, but the sub-deployments should be checked for logging profiles
+            for (DeploymentUnit subDeployment : subDeployments) {
+                // A sub-deployment must have a root resource and a module to process
+                if (subDeployment.hasAttachment(Attachments.MODULE) && subDeployment.hasAttachment(Attachments.DEPLOYMENT_ROOT)) {
+                    processDeployment(phaseContext, subDeployment, subDeployment.getAttachment(Attachments.DEPLOYMENT_ROOT));
+                }
+            }
+        }
+    }
+
+    /**
+     * Find the logging profile attached to any resource.
+     *
+     * @param resourceRoot the root resource
+     *
+     * @return the logging profile name or {@code null} if one was not found
+     */
+    private String findLoggingProfile(final ResourceRoot resourceRoot) {
+        final Manifest manifest = resourceRoot.getAttachment(Attachments.MANIFEST);
+        if (manifest != null) {
+            final String loggingProfile = manifest.getMainAttributes().getValue(LOGGING_PROFILE);
+            if (loggingProfile != null) {
+                LoggingLogger.ROOT_LOGGER.debugf("Logging profile '%s' found in '%s'.", loggingProfile, resourceRoot);
+                return loggingProfile;
+            }
+        }
+        return null;
+    }
+}

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelector.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelector.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.logmanager;
+
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.LogContextSelector;
+
+/**
+ * The log context selector to use for the WildFly logging extension.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public interface WildFlyLogContextSelector extends LogContextSelector {
+
+    /**
+     * Get and set the log context.
+     *
+     * @param securityKey the security key to check (ignored if none was set on construction)
+     * @param newValue    the new log context value, or {@code null} to clear
+     *
+     * @return the previous log context value, or {@code null} if none was set
+     *
+     * @see org.jboss.logmanager.ThreadLocalLogContextSelector#getAndSet(Object, org.jboss.logmanager.LogContext)
+     */
+    LogContext getAndSet(Object securityKey, LogContext newValue);
+
+    /**
+     * Register a class loader with a log context.
+     *
+     * @param classLoader the class loader
+     * @param logContext  the log context
+     *
+     * @throws IllegalArgumentException if the class loader is already associated with a log context
+     * @see org.jboss.logmanager.ClassLoaderLogContextSelector#registerLogContext(ClassLoader,
+     * org.jboss.logmanager.LogContext)
+     */
+    void registerLogContext(ClassLoader classLoader, LogContext logContext);
+
+    /**
+     * Unregister a class loader/log context association.
+     *
+     * @param classLoader the class loader
+     * @param logContext  the log context
+     *
+     * @return {@code true} if the association exists and was removed, {@code false} otherwise
+     *
+     * @see org.jboss.logmanager.ClassLoaderLogContextSelector#unregisterLogContext(ClassLoader,
+     * org.jboss.logmanager.LogContext)
+     */
+    boolean unregisterLogContext(ClassLoader classLoader, LogContext logContext);
+
+    /**
+     * Register a class loader which is a known log API, and thus should be skipped over when searching for the
+     * log context to use for the caller class.
+     *
+     * @param apiClassLoader the API class loader
+     *
+     * @return {@code true} if this class loader was previously unknown, or {@code false} if it was already
+     * registered
+     *
+     * @see org.jboss.logmanager.ClassLoaderLogContextSelector#addLogApiClassLoader(ClassLoader)
+     */
+    boolean addLogApiClassLoader(ClassLoader apiClassLoader);
+
+    /**
+     * Remove a class loader from the known log APIs set.
+     *
+     * @param apiClassLoader the API class loader
+     *
+     * @return {@code true} if the class loader was removed, or {@code false} if it was not known to this selector
+     *
+     * @see org.jboss.logmanager.ClassLoaderLogContextSelector#removeLogApiClassLoader(ClassLoader)
+     */
+    boolean removeLogApiClassLoader(ClassLoader apiClassLoader);
+
+    /**
+     * Returns the number of registered {@link org.jboss.logmanager.LogContext log contexts}.
+     *
+     * @return the number of registered log contexts
+     */
+    int registeredCount();
+
+    class Factory {
+        public static WildFlyLogContextSelector create() {
+            return new WildFlyLogContextSelectorImpl();
+        }
+    }
+
+}

--- a/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/WildFlyLogContextSelectorImpl.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.logging.logmanager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.logmanager.ClassLoaderLogContextSelector;
+import org.jboss.logmanager.LogContext;
+import org.jboss.logmanager.ThreadLocalLogContextSelector;
+
+/**
+* @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+*/
+class WildFlyLogContextSelectorImpl implements WildFlyLogContextSelector {
+
+    private final ClassLoaderLogContextSelector contextSelector;
+
+    private final ThreadLocalLogContextSelector threadLocalContextSelector;
+
+    private final AtomicInteger counter;
+
+    public WildFlyLogContextSelectorImpl() {
+        counter = new AtomicInteger(0);
+        contextSelector = new ClassLoaderLogContextSelector();
+        threadLocalContextSelector = new ThreadLocalLogContextSelector(contextSelector);
+    }
+
+    @Override
+    public LogContext getLogContext() {
+        return threadLocalContextSelector.getLogContext();
+    }
+
+    @Override
+    public LogContext getAndSet(final Object securityKey, final LogContext newValue) {
+        return threadLocalContextSelector.getAndSet(securityKey, newValue);
+    }
+
+    @Override
+    public void registerLogContext(final ClassLoader classLoader, final LogContext logContext) {
+        contextSelector.registerLogContext(classLoader, logContext);
+        counter.incrementAndGet();
+    }
+
+    @Override
+    public boolean unregisterLogContext(final ClassLoader classLoader, final LogContext logContext) {
+        if (contextSelector.unregisterLogContext(classLoader, logContext)) {
+            counter.decrementAndGet();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean addLogApiClassLoader(final ClassLoader apiClassLoader) {
+        return contextSelector.addLogApiClassLoader(apiClassLoader);
+    }
+
+    @Override
+    public boolean removeLogApiClassLoader(final ClassLoader apiClassLoader) {
+        return contextSelector.removeLogApiClassLoader(apiClassLoader);
+    }
+
+    @Override
+    public int registeredCount() {
+        return counter.get();
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -468,6 +468,7 @@ public enum Phase {
     public static final int POST_MODULE_APP_NAMING_CONTEXT              = 0x2900;
     public static final int POST_MODULE_CACHED_CONNECTION_MANAGER       = 0x2A00;
     public static final int POST_MODULE_LOGGING_CONFIG                  = 0x2B00;
+    public static final int POST_MODULE_LOGGING_PROFILE                 = 0x2B10;
     public static final int POST_MODULE_EL_EXPRESSION_FACTORY           = 0x2C00;
     public static final int POST_MODULE_SAR_SERVICE_COMPONENT           = 0x2D00;
     public static final int POST_MODULE_UNDERTOW_WEBSOCKETS             = 0x2E00;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LogContextHackServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LogContextHackServlet.java
@@ -1,0 +1,55 @@
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.logging.LoggingExtension;
+import org.jboss.as.logging.logmanager.WildFlyLogContextSelector;
+
+/**
+ * <strong>NOTE:</strong> This uses a reflection hack to determine the size of the {@link
+ * org.jboss.logmanager.LogContext log context} map from a {@link org.jboss.as.logging.logmanager.WildFlyLogContextSelector
+ * log context selector}. This is rather fragile with a change to the {@link org.jboss.as.logging.LoggingExtension}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@WebServlet(LogContextHackServlet.SERVLET_URL)
+public class LogContextHackServlet extends HttpServlet {
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_URL = "/logContext";
+
+    @Override
+    protected void doGet(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        processRequest(req, resp);
+    }
+
+    @Override
+    protected void doPost(final HttpServletRequest req, final HttpServletResponse resp) throws ServletException, IOException {
+        processRequest(req, resp);
+    }
+
+    private void processRequest(final HttpServletRequest request, final HttpServletResponse response) throws ServletException, IOException {
+        try {
+            final WildFlyLogContextSelector wildflySelector = getFieldValue(LoggingExtension.class, "CONTEXT_SELECTOR", WildFlyLogContextSelector.class);
+            response.getWriter().print(wildflySelector.registeredCount());
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+    }
+
+    private static <T> T getFieldValue(final Class<?> staticType, final String fieldName, final Class<T> type) throws NoSuchFieldException, IllegalAccessException {
+        final Field field = staticType.getDeclaredField(fieldName);
+        if (Modifier.isStatic(field.getModifiers()) && type.isAssignableFrom(field.getType())) {
+            field.setAccessible(true);
+            return type.cast(field.get(null));
+        }
+        return null;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LogContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/perdeploy/LogContextTestCase.java
@@ -1,0 +1,233 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.logging.perdeploy;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.logging.util.AbstractLoggingTest;
+import org.jboss.as.test.integration.logging.util.LoggingBean;
+import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
+import org.jboss.dmr.ModelNode;
+import org.jboss.osgi.metadata.ManifestBuilder;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Note that the servlet uses a reflection hack to get the size of the log context map. This is fragile and may break,
+ * but should be rather obvious if it does.
+ * <p/>
+ * This tests that after a undeploy the {@link org.jboss.logmanager.LogContext log contexts} and class loaders are
+ * cleaned up during an undeploy. Attempts to find leaking class loaders.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@ServerSetup(LogContextTestCase.LoggingProfileSetup.class)
+@RunWith(Arquillian.class)
+public class LogContextTestCase extends AbstractLoggingTest {
+    private static final String LOG_FILE_NAME = "log-context-profile-test.log";
+
+    @Deployment(name = "logcontext", testable = false)
+    public static WebArchive createDeployment() {
+        return logContextDeployment("logcontext-test.war");
+    }
+
+    @Deployment(name = "logging", testable = false, managed = false)
+    public static WebArchive createLoggingDeployment() {
+        return loggingDeployment("logging-test.war")
+                .addAsManifestResource(LoggingBean.class.getPackage(),
+                        "logging.properties", "logging.properties");
+    }
+
+    @Deployment(name = "logging-ear", testable = false, managed = false)
+    public static EnterpriseArchive createEarDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, "logging.ear")
+                .addAsManifestResource(LoggingBean.class.getPackage(),
+                        "logging.properties", "logging.properties")
+                .setManifest(new Asset() {
+                    public InputStream openStream() {
+                        ManifestBuilder builder = ManifestBuilder.newInstance();
+                        builder.addManifestHeader("Dependencies", "org.jboss.logmanager, org.jboss.as.logging");
+                        return builder.openStream();
+                    }
+                })
+                .addAsModules(logContextDeployment("logcontext-in-ear.war"), loggingDeployment("logging-in-ear.war"));
+    }
+
+    @Deployment(name = "logging-profile", testable = false, managed = false)
+    public static WebArchive createLoggingProfileDeployment() {
+        return loggingDeployment("logging-profile-test.war")
+                .setManifest(new Asset() {
+                    public InputStream openStream() {
+                        ManifestBuilder builder = ManifestBuilder.newInstance();
+                        builder.addManifestHeader("Logging-Profile", "test");
+                        return builder.openStream();
+                    }
+                });
+    }
+
+    @Deployment(name = "logging-profile-ear", testable = false, managed = false)
+    public static EnterpriseArchive createEarProfileDeployment() {
+        return ShrinkWrap.create(EnterpriseArchive.class, "logging-profile.ear")
+                .addAsManifestResource(LoggingBean.class.getPackage(),
+                        "logging.properties", "logging.properties")
+                .setManifest(new Asset() {
+                    public InputStream openStream() {
+                        ManifestBuilder builder = ManifestBuilder.newInstance();
+                        builder.addManifestHeader("Dependencies", "org.jboss.logmanager, org.jboss.as.logging");
+                        builder.addManifestHeader("Logging-Profile", "test");
+                        return builder.openStream();
+                    }
+                })
+                .addAsModules(logContextDeployment("logcontext-profile-in-ear.war"), loggingDeployment("logging-profile-in-ear.war"));
+    }
+
+    @ArquillianResource
+    public Deployer deployer;
+
+    @Test
+    @OperateOnDeployment("logcontext")
+    public void contextTest(@ArquillianResource(LogContextHackServlet.class) final URL url) throws Exception {
+        final String u = UrlBuilder.of(url, LogContextHackServlet.SERVLET_URL).build();
+        String result = performCall(u);
+        Assert.assertEquals("No LogContexts should exist in WAR deployment", 0, Integer.valueOf(result).intValue());
+        deployer.deploy("logging");
+        result = performCall(u);
+        Assert.assertEquals("One LogContexts should exist in WAR deployment", 1, Integer.valueOf(result).intValue());
+        deployer.undeploy("logging");
+        result = performCall(u);
+        Assert.assertEquals("No LogContexts should exist in WAR deployment", 0, Integer.valueOf(result).intValue());
+
+        // Deploy an EAR
+        deployer.deploy("logging-ear");
+        result = performCall(u);
+        Assert.assertEquals("Three LogContexts should exist in EAR deployment", 3, Integer.valueOf(result).intValue());
+        deployer.undeploy("logging-ear");
+        result = performCall(u);
+        Assert.assertEquals("No LogContexts should exist in EAR deployment", 0, Integer.valueOf(result).intValue());
+
+        // Deploy with a profile
+        deployer.deploy("logging-profile");
+        result = performCall(u);
+        Assert.assertEquals("One LogContexts should exist in WAR deployment with logging-profile", 1, Integer.valueOf(result).intValue());
+        deployer.undeploy("logging-profile");
+        result = performCall(u);
+        Assert.assertEquals("No LogContexts should exist in WAR deployment with logging-profile", 0, Integer.valueOf(result).intValue());
+
+        // Deploy an EAR with a profile
+        deployer.deploy("logging-profile-ear");
+        result = performCall(u);
+        Assert.assertEquals("Three LogContexts should exist in EAR deployment with logging-profile", 3, Integer.valueOf(result).intValue());
+        deployer.undeploy("logging-profile-ear");
+        result = performCall(u);
+        Assert.assertEquals("No LogContexts should exist in EAR deployment with logging-profile", 0, Integer.valueOf(result).intValue());
+    }
+
+    private static WebArchive loggingDeployment(final String name) {
+        return ShrinkWrap
+                .create(WebArchive.class, name)
+                .addClasses(LoggingBean.class);
+    }
+
+    private static WebArchive logContextDeployment(final String name) {
+        return ShrinkWrap
+                .create(WebArchive.class, name)
+                .addClasses(LogContextHackServlet.class)
+                .setManifest(new Asset() {
+                    public InputStream openStream() {
+                        ManifestBuilder builder = ManifestBuilder.newInstance();
+                        builder.addManifestHeader("Dependencies", "org.jboss.logmanager, org.jboss.as.logging");
+                        return builder.openStream();
+                    }
+                });
+    }
+
+    static class LoggingProfileSetup extends AbstractMgmtServerSetupTask {
+        private final Deque<ModelNode> tearDownOps;
+
+        public LoggingProfileSetup() {
+            tearDownOps = new ArrayDeque<ModelNode>();
+        }
+
+        @Override
+        protected void doSetup(final ManagementClient managementClient) throws Exception {
+            // Setup a logging-profile
+            final ModelNode loggingProfileAddress = AddressBuilder.create()
+                    .add("logging-profile", "test")
+                    .build();
+
+            // Add the profile and add a remove operation
+            ModelNode op = Operations.createAddOperation(loggingProfileAddress);
+            executeOperation(op);
+            tearDownOps.addFirst(Operations.createRemoveOperation(loggingProfileAddress));
+
+            final ModelNode fileHandlerAddress = AddressBuilder.create(loggingProfileAddress)
+                    .add("file-handler", "test-handler")
+                    .build();
+            op = Operations.createAddOperation(fileHandlerAddress);
+            op.get("append").set("true");
+            final ModelNode file = op.get("file");
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(LOG_FILE_NAME);
+            op.get("formatter").set("[test-profile] %d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            executeOperation(op);
+            tearDownOps.addFirst(Operations.createRemoveOperation(fileHandlerAddress));
+
+            final ModelNode rootLoggerAddress = AddressBuilder.create(loggingProfileAddress)
+                    .add("root-logger", "ROOT")
+                    .build();
+            op = Operations.createAddOperation(rootLoggerAddress);
+            op.get("level").set("INFO");
+            final ModelNode handlers = op.get("handlers").setEmptyList();
+            handlers.add("test-handler");
+            executeOperation(op);
+            tearDownOps.addFirst(Operations.createRemoveOperation(rootLoggerAddress));
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+            ModelNode op;
+            while ((op = tearDownOps.poll()) != null) {
+                try {
+                    executeOperation(op);
+                } catch (Exception ignore) {
+                }
+            }
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/util/AbstractLoggingTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/util/AbstractLoggingTest.java
@@ -2,37 +2,133 @@ package org.jboss.as.test.integration.logging.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
 
+/**
+ * A simple abstract test class with helper methods.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
 public abstract class AbstractLoggingTest {
-	public static File prepareLogFile(final ManagementClient client,
-			final String filename) throws IOException, MgmtOperationException {
-		File logFile;
-		final ModelNode address = PathAddress.pathAddress(
-				PathElement.pathElement(ModelDescriptionConstants.PATH,
-						"jboss.server.log.dir")).toModelNode();
-		final ModelNode op = Operations.createReadAttributeOperation(address,
-				ModelDescriptionConstants.PATH);
-		final ModelNode result = client.getControllerClient().execute(op);
-		if (Operations.isSuccessfulOutcome(result)) {
-			logFile = new File(Operations.readResult(result).asString(),
-					filename);
-			logFile.delete();
-			return logFile;
-		}
-		throw new MgmtOperationException("Failed to read the path resource",
-				op, result);
-	}
 
-	public static void testCLI() {
+    static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "logging");
 
-	}
+    static final String ENCODING = "utf-8";
+
+    public static File prepareLogFile(final ManagementClient client,
+                                      final String filename) throws IOException, MgmtOperationException {
+        return getAbsoluteLogFilePath(client, filename);
+    }
+
+    public static File getAbsoluteLogFilePath(final ManagementClient client, final String filename) throws IOException, MgmtOperationException {
+        final ModelNode address = PathAddress.pathAddress(
+                PathElement.pathElement(ModelDescriptionConstants.PATH, "jboss.server.log.dir")
+                                                         ).toModelNode();
+        final ModelNode op = Operations.createReadAttributeOperation(address, ModelDescriptionConstants.PATH);
+        final ModelNode result = client.getControllerClient().execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            return new File(Operations.readResult(result).asString(), filename);
+        }
+        throw new MgmtOperationException("Failed to read the path resource", op, result);
+    }
+
+    protected static String performCall(final String url) throws ExecutionException, IOException, TimeoutException {
+        return HttpRequest.get(url, TimeoutUtil.adjust(10), TimeUnit.SECONDS);
+    }
+
+    protected static String performCall(final UrlBuilder builder) throws ExecutionException, IOException, TimeoutException {
+        return performCall(builder.build());
+    }
+
+    public static class AddressBuilder {
+        private PathAddress pathAddress;
+
+        private AddressBuilder(final PathAddress pathAddress) {
+            this.pathAddress = pathAddress;
+        }
+
+        public static AddressBuilder create() {
+            return new AddressBuilder(PathAddress.pathAddress(SUBSYSTEM_PATH));
+        }
+
+        public static AddressBuilder create(final ModelNode base) {
+            return new AddressBuilder(PathAddress.pathAddress(base));
+        }
+
+        public AddressBuilder add(final String key, final String name) {
+            pathAddress = pathAddress.append(key, name);
+            return this;
+        }
+
+        public ModelNode build() {
+            return pathAddress.toModelNode();
+        }
+    }
+
+    public static class UrlBuilder {
+        private final URL url;
+        private final String[] paths;
+        private final Map<String, String> params;
+
+        private UrlBuilder(final URL url, final String... paths) {
+            this.url = url;
+            this.paths = paths;
+            params = new HashMap<String, String>();
+        }
+
+        public static UrlBuilder of(final URL url, final String... paths) {
+            return new UrlBuilder(url, paths);
+        }
+
+        public UrlBuilder addParameter(final String key, final int value) {
+            return addParameter(key, Integer.toString(value));
+        }
+
+        public UrlBuilder addParameter(final String key, final String value) {
+            params.put(key, value);
+            return this;
+        }
+
+        public String build() throws UnsupportedEncodingException {
+            final StringBuilder result = new StringBuilder(url.toExternalForm());
+            if (paths != null) {
+                for (String path : paths) {
+                    if (!path.startsWith("/")) {
+                        result.append('/');
+                    }
+                    result.append(path);
+                }
+            }
+            boolean isFirst = true;
+            for (String key : params.keySet()) {
+                if (isFirst) {
+                    result.append('?');
+                } else {
+                    result.append('&');
+                }
+                final String value = params.get(key);
+                result.append(URLEncoder.encode(key, ENCODING)).append('=').append(URLEncoder.encode(value, ENCODING));
+                isFirst = false;
+            }
+            return result.toString();
+        }
+    }
 
 }


### PR DESCRIPTION
There was a change to use the `ClassLoaderLogContextSelector` rather than the `ContextClassLoaderLogContextSelector` (526c2ae) class loaders and log contexts were not being removed from the `LogContextSelector`.

The DUP has been split into two more logical DUP's rather than trying to handle it all in one. There has been a test added to check for leaks, but it does use a hack. I'm not opposed to removing the test if it seems to be too much of a hack. I don't love it, but I couldn't find a better way to ensure class loaders and log contexts weren't being leaked.
