### PR TITLE
[WFLY-2633] Correct validation of duplicate runtime names

### DIFF
--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/deployment/standalone.xml
@@ -7,5 +7,8 @@
         <deployment name="mySecondApp" runtime-name="def.war">
             <content sha1="12345678901234567890"/>
         </deployment>
+        <deployment name="myThirdApp" runtime-name="def.war" enabled="false">
+            <content sha1="12345678901234567890"/>
+        </deployment>
     </deployments>
 </server>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-deployments.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-deployments.xml
@@ -8,6 +8,9 @@
         <deployment name="other-test-deployment" runtime-name="abc.war">
             <content sha1="12345678901234567890"/>
         </deployment>
+        <deployment name="dup-deployment" runtime-name="abc.war">
+            <content sha1="12345678901234567890"/>
+        </deployment>
     </deployments>
 
    <server-groups>
@@ -36,6 +39,7 @@
             <deployments>
                 <deployment name="test-deployment" runtime-name="foo.war" enabled="false" />
                 <deployment name="other-test-deployment" runtime-name="abc.war" enabled="false" />
+                <deployment name="dup-deployment" runtime-name="abc.war" enabled="false" />
             </deployments>
 
         </server-group>

--- a/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-duplicate-runtime-names.xml
+++ b/core-model-test/tests/src/test/resources/org/jboss/as/core/model/test/servergroup/servergroup-with-duplicate-runtime-names.xml
@@ -34,8 +34,8 @@
             <socket-binding-group ref="test-sockets" port-offset="10"/>
 
             <deployments>
-                <deployment name="test-deployment" runtime-name="foo.war" enabled="false" />
-                <deployment name="other-test-deployment" runtime-name="foo.war" enabled="false" />
+                <deployment name="test-deployment" runtime-name="foo.war" />
+                <deployment name="other-test-deployment" runtime-name="foo.war" />
             </deployments>
 
         </server-group>

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/ServerGroupDeploymentAddHandler.java
@@ -18,15 +18,20 @@
  */
 package org.jboss.as.domain.controller.operations.deployment;
 
-import java.util.List;
-import java.util.Set;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CONTENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_HASH;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME_NILLABLE;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.SERVER_GROUP_ADD_ATTRIBUTES;
+
+import java.util.List;
+import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -34,12 +39,10 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADDRESS;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.DomainControllerMessages;
 import org.jboss.as.repository.HostFileRepository;
-import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
@@ -63,15 +66,11 @@ public class ServerGroupDeploymentAddHandler implements OperationStepHandler {
      */
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
         final ModelNode opAddr = operation.get(OP_ADDR);
-        PathAddress address = PathAddress.pathAddress(opAddr);
-        String name = address.getLastElement().getValue();
+        final PathAddress address = PathAddress.pathAddress(opAddr);
+        final String name = address.getLastElement().getValue();
 
         final Resource deploymentResource = context.readResourceFromRoot(PathAddress.pathAddress(PathElement.pathElement(DEPLOYMENT, name)));
         ModelNode deployment = deploymentResource.getModel();
-        String runtimeName = deployment.get(RUNTIME_NAME.getName()).asString();
-
-        String serverGroupName = getServerGroupName(operation);
-        isRuntimeNameUniqueForServerGroup(serverGroupName, context, name, runtimeName);
 
         for (ModelNode content : deployment.require(CONTENT).asList()) {
             if ((content.hasDefined(CONTENT_HASH.getName()))) {
@@ -91,7 +90,52 @@ public class ServerGroupDeploymentAddHandler implements OperationStepHandler {
             RUNTIME_NAME_NILLABLE.validateAndSet(deployment, subModel);
         }
 
+        // Add a step to validate uniqueness of runtime names
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                validateRuntimeNames(name, context, address);
+            }
+        }, OperationContext.Stage.MODEL);
+
         context.stepCompleted();
