### PR TITLE
Moved implicit logging dependency additions and deprecated per-deployment logging system property

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-logging_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_2_0.xsd
@@ -51,6 +51,15 @@
             <xs:element name="custom-handler" type="customHandlerType"/>
             <xs:element name="syslog-handler" type="syslogHandlerType"/>
             <xs:element name="formatter" type="formatterType"/>
+            <xs:element name="add-logging-api-dependencies" type="booleanValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Determines whether or not the default logging dependencies should be added to deployments during the deployment process.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
         </xs:choice>
     </xs:complexType>

--- a/build/src/main/resources/docs/schema/jboss-as-logging_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_2_0.xsd
@@ -60,6 +60,15 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:element name="use-deployment-logging-config" type="booleanValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                            Determines whether or not deployments should be scanned for configuration files. If set to
+                            true and a configuration file is found the log manager will be configured based on the
+                            configuration file.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
             <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
         </xs:choice>
     </xs:complexType>

--- a/logging/src/main/java/org/jboss/as/logging/Element.java
+++ b/logging/src/main/java/org/jboss/as/logging/Element.java
@@ -35,6 +35,7 @@ enum Element {
     UNKNOWN((String) null),
 
     ACCEPT(CommonAttributes.ACCEPT),
+    ADD_LOGGING_API_DEPENDENCIES(LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES),
     ALL(CommonAttributes.ALL),
     ANY(CommonAttributes.ANY),
     APP_NAME(SyslogHandlerResourceDefinition.APP_NAME),

--- a/logging/src/main/java/org/jboss/as/logging/Element.java
+++ b/logging/src/main/java/org/jboss/as/logging/Element.java
@@ -81,7 +81,9 @@ enum Element {
     SUFFIX(PeriodicHandlerResourceDefinition.SUFFIX),
     SYSLOG_FORMATTER(SyslogHandlerResourceDefinition.SYSLOG_FORMATTER),
     SYSLOG_HANDLER(SyslogHandlerResourceDefinition.SYSLOG_HANDLER),
-    TARGET(ConsoleHandlerResourceDefinition.TARGET),;
+    TARGET(ConsoleHandlerResourceDefinition.TARGET),
+    USE_DEPLOYMENT_LOGGING_CONFIG(LoggingRootResource.USE_DEPLOYMENT_LOGGING_CONFIG),
+    ;
 
     private final String name;
     private final AttributeDefinition definition;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -138,7 +138,7 @@ public class LoggingExtension implements Extension {
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(rootResource);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, DESCRIBE_HANDLER);
         // Register root sub-models
-        registerSubModels(registration, resolvePathHandler, true, subsystem, context.isRegisterTransformers());
+        registerSubModels(registration, resolvePathHandler, true, subsystem, rootResource, context.isRegisterTransformers());
         // Register logging profile sub-models
         ApplicationTypeConfig atc = new ApplicationTypeConfig(SUBSYSTEM_NAME, CommonAttributes.LOGGING_PROFILE);
         final List<AccessConstraintDefinition> accessConstraints = new ApplicationTypeAccessConstraintDefinition(atc).wrapAsList();
@@ -167,12 +167,12 @@ public class LoggingExtension implements Extension {
     }
 
     private void registerLoggingProfileSubModels(final ManagementResourceRegistration registration, final ResolvePathHandler resolvePathHandler) {
-        registerSubModels(registration, resolvePathHandler, false, null, false);
+        registerSubModels(registration, resolvePathHandler, false, null, null, false);
     }
 
     private void registerSubModels(final ManagementResourceRegistration registration, final ResolvePathHandler resolvePathHandler,
                                    final boolean includeLegacyAttributes, final SubsystemRegistration subsystem,
-                                   final boolean registerTransformers) {
+                                   final LoggingRootResource subsystemResourceDefinition, final boolean registerTransformers) {
         final RootLoggerResourceDefinition rootLoggerResourceDefinition = new RootLoggerResourceDefinition(includeLegacyAttributes);
         registration.registerSubModel(rootLoggerResourceDefinition);
 
@@ -215,6 +215,7 @@ public class LoggingExtension implements Extension {
                     }
 
                     // Register the transformers
+                    subsystemResourceDefinition.registerTransformers(modelVersion, subsystemBuilder, loggingProfileBuilder);
                     rootLoggerResourceDefinition.registerTransformers(modelVersion, subsystemBuilder, loggingProfileBuilder);
                     loggerResourceDefinition.registerTransformers(modelVersion, subsystemBuilder, loggingProfileBuilder);
                     asyncHandlerResourceDefinition.registerTransformers(modelVersion, subsystemBuilder, loggingProfileBuilder);

--- a/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingLogger.java
@@ -175,4 +175,35 @@ public interface LoggingLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 11513, value = "The log context (%s) could not be removed for deployment %s")
     void logContextNotRemoved(LogContext logContext, String deploymentName);
+
+    /**
+     * Logs a warning message indicating the per-logging deployment property has been deprecated and should not be
+     * used. Instead the attribute on the root subsystem should be used.
+     *
+     * @param propertyName  the per-deployment property name
+     * @param attributeName the name of the new attribute
+     *
+     * @deprecated will be removed when the {@link org.jboss.as.logging.deployments.LoggingConfigDeploymentProcessor#PER_DEPLOYMENT_LOGGING}
+     * is removed
+     */
+    @Deprecated
+    @LogMessage(level = WARN)
+    @Message(id = 11514, value = "The per-logging deployment property (%s) has been deprecated. Please use the %s attribute to enable/disable per-deployment logging.")
+    void perDeploymentPropertyDeprecated(String propertyName, String attributeName);
+
+    /**
+     * Logs a warning message indicating the per-logging deployment property is being ignored because the attribute has
+     * been set to ignore the deployments logging configuration.
+     *
+     * @param propertyName   the per-deployment property name
+     * @param attributeName  the name of the new attribute
+     * @param deploymentName the name of the deployment
+     *
+     * @deprecated will be removed when the {@link org.jboss.as.logging.deployments.LoggingConfigDeploymentProcessor#PER_DEPLOYMENT_LOGGING}
+     * is removed
+     */
+    @Deprecated
+    @LogMessage(level = WARN)
+    @Message(id = 11515, value = "The per-logging deployment property (%s) is being ignored because the attribute %s has been set to ignore configuration files in the deployment %s.")
+    void perLoggingDeploymentIgnored(String propertyName, String attributeName, String deploymentName);
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.logging.deployments.LoggingConfigDeploymentProcessor;
+import org.jboss.as.logging.deployments.LoggingDependencyDeploymentProcessor;
 import org.jboss.as.logging.deployments.LoggingProfileDeploymentProcessor;
 import org.jboss.as.logging.logmanager.ConfigurationPersistence;
 import org.jboss.as.server.AbstractDeploymentChainStep;
@@ -55,15 +56,20 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
     }
 
     @Override
-    protected void populateModel(ModelNode operation, ModelNode model) {
+    protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
         model.setEmptyObject();
+        LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.validateAndSet(operation, model);
     }
 
     @Override
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers) throws OperationFailedException {
+        final boolean addDependencies = LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.resolveModelAttribute(context, model).asBoolean();
         context.addStep(new AbstractDeploymentChainStep() {
             @Override
             protected void execute(final DeploymentProcessorTarget processorTarget) {
+                if (addDependencies) {
+                    processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_LOGGING, new LoggingDependencyDeploymentProcessor());
+                }
                 processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG, new LoggingConfigDeploymentProcessor(LoggingExtension.CONTEXT_SELECTOR));
                 processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_PROFILE, new LoggingProfileDeploymentProcessor(LoggingExtension.CONTEXT_SELECTOR));
             }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.logging.deployments.LoggingConfigDeploymentProcessor;
 import org.jboss.as.logging.deployments.LoggingDependencyDeploymentProcessor;
