### PR TITLE
Fix testsuite/domain jboss.home value

### DIFF
--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -40,6 +40,8 @@
         <!-- used to provide an absolute location for the distribution under test -->
         <!-- this value is overridden in modules with the correct relative pathname -->
         <jboss.dist>${project.basedir}/../../${wildfly.build.output.dir}</jboss.dist>
+        <!-- This really should be ${project.basedir}/target/jbossas but the parent pom's
+             ts.copy-jbossas.groups execution assumes it's the same as jboss.dist -->
         <jboss.home>${jboss.dist}</jboss.home>
 
         <!-- Used to provide an absolute location for the XSLT scripts. -->
@@ -103,8 +105,8 @@
                     <systemPropertyVariables>
                         <jboss.options>${surefire.system.args}</jboss.options>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <jboss.home>${jboss.home}</jboss.home>
-                        <module.path>${jboss.home}/modules</module.path>
+                        <jboss.home>${project.basedir}/target/jbossas</jboss.home>
+                        <module.path>${jboss.dist}/modules</module.path>
                         <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                         <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
                         <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts}</server.jvm.args>
@@ -121,6 +123,7 @@
     </build>
 
     <profiles>
+
         <profile>
             <id>rbac-soak</id>
             <activation>
@@ -147,8 +150,8 @@
                             <systemPropertyVariables>
                                 <jboss.options>${surefire.system.args}</jboss.options>
                                 <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                                <jboss.home>${jboss.home}</jboss.home>
-                                <module.path>${jboss.home}/modules</module.path>
+                                <jboss.home>${project.basedir}/target/jbossas</jboss.home>
+                                <module.path>${jboss.dist}/modules</module.path>
                                 <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                                 <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
                                 <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts}</server.jvm.args>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainLifecycleUtil.java
@@ -276,6 +276,8 @@ public class DomainLifecycleUtil {
             awaitHostController(start);
             log.info("HostController started in " + (System.currentTimeMillis() - start) + " ms");
 
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             throw new RuntimeException("Could not start container", e);
         }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
@@ -124,12 +124,12 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
     public void validate() throws ConfigurationException {
         super.validate();
 
-        Validate.configurationDirectoryExists(jbossHome, "jbossHome must exist");
+        Validate.configurationDirectoryExists(jbossHome, "jbossHome must exist at " + jbossHome);
         if (javaHome != null) {
-            Validate.configurationDirectoryExists(javaHome, "javaHome must exist");
+            Validate.configurationDirectoryExists(javaHome, "javaHome must exist at " + javaHome);
         }
         if (controllerJavaHome != null) {
-            Validate.configurationDirectoryExists(javaHome, "controllerJavaHome must exist");
+            Validate.configurationDirectoryExists(javaHome, "controllerJavaHome must exist at " + controllerJavaHome);
         }
     }
 


### PR DESCRIPTION
Cause the domain testsuite tests to run with jboss.home as testsuite/domain/target/jbossas (which already exists) instead of build/target/wildfly-<version>.  Apparently this eases security manager testing in EAP by making it possible to set jboss.dist to some arbitrary build location and have the policy file refer to that location.
