### PR TITLE
[WFLY-2649][WFLY-2128] HornetQ 2.4.0.Final Upgrade + one-port support for JMS

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -842,6 +842,7 @@
             <maven-resource group="org.hornetq" artifact="hornetq-core-client"/>
             <maven-resource group="org.hornetq" artifact="hornetq-server"/>
             <maven-resource group="org.hornetq" artifact="hornetq-commons"/>
+            <maven-resource group="org.hornetq" artifact="hornetq-tools"/>
             <maven-resource group="org.hornetq" artifact="hornetq-journal"/>
             <maven-resource group="org.hornetq" artifact="hornetq-jms-client"/>
             <maven-resource group="org.hornetq" artifact="hornetq-jms-server"/>

--- a/build/build.xml
+++ b/build/build.xml
@@ -1378,6 +1378,10 @@
             <maven-resource group="org.jboss.ws" artifact="jbossws-common-tools"/>
         </module-def>
 
+        <module-def name="org.jboss.xnio.netty.netty-xnio-transport">
+            <maven-resource group="org.jboss.xnio.netty" artifact="netty-xnio-transport"/>
+        </module-def>
+
         <module-def name="org.opensaml">
             <maven-resource group="org.opensaml" artifact="opensaml"/>
             <maven-resource group="org.opensaml" artifact="openws"/>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -849,6 +849,11 @@
 
                 <dependency>
                     <groupId>org.hornetq</groupId>
+                    <artifactId>hornetq-tools</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.hornetq</groupId>
                     <artifactId>hornetq-core-client</artifactId>
                 </dependency>
 

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1530,6 +1530,21 @@
                 </dependency>
 
                 <dependency>
+                    <groupId>org.jboss.xnio.netty</groupId>
+                    <artifactId>netty-xnio-transport</artifactId>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-transport</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>io.netty</groupId>
+                            <artifactId>netty-buffer</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+
+                <dependency>
                     <groupId>io.undertow</groupId>
                     <artifactId>undertow-core</artifactId>
                 </dependency>

--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -10,6 +10,7 @@
            <journal-min-files>2</journal-min-files>
 
            <connectors>
+               <http-connector name="http" socket-binding="http"/>
                <netty-connector name="netty" socket-binding="messaging"/>
                <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                    <param key="batch-delay" value="50"/>
@@ -18,6 +19,7 @@
            </connectors>
 
            <acceptors>
+               <http-acceptor name="http" http-listener="default"/>
                <netty-acceptor name="netty" socket-binding="messaging"/>
                <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
                    <param key="batch-delay" value="50"/>
@@ -72,6 +74,14 @@
                        <entry name="java:jboss/exported/jms/RemoteConnectionFactory"/>
                    </entries>
                    <?HA-REMOTE-CONNECTION-FACTORY?>
+               </connection-factory>
+               <connection-factory name="HTTPConnectionFactory">
+                   <connectors>
+                       <connector-ref connector-name="http"/>
+                   </connectors>
+                   <entries>
+                       <entry name="java:jboss/exported/jms/HTTPConnectionFactory"/>
+                   </entries>
                </connection-factory>
                <pooled-connection-factory name="hornetq-ra">
                    <transaction mode="xa"/>

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_2_0.xsd
@@ -159,6 +159,7 @@
           <xs:element maxOccurs="1" minOccurs="0" name="connectors">
               <xs:complexType>
                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="http-connector" type="http-connectorType" />
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-connector" type="netty-connectorType" />
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-connector" type="inVM-connectorType" />
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="connector" type="connectorType" />
@@ -168,6 +169,7 @@
           <xs:element maxOccurs="1" minOccurs="0" name="acceptors">
               <xs:complexType>
                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="http-acceptor" type="http-acceptorType" />
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-acceptor" type="netty-acceptorType" />
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-acceptor" type="inVM-acceptorType" />
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="acceptor" type="acceptorType" />
@@ -399,6 +401,29 @@
        <xs:attribute name="value" type="xs:string" use="required"/>
     </xs:complexType>
 
+    <xs:complexType name="http-connectorType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+              The HTTP connector type. Messaging clients that uses this connector initiates a HTTP request that is upgraded to HornetQ protocol.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-connectorType">
+                <xs:attribute name="socket-binding" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                This attribute references the socket-binding used by the web server. Its host and port will be used to configure the connector.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
     <xs:complexType name="netty-connectorType">
        <xs:annotation>
           <xs:documentation>
@@ -453,6 +478,29 @@
           <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
        </xs:sequence>
        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="http-acceptorType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+              The HTTP acceptor type. HornetQ server will accepts HTTP connections on this acceptor to upgrade to HornetQ protocol.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="base-connectorType">
+                <xs:attribute name="http-listener" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                This attribute references the undertow's http-listener that will handle the initial HTTP request.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
 
     <xs:complexType name="netty-acceptorType">

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -32,6 +32,9 @@
     </resources>
 
     <dependencies>
+        <!-- io.undertow.core is required only if http-acceptor are used -->
+        <module name="io.undertow.core" optional="true" />
+        <module name="io.netty" />
         <module name="javax.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.jms.api"/>
@@ -45,6 +48,8 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
+        <!-- required only to access the HttpListenerRegistryService used by http-acceptor -->
+        <module name="org.jboss.as.remoting" optional="true"/>
         <module name="org.wildfly.security.manager"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.weld"/>
@@ -69,5 +74,9 @@
         <module name="org.jboss.weld.api" />
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi" />
+        <!-- org.jboss.xnio is required only if http-acceptor are used -->
+        <module name="org.jboss.xnio" optional="true" />
+        <!-- org.jboss.xnio.netty.netty-xnio-transport is required only if http-acceptor are used -->
+        <module name="org.jboss.xnio.netty.netty-xnio-transport" optional="true" />
     </dependencies>
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/netty/netty-xnio-transport/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/netty/netty-xnio-transport/main/module.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.xnio.netty.netty-xnio-transport">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="io.netty"/>
+        <module name="org.jboss.xnio"/>
+        <module name="org.jboss.xnio.nio"/>
+    </dependencies>
+</module>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -168,6 +168,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.xnio.netty</groupId>
+            <artifactId>netty-xnio-transport</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -71,6 +71,11 @@
 
         <dependency>
             <groupId>org.hornetq</groupId>
+            <artifactId>hornetq-tools</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hornetq</groupId>
             <artifactId>hornetq-journal</artifactId>
         </dependency>
 