@@ -58,19 +59,23 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
     @Override
     protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
         model.setEmptyObject();
-        LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.validateAndSet(operation, model);
+        for (SimpleAttributeDefinition attribute : LoggingRootResource.ATTRIBUTES) {
+            attribute.validateAndSet(operation, model);
+        }
     }
 
     @Override
     protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers) throws OperationFailedException {
         final boolean addDependencies = LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.resolveModelAttribute(context, model).asBoolean();
+        final boolean useLoggingConfig = LoggingRootResource.USE_DEPLOYMENT_LOGGING_CONFIG.resolveModelAttribute(context, model).asBoolean();
         context.addStep(new AbstractDeploymentChainStep() {
             @Override
             protected void execute(final DeploymentProcessorTarget processorTarget) {
                 if (addDependencies) {
                     processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_LOGGING, new LoggingDependencyDeploymentProcessor());
                 }
-                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG, new LoggingConfigDeploymentProcessor(LoggingExtension.CONTEXT_SELECTOR));
+                processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_CONFIG,
+                        new LoggingConfigDeploymentProcessor(LoggingExtension.CONTEXT_SELECTOR, LoggingRootResource.USE_DEPLOYMENT_LOGGING_CONFIG.getName(), useLoggingConfig));
                 processorTarget.addDeploymentProcessor(LoggingExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_LOGGING_PROFILE, new LoggingProfileDeploymentProcessor(LoggingExtension.CONTEXT_SELECTOR));
             }
         }, Stage.RUNTIME);

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -96,6 +96,7 @@ import javax.xml.stream.XMLStreamException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
@@ -120,7 +121,9 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
         }
         final PathAddress address = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, LoggingExtension.SUBSYSTEM_NAME));
 
