### PR TITLE
[WFLY-490] domain tests are passing JVM arguments to servers just like integration tests

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -107,6 +107,7 @@
                         <module.path>${jboss.home}/modules</module.path>
                         <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                         <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts}</server.jvm.args>
                     </systemPropertyVariables>
                     <includes>
                          <include>org/jboss/as/test/integration/autoignore/*TestCase.java</include>
@@ -150,6 +151,7 @@
                                 <module.path>${jboss.home}/modules</module.path>
                                 <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                                 <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
+                                <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts}</server.jvm.args>
                                 <jboss.test.rbac.soak.clients>${jboss.test.rbac.soak.clients}</jboss.test.rbac.soak.clients>
                                 <jboss.test.rbac.soak.iterations>${jboss.test.rbac.soak.iterations}</jboss.test.rbac.soak.iterations>
                             </systemPropertyVariables>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
@@ -71,7 +71,7 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
 
     private String modulePath = System.getProperty("module.path");
 
-    private String javaVmArguments = "-Xmx512m -XX:MaxPermSize=128m";
+    private String javaVmArguments = System.getProperty("server.jvm.args", "-Xmx512m -XX:MaxPermSize=128m");
 
     private int startupTimeoutInSeconds = TimeoutUtil.adjust(120);
 


### PR DESCRIPTION
Small change to domain tests infrastructure so that the JVM arguments from the testsuite POM are passed to the servers, just like in integration tests. Few notes:
- I'm marking this as `WFLY-490` because my ultimate goal with this is to run the RBAC domain tests under security manager (which is now possible, with this commit).
- This might have some unforeseen consequences, not sure. I only know about a single difference: default memory configuration of the newly spawned servers used to be `-Xmx512m -XX:MaxPermSize=128m`, but with this change, it becomes `-Xmx512m -XX:MaxPermSize=256m` (see `testsuite/pom.xml`, line 148, `surefire.memory.args`).

Comments welcome.