--- a/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Attribute.java
@@ -40,6 +40,8 @@ public enum Attribute {
    @Deprecated
    BACKUP_CONNECTOR_NAME("backup-connector-name"),
    CONNECTOR_NAME(CommonAttributes.CONNECTOR_NAME),
+   CONNECTOR_REF(CommonAttributes.CONNECTOR_REF_STRING),
+   HTTP_LISTENER(CommonAttributes.HTTP_LISTENER),
    KEY(CommonAttributes.KEY),
    MATCH(CommonAttributes.MATCH),
    NAME(CommonAttributes.NAME),

--- a/messaging/src/main/java/org/jboss/as/messaging/BroadcastGroupDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/BroadcastGroupDefinition.java
@@ -148,6 +148,7 @@ public class BroadcastGroupDefinition extends SimpleResourceDefinition {
         PathAddress hornetqServer = MessagingServices.getHornetQServerPathAddress(address);
         Resource hornetQServerResource = context.readResourceFromRoot(hornetqServer);
         Set<String> availableConnectors = new HashSet<String>();
+        availableConnectors.addAll(hornetQServerResource.getChildrenNames(CommonAttributes.HTTP_CONNECTOR));
         availableConnectors.addAll(hornetQServerResource.getChildrenNames(CommonAttributes.IN_VM_CONNECTOR));
         availableConnectors.addAll(hornetQServerResource.getChildrenNames(CommonAttributes.REMOTE_CONNECTOR));
         availableConnectors.addAll(hornetQServerResource.getChildrenNames(CommonAttributes.CONNECTOR));

--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -774,6 +774,7 @@ public interface CommonAttributes {
     String CONNECTOR_REF_STRING = "connector-ref";
     String CONNECTOR_SERVICE = "connector-service";
     String CONNECTOR_SERVICES = "connector-services";
+    String CORE = "core";
     String CORE_ADDRESS = "core-address";
     String CORE_QUEUE = "core-queue";
     String CORE_QUEUES = "core-queues";
@@ -790,6 +791,10 @@ public interface CommonAttributes {
     String FILE_DEPLOYMENT_ENABLED = "file-deployment-enabled";
     String GROUPING_HANDLER = "grouping-handler";
     String HOST = "host";
+    String HTTP = "http";
+    String HTTP_ACCEPTOR = "http-acceptor";
+    String HTTP_CONNECTOR = "http-connector";
+    String HTTP_LISTENER = "http-listener";
     String ID = "id";
     String IN_VM_ACCEPTOR = "in-vm-acceptor";
     String IN_VM_CONNECTOR = "in-vm-connector";
@@ -869,5 +874,4 @@ public interface CommonAttributes {
 
     AttributeDefinition[] SIMPLE_ROOT_RESOURCE_WRITE_ATTRIBUTES = { FAILOVER_ON_SHUTDOWN, MESSAGE_COUNTER_ENABLED,
             MESSAGE_COUNTER_MAX_DAY_HISTORY, MESSAGE_COUNTER_SAMPLE_PERIOD };
-
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/Element.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Element.java
@@ -89,6 +89,8 @@ public enum Element {
    GROUPING_HANDLER(CommonAttributes.GROUPING_HANDLER),
    GROUP_TIMEOUT(GroupingHandlerDefinition.GROUP_TIMEOUT),
    HORNETQ_SERVER(CommonAttributes.HORNETQ_SERVER),
+   HTTP_ACCEPTOR(CommonAttributes.HTTP_ACCEPTOR),
+   HTTP_CONNECTOR(CommonAttributes.HTTP_CONNECTOR),
    ID_CACHE_SIZE(CommonAttributes.ID_CACHE_SIZE),
    INITIAL_WAIT_TIMEOUT(DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT),
    IN_VM_ACCEPTOR(CommonAttributes.IN_VM_ACCEPTOR),

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorAdd.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import java.util.List;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.descriptions.DescriptionProvider;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+
+/**
+ * The add operation for the messaging subsystem's http-acceptor resource.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class HTTPAcceptorAdd extends TransportConfigOperationHandlers.BasicTransportConfigAdd implements DescriptionProvider {
+
+    public static final HTTPAcceptorAdd INSTANCE = new HTTPAcceptorAdd();
+
+    private HTTPAcceptorAdd() {
+        super(false, HTTPAcceptorDefinition.ATTRIBUTES);
+    }
+
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode
+            model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws
+            OperationFailedException {
+        super.performRuntime(context, operation, model, verificationHandler, newControllers);
+
+        PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
+        String hornetqServerName = address.getElement(address.size() - 2).getValue();
+        String acceptorName = address.getLastElement().getValue();
+        final ModelNode fullModel = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+
+        launchServices(context, hornetqServerName, acceptorName, fullModel, verificationHandler, newControllers);
+    }
+
+    void launchServices(OperationContext context, String hornetqServerName, String acceptorName, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        String httpConnectorName = HTTPAcceptorDefinition.HTTP_LISTENER.resolveModelAttribute(context, model).asString();
+
+        HTTPUpgradeService.installService(context.getServiceTarget(),
+                hornetqServerName,
+                acceptorName,
+                httpConnectorName,
+                verificationHandler,
+                newControllers);
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorDefinition.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+import static org.jboss.as.messaging.CommonAttributes.HTTP_ACCEPTOR;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelType;
+
+/**
+ * HTTP acceptor resource definition
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2013 Red Hat Inc.
+ */
+public class HTTPAcceptorDefinition extends SimpleResourceDefinition {
+
+    public static final PathElement PATH = PathElement.pathElement(HTTP_ACCEPTOR);
+
+    private final boolean registerRuntimeOnly;
+
+    static final SimpleAttributeDefinition HTTP_LISTENER = create(CommonAttributes.HTTP_LISTENER, ModelType.STRING)
+            .setAllowNull(false)
+            .build();
+
+    static AttributeDefinition[] ATTRIBUTES = { HTTP_LISTENER };
+
+    HTTPAcceptorDefinition(final boolean registerRuntimeOnly) {
+        super(PATH,
+                new StandardResourceDescriptionResolver(CommonAttributes.ACCEPTOR, MessagingExtension.RESOURCE_NAME, MessagingExtension.class.getClassLoader(), true, false) {
+                    @Override
+                    public String getResourceDescription(Locale locale, ResourceBundle bundle) {
+                        return bundle.getString(HTTP_ACCEPTOR);
+                    }
+                },
+                HTTPAcceptorAdd.INSTANCE,
+                HTTPAcceptorRemove.INSTANCE);
+        this.registerRuntimeOnly = registerRuntimeOnly;
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration registry) {
+        super.registerAttributes(registry);
+
+        OperationStepHandler attributeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
+        for (AttributeDefinition attr : ATTRIBUTES) {
+            if (registerRuntimeOnly || !attr.getFlags().contains(AttributeAccess.Flag.STORAGE_RUNTIME)) {
+                registry.registerReadWriteAttribute(attr, null, attributeHandler);
+            }
+        }
+    }
+
+    @Override
+    public void registerChildren(ManagementResourceRegistration registry) {
+        super.registerChildren(registry);
+
+        registry.registerSubModel(new TransportParamDefinition());
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorRemove.java
@@ -1,0 +1,54 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import org.jboss.as.controller.AbstractRemoveStepHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * The remove operation for the messaging subsystem's http-acceptor resource.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class HTTPAcceptorRemove extends AbstractRemoveStepHandler {
+
+    static final HTTPAcceptorRemove INSTANCE = new HTTPAcceptorRemove();
+
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+        final String name = address.getLastElement().getValue();
+        context.removeService(HTTPUpgradeService.UPGRADE_SERVICE_NAME.append(name));
+    }
+
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        final PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+        String hornetqServerName = address.getElement(address.size() - 2).getValue();
+        String acceptorName = address.getLastElement().getValue();
+        HTTPAcceptorAdd.INSTANCE.launchServices(context, hornetqServerName, acceptorName, model, null, null);
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPConnectorDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPConnectorDefinition.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
+
+import javax.xml.stream.XMLStreamWriter;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * HTTP connector resource definition
+ *
+ * @author <a href="http://jmesnil.net">Jeff Mesnil</a> (c) 2012 Red Hat Inc.
+ */
+public class HTTPConnectorDefinition extends AbstractTransportDefinition {
+
+    // for remote acceptor, the socket-binding is required
+    public static final SimpleAttributeDefinition SOCKET_BINDING = create(GenericTransportDefinition.SOCKET_BINDING)
+            .setAllowNull(false)
+            .setAllowExpression(false) // references another resource
+            .setAttributeMarshaller(new AttributeMarshaller() {
+                public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws javax.xml.stream.XMLStreamException {
+                    if (isMarshallable(attribute, resourceModel)) {
+                        writer.writeAttribute(attribute.getXmlName(), resourceModel.get(attribute.getName()).asString());
+                    }
+                }
+            })
+            .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
+            .build();
+
+    public HTTPConnectorDefinition(final boolean registerRuntimeOnly) {
+        super(registerRuntimeOnly, false, CommonAttributes.HTTP_CONNECTOR, SOCKET_BINDING);
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPUpgradeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPUpgradeService.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.HORNETQ_REMOTING;
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.MAGIC_NUMBER;
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_REMOTING_ACCEPT;
+import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_REMOTING_KEY;
+import static org.jboss.as.messaging.CommonAttributes.CORE;
+import static org.jboss.as.messaging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.remoting.HandshakeUtil.createHttpUpgradeHandshake;
+
+import java.util.List;
+
+import io.netty.channel.socket.SocketChannel;
+import io.undertow.server.ListenerRegistry;
+import io.undertow.server.handlers.ChannelUpgradeHandler;
+import org.hornetq.core.remoting.impl.netty.NettyAcceptor;
+import org.hornetq.core.remoting.server.RemotingService;
+import org.hornetq.core.server.HornetQServer;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.remoting.HttpListenerRegistryService;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
+import org.xnio.ChannelListener;
+import org.xnio.StreamConnection;
+import org.xnio.netty.transport.WrappingXnioSocketChannel;
+
+/**
+ * Service that handles HTTP upgrade for HornetQ remoting protocol.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
+
+    public static final ServiceName HTTP_UPGRADE_REGISTRY = ServiceName.JBOSS.append("http-upgrade-registry");
+    public static final ServiceName UPGRADE_SERVICE_NAME = MessagingServices.JBOSS_MESSAGING.append("http-upgrade-service");
+
+    private final String hornetQServerName;
+    private final String acceptorName;
+    private final String httpListenerName;
+    private InjectedValue<ChannelUpgradeHandler> injectedRegistry = new InjectedValue<>();
+    private InjectedValue<ListenerRegistry> listenerRegistry = new InjectedValue<>();
+
+    private ListenerRegistry.HttpUpgradeMetadata httpUpgradeMetadata;
+
+    public HTTPUpgradeService(String hornetQServerName, String acceptorName, String httpListenerName) {
+        this.hornetQServerName = hornetQServerName;
+        this.acceptorName = acceptorName;
+        this.httpListenerName = httpListenerName;
+    }
+
+    public static void installService(final ServiceTarget serviceTarget, String hornetQServerName, final String acceptorName, final String httpListenerName, final ServiceVerificationHandler verificationHandler, final List<ServiceController<?>> newControllers) {
+
+        final HTTPUpgradeService service = new HTTPUpgradeService(hornetQServerName, acceptorName, httpListenerName);
+
+        ServiceBuilder<HTTPUpgradeService> builder = serviceTarget.addService(UPGRADE_SERVICE_NAME.append(acceptorName), service)
+                .addDependency(HTTP_UPGRADE_REGISTRY.append(httpListenerName), ChannelUpgradeHandler.class, service.injectedRegistry)
+                .addDependency(HttpListenerRegistryService.SERVICE_NAME, ListenerRegistry.class, service.listenerRegistry)
+                .addDependency(HornetQActivationService.getHornetQActivationServiceName(MessagingServices.getHornetQServiceName(hornetQServerName)));
+
+        if (verificationHandler != null) {
+            builder.addListener(verificationHandler);
+        }
+
+        builder.setInitialMode(ServiceController.Mode.PASSIVE);
+
+        ServiceController<HTTPUpgradeService> controller = builder.install();
+        if(newControllers != null) {
+            newControllers.add(controller);
+        }
+    }
+
+    @Override
+    public void start(StartContext context) throws StartException {
+        ListenerRegistry.Listener listenerInfo = listenerRegistry.getValue().getListener(httpListenerName);
+        assert listenerInfo != null;
+        httpUpgradeMetadata = new ListenerRegistry.HttpUpgradeMetadata(HORNETQ_REMOTING, CORE);
+        listenerInfo.addHttpUpgradeMetadata(httpUpgradeMetadata);
+
+        MESSAGING_LOGGER.registeredHTTPUpgradeHandler(HORNETQ_REMOTING);
+        ServiceController<?> hornetqService = context.getController().getServiceContainer().getService(MessagingServices.getHornetQServiceName(hornetQServerName));
+        HornetQServer hornetQServer = HornetQServer.class.cast(hornetqService.getValue());
+
+        injectedRegistry.getValue().addProtocol(HORNETQ_REMOTING,
+                switchToHornetQProtocol(hornetQServer, acceptorName),
+                createHttpUpgradeHandshake(MAGIC_NUMBER, SEC_HORNETQ_REMOTING_KEY, SEC_HORNETQ_REMOTING_ACCEPT));
+    }
+
+    @Override
+    public void stop(StopContext context) {
+        listenerRegistry.getValue().getListener(httpListenerName).removeHttpUpgradeMetadata(httpUpgradeMetadata);
+        httpUpgradeMetadata = null;
+        injectedRegistry.getValue().removeProtocol(HORNETQ_REMOTING);
+    }
+
+    @Override
+    public HTTPUpgradeService getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    private static ChannelListener<StreamConnection> switchToHornetQProtocol(final HornetQServer hornetqServer, final String acceptorName) {
+        return new ChannelListener<StreamConnection>() {
+            @Override
+            public void handleEvent(final StreamConnection connection) {
+                MESSAGING_LOGGER.debugf("Switching to %s protocol for %s http-acceptor", HORNETQ_REMOTING, acceptorName);
+                SocketChannel channel = new WrappingXnioSocketChannel(connection);
+                RemotingService remotingService = hornetqServer.getRemotingService();
+
+                NettyAcceptor acceptor = (NettyAcceptor)remotingService.getAcceptor(acceptorName);
+                acceptor.transfer(channel);
+                connection.getSourceChannel().resumeReads();
+            }
+        };
+    }
+
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -172,11 +172,13 @@ public class MessagingExtension implements Extension {
         serverRegistration.registerSubModel(QueueDefinition.newRuntimeQueueDefinition(registerRuntimeOnly));
 
         // Acceptors
+        serverRegistration.registerSubModel(new HTTPAcceptorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(GenericTransportDefinition.createAcceptorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(RemoteTransportDefinition.createAcceptorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(InVMTransportDefinition.createAcceptorDefinition(registerRuntimeOnly));
 
         // Connectors
+        serverRegistration.registerSubModel(new HTTPConnectorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(GenericTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(RemoteTransportDefinition.createConnectorDefinition(registerRuntimeOnly));
         serverRegistration.registerSubModel(InVMTransportDefinition.createConnectorDefinition(registerRuntimeOnly));

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -202,4 +202,13 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 11614, value = "Ignoring %s property that is not a known property for pooled connection factory.")
     void unknownPooledConnectionFactoryAttribute(String name);
+
+    /**
+     * Logs an info message when a HTTP Upgrade handler is registered for the given {@code protocol}.
+     *
+     * @param name the name of the protocol that is handled
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 11615, value = "Registered HTTP upgrade handler for %s protocol")
+    void registeredHTTPUpgradeHandler(String name);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingServices.java
@@ -34,7 +34,7 @@ import org.jboss.msc.service.ServiceName;
 public class MessagingServices {
 
     /** The service name "jboss.messaging". */
-    private static final ServiceName JBOSS_MESSAGING = ServiceName.JBOSS.append("messaging");
+    static final ServiceName JBOSS_MESSAGING = ServiceName.JBOSS.append("messaging");
 
     /** The core queue name base. */
     private static final String CORE_QUEUE_BASE = "queue";

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingTransformers.java
@@ -132,6 +132,9 @@ public class MessagingTransformers {
             rejectAttributesWithExpression(transportParam, TransportParamDefinition.VALUE);
         }
 
+        hornetqServer.rejectChildResource(HTTPAcceptorDefinition.PATH);
+        hornetqServer.rejectChildResource(pathElement(CommonAttributes.HTTP_CONNECTOR));
+
         ResourceTransformationDescriptionBuilder broadcastGroup = hornetqServer.addChildResource(BroadcastGroupDefinition.PATH);
         rejectAttributesWithExpression(broadcastGroup, BroadcastGroupDefinition.BROADCAST_PERIOD);
         rejectDefinedAttribute(broadcastGroup, CommonAttributes.JGROUPS_CHANNEL, CommonAttributes.JGROUPS_STACK);
@@ -238,6 +241,9 @@ public class MessagingTransformers {
                 .end();
         rejectDefinedAttributeWithDefaultValue(hornetqServer, MAX_SAVED_REPLICATED_JOURNAL_SIZE);
 
+        hornetqServer.rejectChildResource(HTTPAcceptorDefinition.PATH);
+        hornetqServer.rejectChildResource(pathElement(CommonAttributes.HTTP_CONNECTOR));
+
         ResourceTransformationDescriptionBuilder addressSetting = hornetqServer.addChildResource(AddressSettingDefinition.PATH);
         rejectDefinedAttributeWithDefaultValue(addressSetting, EXPIRY_DELAY);
 
@@ -268,6 +274,9 @@ public class MessagingTransformers {
 
         ResourceTransformationDescriptionBuilder hornetqServer = subsystemRoot.addChildResource(pathElement(HORNETQ_SERVER));
         rejectDefinedAttributeWithDefaultValue(hornetqServer, MAX_SAVED_REPLICATED_JOURNAL_SIZE);
+
+        hornetqServer.rejectChildResource(HTTPAcceptorDefinition.PATH);
+        hornetqServer.rejectChildResource(pathElement(CommonAttributes.HTTP_CONNECTOR));
 
         ResourceTransformationDescriptionBuilder bridge = hornetqServer.addChildResource(BridgeDefinition.PATH);
         rejectDefinedAttributeWithDefaultValue(bridge, RECONNECT_ATTEMPTS_ON_SAME_NODE);

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingXMLWriter.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingXMLWriter.java
@@ -35,6 +35,8 @@ import static org.jboss.as.messaging.CommonAttributes.DIVERT;
 import static org.jboss.as.messaging.CommonAttributes.DURABLE;
 import static org.jboss.as.messaging.CommonAttributes.GROUPING_HANDLER;
 import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
+import static org.jboss.as.messaging.CommonAttributes.HTTP_ACCEPTOR;
+import static org.jboss.as.messaging.CommonAttributes.HTTP_CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.IN_VM_CONNECTOR;
 import static org.jboss.as.messaging.CommonAttributes.JMS_BRIDGE;
@@ -182,6 +184,15 @@ public class MessagingXMLWriter implements XMLElementWriter<SubsystemMarshalling
     private static void writeConnectors(final XMLExtendedStreamWriter writer, final ModelNode node) throws XMLStreamException {
         if (node.hasDefined(CONNECTOR) || node.hasDefined(REMOTE_CONNECTOR) || node.hasDefined(IN_VM_CONNECTOR)) {
             writer.writeStartElement(Element.CONNECTORS.getLocalName());
+            if(node.hasDefined(HTTP_CONNECTOR)) {
+                for(final Property property : node.get(HTTP_CONNECTOR).asPropertyList()) {
+                    writer.writeStartElement(Element.HTTP_CONNECTOR.getLocalName());
+                    writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
+                    HTTPConnectorDefinition.SOCKET_BINDING.marshallAsAttribute(property.getValue(), writer);
+                    writeTransportParam(writer, property.getValue().get(PARAM));
+                    writer.writeEndElement();
+                }
+            }
             if(node.hasDefined(REMOTE_CONNECTOR)) {
                 for(final Property property : node.get(REMOTE_CONNECTOR).asPropertyList()) {
                     writer.writeStartElement(Element.NETTY_CONNECTOR.getLocalName());
@@ -218,6 +229,14 @@ public class MessagingXMLWriter implements XMLElementWriter<SubsystemMarshalling
     private static void writeAcceptors(final XMLExtendedStreamWriter writer, final ModelNode node) throws XMLStreamException {
         if (node.hasDefined(ACCEPTOR) || node.hasDefined(REMOTE_ACCEPTOR) || node.hasDefined(IN_VM_ACCEPTOR)) {
             writer.writeStartElement(Element.ACCEPTORS.getLocalName());
+            if(node.hasDefined(HTTP_ACCEPTOR)) {
+                for(final Property property : node.get(HTTP_ACCEPTOR).asPropertyList()) {
+                    writer.writeStartElement(Element.HTTP_ACCEPTOR.getLocalName());
+                    HTTPAcceptorDefinition.HTTP_LISTENER.marshallAsAttribute(property.getValue(), writer);
+                    writeAcceptorContent(writer, property);
+                    writer.writeEndElement();
+                }
+            }
             if(node.hasDefined(REMOTE_ACCEPTOR)) {
                 for(final Property property : node.get(REMOTE_ACCEPTOR).asPropertyList()) {
                     writer.writeStartElement(Element.NETTY_ACCEPTOR.getLocalName());

--- a/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
+++ b/messaging/src/main/resources/org/jboss/as/messaging/LocalDescriptions.properties
@@ -167,6 +167,8 @@ grouping-handler.reaper-period=How often the reaper will be run to check for tim
 
 in-vm-acceptor=Defines a way in which in-VM connections can be made to the HornetQ server.
 remote-acceptor=Defines a way in which remote connections can be made to the HornetQ server.
+http-acceptor=Defines a way in which remote connections can be made to the HornetQ server over HTTP.
+acceptor.http-listener=The Undertow's http-listener that handles HTTP upgrade requests.
 acceptor=An acceptor defines a way in which connections can be made to the HornetQ server.
 acceptor.factory-class=Class name of the factory class that can instantiate the acceptor.
 acceptor.socket-binding=The socket binding that the acceptor will use to accept connections.
@@ -200,6 +202,7 @@ address-setting.send-to-dla-on-no-route=If this parameter is set to true for tha
 connector=A connector can be used by a client to define how it connects to a server.
 remote-connector=Used by a remote client to define how it connects to a server.
 in-vm-connector=Used by an in-VM client to define how it connects to a server.
+http-connector=Used by a remote client to define how it connects to a server over HTTP.
 connector.factory-class=Class name of the factory class that can instantiate the connector.
 connector.socket-binding=The socket binding that the connector will use to create connections.
 connector.server-id=The server id.
@@ -646,8 +649,8 @@ role.manage=This permission allows the user to invoke management operations by s
 
 host=The host of the HTTP connector.
 server-id=The connector server ID.
-
 socket-binding=The socket binding reference.
+http-listener=The Undertow's http-listener that handles HTTP upgrade requests.
 
 deployed=Runtime resources exposed by messaging resources included in this deployment.
 

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
@@ -83,6 +83,7 @@ import org.jboss.as.messaging.ConnectorServiceParamDefinition;
 import org.jboss.as.messaging.DiscoveryGroupDefinition;
 import org.jboss.as.messaging.DivertDefinition;
 import org.jboss.as.messaging.GroupingHandlerDefinition;
+import org.jboss.as.messaging.HTTPAcceptorDefinition;
 import org.jboss.as.messaging.HornetQServerResourceDefinition;
 import org.jboss.as.messaging.InVMTransportDefinition;
 import org.jboss.as.messaging.MessagingExtension;
@@ -117,12 +118,9 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("subsystem_2_0.xml");
-    }
-
-    @Test
-    public void testExpressions() throws Exception {
-        standardSubsystemTest("subsystem_2_0_expressions.xml");
+        // subsystem_2_0_expressions.xml contains new http-connector resource
+        // introduces in 2.0 management version
+        return readResource("subsystem_2_0_expressions.xml");
     }
 
     @Test
@@ -307,6 +305,12 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
                                 subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.REMOTE_CONNECTOR), TransportParamDefinition.PATH),
                                 new RejectExpressionsConfig(TransportParamDefinition.VALUE))
                         .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR)),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_ACCEPTOR)),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(
                                 subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.ACCEPTOR)),
                                 new RejectExpressionsConfigWithAddOnlyParam(PARAM))
                         .addFailedAttribute(
@@ -424,6 +428,12 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
                                 createChainedConfig(new AttributeDefinition[]{},
                                         new AttributeDefinition[]{BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE}))
                         .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR)),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, HTTPAcceptorDefinition.PATH),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(
                                 subsystemAddress.append(HORNETQ_SERVER_PATH, GroupingHandlerDefinition.PATH),
                                 createChainedConfig(new AttributeDefinition[] {},
                                         new AttributeDefinition[] { GroupingHandlerDefinition.GROUP_TIMEOUT, GroupingHandlerDefinition.REAPER_PERIOD }))
@@ -467,6 +477,12 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
                                 subsystemAddress.append(HORNETQ_SERVER_PATH, BridgeDefinition.PATH),
                                 createChainedConfig(new AttributeDefinition[]{},
                                         new AttributeDefinition[]{BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE}))
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR)),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(
+                                subsystemAddress.append(HORNETQ_SERVER_PATH, HTTPAcceptorDefinition.PATH),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
                         .addFailedAttribute(
                                 subsystemAddress.append(HORNETQ_SERVER_PATH, GroupingHandlerDefinition.PATH),
                                 createChainedConfig(new AttributeDefinition[] {},

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_2_0_expressions.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_2_0_expressions.xml
@@ -74,6 +74,9 @@
         <journal-directory path="${my.journal.dir:test}" relative-to="test" />
         <large-messages-directory path="${my.largemessages.dir:test}" relative-to="test" />
         <connectors>
+            <http-connector name="http" socket-binding="http">
+                <param key="batch-delay" value="${batch.delay:50}"/>
+            </http-connector>
             <netty-connector name="netty" socket-binding="messaging" />
             <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                 <param key="batch-delay" value="${batch.delay:50}"/>
@@ -90,6 +93,9 @@
             </connector>
         </connectors>
         <acceptors>
+            <http-acceptor name="http" http-listener="default">
+                <param key="batch-delay" value="${batch.delay:50}"/>
+            </http-acceptor>
             <netty-acceptor name="netty" socket-binding="messaging" />
             <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
                 <param key="batch-delay" value="50"/>

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,7 @@
         <version.org.jboss.mod_cluster>1.3.0.Alpha1</version.org.jboss.mod_cluster>
         <version.org.jboss.modules.jboss-modules>1.3.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.0.CR1</version.org.jboss.msc.jboss-msc>
+        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.0</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.osgi.metadata>3.0.1.Final</version.org.jboss.osgi.metadata>
         <version.org.jboss.remote-naming>2.0.0.Beta2</version.org.jboss.remote-naming>
         <version.org.jboss.remoting>4.0.0.Beta3</version.org.jboss.remoting>
@@ -5784,6 +5785,12 @@
                 <groupId>org.jboss.xnio</groupId>
                 <artifactId>xnio-nio</artifactId>
                 <version>${version.org.jboss.xnio.xnio-nio}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.xnio.netty</groupId>
+                <artifactId>netty-xnio-transport</artifactId>
+                <version>${version.org.jboss.xnio.netty.netty-xnio-transport}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <version.gnu.getopt>1.0.13</version.gnu.getopt>
         <version.groovy-all>2.1.8</version.groovy-all>
         <version.io.netty3>3.6.6.Final</version.io.netty3>
-        <version.io.netty>4.0.12.Final</version.io.netty>
+        <version.io.netty>4.0.13.Final</version.io.netty>
         <version.io.undertow>1.0.0.Beta28</version.io.undertow>
         <version.io.undertow.jastow>1.0.0.CR1</version.io.undertow.jastow>
         <version.javax.activation>1.1.1</version.javax.activation>
@@ -159,7 +159,7 @@
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.0.0.Alpha5</version.org.hibernate.hql>
         <version.org.hibernate.search>4.4.0.Final</version.org.hibernate.search>
-        <version.org.hornetq>2.4.0.Beta3</version.org.hornetq>
+        <version.org.hornetq>2.4.0.Final</version.org.hornetq>
         <version.org.infinispan>6.0.0.Final</version.org.infinispan>
         <version.org.infinispan.protostream>1.0.0.CR1</version.org.infinispan.protostream>
         <version.org.jacorb>2.3.2-jbossorg-5</version.org.jacorb>
@@ -3813,6 +3813,12 @@
             <dependency>
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-amqp-protocol</artifactId>
+                <version>${version.org.hornetq}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hornetq</groupId>
+                <artifactId>hornetq-tools</artifactId>
                 <version>${version.org.hornetq}</version>
             </dependency>
 

--- a/remoting/src/main/java/org/jboss/as/remoting/HandshakeUtil.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/HandshakeUtil.java
@@ -1,0 +1,196 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.remoting;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Constructor;
+import java.security.AccessController;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedExceptionAction;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.handlers.HttpUpgradeHandshake;
+import io.undertow.util.HttpString;
+
+/**
+ * Utility class to create a server-side HTTP Upgrade handshake.
+ *
+ * @author Stuart Douglas
+ */
+public class HandshakeUtil {
+
+    public static HttpUpgradeHandshake createHttpUpgradeHandshake(final String magicNumber, final String keyHeader, final String acceptHeader) {
+        return new HttpUpgradeHandshake() {
+            public boolean handleUpgrade(final HttpServerExchange exchange) throws IOException {
+                String secretKey = exchange.getRequestHeaders().getFirst(keyHeader);
+                if (secretKey == null) {
+                    throw RemotingMessages.MESSAGES.upgradeRequestMissingKey();
+                }
+                String response = createExpectedResponse(magicNumber, secretKey);
+                exchange.getResponseHeaders().put(HttpString.tryFromString(acceptHeader), response);
+                return true;
+            }
+
+            private String createExpectedResponse(final String magicNumber, final String secretKey) throws IOException {
+                try {
+                    final String concat = secretKey + magicNumber;
+                    final MessageDigest digest = MessageDigest.getInstance("SHA1");
+
+                    digest.update(concat.getBytes("UTF-8"));
+                    final byte[] bytes = digest.digest();
+                    return FlexBase64.encodeString(bytes, false);
+                } catch (NoSuchAlgorithmException e) {
+                    throw new IOException(e);
+                }
+            }
+        };
+    }
+
+    private static class FlexBase64 {
+        /*
+         * Note that this code heavily favors performance over reuse and clean style.
+         */
+
+        private static final byte[] ENCODING_TABLE;
+        private static final byte[] DECODING_TABLE = new byte[80];
+        private static final Constructor<String> STRING_CONSTRUCTOR;
+
+        static {
+            try {
+                ENCODING_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".getBytes("ASCII");
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalStateException();
+            }
+
+            for (int i = 0; i < ENCODING_TABLE.length; i++) {
+                int v = (ENCODING_TABLE[i] & 0xFF) - 43;
+                DECODING_TABLE[v] = (byte) (i + 1);  // zero = illegal
+            }
+
+            Constructor<String> c = null;
+            try {
+                PrivilegedExceptionAction<Constructor<String>> runnable = new PrivilegedExceptionAction<Constructor<String>>() {
+                    @Override
+                    public Constructor<String> run() throws Exception {
+                        Constructor<String> c;
+                        c = String.class.getDeclaredConstructor(char[].class, boolean.class);
+                        c.setAccessible(true);
+                        return c;
+                    }
+                };
+                if (System.getSecurityManager() != null) {
+                    c = AccessController.doPrivileged(runnable);
+                } else {
+                    c = runnable.run();
+                }
+            } catch (Throwable t) {
+            }
+
+            STRING_CONSTRUCTOR = c;
+        }
+
+        /**
+         * Encodes a fixed and complete byte array into a Base64 String.
+         *
+         * @param source the byte array to encode from
+         * @param wrap   whether or not to wrap the output at 76 chars with CRLFs
+         * @return a new String representing the Base64 output
+         */
+        public static String encodeString(byte[] source, boolean wrap) {
+            return encodeString(source, 0, source.length, wrap);
+        }
+
+
+        private static String encodeString(byte[] source, int pos, int limit, boolean wrap) {
+            int olimit = (limit - pos);
+            int remainder = olimit % 3;
+            olimit = (olimit + (remainder == 0 ? 0 : 3 - remainder)) / 3 * 4;
+            olimit += (wrap ? (olimit / 76) * 2 + 2 : 0);
+            char[] target = new char[olimit];
+            int opos = 0;
+            int last = 0;
+            int count = 0;
+            int state = 0;
+            final byte[] ENCODING_TABLE = FlexBase64.ENCODING_TABLE;
+
+            while (limit > pos) {
+                //  ( 6 | 2) (4 | 4) (2 | 6)
+                int b = source[pos++] & 0xFF;
+                target[opos++] = (char) ENCODING_TABLE[b >>> 2];
+                last = (b & 0x3) << 4;
+                if (pos >= limit) {
+                    state = 1;
+                    break;
+                }
+                b = source[pos++] & 0xFF;
+                target[opos++] = (char) ENCODING_TABLE[last | (b >>> 4)];
+                last = (b & 0x0F) << 2;
+                if (pos >= limit) {
+                    state = 2;
+                    break;
+                }
+                b = source[pos++] & 0xFF;
+                target[opos++] = (char) ENCODING_TABLE[last | (b >>> 6)];
+                target[opos++] = (char) ENCODING_TABLE[b & 0x3F];
+
+                if (wrap) {
+                    count += 4;
+                    if (count >= 76) {
+                        count = 0;
+                        target[opos++] = 0x0D;
+                        target[opos++] = 0x0A;
+                    }
+                }
+            }
+
+            complete(target, opos, state, last, wrap);
+
+            try {
+                // Eliminate copying on Open/Oracle JDK
+                if (STRING_CONSTRUCTOR != null) {
+                    return STRING_CONSTRUCTOR.newInstance(target, Boolean.TRUE);
+                }
+            } catch (Exception e) {
+            }
+
+            return new String(target);
+        }
+
+        private static int complete(char[] target, int pos, int state, int last, boolean wrap) {
+            if (state > 0) {
+                target[pos++] = (char) ENCODING_TABLE[last];
+                for (int i = state; i < 3; i++) {
+                    target[pos++] = '=';
+                }
+            }
+            if (wrap) {
+                target[pos++] = 0x0D;
+                target[pos++] = 0x0A;
+            }
+
+            return pos;
+        }
+    }
+}

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingHttpUpgradeService.java
@@ -1,18 +1,9 @@
 package org.jboss.as.remoting;
 
-import io.undertow.server.HttpServerExchange;
 import io.undertow.server.ListenerRegistry;
 import io.undertow.server.handlers.ChannelUpgradeHandler;
-import io.undertow.server.handlers.HttpUpgradeHandshake;
-import io.undertow.util.HttpString;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Constructor;
-import java.security.AccessController;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedExceptionAction;
 import java.util.List;
 
 import org.jboss.as.controller.ServiceVerificationHandler;
@@ -46,6 +37,18 @@ public class RemotingHttpUpgradeService implements Service<RemotingHttpUpgradeSe
 
 
     public static final String JBOSS_REMOTING = "jboss-remoting";
+
+    /**
+     * Magic number used in the handshake.
+     * <p/>
+     * The handshake borrows heavily from the web socket protocol, but uses different header
+     * names and a different magic number.
+     */
+    public static final String MAGIC_NUMBER = "CF70DEB8-70F9-4FBA-8B4F-DFC3E723B4CD";
+
+    //headers
+    public static final String SEC_JBOSS_REMOTING_KEY = "Sec-JbossRemoting-Key";
+    public static final String SEC_JBOSS_REMOTING_ACCEPT = "Sec-JbossRemoting-Accept";
 
     /**
      * Base service name for this HTTP Upgrade refist
@@ -125,7 +128,7 @@ public class RemotingHttpUpgradeService implements Service<RemotingHttpUpgradeSe
                         adaptor.adapt(new AssembledConnectedStreamChannel(channel, channel.getSourceChannel(), channel.getSinkChannel()));
                     }
                 }
-            }, new RemotingUpgradeHanshake());
+            }, HandshakeUtil.createHttpUpgradeHandshake(MAGIC_NUMBER, SEC_JBOSS_REMOTING_KEY, SEC_JBOSS_REMOTING_ACCEPT));
 
         } catch (UnknownURISchemeException e) {
             throw new StartException(e);
@@ -145,174 +148,4 @@ public class RemotingHttpUpgradeService implements Service<RemotingHttpUpgradeSe
     public synchronized RemotingHttpUpgradeService getValue() throws IllegalStateException, IllegalArgumentException {
         return this;
     }
-
-    private static final class RemotingUpgradeHanshake implements HttpUpgradeHandshake {
-
-
-        /**
-         * Magic number used in the handshake.
-         * <p/>
-         * The handshake borrows heavily from the web socket protocol, but uses different header
-         * names and a different magic number.
-         */
-        public static final String MAGIC_NUMBER = "CF70DEB8-70F9-4FBA-8B4F-DFC3E723B4CD";
-
-        //headers
-        public static final HttpString SEC_JBOSS_REMOTING_KEY = new HttpString("Sec-JbossRemoting-Key");
-        public static final HttpString SEC_JBOSS_REMOTING_ACCEPT = new HttpString("Sec-JbossRemoting-Accept");
-
-        @Override
-        public boolean handleUpgrade(final HttpServerExchange exchange) throws IOException {
-            String key = exchange.getRequestHeaders().getFirst(SEC_JBOSS_REMOTING_KEY);
-            if (key == null) {
-                throw RemotingMessages.MESSAGES.upgradeRequestMissingKey();
-            }
-            exchange.getResponseHeaders().put(SEC_JBOSS_REMOTING_ACCEPT, createExpectedResponse(key));
-            return true;
-        }
-
-        protected String createExpectedResponse(String secKey) throws IOException {
-            try {
-                final String concat = secKey + MAGIC_NUMBER;
-                final MessageDigest digest = MessageDigest.getInstance("SHA1");
-
-                digest.update(concat.getBytes("UTF-8"));
-                final byte[] bytes = digest.digest();
-                return FlexBase64.encodeString(bytes, false);
-            } catch (NoSuchAlgorithmException e) {
-                throw new IOException(e);
-            }
-
-        }
-
-
-        private static class FlexBase64 {
-            /*
-             * Note that this code heavily favors performance over reuse and clean style.
-             */
-
-            private static final byte[] ENCODING_TABLE;
-            private static final byte[] DECODING_TABLE = new byte[80];
-            private static final Constructor<String> STRING_CONSTRUCTOR;
-
-            static {
-                try {
-                    ENCODING_TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".getBytes("ASCII");
-                } catch (UnsupportedEncodingException e) {
-                    throw new IllegalStateException();
-                }
-
-                for (int i = 0; i < ENCODING_TABLE.length; i++) {
-                    int v = (ENCODING_TABLE[i] & 0xFF) - 43;
-                    DECODING_TABLE[v] = (byte) (i + 1);  // zero = illegal
-                }
-
-                Constructor<String> c = null;
-                try {
-                    PrivilegedExceptionAction<Constructor<String>> runnable = new PrivilegedExceptionAction<Constructor<String>>() {
-                        @Override
-                        public Constructor<String> run() throws Exception {
-                            Constructor<String> c;
-                            c = String.class.getDeclaredConstructor(char[].class, boolean.class);
-                            c.setAccessible(true);
-                            return c;
-                        }
-                    };
-                    if (System.getSecurityManager() != null) {
-                        c = AccessController.doPrivileged(runnable);
-                    } else {
-                        c = runnable.run();
-                    }
-                } catch (Throwable t) {
-                }
-
-                STRING_CONSTRUCTOR = c;
-            }
-
-            /**
-             * Encodes a fixed and complete byte array into a Base64 String.
-             *
-             * @param source the byte array to encode from
-             * @param wrap   whether or not to wrap the output at 76 chars with CRLFs
-             * @return a new String representing the Base64 output
-             */
-            public static String encodeString(byte[] source, boolean wrap) {
-                return encodeString(source, 0, source.length, wrap);
-            }
-
-
-            private static String encodeString(byte[] source, int pos, int limit, boolean wrap) {
-                int olimit = (limit - pos);
-                int remainder = olimit % 3;
-                olimit = (olimit + (remainder == 0 ? 0 : 3 - remainder)) / 3 * 4;
-                olimit += (wrap ? (olimit / 76) * 2 + 2 : 0);
-                char[] target = new char[olimit];
-                int opos = 0;
-                int last = 0;
-                int count = 0;
-                int state = 0;
-                final byte[] ENCODING_TABLE = FlexBase64.ENCODING_TABLE;
-
-                while (limit > pos) {
-                    //  ( 6 | 2) (4 | 4) (2 | 6)
-                    int b = source[pos++] & 0xFF;
-                    target[opos++] = (char) ENCODING_TABLE[b >>> 2];
-                    last = (b & 0x3) << 4;
-                    if (pos >= limit) {
-                        state = 1;
-                        break;
-                    }
-                    b = source[pos++] & 0xFF;
-                    target[opos++] = (char) ENCODING_TABLE[last | (b >>> 4)];
-                    last = (b & 0x0F) << 2;
-                    if (pos >= limit) {
-                        state = 2;
-                        break;
-                    }
-                    b = source[pos++] & 0xFF;
-                    target[opos++] = (char) ENCODING_TABLE[last | (b >>> 6)];
-                    target[opos++] = (char) ENCODING_TABLE[b & 0x3F];
-
-                    if (wrap) {
-                        count += 4;
-                        if (count >= 76) {
-                            count = 0;
-                            target[opos++] = 0x0D;
-                            target[opos++] = 0x0A;
-                        }
-                    }
-                }
-
-                complete(target, opos, state, last, wrap);
-
-                try {
-                    // Eliminate copying on Open/Oracle JDK
-                    if (STRING_CONSTRUCTOR != null) {
-                        return STRING_CONSTRUCTOR.newInstance(target, Boolean.TRUE);
-                    }
-                } catch (Exception e) {
-                }
-
-                return new String(target);
-            }
-
-            private static int complete(char[] target, int pos, int state, int last, boolean wrap) {
-                if (state > 0) {
-                    target[pos++] = (char) ENCODING_TABLE[last];
-                    for (int i = state; i < 3; i++) {
-                        target[pos++] = '=';
-                    }
-                }
-                if (wrap) {
-                    target[pos++] = 0x0D;
-                    target[pos++] = 0x0A;
-                }
-
-                return pos;
-            }
-
-        }
-
-    }
-
 }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/jms/JmsClientTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/jms/JmsClientTestCase.java
@@ -100,10 +100,19 @@ public class JmsClientTestCase {
     }
 
     @Test
-    public void testSendAndReceive() throws  Exception {
+    public void testSendAndReceiveUsingMessagingPort() throws Exception {
+        doSendAndReceive("jms/RemoteConnectionFactory");
+    }
+
+    @Test
+    public void testSendAndReceiveUsingHTTPPort() throws Exception {
+        doSendAndReceive("jms/HTTPConnectionFactory");
+    }
+
+    private void doSendAndReceive(String connectionFactoryLookup) throws  Exception {
         Connection conn = null;
         try {
-            ConnectionFactory cf = (ConnectionFactory) remoteContext.lookup("jms/RemoteConnectionFactory");
+            ConnectionFactory cf = (ConnectionFactory) remoteContext.lookup(connectionFactoryLookup);
             assertNotNull(cf);
             Destination destination = (Destination) remoteContext.lookup(QUEUE_NAME);
             assertNotNull(destination);

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/messaging/MessagingClientTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/messaging/MessagingClientTestCase.java
@@ -66,11 +66,20 @@ public class MessagingClientTestCase {
     private ManagementClient managementClient;
 
     @Test
-    public void testMessagingClient() throws Exception {
+    public void testMessagingClientUsingMessagingPort() throws Exception {
+        final ClientSessionFactory sf = createClientSessionFactory(managementClient.getWebUri().getHost(), 5445, false);
+        doMessagingClient(sf);
+    }
 
+    @Test
+    public void testMessagingClientUsingHTTPPort() throws Exception {
+        final ClientSessionFactory sf = createClientSessionFactory(managementClient.getWebUri().getHost(), managementClient.getWebUri().getPort(), true);
+        doMessagingClient(sf);
+    }
+
+    private void doMessagingClient(ClientSessionFactory sf) throws Exception {
         final String queueName = "queue.standalone";
 
-        final ClientSessionFactory sf = createClientSessionFactory(managementClient.getMgmtAddress(), 5445);
         final ModelControllerClient client = managementClient.getControllerClient();
 
         // Check that the queue does not exists
@@ -149,10 +158,11 @@ public class MessagingClientTestCase {
         }
     }
 
-    static ClientSessionFactory createClientSessionFactory(String host, int port) throws Exception {
+    static ClientSessionFactory createClientSessionFactory(String host, int port, boolean httpUpgradeEnabled) throws Exception {
         final Map<String, Object> properties = new HashMap<String, Object>();
         properties.put(TransportConstants.HOST_PROP_NAME, host);
         properties.put(TransportConstants.PORT_PROP_NAME, port);
+        properties.put(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME, httpUpgradeEnabled);
         final TransportConfiguration configuration = new TransportConfiguration(NettyConnectorFactory.class.getName(), properties);
         return HornetQClient.createServerLocatorWithoutHA(configuration).createSessionFactory();
     }


### PR DESCRIPTION
[WFLY-2649] upgrade to HornetQ 2.4.0.Final …
- upgrade netty to 4.0.13.Final too

[WFLY-2128] JMS one-port support …
- add http-connector and http-acceptor resources to handle connections
  from HTTP and upgrade to HornetQ protocol.
- use netty-xnio-transport to wrap the XNIO channel into a Netty channel
  to hand it over to HornetQ server.
- component changes:
  - add org.jboss.xnio.netty:netty-xnio-transport:0.1.0
