### PR TITLE
Upgrade netty-xnio-transport to 0.1.1.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,7 +196,7 @@
         <version.org.jboss.mod_cluster>1.3.0.Alpha1</version.org.jboss.mod_cluster>
         <version.org.jboss.modules.jboss-modules>1.3.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.0.CR1</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.0</version.org.jboss.xnio.netty.netty-xnio-transport>
+        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.1.CR1</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.osgi.metadata>3.0.1.Final</version.org.jboss.osgi.metadata>
         <version.org.jboss.remote-naming>2.0.0.Beta2</version.org.jboss.remote-naming>
         <version.org.jboss.remoting>4.0.0.Beta3</version.org.jboss.remoting>

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/messaging/MessagingClientTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/messaging/client/messaging/MessagingClientTestCase.java
@@ -69,12 +69,21 @@ public class MessagingClientTestCase {
     public void testMessagingClientUsingMessagingPort() throws Exception {
         final ClientSessionFactory sf = createClientSessionFactory(managementClient.getWebUri().getHost(), 5445, false);
         doMessagingClient(sf);
+        sf.close();
     }
 
     @Test
     public void testMessagingClientUsingHTTPPort() throws Exception {
         final ClientSessionFactory sf = createClientSessionFactory(managementClient.getWebUri().getHost(), managementClient.getWebUri().getPort(), true);
         doMessagingClient(sf);
+        sf.close();
+    }
+
+    public void loop() throws Exception {
+        for (int i = 0; i < 1000; i++) {
+            System.out.println("i = " + i);
+            testMessagingClientUsingHTTPPort();
+        }
     }
 
     private void doMessagingClient(ClientSessionFactory sf) throws Exception {


### PR DESCRIPTION
this version fixes intermittent failures in MessagingClientTestCase and
JmsClientTestCase
