### PR TITLE
WFLY-2625 WFLY-2653 WFLY-2196 WFLY-1070 Undertow subsystem upgrades

### DIFF
--- a/build/src/main/resources/docs/schema/wildfly-undertow_1_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-undertow_1_0.xsd
@@ -96,12 +96,21 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="port-forwarding" use="optional" type="xs:string">
+                <xs:attribute name="redirect-socket" use="optional" type="xs:string">
                     <xs:annotation>
                         <xs:documentation>
                             <![CDATA[
                                 If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
-                                undertow will automatically redirect the request to the port number specified here.
+                                undertow will automatically redirect the request to the socket binding port specified here.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="proxy-address-forwarding" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                              enables x-forwarded-host and similar headers and set a remote ip address and hostname
                                ]]>
                         </xs:documentation>
                     </xs:annotation>

--- a/build/src/main/resources/docs/schema/wildfly-undertow_1_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-undertow_1_0.xsd
@@ -124,6 +124,7 @@
             <xs:extension base="listener-type">
                 <xs:attribute name="security-realm" use="required" type="xs:string"/>
                 <xs:attribute name="verify-client" use="optional" type="xs:string"/>
+                <xs:attribute name="enabled-cipher-suites" use="optional" type="xs:string"/>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/build/src/main/resources/docs/schema/wildfly-undertow_1_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-undertow_1_0.xsd
@@ -96,6 +96,16 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
+                <xs:attribute name="port-forwarding" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                undertow will automatically redirect the request to the port number specified here.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
@@ -113,6 +123,16 @@
         <xs:complexContent>
             <xs:extension base="listener-type">
                 <xs:attribute name="scheme" type="xs:string"/>
+                <xs:attribute name="port-forwarding" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                                undertow will automatically redirect the request to the port number specified here.
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>

