### PR TITLE
[WFLY-1714] Remove unused attributes from the async-handler model.

### DIFF
--- a/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerLegacyOperationsTestCase.java
@@ -113,7 +113,9 @@ public class HandlerLegacyOperationsTestCase extends AbstractOperationsTestCase 
         assertTrue("Subhandlers should be empty: " + result, SubsystemOperations.readResultAsList(result).isEmpty());
 
         // Write each attribute and check the value
-        testUpdateCommonHandlerAttributes(kernelServices, address);
+
+        testUpdateProperties(kernelServices, address, CommonAttributes.LEVEL, "TRACE");
+        testUpdateProperties(kernelServices, address, CommonAttributes.FILTER_SPEC, "deny");
         testUpdateProperties(kernelServices, address, AsyncHandlerResourceDefinition.OVERFLOW_ACTION, "BLOCK");
         testUpdateProperties(kernelServices, address, AsyncHandlerResourceDefinition.SUBHANDLERS, subhandlers);
         testUpdateProperties(kernelServices, address, AsyncHandlerResourceDefinition.QUEUE_LENGTH, 20);

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -47,12 +47,14 @@ import org.jboss.as.logging.logmanager.ConfigurationPersistence;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.NewAttributesConfig;
 import org.jboss.as.model.test.FailedOperationTransformationConfig.RejectExpressionsConfig;
+import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.as.subsystem.test.SubsystemOperations;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 import org.jboss.logmanager.LogContext;
 import org.junit.Assert;
 import org.junit.Test;
@@ -136,7 +138,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
         Assert.assertNotNull(legacyServices);
-        final ModelNode legacyModel = checkSubsystemModelTransformation(mainServices, modelVersion);
+        final ModelNode legacyModel = checkSubsystemModelTransformation(mainServices, modelVersion, AsyncModelFixer.INSTANCE);
 
         testTransformOperations(mainServices, modelVersion, legacyModel);
     }
@@ -231,7 +233,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
         Assert.assertTrue(legacyServices.isSuccessfulBoot());
         Assert.assertNotNull(legacyServices);
-        checkSubsystemModelTransformation(mainServices, modelVersion);
+        checkSubsystemModelTransformation(mainServices, modelVersion, AsyncModelFixer.INSTANCE);
     }
 
     private void testFailedTransformedBootOperations1_2_0(final ModelTestControllerVersion controllerVersion) throws Exception {
@@ -436,5 +438,25 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
         op = SubsystemOperations.createReadAttributeOperation(address, CommonAttributes.FILTER);
         result = executeTransformOperation(kernelServices, modelVersion, op);
         Assert.assertEquals("Transformed spec does not match filter expression.", Filters.filterToFilterSpec(SubsystemOperations.readResult(result)), filterExpression);
+    }
+
+    private static class AsyncModelFixer implements ModelFixer {
+
+        static final AsyncModelFixer INSTANCE = new AsyncModelFixer();
+
+        @Override
+        public ModelNode fixModel(final ModelNode modelNode) {
+            // Find the async-handler
+            if (modelNode.hasDefined(AsyncHandlerResourceDefinition.ASYNC_HANDLER)) {
+                final ModelNode asyncHandlers = modelNode.get(AsyncHandlerResourceDefinition.ASYNC_HANDLER);
+                for (Property asyncHandler : asyncHandlers.asPropertyList()) {
+                    final ModelNode async = asyncHandler.getValue();
+                    async.remove(CommonAttributes.ENCODING.getName());
+                    async.remove(AbstractHandlerDefinition.FORMATTER.getName());
+                    asyncHandlers.get(asyncHandler.getName()).set(async);
+                }
+            }
+            return modelNode;
+        }
     }
 }


### PR DESCRIPTION
These attribute some how made it into the model. They are not used by the handler and they are not persisted to the XML.
