### PR TITLE
[WFLY-2656] Remove clustered-cache-ref attribute from ejb3 schema

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
@@ -117,7 +117,6 @@
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="cache-ref" type="xs:string"/>
-        <xs:attribute name="clustered-cache-ref" type="xs:string" use="optional"/>
         <xs:attribute name="passivation-disabled-cache-ref" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>


### PR DESCRIPTION
Looks like this should not be here anymore.