-        operations.add(Util.createAddOperation(address));
+        // Subsystem add operation
+        final ModelNode subsystemAddOp = Util.createAddOperation(address);
+        operations.add(subsystemAddOp);
 
         final List<ModelNode> loggerOperations = new ArrayList<ModelNode>();
         final List<ModelNode> asyncHandlerOperations = new ArrayList<ModelNode>();
@@ -142,6 +145,14 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                 case LOGGING_2_0: {
                     final Element element = Element.forName(reader.getLocalName());
                     switch (element) {
+                        case ADD_LOGGING_API_DEPENDENCIES:{
+                            if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1 ||
+                                    namespace == Namespace.LOGGING_1_2 || namespace == Namespace.LOGGING_1_3)
+                                throw unexpectedElement(reader);
+                            final String value = ParseUtils.readStringAttributeElement(reader, Attribute.VALUE.getLocalName());
+                            LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.parseAndSetParameter(value, subsystemAddOp, reader);
+                            break;
+                        }
                         case LOGGER: {
                             parseLoggerElement(reader, address, loggerOperations, loggerNames);
                             break;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -153,6 +153,14 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                             LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.parseAndSetParameter(value, subsystemAddOp, reader);
                             break;
                         }
+                        case USE_DEPLOYMENT_LOGGING_CONFIG:{
+                            if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1 ||
+                                    namespace == Namespace.LOGGING_1_2 || namespace == Namespace.LOGGING_1_3)
+                                throw unexpectedElement(reader);
+                            final String value = ParseUtils.readStringAttributeElement(reader, Attribute.VALUE.getLocalName());
+                            LoggingRootResource.USE_DEPLOYMENT_LOGGING_CONFIG.parseAndSetParameter(value, subsystemAddOp, reader);
+                            break;
+                        }
                         case LOGGER: {
                             parseLoggerElement(reader, address, loggerOperations, loggerNames);
                             break;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
@@ -93,7 +93,9 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
         ModelNode model = context.getModelNode();
 
         // Marshall attributes
-        LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.marshallAsElement(model, false, writer);
+        for (AttributeDefinition attribute : LoggingRootResource.ATTRIBUTES) {
+            attribute.marshallAsElement(model, false, writer);
+        }
 
         writeContent(writer, model);
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemWriter.java
@@ -92,6 +92,9 @@ public class LoggingSubsystemWriter implements XMLStreamConstants, XMLElementWri
 
         ModelNode model = context.getModelNode();
 
+        // Marshall attributes
+        LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES.marshallAsElement(model, false, writer);
+
         writeContent(writer, model);
 
         if (model.hasDefined(LOGGING_PROFILE)) {

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -14,6 +14,11 @@ logging.list-log-files=Lists the log files in the jboss.server.log.dir directory
 logging.list-log-files.file-name=The name of the file.
 logging.list-log-files.file-size=The size of the log file in bytes.
 
+# Root resource attributes
+logging.add-logging-api-dependencies=Indicates whether or not logging API dependencies should be added to deployments \
+  during the deployment process. A value of true will add the dependencies to the deployment. A value of false will skip \
+  the deployment from being processed for logging API dependencies.
+
 # Logging profiles
 logging.logging-profile=A profile that can be assigned to a deployment for it's logging configuration.
 logging.logging-profile.add=Adds a logging profile.

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -18,6 +18,11 @@ logging.list-log-files.file-size=The size of the log file in bytes.
 logging.add-logging-api-dependencies=Indicates whether or not logging API dependencies should be added to deployments \
   during the deployment process. A value of true will add the dependencies to the deployment. A value of false will skip \
   the deployment from being processed for logging API dependencies.
+logging.use-deployment-logging-config=Indicates whether or not deployments should use a logging configuration file found \
+  in the deployment to configure the log manager. If set to true and a logging configuration file was found in the \
+  deployments META-INF or WEB-INF/classes directory, then a log manager will be configured with those settings. If set \
+  false the servers logging configuration will be used regardless of any logging configuration files supplied in the \
+  deployment.
 
 # Logging profiles
 logging.logging-profile=A profile that can be assigned to a deployment for it's logging configuration.

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -160,6 +160,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         final List<ModelNode> ops = builder.parseXmlResource("/expressions.xml");
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops,
                 new FailedOperationTransformationConfig()
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS, new NewAttributesConfig(LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES))
                         .addFailedAttribute(createRootLoggerAddress(),
                                 new RejectExpressionsConfig(RootLoggerResourceDefinition.EXPRESSION_ATTRIBUTES))
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(LoggerResourceDefinition.LOGGER_PATH),
@@ -252,6 +253,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         final List<ModelNode> ops = builder.parseXmlResource("/expressions.xml");
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops,
                 new FailedOperationTransformationConfig()
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS, new NewAttributesConfig(LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES))
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(FileHandlerResourceDefinition.FILE_HANDLER_PATH),
                                 new NewAttributesConfig(FileHandlerResourceDefinition.NAMED_FORMATTER))
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_HANDLER_PATH),

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -160,7 +160,8 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         final List<ModelNode> ops = builder.parseXmlResource("/expressions.xml");
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops,
                 new FailedOperationTransformationConfig()
