### PR TITLE
WFLY-2527 Don't require a generic (foo=*) ManagementResourceRegistration to execute wildcard ops

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.management.cli;
+
+import java.io.IOException;
+
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.suites.CLITestSuite;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests related to read ops for wildcard addresses.
+ *
+ * @author Brian Stansberry (c) 2013 Red Hat Inc.
+ */
+public class WildCardReadsTestCase extends AbstractCliTestBase {
+
+    private static final String OP_PATTERN = "/profile=default/subsystem=infinispan/cache-container=web/distributed-cache=dist/eviction=%s:%s";
+    private static final String READ_OP_DESC_OP = ModelDescriptionConstants.READ_OPERATION_DESCRIPTION_OPERATION + "(name=%s)";
+    private static final String READ_RES_DESC_OP = ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION + "(access-control=combined-descriptions,operations=true,recursive=true)";
+    private static final String EVICTION = "EVICTION";
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
+    }
+
+    @AfterClass
+    public static void cleanup() throws Exception {
+        AbstractCliTestBase.closeCLI();
+    }
+
+    /**
+     * Tests WFLY-2527 added behavior of supporting read-operation-description for
+     * wildcard addresses where there is no generic resource registration for the type
+     */
+    @Test
+    public void testLenientReadOperationDescription() throws IOException {
+        cli.sendLine(String.format(OP_PATTERN, EVICTION, ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION));
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        for (ModelNode node : opResult.getResponseNode().get(ModelDescriptionConstants.RESULT).asList()) {
+            String opPart = String.format(READ_OP_DESC_OP, node.asString());
+            cli.sendLine(String.format(OP_PATTERN, EVICTION, opPart));
+            opResult = cli.readAllAsOpResult();
+            Assert.assertTrue(opResult.isIsOutcomeSuccess());
+            ModelNode specific = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+            cli.sendLine(String.format(OP_PATTERN, "*", opPart));
+            opResult = cli.readAllAsOpResult();
+            Assert.assertTrue(opResult.isIsOutcomeSuccess());
+            Assert.assertEquals("mismatch for " + node.asString(), specific, opResult.getResponseNode().get(ModelDescriptionConstants.RESULT));
+        }
+    }
+
+    /**
+     * Tests WFLY-2527 fix.
+     */
+    @Test
+    public void testReadResourceDescriptionNoGenericRegistration() throws IOException {
+        cli.sendLine(String.format(OP_PATTERN, EVICTION, READ_RES_DESC_OP));
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode specific = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        cli.sendLine(String.format(OP_PATTERN, "*", READ_RES_DESC_OP));
+        opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode generic = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        Assert.assertEquals(ModelType.LIST, generic.getType());
+        Assert.assertEquals(1, generic.asInt());
+        Assert.assertEquals(specific, generic.get(0).get(ModelDescriptionConstants.RESULT));
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/CLITestSuite.java
@@ -36,6 +36,7 @@ import org.jboss.as.test.integration.domain.management.cli.DomainDeploymentOverl
 import org.jboss.as.test.integration.domain.management.cli.JmsTestCase;
 import org.jboss.as.test.integration.domain.management.cli.RolloutPlanTestCase;
 import org.jboss.as.test.integration.domain.management.cli.UndeployWildcardDomainTestCase;
+import org.jboss.as.test.integration.domain.management.cli.WildCardReadsTestCase;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -56,7 +57,8 @@ import org.junit.runners.Suite;
     JmsTestCase.class,
     DataSourceTestCase.class,
     RolloutPlanTestCase.class,
-    DomainDeployWithRuntimeNameTestCase.class
+    DomainDeployWithRuntimeNameTestCase.class,
+    WildCardReadsTestCase.class
 })
 public class CLITestSuite {
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/WildCardReadsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/WildCardReadsTestCase.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.cli;
+
+import java.io.IOException;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests related to read ops for wildcard addresses.
+ *
+ * @author Brian Stansberry (c) 2013 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class WildCardReadsTestCase extends AbstractCliTestBase {
+
+    private static final String OP_PATTERN = "/subsystem=infinispan/cache-container=web/distributed-cache=dist/eviction=%s:%s";
+    private static final String READ_OP_DESC_OP = ModelDescriptionConstants.READ_OPERATION_DESCRIPTION_OPERATION + "(name=%s)";
+    private static final String READ_RES_DESC_OP = ModelDescriptionConstants.READ_RESOURCE_DESCRIPTION_OPERATION + "(access-control=combined-descriptions,operations=true,recursive=true)";
+    private static final String EVICTION = "EVICTION";
+
+    @BeforeClass
+    public static void before() throws Exception {
+        initCLI();
+    }
+
+    @AfterClass
+    public static void after() throws Exception {
+        closeCLI();
+    }
+
+    /**
+     * Tests WFLY-2527 added behavior of supporting read-operation-description for
+     * wildcard addresses where there is no generic resource registration for the type
+     */
+    @Test
+    public void testLenientReadOperationDescription() throws IOException {
+        cli.sendLine(String.format(OP_PATTERN, EVICTION, ModelDescriptionConstants.READ_OPERATION_NAMES_OPERATION));
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        for (ModelNode node : opResult.getResponseNode().get(ModelDescriptionConstants.RESULT).asList()) {
+            String opPart = String.format(READ_OP_DESC_OP, node.asString());
+            cli.sendLine(String.format(OP_PATTERN, EVICTION, opPart));
+            opResult = cli.readAllAsOpResult();
+            Assert.assertTrue(opResult.isIsOutcomeSuccess());
+            ModelNode specific = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+            cli.sendLine(String.format(OP_PATTERN, "*", opPart));
+            opResult = cli.readAllAsOpResult();
+            Assert.assertTrue(opResult.isIsOutcomeSuccess());
+            Assert.assertEquals("mismatch for " + node.asString(), specific, opResult.getResponseNode().get(ModelDescriptionConstants.RESULT));
+        }
+    }
+
+    /**
+     * Tests WFLY-2527 fix.
+     */
+    @Test
+    public void testReadResourceDescriptionNoGenericRegistration() throws IOException {
+        cli.sendLine(String.format(OP_PATTERN, EVICTION, READ_RES_DESC_OP));
+        CLIOpResult opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode specific = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        cli.sendLine(String.format(OP_PATTERN, "*", READ_RES_DESC_OP));
+        opResult = cli.readAllAsOpResult();
+        Assert.assertTrue(opResult.isIsOutcomeSuccess());
+        ModelNode generic = opResult.getResponseNode().get(ModelDescriptionConstants.RESULT);
+        Assert.assertEquals(ModelType.LIST, generic.getType());
+        Assert.assertEquals(1, generic.asInt());
+        Assert.assertEquals(specific, generic.get(0).get(ModelDescriptionConstants.RESULT));
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
@@ -62,7 +62,7 @@ public class CLISecurityTestCase {
     public static class UnauthentizedCLI extends CLIWrapper {
 
         public UnauthentizedCLI() throws Exception {
-            super();
+            super(false, null, createConsoleInput());
         }
 
         @Override
@@ -70,8 +70,7 @@ public class CLISecurityTestCase {
             return null;
         }
 
-        @Override
-        protected InputStream createConsoleInput() {
+        private static InputStream createConsoleInput() {
             return new InputStream() {
                 private final byte[] bytes = (Authentication.USERNAME + '\n').getBytes();
                 private int i = 0;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIOpResult.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/util/CLIOpResult.java
@@ -39,12 +39,14 @@ import org.jboss.dmr.Property;
  */
 public class CLIOpResult {
 
+    private ModelNode responseNode;
     private boolean isOutcomeSuccess;
     private Map<String, Object> responseMap;
 
     public CLIOpResult() {}
 
     public CLIOpResult(ModelNode node) {
+        this.responseNode = node;
         this.responseMap = toMap(node);
         this.isOutcomeSuccess = ModelDescriptionConstants.SUCCESS.equals(this.responseMap.get(ModelDescriptionConstants.OUTCOME));
     }
@@ -87,6 +89,10 @@ public class CLIOpResult {
 
     public Object getResult() {
         return getFromResponse(ModelDescriptionConstants.RESULT);
+    }
+
+    public ModelNode getResponseNode() {
+        return responseNode;
     }
 
     /**


### PR DESCRIPTION
The read-resource-description op supports wildcard results (with the result being a list with one element per match) but this fails if the target resource type does not have a generic MRR registered. This patch fixes that.

The last commit also makes read-operation-description more lenient when the user specifies a wildcard address but there is no wildcard registration. The OSH now checks if all registered non-wildcard MRRs have the op and with the same description and flags; if so that description/flags are used to prepare the response.

The more lenient read-operation-description behavior is necessary to make the read-resource-description fix useful in the CLI. Without it the CLI's background validation of the user's read-resource-description input will fail. The validation uses read-operation-description.