--- a/io/src/main/java/org/wildfly/extension/io/OptionAttributeDefinition.java
+++ b/io/src/main/java/org/wildfly/extension/io/OptionAttributeDefinition.java
@@ -69,18 +69,20 @@ public class OptionAttributeDefinition extends SimpleAttributeDefinition {
 
     public OptionMap.Builder resolveOption(final OperationContext context, final ModelNode model, OptionMap.Builder builder) throws OperationFailedException {
         ModelNode value = resolveModelAttribute(context, model);
-        if (getType() == ModelType.INT) {
-            builder.set((Option<Integer>) option, value.asInt());
-        } else if (getType() == ModelType.LONG) {
-            builder.set(option, value.asLong());
-        } else if (getType() == ModelType.BOOLEAN) {
-            builder.set(option, value.asBoolean());
-        } else if (optionType.isEnum()) {
-            builder.set(option, option.parseValue(value.asString(),option.getClass().getClassLoader()));
-        } else if (getType() == ModelType.STRING) {
-            builder.set(option, value.asString());
-        } else {
-            throw new OperationFailedException("Dont know how to handle: " + option + " with value: " + value);
+        if (value.isDefined()) {
+            if (getType() == ModelType.INT) {
+                builder.set((Option<Integer>) option, value.asInt());
+            } else if (getType() == ModelType.LONG) {
+                builder.set(option, value.asLong());
+            } else if (getType() == ModelType.BOOLEAN) {
+                builder.set(option, value.asBoolean());
+            } else if (optionType.isEnum()) {
+                builder.set(option, option.parseValue(value.asString(), option.getClass().getClassLoader()));
+            } else if (getType() == ModelType.STRING) {
+                builder.set(option, value.asString());
+            } else {
+                throw new OperationFailedException("Dont know how to handle: " + option + " with value: " + value);
+            }
         }
         return builder;
     }
@@ -113,7 +115,13 @@ public class OptionAttributeDefinition extends SimpleAttributeDefinition {
 
         private void setType() {
             try {
-                Field typeField = option.getClass().getDeclaredField("type");
+                final Field typeField;
+                if (option.getClass().getSimpleName().equals("SequenceOption")){
+                    typeField = option.getClass().getDeclaredField("elementType");
+                }else{
+                    typeField = option.getClass().getDeclaredField("type");
+                }
+
                 typeField.setAccessible(true);
                 optionType = (Class<?>) typeField.get(option);
 

--- a/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowConnectorTestCase.java
+++ b/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowConnectorTestCase.java
@@ -49,8 +49,8 @@ public class UndertowConnectorTestCase {
     @Test
     public void getType() {
         OptionMap options = OptionMap.builder().getMap();
-        assertSame(Connector.Type.AJP, new UndertowConnector(new AjpListenerService("", "", options)).getType());
-        assertSame(Connector.Type.HTTP, new UndertowConnector(new HttpListenerService("", "", options, false)).getType());
+        assertSame(Connector.Type.AJP, new UndertowConnector(new AjpListenerService("", "", options,443)).getType());
+        assertSame(Connector.Type.HTTP, new UndertowConnector(new HttpListenerService("", "", options, false,443)).getType());
         assertSame(Connector.Type.HTTPS, new UndertowConnector(new HttpsListenerService("", "", options)).getType());
     }
 

--- a/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowConnectorTestCase.java
+++ b/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowConnectorTestCase.java
@@ -49,8 +49,8 @@ public class UndertowConnectorTestCase {
     @Test
     public void getType() {
         OptionMap options = OptionMap.builder().getMap();
-        assertSame(Connector.Type.AJP, new UndertowConnector(new AjpListenerService("", "", options,443)).getType());
-        assertSame(Connector.Type.HTTP, new UndertowConnector(new HttpListenerService("", "", options, false,443)).getType());
+        assertSame(Connector.Type.AJP, new UndertowConnector(new AjpListenerService("", "", options)).getType());
+        assertSame(Connector.Type.HTTP, new UndertowConnector(new HttpListenerService("", "", options, false, false)).getType());
         assertSame(Connector.Type.HTTPS, new UndertowConnector(new HttpsListenerService("", "", options)).getType());
     }
 

--- a/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowEngineTestCase.java
+++ b/mod_cluster/undertow/src/test/java/org/wildfly/mod_cluster/undertow/UndertowEngineTestCase.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import org.jboss.modcluster.container.Connector;
 import org.jboss.modcluster.container.Engine;
 import org.junit.Test;
+import org.wildfly.extension.undertow.HttpsListenerService;
 import org.wildfly.extension.undertow.ListenerService;
 import org.wildfly.extension.undertow.Host;
 import org.wildfly.extension.undertow.Server;
@@ -40,7 +41,7 @@ public class UndertowEngineTestCase {
     private final String serverName = "name";
     private final String hostName = "host";
     private final Host host = new Host(this.hostName, Collections.<String>emptyList(), "ROOT.war") {};
-    private final ListenerService<?> listener = mock(ListenerService.class);
+    private final HttpsListenerService listener = new HttpsListenerService("default", "https",null);
     private final Server server = new TestServer(this.serverName, this.defaultHost, this.host, this.listener);
     private final UndertowService service = new TestUndertowService("default-container", "default-server", "default-virtual-host", "instance-id", this.server);
     private final Connector connector = mock(Connector.class);
@@ -67,8 +68,7 @@ public class UndertowEngineTestCase {
         assertTrue(results.hasNext());
         org.jboss.modcluster.container.Connector connector = results.next();
         
-        String listenerName = "listener";
-        when(this.listener.getName()).thenReturn(listenerName);
+        String listenerName = "default";
         assertSame(listenerName, connector.toString());
         assertFalse(results.hasNext());
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerAdd.java
@@ -44,8 +44,7 @@ class AjpListenerAdd extends ListenerAdd {
         if(schemeNode.isDefined()) {
             scheme = schemeNode.asString();
         }
-        final Integer redirectPort = ListenerResourceDefinition.REDIRECT_PORT.resolveModelAttribute(context, model).asInt();
-        return new AjpListenerService(name, scheme, listenerOptions, redirectPort);
+        return new AjpListenerService(name, scheme, listenerOptions);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerAdd.java
@@ -44,7 +44,8 @@ class AjpListenerAdd extends ListenerAdd {
         if(schemeNode.isDefined()) {
             scheme = schemeNode.asString();
         }
-        return new AjpListenerService(name, scheme, listenerOptions);
+        final Integer redirectPort = ListenerResourceDefinition.REDIRECT_PORT.resolveModelAttribute(context, model).asInt();
+        return new AjpListenerService(name, scheme, listenerOptions, redirectPort);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
@@ -57,6 +57,7 @@ public class AjpListenerResourceDefinition extends ListenerResourceDefinition {
     public Collection<AttributeDefinition> getAttributes() {
         List<AttributeDefinition> attrs = new ArrayList<>(super.getAttributes());
         attrs.add(SCHEME);
+        attrs.add(REDIRECT_PORT);
         return attrs;
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerResourceDefinition.java
@@ -57,7 +57,7 @@ public class AjpListenerResourceDefinition extends ListenerResourceDefinition {
     public Collection<AttributeDefinition> getAttributes() {
         List<AttributeDefinition> attrs = new ArrayList<>(super.getAttributes());
         attrs.add(SCHEME);
-        attrs.add(REDIRECT_PORT);
+        attrs.add(REDIRECT_SOCKET);
         return attrs;
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
@@ -43,8 +43,8 @@ public class AjpListenerService extends ListenerService<AjpListenerService> {
     private volatile AcceptingChannel<StreamConnection> server;
     private final String scheme;
 
-    public AjpListenerService(String name, final String scheme, OptionMap listenerOptions, int redirectPort) {
-        super(name, listenerOptions, redirectPort);
+    public AjpListenerService(String name, final String scheme, OptionMap listenerOptions) {
+        super(name, listenerOptions);
         this.scheme = scheme;
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
@@ -43,8 +43,8 @@ public class AjpListenerService extends ListenerService<AjpListenerService> {
     private volatile AcceptingChannel<StreamConnection> server;
     private final String scheme;
 
-    public AjpListenerService(String name, final String scheme, OptionMap listenerOptions) {
-        super(name,listenerOptions);
+    public AjpListenerService(String name, final String scheme, OptionMap listenerOptions, int redirectPort) {
+        super(name, listenerOptions, redirectPort);
         this.scheme = scheme;
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
@@ -122,7 +122,7 @@ public interface Constants {
     String DEFAULT_BUFFER_CACHE = "default-buffer-cache";
 
     String RELATIVE_TO = "relative-to";
-    String REDIRECT_PORT = "redirect-port";
+    String REDIRECT_SOCKET = "redirect-socket";
     String DIRECTORY = "directory";
     String STACK_TRACE_ON_ERROR = "stack-trace-on-error";
     String DEFAULT_ENCODING = "default-encoding";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
@@ -122,6 +122,7 @@ public interface Constants {
     String DEFAULT_BUFFER_CACHE = "default-buffer-cache";
 
     String RELATIVE_TO = "relative-to";
+    String REDIRECT_PORT = "redirect-port";
     String DIRECTORY = "directory";
     String STACK_TRACE_ON_ERROR = "stack-trace-on-error";
     String DEFAULT_ENCODING = "default-encoding";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
@@ -44,8 +44,8 @@ public class HttpListenerAdd extends ListenerAdd {
     @Override
     ListenerService<? extends ListenerService> createService(String name, final String serverName, final OperationContext context, ModelNode model, OptionMap listenerOptions) throws OperationFailedException {
         final boolean certificateForwarding = HttpListenerResourceDefinition.CERTIFICATE_FORWARDING.resolveModelAttribute(context, model).asBoolean();
-
-        return new HttpListenerService(name, serverName, listenerOptions, certificateForwarding);
+        final Integer redirectPort = ListenerResourceDefinition.REDIRECT_PORT.resolveModelAttribute(context, model).asInt();
+        return new HttpListenerService(name, serverName, listenerOptions, certificateForwarding, redirectPort);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerAdd.java
@@ -44,8 +44,8 @@ public class HttpListenerAdd extends ListenerAdd {
     @Override
     ListenerService<? extends ListenerService> createService(String name, final String serverName, final OperationContext context, ModelNode model, OptionMap listenerOptions) throws OperationFailedException {
         final boolean certificateForwarding = HttpListenerResourceDefinition.CERTIFICATE_FORWARDING.resolveModelAttribute(context, model).asBoolean();
-        final Integer redirectPort = ListenerResourceDefinition.REDIRECT_PORT.resolveModelAttribute(context, model).asInt();
-        return new HttpListenerService(name, serverName, listenerOptions, certificateForwarding, redirectPort);
+        final boolean proxyAddressForwarding = HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING.resolveModelAttribute(context, model).asBoolean();
+        return new HttpListenerService(name, serverName, listenerOptions, certificateForwarding, proxyAddressForwarding);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
@@ -47,6 +47,13 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
             .setAllowExpression(true)
             .build();
 
+    protected static final SimpleAttributeDefinition PROXY_ADDRESS_FORWARDING = new SimpleAttributeDefinitionBuilder("proxy-address-forwarding", ModelType.BOOLEAN)
+            .setAllowNull(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setDefaultValue(new ModelNode(false))
+            .setAllowExpression(true)
+            .build();
+
 
     private HttpListenerResourceDefinition() {
         super(UndertowExtension.HTTP_LISTENER_PATH);
@@ -60,7 +67,8 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
     public Collection<AttributeDefinition> getAttributes() {
         List<AttributeDefinition> attrs = new ArrayList<>(super.getAttributes());
         attrs.add(CERTIFICATE_FORWARDING);
-        attrs.add(REDIRECT_PORT);
+        attrs.add(REDIRECT_SOCKET);
+        attrs.add(PROXY_ADDRESS_FORWARDING);
         return attrs;
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerResourceDefinition.java
@@ -42,7 +42,7 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
 
     protected static final SimpleAttributeDefinition CERTIFICATE_FORWARDING = new SimpleAttributeDefinitionBuilder(Constants.CERTIFICATE_FORWARDING, ModelType.BOOLEAN)
             .setAllowNull(true)
-            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setDefaultValue(new ModelNode(false))
             .setAllowExpression(true)
             .build();
@@ -60,6 +60,7 @@ public class HttpListenerResourceDefinition extends ListenerResourceDefinition {
     public Collection<AttributeDefinition> getAttributes() {
         List<AttributeDefinition> attrs = new ArrayList<>(super.getAttributes());
         attrs.add(CERTIFICATE_FORWARDING);
+        attrs.add(REDIRECT_PORT);
         return attrs;
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
@@ -30,6 +30,7 @@ import io.undertow.server.HttpHandler;
 import io.undertow.server.ListenerRegistry;
 import io.undertow.server.OpenListener;
 import io.undertow.server.handlers.ChannelUpgradeHandler;
+import io.undertow.server.handlers.ProxyPeerAddressHandler;
 import io.undertow.server.handlers.SSLHeaderHandler;
 import io.undertow.server.protocol.http.HttpOpenListener;
 import org.jboss.msc.service.ServiceName;
@@ -58,8 +59,8 @@ public class HttpListenerService extends ListenerService<HttpListenerService> {
 
     private final String serverName;
 
-    public HttpListenerService(String name, final String serverName, OptionMap listenerOptions, boolean certificateForwarding, int redirectPort) {
-        super(name, listenerOptions, redirectPort);
+    public HttpListenerService(String name, final String serverName, OptionMap listenerOptions, boolean certificateForwarding, boolean proxyAddressForwarding) {
+        super(name, listenerOptions);
         this.serverName = serverName;
         listenerHandlerWrappers.add(new HandlerWrapper() {
             @Override
@@ -73,6 +74,13 @@ public class HttpListenerService extends ListenerService<HttpListenerService> {
                 @Override
                 public HttpHandler wrap(HttpHandler handler) {
                     return new SSLHeaderHandler(handler);
+                }
+            });
+        }if (proxyAddressForwarding) {
+            listenerHandlerWrappers.add(new HandlerWrapper() {
+                @Override
+                public HttpHandler wrap(HttpHandler handler) {
+                    return new ProxyPeerAddressHandler(handler);
                 }
             });
         }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
@@ -58,8 +58,8 @@ public class HttpListenerService extends ListenerService<HttpListenerService> {
 
     private final String serverName;
 
-    public HttpListenerService(String name, final String serverName, OptionMap listenerOptions, boolean certificateForwarding) {
-        super(name, listenerOptions);
+    public HttpListenerService(String name, final String serverName, OptionMap listenerOptions, boolean certificateForwarding, int redirectPort) {
+        super(name, listenerOptions, redirectPort);
         this.serverName = serverName;
         listenerHandlerWrappers.add(new HandlerWrapper() {
             @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerAdd.java
@@ -45,6 +45,7 @@ public class HttpsListenerAdd extends ListenerAdd {
     ListenerService<? extends ListenerService> createService(String name, final String serverName, final OperationContext context, ModelNode model, OptionMap listenerOptions) throws OperationFailedException {
         OptionMap.Builder builder = OptionMap.builder().addAll(listenerOptions);
         HttpsListenerResourceDefinition.VERIFY_CLIENT.resolveOption(context, model,builder);
+        HttpsListenerResourceDefinition.ENABLED_CIPHER_SUITES.resolveOption(context, model, builder);
         return new HttpsListenerService(name, serverName, builder.getMap());
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerResourceDefinition.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.io.OptionAttributeDefinition;
+import org.xnio.Options;
 import org.xnio.SslClientAuthMode;
 
 /**
@@ -60,6 +61,12 @@ public class HttpsListenerResourceDefinition extends ListenerResourceDefinition 
             .setDefaultValue(new ModelNode(SslClientAuthMode.NOT_REQUESTED.name()))
             .build();
 
+    protected static final OptionAttributeDefinition ENABLED_CIPHER_SUITES = OptionAttributeDefinition.builder("enabled-cipher-suites", Options.SSL_ENABLED_CIPHER_SUITES)
+            .setAllowNull(true)
+            .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+            .setAllowExpression(true)
+            .build();
+
 
     private HttpsListenerResourceDefinition() {
         super(UndertowExtension.HTTPS_LISTENER_PATH);
@@ -70,6 +77,7 @@ public class HttpsListenerResourceDefinition extends ListenerResourceDefinition 
         Collection<AttributeDefinition> res = new LinkedList<>(super.getAttributes());
         res.add(SECURITY_REALM);
         res.add(VERIFY_CLIENT);
+        res.add(ENABLED_CIPHER_SUITES);
         return res;
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
@@ -53,7 +53,7 @@ public class HttpsListenerService extends HttpListenerService {
     static final String PROTOCOL = "https";
 
     public HttpsListenerService(final String name, String serverName, OptionMap listenerOptions) {
-        super(name, serverName, listenerOptions, false, -1);
+        super(name, serverName, listenerOptions, false, false);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
@@ -53,7 +53,7 @@ public class HttpsListenerService extends HttpListenerService {
     static final String PROTOCOL = "https";
 
     public HttpsListenerService(final String name, String serverName, OptionMap listenerOptions) {
-        super(name, serverName, listenerOptions, false);
+        super(name, serverName, listenerOptions, false, -1);
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerAdd.java
@@ -67,6 +67,7 @@ abstract class ListenerAdd extends AbstractAddStepHandler {
         final PathAddress parent = address.subAddress(0, address.size() - 1);
         String name = address.getLastElement().getValue();
         String bindingRef = ListenerResourceDefinition.SOCKET_BINDING.resolveModelAttribute(context, model).asString();
+        String redirectBindingRef = ListenerResourceDefinition.REDIRECT_SOCKET.resolveModelAttribute(context, model).asString();
         String workerName = ListenerResourceDefinition.WORKER.resolveModelAttribute(context, model).asString();
         String bufferPoolName = ListenerResourceDefinition.BUFFER_POOL.resolveModelAttribute(context, model).asString();
         boolean enabled = ListenerResourceDefinition.ENABLED.resolveModelAttribute(context, model).asBoolean();
@@ -77,6 +78,7 @@ abstract class ListenerAdd extends AbstractAddStepHandler {
         final ServiceBuilder<? extends ListenerService> serviceBuilder = context.getServiceTarget().addService(listenerServiceName, service);
         serviceBuilder.addDependency(IOServices.WORKER.append(workerName), XnioWorker.class, service.getWorker())
                 .addDependency(SocketBinding.JBOSS_BINDING_NAME.append(bindingRef), SocketBinding.class, service.getBinding())
+                .addDependency(SocketBinding.JBOSS_BINDING_NAME.append(redirectBindingRef), SocketBinding.class, service.getRedirectSocket())
                 .addDependency(IOServices.BUFFER_POOL.append(bufferPoolName), Pool.class, service.getBufferPool())
                 .addDependency(UndertowService.SERVER.append(serverName), Server.class, service.getServerService());
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -74,6 +74,13 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .build();
 
+    protected static final SimpleAttributeDefinition REDIRECT_PORT = new SimpleAttributeDefinitionBuilder(Constants.REDIRECT_PORT, ModelType.INT)
+            .setAllowNull(true)
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+            .setDefaultValue(new ModelNode(443))
+            .setAllowExpression(true)
+            .build();
+
 
     static final List<OptionAttributeDefinition> OPTIONS = OptionList.builder()
             .addOption(UndertowOptions.MAX_HEADER_SIZE, "max-header-size", new ModelNode(UndertowOptions.DEFAULT_MAX_HEADER_SIZE))

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -74,11 +74,11 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .build();
 
-    protected static final SimpleAttributeDefinition REDIRECT_PORT = new SimpleAttributeDefinitionBuilder(Constants.REDIRECT_PORT, ModelType.INT)
+    protected static final SimpleAttributeDefinition REDIRECT_SOCKET = new SimpleAttributeDefinitionBuilder(Constants.REDIRECT_SOCKET, ModelType.STRING)
             .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            .setDefaultValue(new ModelNode(443))
-            .setAllowExpression(true)
+            .setDefaultValue(new ModelNode("https"))
+            .setAllowExpression(false)
             .build();
 
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
@@ -57,6 +57,7 @@ public abstract class ListenerService<T> implements Service<T> {
             .getMap();
     protected final InjectedValue<XnioWorker> worker = new InjectedValue<>();
     protected final InjectedValue<SocketBinding> binding = new InjectedValue<>();
+    protected final InjectedValue<SocketBinding> redirectSocket = new InjectedValue<>();
     protected final InjectedValue<Pool> bufferPool = new InjectedValue<>();
     protected final InjectedValue<Server> serverService = new InjectedValue<>();
     protected final List<HandlerWrapper> listenerHandlerWrappers = new ArrayList<>();
@@ -64,13 +65,11 @@ public abstract class ListenerService<T> implements Service<T> {
     private final String name;
     protected final OptionMap listenerOptions;
     protected volatile OpenListener openListener;
-    private final int redirectPort;
 
 
-    protected ListenerService(String name, OptionMap listenerOptions, int redirectPort) {
+    protected ListenerService(String name, OptionMap listenerOptions) {
         this.name = name;
         this.listenerOptions = listenerOptions;
-        this.redirectPort = redirectPort;
     }
 
     public InjectedValue<XnioWorker> getWorker() {
@@ -79,6 +78,10 @@ public abstract class ListenerService<T> implements Service<T> {
 
     public InjectedValue<SocketBinding> getBinding() {
         return binding;
+    }
+
+    public InjectedValue<SocketBinding> getRedirectSocket() {
+        return redirectSocket;
     }
 
     public InjectedValue<Pool> getBufferPool() {
@@ -137,9 +140,7 @@ public abstract class ListenerService<T> implements Service<T> {
         unregisterBinding();
     }
 
-    public Integer getRedirectPort() {
-        return redirectPort;
-    }
+
 
     protected abstract OpenListener createOpenListener();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
@@ -64,11 +64,13 @@ public abstract class ListenerService<T> implements Service<T> {
     private final String name;
     protected final OptionMap listenerOptions;
     protected volatile OpenListener openListener;
+    private final int redirectPort;
 
 
-    protected ListenerService(String name, OptionMap listenerOptions) {
+    protected ListenerService(String name, OptionMap listenerOptions, int redirectPort) {
         this.name = name;
         this.listenerOptions = listenerOptions;
+        this.redirectPort = redirectPort;
     }
 
     public InjectedValue<XnioWorker> getWorker() {
@@ -133,6 +135,10 @@ public abstract class ListenerService<T> implements Service<T> {
         serverService.getValue().unregisterListener(this);
         stopListening();
         unregisterBinding();
+    }
+
+    public Integer getRedirectPort() {
+        return redirectPort;
     }
 
     protected abstract OpenListener createOpenListener();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Server.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Server.java
@@ -75,7 +75,8 @@ public class Server implements Service<Server> {
            listeners.add(listener);
            if (!listener.isSecure()) {
                SocketBinding binding = (SocketBinding) listener.getBinding().getValue();
-               securePortMappings.put(binding.getAbsolutePort(), listener.getRedirectPort());
+               SocketBinding redirectBinding = (SocketBinding) listener.getRedirectSocket().getValue();
+               securePortMappings.put(binding.getAbsolutePort(), redirectBinding.getAbsolutePort());
            }
        }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerService.java
@@ -32,10 +32,6 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 
-import java.util.ConcurrentModificationException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 /**
  * Central Undertow 'Container' HTTP listeners will make this container accessible whilst deployers will add content.
  *
@@ -48,8 +44,6 @@ public class ServletContainerService implements Service<ServletContainerService>
     private final SessionCookieConfig sessionCookieConfig;
     private final JSPConfig jspConfig;
     private volatile ServletContainer servletContainer;
-    @Deprecated
-    private final Map<String, Integer> secureListeners = new ConcurrentHashMap<>(1);
     private final InjectedValue<DirectBufferCache> bufferCacheInjectedValue = new InjectedValue<>();
     private final InjectedValue<SessionPersistenceManager> sessionPersistenceManagerInjectedValue = new InjectedValue<>();
     private final String defaultEncoding;
@@ -90,37 +84,6 @@ public class ServletContainerService implements Service<ServletContainerService>
 
     public ServletStackTraces getStackTraces() {
         return stackTraces;
-    }
-
-    public Integer lookupSecurePort(final String listenerName) {
-        Integer response = null;
-        response = secureListeners.get(listenerName);
-        if (response == null) {
-            while (response == null && secureListeners.isEmpty() == false) {
-                try {
-                    response = secureListeners.values().iterator().next();
-                } catch (ConcurrentModificationException cme) {
-                    // Ignored - The chance of happening is so small but do not wish to add
-                    // additional synchronisation. If listeners are being added and removed
-                    // to a server under load then behaviour could not be expected to be consistent.
-                }
-            }
-        }
-
-        if (response == null) {
-            throw new IllegalStateException("No secure listeners defined.");
-        }
-
-        return response;
-
-    }
-
-    public void registerSecurePort(final String listenerName, final Integer port) {
-        secureListeners.put(listenerName, port);
-    }
-
-    public void unregisterSecurePort(final String name) {
-        secureListeners.remove(name);
     }
 
     public SessionCookieConfig getSessionCookieConfig() {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
@@ -70,12 +70,12 @@ public class UndertowSubsystemParser_1_0 implements XMLStreamConstants, XMLEleme
                         .addAttributes(ServerDefinition.DEFAULT_HOST, ServerDefinition.SERVLET_CONTAINER)
                         .addChild(
                                 builder(AjpListenerResourceDefinition.INSTANCE)
-                                        .addAttributes(AjpListenerResourceDefinition.SCHEME, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED, AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_PORT)
+                                        .addAttributes(AjpListenerResourceDefinition.SCHEME, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED, AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_SOCKET)
                                         .addAttributes(ListenerResourceDefinition.OPTIONS)
                         )
                         .addChild(
                                 builder(HttpListenerResourceDefinition.INSTANCE)
-                                        .addAttributes(HttpListenerResourceDefinition.BUFFER_POOL, HttpListenerResourceDefinition.CERTIFICATE_FORWARDING, HttpListenerResourceDefinition.ENABLED, HttpListenerResourceDefinition.SOCKET_BINDING, HttpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_PORT)
+                                        .addAttributes(HttpListenerResourceDefinition.BUFFER_POOL, HttpListenerResourceDefinition.CERTIFICATE_FORWARDING, HttpListenerResourceDefinition.ENABLED, HttpListenerResourceDefinition.SOCKET_BINDING, HttpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_SOCKET, HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING)
                                         .addAttributes(ListenerResourceDefinition.OPTIONS)
                         ).addChild(
                                 builder(HttpsListenerResourceDefinition.INSTANCE)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
@@ -70,12 +70,12 @@ public class UndertowSubsystemParser_1_0 implements XMLStreamConstants, XMLEleme
                         .addAttributes(ServerDefinition.DEFAULT_HOST, ServerDefinition.SERVLET_CONTAINER)
                         .addChild(
                                 builder(AjpListenerResourceDefinition.INSTANCE)
-                                        .addAttributes(AjpListenerResourceDefinition.SCHEME, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED, AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER)
+                                        .addAttributes(AjpListenerResourceDefinition.SCHEME, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED, AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_PORT)
                                         .addAttributes(ListenerResourceDefinition.OPTIONS)
                         )
                         .addChild(
                                 builder(HttpListenerResourceDefinition.INSTANCE)
-                                        .addAttributes(HttpListenerResourceDefinition.BUFFER_POOL, HttpListenerResourceDefinition.CERTIFICATE_FORWARDING, HttpListenerResourceDefinition.ENABLED, HttpListenerResourceDefinition.SOCKET_BINDING, HttpListenerResourceDefinition.WORKER)
+                                        .addAttributes(HttpListenerResourceDefinition.BUFFER_POOL, HttpListenerResourceDefinition.CERTIFICATE_FORWARDING, HttpListenerResourceDefinition.ENABLED, HttpListenerResourceDefinition.SOCKET_BINDING, HttpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_PORT)
                                         .addAttributes(ListenerResourceDefinition.OPTIONS)
                         ).addChild(
                                 builder(HttpsListenerResourceDefinition.INSTANCE)

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -351,7 +351,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
     private void handleJASPIMechanism(final DeploymentInfo deploymentInfo) {
         ApplicationPolicy applicationPolicy = SecurityConfiguration.getApplicationPolicy(this.securityDomain);
 
-        if (JASPIAuthenticationInfo.class.isInstance(applicationPolicy.getAuthenticationInfo())) {
+        if (applicationPolicy!=null && JASPIAuthenticationInfo.class.isInstance(applicationPolicy.getAuthenticationInfo())) {
             deploymentInfo.setJaspiAuthenticationMechanism(new JASPIAuthenticationMechanism(this.securityDomain));
         }
     }
@@ -396,7 +396,8 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
 
             @Override
             public int getConfidentialPort(HttpServerExchange exchange) {
-                return container.getValue().lookupSecurePort("default");
+                int port = exchange.getHostPort();
+                return host.getValue().getServer().getValue().lookupSecurePort(port);
             }
         };
     }

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -102,6 +102,7 @@ undertow.listener.verify-client=The desired SSL client authentication mode for S
 undertow.listener.always-set-keep-alive=If this is true then a Connection: keep-alive header will be added to responses, even when it is not strictly required by the specification.
 undertow.listener.redirect-socket=If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport, undertow will automatically redirect the request to the socket binding port specified here.
 undertow.listener.proxy-address-forwarding=enables x-forwarded-host and similar headers and set a remote ip address and hostname
+undertow.listener.enabled-cipher-suites=Configures Enabled SSL cyphers
 undertow.host=An Undertow host
 undertow.host.add=Adds a new host
 undertow.host.remove=Removes a host

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -100,6 +100,7 @@ undertow.listener.max-parameters=The maximum number of parameters that will be p
   This applies to both query parameters, and to POST data, but is not cumulative (i.e. you can potentially have max parameters * 2 total parameters).
 undertow.listener.verify-client=The desired SSL client authentication mode for SSL channels
 undertow.listener.always-set-keep-alive=If this is true then a Connection: keep-alive header will be added to responses, even when it is not strictly required by the specification.
+undertow.listener.redirect-port=If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport, undertow will automatically redirect the request to the port number specified here.
 undertow.host=An Undertow host
 undertow.host.add=Adds a new host
 undertow.host.remove=Removes a host

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -100,7 +100,8 @@ undertow.listener.max-parameters=The maximum number of parameters that will be p
   This applies to both query parameters, and to POST data, but is not cumulative (i.e. you can potentially have max parameters * 2 total parameters).
 undertow.listener.verify-client=The desired SSL client authentication mode for SSL channels
 undertow.listener.always-set-keep-alive=If this is true then a Connection: keep-alive header will be added to responses, even when it is not strictly required by the specification.
-undertow.listener.redirect-port=If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport, undertow will automatically redirect the request to the port number specified here.
+undertow.listener.redirect-socket=If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport, undertow will automatically redirect the request to the socket binding port specified here.
+undertow.listener.proxy-address-forwarding=enables x-forwarded-host and similar headers and set a remote ip address and hostname
 undertow.host=An Undertow host
 undertow.host.add=Adds a new host
 undertow.host.remove=Removes a host

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
@@ -32,7 +32,7 @@
         <http-listener name="default" socket-binding="http" certificate-forwarding="true" always-set-keep-alive="${prop.smth:false}" redirect-socket="ajp" proxy-address-forwarding="${prop.smth:false}"/>
         <http-listener name="second" socket-binding="http" max-cookies="100" max-parameters="30" url-charset="windows-1250" max-post-size="100000" max-headers="30"/>
         <https-listener name="https" socket-binding="https" security-realm="UndertowRealm" verify-client="REQUESTED"/>
-        <https-listener name="https-2" socket-binding="https" security-realm="UndertowRealm" />
+        <https-listener name="https-2" socket-binding="https" security-realm="UndertowRealm" enabled-cipher-suites="ALL:!MD5:!DHA"/>
 
         <host name="default-host" alias="localhost, some.host" default-web-module="something.war">
             <location name="/" handler="welcome-content">

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
@@ -28,8 +28,8 @@
     </buffer-caches>
 
     <server name="default-server" default-host="localhost" servlet-container="myContainer">
-        <ajp-listener name="ajp-connector" socket-binding="ajp" redirect-port="${foo:5433}"/>
-        <http-listener name="default" socket-binding="http" certificate-forwarding="true" always-set-keep-alive="${prop.smth:false}" redirect-port="5555"/>
+        <ajp-listener name="ajp-connector" socket-binding="ajp" redirect-socket="ajps"/>
+        <http-listener name="default" socket-binding="http" certificate-forwarding="true" always-set-keep-alive="${prop.smth:false}" redirect-socket="ajp" proxy-address-forwarding="${prop.smth:false}"/>
         <http-listener name="second" socket-binding="http" max-cookies="100" max-parameters="30" url-charset="windows-1250" max-post-size="100000" max-headers="30"/>
         <https-listener name="https" socket-binding="https" security-realm="UndertowRealm" verify-client="REQUESTED"/>
         <https-listener name="https-2" socket-binding="https" security-realm="UndertowRealm" />

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.0.xml
@@ -28,8 +28,8 @@
     </buffer-caches>
 
     <server name="default-server" default-host="localhost" servlet-container="myContainer">
-        <ajp-listener name="ajp-connector" socket-binding="ajp"/>
-        <http-listener name="default" socket-binding="http" certificate-forwarding="true" always-set-keep-alive="${prop.smth:false}"/>
+        <ajp-listener name="ajp-connector" socket-binding="ajp" redirect-port="${foo:5433}"/>
+        <http-listener name="default" socket-binding="http" certificate-forwarding="true" always-set-keep-alive="${prop.smth:false}" redirect-port="5555"/>
         <http-listener name="second" socket-binding="http" max-cookies="100" max-parameters="30" url-charset="windows-1250" max-post-size="100000" max-headers="30"/>
         <https-listener name="https" socket-binding="https" security-realm="UndertowRealm" verify-client="REQUESTED"/>
         <https-listener name="https-2" socket-binding="https" security-realm="UndertowRealm" />


### PR DESCRIPTION
- WFLY-2625 Undertow 'redirect-port' parameter for HTTPS
- WFLY-2653 HTTPS undertow listener select cipher-suites
- WFLY-2196 WFLY-1070 use socket binding reference for redirect-socket