-                        .addFailedAttribute(SUBSYSTEM_ADDRESS, new NewAttributesConfig(LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES))
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS,
+                                new NewAttributesConfig(LoggingRootResource.ATTRIBUTES))
                         .addFailedAttribute(createRootLoggerAddress(),
                                 new RejectExpressionsConfig(RootLoggerResourceDefinition.EXPRESSION_ATTRIBUTES))
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(LoggerResourceDefinition.LOGGER_PATH),
@@ -253,7 +254,8 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         final List<ModelNode> ops = builder.parseXmlResource("/expressions.xml");
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops,
                 new FailedOperationTransformationConfig()
-                        .addFailedAttribute(SUBSYSTEM_ADDRESS, new NewAttributesConfig(LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES))
+                        .addFailedAttribute(SUBSYSTEM_ADDRESS,
+                                new NewAttributesConfig(LoggingRootResource.ATTRIBUTES))
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(FileHandlerResourceDefinition.FILE_HANDLER_PATH),
                                 new NewAttributesConfig(FileHandlerResourceDefinition.NAMED_FORMATTER))
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_HANDLER_PATH),

--- a/logging/src/test/java/org/jboss/as/logging/RootSubsystemOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/RootSubsystemOperationsTestCase.java
@@ -69,7 +69,9 @@ public class RootSubsystemOperationsTestCase extends AbstractOperationsTestCase 
         final KernelServices kernelServices = boot();
         final ModelNode address = SUBSYSTEM_ADDRESS.toModelNode();
         testWrite(kernelServices, address, LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES, true);
+        testWrite(kernelServices, address, LoggingRootResource.USE_DEPLOYMENT_LOGGING_CONFIG, false);
         testUndefine(kernelServices, address, LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES);
+        testUndefine(kernelServices, address, LoggingRootResource.USE_DEPLOYMENT_LOGGING_CONFIG);
     }
 
     @Test

