### PR TITLE
[WFLY-149] Remove left over filter element from the console-handler schema

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-logging_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_2_0.xsd
@@ -178,7 +178,6 @@
             <xs:element name="level" type="refType" minOccurs="0"/>
             <xs:element name="encoding" type="valueType" minOccurs="0"/>
             <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
-            <xs:element name="filter" type="valueType" minOccurs="0"/>
             <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
             <xs:element name="target" minOccurs="0">
                 <xs:complexType>


### PR DESCRIPTION
The attribute is no longer marshalled and hasn't been for some time. Just removes the attribute from the schema.
