### PR TITLE
WFLY-2665 Make JPA statistics enabling config consistent with other subsystems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,7 +246,7 @@
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
         <version.org.jgroups>3.4.2.Final</version.org.jgroups>
-        <version.org.jipijapa>1.0.0.Final</version.org.jipijapa>
+        <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.mockito>1.9.5</version.org.mockito>
         <version.org.opensaml.opensaml>2.5.3</version.org.opensaml.opensaml>


### PR DESCRIPTION
This is the JPA changes that I think should go with https://github.com/wildfly/wildfly/pull/5609 (if pr#5609 gets merged).  This pull request brings in jipijapa 1.0.1.CR1 (which now has "statistics-enabled" in addition to "enabled" attribute) for Hibernate.
