### PR TITLE
WFLY-2621 Distributable @StatefulTimeout(0L) EJBs should not be immortal

### DIFF
--- a/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/BeanExpirationSchedulerTestCase.java
+++ b/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/BeanExpirationSchedulerTestCase.java
@@ -49,7 +49,8 @@ public class BeanExpirationSchedulerTestCase {
         when(bean.getId()).thenReturn(beanId);
         when(bean.isExpired()).thenReturn(false);
 
-        when(config.getTimeout()).thenReturn(new Time(0, TimeUnit.SECONDS));
+        // Fun fact: the EJB specification allows a timeout value of 0, so only negative timeouts are treated as immortal
+        when(config.getTimeout()).thenReturn(new Time(-1, TimeUnit.SECONDS));
         when(config.getRemoveListener()).thenReturn(listener);
 
         try (Scheduler<Bean<Object, String, Object>> scheduler = new BeanExpirationScheduler<>(batcher, remover, config)) {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/provider/ServiceProviderRegistrationTestCase.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 
-import javax.naming.NamingException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -23,8 +21,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,7 +30,6 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
     private static final Logger log = Logger.getLogger(ServiceProviderRegistrationTestCase.class);
     private static final String MODULE_NAME = "service-provider-registration";
     private static final String CLIENT_PROPERTIES = "cluster/ejb3/stateless/jboss-ejb-client.properties";
-    private static EJBDirectory context;
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -55,16 +50,6 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
         return ejbJar;
     }
 
-    @BeforeClass
-    public static void beforeClass() throws NamingException {
-        context = new RemoteEJBDirectory(MODULE_NAME);
-    }
-
-    @AfterClass
-    public static void destroy() throws NamingException {
-        context.close();
-    }
-
     @Test
     public void test() throws Exception {
 
@@ -75,8 +60,8 @@ public class ServiceProviderRegistrationTestCase extends ClusterAbstractTestCase
 
         ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
-        try {
-            ServiceProviderRetriever bean = context.lookupStateless(ServiceProviderRetrieverBean.class, ServiceProviderRetriever.class);
+        try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {
+            ServiceProviderRetriever bean = directory.lookupStateless(ServiceProviderRetrieverBean.class, ServiceProviderRetriever.class);
             Collection<String> names = bean.getProviders();
             assertEquals(2, names.size());
             assertTrue(names.toString(), names.contains(nodeName1));

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/registry/RegistryTestCase.java
@@ -5,8 +5,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 
-import javax.naming.NamingException;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
@@ -23,8 +21,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,7 +30,6 @@ public class RegistryTestCase extends ClusterAbstractTestCase {
     private static final Logger log = Logger.getLogger(RegistryTestCase.class);
     private static final String MODULE_NAME = "registry";
     private static final String CLIENT_PROPERTIES = "cluster/ejb3/stateless/jboss-ejb-client.properties";
-    private static EJBDirectory context;
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -55,22 +50,12 @@ public class RegistryTestCase extends ClusterAbstractTestCase {
         return jar;
     }
 
-    @BeforeClass
-    public static void beforeClass() throws NamingException {
-        context = new RemoteEJBDirectory(MODULE_NAME);
-    }
-
-    @AfterClass
-    public static void destroy() throws NamingException {
-        context.close();
-    }
-
     @Test
     public void test() throws Exception {
 
         ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
 
-        try {
+        try (EJBDirectory context = new RemoteEJBDirectory(MODULE_NAME)) {
             RegistryRetriever bean = context.lookupStateless(RegistryRetrieverBean.class, RegistryRetriever.class);
             Collection<String> names = bean.getNodes();
             assertEquals(2, names.size());


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2621
WFLY-2590 only addressed the simple SFSB cache.  This PR completes that fix for the distributed cache.

Also, fix transient failures in clustering api tests, e.g CommandDispatcherTestCase, etc.