+    }
+
+    private void validateRuntimeNames(String deploymentName, OperationContext context, PathAddress address) throws OperationFailedException {
+        ModelNode deployment = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+
+        if (ENABLED.resolveModelAttribute(context, deployment).asBoolean()) {
+            Resource root = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
+            ModelNode domainDeployment = root.getChild(PathElement.pathElement(DEPLOYMENT, deploymentName)).getModel();
+            String runtimeName = getRuntimeName(deploymentName, deployment, domainDeployment);
+            PathAddress sgAddress = address.subAddress(0, address.size() - 1);
+            Resource serverGroup = root.navigate(sgAddress);
+            for (Resource.ResourceEntry re : serverGroup.getChildren(DEPLOYMENT)) {
+                String reName = re.getName();
+                if (!deploymentName.equals(reName)) {
+                    ModelNode otherDepl = re.getModel();
+                    if (ENABLED.resolveModelAttribute(context, otherDepl).asBoolean()) {
+                        domainDeployment = root.getChild(PathElement.pathElement(DEPLOYMENT, reName)).getModel();
+                        String otherRuntimeName = getRuntimeName(reName, otherDepl, domainDeployment);
+                        if (runtimeName.equals(otherRuntimeName)) {
+                            throw DomainControllerMessages.MESSAGES.runtimeNameMustBeUnique(reName, runtimeName,
+                                    sgAddress.getLastElement().getValue());
+                        }
+                    }
+                }
+            }
+        }
+
+        context.stepCompleted();
+    }
+
+    private static String getRuntimeName(String name, ModelNode deployment, ModelNode domainDeployment) {
+        if (deployment.hasDefined(ModelDescriptionConstants.RUNTIME_NAME)) {
+            return deployment.get(ModelDescriptionConstants.RUNTIME_NAME).asString();
+        } else if (domainDeployment.hasDefined(ModelDescriptionConstants.RUNTIME_NAME)) {
+            return domainDeployment.get(ModelDescriptionConstants.RUNTIME_NAME).asString();
+        }
+        return name;
     }
 
     private void isRuntimeNameUniqueForServerGroup(String serverGroupName, OperationContext context, String name, String runtimeName) throws OperationFailedException {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/DomainXml.java
@@ -270,7 +270,7 @@ public class DomainXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), false);
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.SERVER_GROUPS) {
@@ -321,7 +321,7 @@ public class DomainXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), false);
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.SERVER_GROUPS) {
@@ -376,7 +376,7 @@ public class DomainXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), false);
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.SERVER_GROUPS) {
@@ -431,7 +431,7 @@ public class DomainXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), false);
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.DEPLOYMENT_OVERLAYS) {
@@ -495,7 +495,7 @@ public class DomainXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, expectedNs, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), false);
             element = nextElement(reader, expectedNs);
         }
         if (element == Element.DEPLOYMENT_OVERLAYS) {
@@ -820,8 +820,9 @@ public class DomainXml extends CommonXml {
                         }
                         sawDeployments = true;
                         List<ModelNode> deployments = new ArrayList<ModelNode>();
-                        parseDeployments(reader, groupAddress, expectedNs, deployments, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED), Collections.<Element>emptySet());
-                        checkDeployments(deployments, reader);
+                        parseDeployments(reader, groupAddress, expectedNs, deployments,
+                                EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED),
+                                Collections.<Element>emptySet(), true);
                         list.addAll(deployments);
                         break;
                     }
@@ -838,26 +839,6 @@ public class DomainXml extends CommonXml {
                 }
             }
 
-        }
-    }
-
-    private void checkDeployments(List<ModelNode> deployments, final XMLExtendedStreamReader reader) throws XMLStreamException {
-        final Set<String> uniqueDeploymentNames = new HashSet<String>(deployments.size());
-        final Set<String> uniqueRuntimeNames = new HashSet<String>(deployments.size());
-        for (ModelNode deployment : deployments) {
-            String deploymentName = null;
-            for (Property property : deployment.get(ModelDescriptionConstants.ADDRESS).asPropertyList()) {
-                if (ModelDescriptionConstants.DEPLOYMENT.equals(property.getName())) {
-                    deploymentName = property.getValue().asString();
-                }
-            }
-            if (!uniqueDeploymentNames.add(deploymentName)) {
-                throw ParseUtils.duplicateNamedElement(reader, deploymentName);
-            }
-            String runtimeName = deployment.get(ModelDescriptionConstants.RUNTIME_NAME).asString();
-            if (!uniqueRuntimeNames.add(runtimeName)) {
-                throw ParseUtils.duplicateNamedElement(reader, runtimeName);
-            }
         }
     }
 

--- a/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
+++ b/server/src/main/java/org/jboss/as/server/parsing/StandaloneXml.java
@@ -254,7 +254,7 @@ public class StandaloneXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, DOMAIN_1_0, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), true);
             element = nextElement(reader, DOMAIN_1_0);
         }
 
@@ -364,7 +364,7 @@ public class StandaloneXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, namespace, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), true);
             element = nextElement(reader, namespace);
         }
         if (element != null) {
@@ -472,7 +472,7 @@ public class StandaloneXml extends CommonXml {
         }
         if (element == Element.DEPLOYMENTS) {
             parseDeployments(reader, address, namespace, list, EnumSet.of(Attribute.NAME, Attribute.RUNTIME_NAME, Attribute.ENABLED),
-                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED));
+                    EnumSet.of(Element.CONTENT, Element.FS_ARCHIVE, Element.FS_EXPLODED), true);
             element = nextElement(reader, namespace);
         }
 


### PR DESCRIPTION
1) Don't do runtime-name dup checks for domain level deployment resources.
2) Exclude disabled deployments from runtime-name dup checks
3) When checking dup runtime-name, get the name from the domain level resource if the server group resource doesn't set the runtime name, and if neither do use the resource name.