--- a/logging/src/test/java/org/jboss/as/logging/RootSubsystemOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/RootSubsystemOperationsTestCase.java
@@ -65,6 +65,14 @@ public class RootSubsystemOperationsTestCase extends AbstractOperationsTestCase 
     }
 
     @Test
+    public void testAttributes() throws Exception {
+        final KernelServices kernelServices = boot();
+        final ModelNode address = SUBSYSTEM_ADDRESS.toModelNode();
+        testWrite(kernelServices, address, LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES, true);
+        testUndefine(kernelServices, address, LoggingRootResource.ADD_LOGGING_API_DEPENDENCIES);
+    }
+
+    @Test
     public void testListLogFiles() throws Exception {
         final KernelServices kernelServices = boot();
 

--- a/logging/src/test/resources/expressions.xml
+++ b/logging/src/test/resources/expressions.xml
@@ -22,6 +22,7 @@
 
 <subsystem xmlns="urn:jboss:domain:logging:2.0">
     <add-logging-api-dependencies value="${test.add.deps:true}"/>
+    <use-deployment-logging-config value="${test.use.dep.config:true}"/>
 
     <async-handler name="async">
         <queue-length value="${test.queue.length:10}"/>

--- a/logging/src/test/resources/expressions.xml
+++ b/logging/src/test/resources/expressions.xml
@@ -21,6 +21,8 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:logging:2.0">
+    <add-logging-api-dependencies value="${test.add.deps:true}"/>
+
     <async-handler name="async">
         <queue-length value="${test.queue.length:10}"/>
         <overflow-action value="${test.overflow.action:block}"/>

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -21,6 +21,8 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:logging:2.0">
+    <add-logging-api-dependencies value="false"/>
+
     <async-handler name="async">
         <queue-length value="10"/>
         <overflow-action value="block"/>

--- a/logging/src/test/resources/logging.xml
+++ b/logging/src/test/resources/logging.xml
@@ -22,6 +22,7 @@
 
 <subsystem xmlns="urn:jboss:domain:logging:2.0">
     <add-logging-api-dependencies value="false"/>
+    <use-deployment-logging-config value="false"/>
 
     <async-handler name="async">
         <queue-length value="10"/>

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -368,6 +368,7 @@ public enum Phase {
     public static final int DEPENDENCIES_BUNDLE_CONTEXT_BINDING         = 0x1A00;
     public static final int DEPENDENCIES_BATCH                          = 0x1B00;
     public static final int DEPENDENCIES_CLUSTERING                     = 0x1C00;
+    public static final int DEPENDENCIES_LOGGING                        = 0x1D00;
     //these must be last, and in this specific order
     public static final int DEPENDENCIES_APPLICATION_CLIENT             = 0x2000;
     public static final int DEPENDENCIES_VISIBLE_MODULES                = 0x2100;

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/SubsystemTestDelegate.java
@@ -422,7 +422,7 @@ final class SubsystemTestDelegate {
         try {
             desc.writeString(pw, false);
             //Leave this println - it only gets executed when people generate the legacy dmr files, and is useful to know where it has been written.
-            System.out.println("Legact resource defintion dmr written to: " + dmrFile.getAbsolutePath());
+            System.out.println("Legacy resource definition dmr written to: " + dmrFile.getAbsolutePath());
         } finally {
             IoUtils.safeClose(pw);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/misc/LoggingPerDeployFalseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/misc/LoggingPerDeployFalseTestCase.java
@@ -26,7 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -38,10 +38,7 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.servlet.http.HttpServletResponse;
-
-import org.junit.Assert;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -59,171 +56,175 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * 
  * @author Petr Křemenský <pkremens@redhat.com>
+ * @deprecated this needs to be moved/copied to the manualmode tests and the new use-deployment-logging-config attribute
+ * needs to be used which requires a reload/restart of the server. Also I'm not sure the test actually works as it
+ * passed when I broke the property. See WFLY-2648
  */
 
 @ServerSetup(LoggingPerDeployFalseTestCase.LoggingPerDeployFalseTestCaseSetup.class)
 @RunWith(Arquillian.class)
+@Deprecated
 public class LoggingPerDeployFalseTestCase extends AbstractLoggingTest {
 
-	private static Logger log = Logger
-			.getLogger(LoggingPerDeployFalseTestCase.class);
+    private static Logger log = Logger
+            .getLogger(LoggingPerDeployFalseTestCase.class);
 
-	private static final String LOG_FILE_NAME = "per-deploy-false-test.log";
-	private static final String PER_DEPLOY_NAME = "jboss-logging-properties-test.log";
-	private static File logFile;
-	private static File perDeployLogFile;
+    private static final String LOG_FILE_NAME = "per-deploy-false-test.log";
+    private static final String PER_DEPLOY_NAME = "jboss-logging-properties-test.log";
+    private static File logFile;
+    private static File perDeployLogFile;
 
-	static class LoggingPerDeployFalseTestCaseSetup extends
-			AbstractMgmtServerSetupTask {
+    static class LoggingPerDeployFalseTestCaseSetup extends
+            AbstractMgmtServerSetupTask {
 
-		@Override
-		protected void doSetup(ManagementClient managementClient)
-				throws Exception {
-			final List<ModelNode> updates = new ArrayList<ModelNode>();
+        @Override
+        protected void doSetup(ManagementClient managementClient)
+                throws Exception {
+            final List<ModelNode> updates = new ArrayList<ModelNode>();
 
-			// prepare log files
-			logFile = prepareLogFile(managementClient,
-					LOG_FILE_NAME);
-			perDeployLogFile = prepareLogFile(managementClient,
-					PER_DEPLOY_NAME);
+            // prepare log files
+            logFile = prepareLogFile(managementClient,
+                    LOG_FILE_NAME);
+            perDeployLogFile = prepareLogFile(managementClient,
+                    PER_DEPLOY_NAME);
 
-			// add custom file-handler
-			ModelNode op = new ModelNode();
-			op.get(OP).set(ADD);
-			op.get(OP_ADDR).add(SUBSYSTEM, "logging");
-			op.get(OP_ADDR).add("periodic-rotating-file-handler",
-					"LOGGING_TEST");
-			op.get("append").set("true");
-			op.get("suffix").set(".yyyy-MM-dd");
-			ModelNode file = new ModelNode();
-			file.get("relative-to").set("jboss.server.log.dir");
-			file.get("path").set(LOG_FILE_NAME);
-			op.get("file").set(file);
-			op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
-			updates.add(op);
+            // add custom file-handler
+            ModelNode op = new ModelNode();
+            op.get(OP).set(ADD);
+            op.get(OP_ADDR).add(SUBSYSTEM, "logging");
+            op.get(OP_ADDR).add("periodic-rotating-file-handler",
+                    "LOGGING_TEST");
+            op.get("append").set("true");
+            op.get("suffix").set(".yyyy-MM-dd");
+            ModelNode file = new ModelNode();
+            file.get("relative-to").set("jboss.server.log.dir");
+            file.get("path").set(LOG_FILE_NAME);
+            op.get("file").set(file);
+            op.get("formatter").set("%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n");
+            updates.add(op);
 
-			// add handler to root-logger
-			op = new ModelNode();
-			op.get(OP).set("root-logger-assign-handler");
-			op.get(OP_ADDR).add(SUBSYSTEM, "logging");
-			op.get(OP_ADDR).add("root-logger", "ROOT");
-			op.get("name").set("LOGGING_TEST");
-			updates.add(op);
+            // add handler to root-logger
+            op = new ModelNode();
+            op.get(OP).set("root-logger-assign-handler");
+            op.get(OP_ADDR).add(SUBSYSTEM, "logging");
+            op.get(OP_ADDR).add("root-logger", "ROOT");
+            op.get("name").set("LOGGING_TEST");
+            updates.add(op);
 
-			// add "org.jboss.as.logging.per-deployment=false" system property
-			op = new ModelNode();
-			op.get(OP).set(ADD);
-			op.get(OP_ADDR).add("system-property",
-					"org.jboss.as.logging.per-deployment");
-			op.get("value").set("false");
-			updates.add(op);
+            // add "org.jboss.as.logging.per-deployment=false" system property
+            op = new ModelNode();
+            op.get(OP).set(ADD);
+            op.get(OP_ADDR).add("system-property",
+                    "org.jboss.as.logging.per-deployment");
+            op.get("value").set("false");
+            updates.add(op);
 
-			// we want all operations to perform
-			for (ModelNode modelNode : updates) {
-				try {
-					executeOperation(modelNode);
-				} catch (MgmtOperationException exp) {
-					log.warn(exp.getMessage());
-				}
-			}
-		}
+            // we want all operations to perform
+            for (ModelNode modelNode : updates) {
+                try {
+                    executeOperation(modelNode);
+                } catch (MgmtOperationException exp) {
+                    log.warn(exp.getMessage());
+                }
+            }
+        }
 
-		@Override
-		public void tearDown(ManagementClient managementClient,
-				String containerId) throws Exception {
-			final List<ModelNode> updates = new ArrayList<ModelNode>();
+        @Override
+        public void tearDown(ManagementClient managementClient,
+                             String containerId) throws Exception {
+            final List<ModelNode> updates = new ArrayList<ModelNode>();
 
-			// delete log files
-			logFile.delete();
-			perDeployLogFile.delete();
+            // delete log files
+            logFile.delete();
+            perDeployLogFile.delete();
 
-			// remove LOGGING_TEST from root-logger
-			ModelNode op = new ModelNode();
-			op.get(OP).set("root-logger-unassign-handler");
-			op.get(OP_ADDR).add(SUBSYSTEM, "logging");
-			op.get(OP_ADDR).add("root-logger", "ROOT");
-			op.get("name").set("LOGGING_TEST");
-			updates.add(op);
+            // remove LOGGING_TEST from root-logger
+            ModelNode op = new ModelNode();
+            op.get(OP).set("root-logger-unassign-handler");
+            op.get(OP_ADDR).add(SUBSYSTEM, "logging");
+            op.get(OP_ADDR).add("root-logger", "ROOT");
+            op.get("name").set("LOGGING_TEST");
+            updates.add(op);
 
-			// remove custom file handler
-			op = new ModelNode();
-			op.get(OP).set(REMOVE);
-			op.get(OP_ADDR).add(SUBSYSTEM, "logging");
-			op.get(OP_ADDR).add("periodic-rotating-file-handler",
-					"LOGGING_TEST");
-			updates.add(op);
+            // remove custom file handler
+            op = new ModelNode();
+            op.get(OP).set(REMOVE);
+            op.get(OP_ADDR).add(SUBSYSTEM, "logging");
+            op.get(OP_ADDR).add("periodic-rotating-file-handler",
+                    "LOGGING_TEST");
+            updates.add(op);
 
-			// remove "org.jboss.as.logging.per-deployment=false" system
-			// property
-			op = new ModelNode();
-			op.get(OP).set(REMOVE);
-			op.get(OP_ADDR).add("system-property",
-					"org.jboss.as.logging.per-deployment");
-			updates.add(op);
+            // remove "org.jboss.as.logging.per-deployment=false" system
+            // property
+            op = new ModelNode();
+            op.get(OP).set(REMOVE);
+            op.get(OP_ADDR).add("system-property",
+                    "org.jboss.as.logging.per-deployment");
+            updates.add(op);
 
-			// we want to perform all operations
-			for (ModelNode modelNode : updates) {
-				try {
-					executeOperation(modelNode);
-				} catch (MgmtOperationException exp) {
-					log.warn(exp.getMessage());
-				}
-			}
+            // we want to perform all operations
+            for (ModelNode modelNode : updates) {
+                try {
+                    executeOperation(modelNode);
+                } catch (MgmtOperationException exp) {
+                    log.warn(exp.getMessage());
+                }
+            }
 
-		}
+        }
 
-	}
+    }
 
-	@ArquillianResource(LoggingServlet.class)
-	URL url;
+    @ArquillianResource(LoggingServlet.class)
+    URL url;
 
-	@Deployment
-	public static WebArchive createDeployment() {
-		WebArchive archive = ShrinkWrap.create(WebArchive.class, "logging.war");
-		archive.addClasses(LoggingServlet.class);
-		archive.addAsResource(LoggingBean.class.getPackage(),
-				"jboss-logging.properties",
-				"WEB-INF/classes/jboss-logging.properties");
-		return archive;
-	}
+    @Deployment
+    public static WebArchive createDeployment() {
+        WebArchive archive = ShrinkWrap.create(WebArchive.class, "logging.war");
+        archive.addClasses(LoggingServlet.class);
+        archive.addAsResource(LoggingBean.class.getPackage(),
+                "jboss-logging.properties",
+                "WEB-INF/classes/jboss-logging.properties");
+        return archive;
+    }
 
-	@Test
-	@RunAsClient
-	@InSequence(1)
-	public void defaultLoggingTest() throws IOException {
-		// make some logs
-		HttpURLConnection http = (HttpURLConnection) new URL(url, "Logger")
-				.openConnection();
-		int statusCode = http.getResponseCode();
-		assertTrue("Invalid response statusCode: " + statusCode,
-				statusCode == HttpServletResponse.SC_OK);
-		// check logs
-		BufferedReader br = new BufferedReader(new InputStreamReader(
-				new FileInputStream(logFile), Charset.forName("UTF-8")));
-		String line;
-		boolean logFound = false;
-		while ((line = br.readLine()) != null) {
-			if (line.contains("LoggingServlet is logging")) {
-				logFound = true;
-				break;
-			}
-		}
-		br.close();
-		Assert.assertTrue(logFound);
-	}
+    @Test
+    @RunAsClient
+    @InSequence(1)
+    public void defaultLoggingTest() throws IOException {
+        // make some logs
+        HttpURLConnection http = (HttpURLConnection) new URL(url, "Logger")
+                .openConnection();
+        int statusCode = http.getResponseCode();
+        assertTrue("Invalid response statusCode: " + statusCode,
+                statusCode == HttpServletResponse.SC_OK);
+        // check logs
+        BufferedReader br = new BufferedReader(new InputStreamReader(
+                new FileInputStream(logFile), Charset.forName("UTF-8")));
+        String line;
+        boolean logFound = false;
+        while ((line = br.readLine()) != null) {
+            if (line.contains("LoggingServlet is logging")) {
+                logFound = true;
+                break;
+            }
+        }
+        br.close();
+        Assert.assertTrue(logFound);
+    }
 
-	@Test
-	@RunAsClient
-	@InSequence(2)
-	public void perDeployFilePresenceTest() {
-		Assert.assertFalse("File: " + perDeployLogFile.toString()
-				+ " should not be created!", perDeployLogFile.exists());
-	}
+    @Test
+    @RunAsClient
+    @InSequence(2)
+    public void perDeployFilePresenceTest() {
+        Assert.assertFalse("File: " + perDeployLogFile.toString()
+                + " should not be created!", perDeployLogFile.exists());
+    }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/misc/LoggingPreferencesPerDeployFalseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/misc/LoggingPreferencesPerDeployFalseTestCase.java
@@ -66,18 +66,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * 
+ *
  * @author Petr Křemenský <pkremens@redhat.com>
+ * @deprecated this needs to be moved/copied to the manualmode tests and the new use-deployment-logging-config attribute
+ * needs to be used which requires a reload/restart of the server. Also I'm not sure the test actually works as it
+ * passed when I broke the property. See WFLY-2648
  */
 
 @ServerSetup(LoggingPreferencesPerDeployFalseTestCase.LoggingPreferencesPerDeployFalseTestCaseSetup.class)
 @RunWith(Arquillian.class)
+@Deprecated
 public class LoggingPreferencesPerDeployFalseTestCase extends
 		AbstractLoggingTest {
 
 	private static Logger log = Logger
 			.getLogger(LoggingPreferencesPerDeployFalseTestCase.class);
-	
+
 	private static final String PER_DEPLOY_NAME = "jboss-logging-properties-test.log";
 	private static final String PROFILE_LOG_NAME = "dummy-profile.log";
 	private static File perDeployLogFile;


### PR DESCRIPTION
## [WFLY-2599](https://issues.jboss.org/browse/WFLY-2599)

Removed the implicit logging dependencies from the server and create a new DUP in the logging subsystem. This allows the logging subsystem to be excluded in a `jboss-deployment-structure.xml` to skip adding of logging dependencies as well as executing logging DUP's.

Alternatively an attribute was added to the root subsystem to enable/disable the adding of logging dependencies.
## [WFLY-2700](https://issues.jboss.org/browse/WFLY-2600)

Deprecates the `org.jboss.as.logging.per-deployment` system property and adds an attribute to enable/disable the processing of logging configurations during deployment.
