### PR TITLE
add Principal to subject

### DIFF
--- a/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -393,6 +393,8 @@ public class SimpleSecurityManager implements ServerSecurityManager {
             auditPrincipal = unauthenticatedIdentity.asPrincipal();
             subject.getPrincipals().add(auditPrincipal);
             authenticated = true;
+        } else {
+            subject.getPrincipals().add(principal);
         }
 
         if (authenticated == false) {


### PR DESCRIPTION
Principal is only added to subject if we use RemotingConnectionCredential or when there is no Principal at all.
If we have valid principal we forget about it.

This causes org.jboss.security.auth.spi.RoleMappingLoginModule to be broken.
I'm not sure if this fix is correct (we can always get Principal from callbackHandler in LoginModule).

Another question what to do with roles? (JbossCallbackHandler don't contain this information) and what to do with roles added in LoginModule
