### PR TITLE
Fix wildfly-core build order

### DIFF
--- a/build/build-configs.xml
+++ b/build/build-configs.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project name="build-configs" basedir="." default="all">
+<project name="build-configs" basedir="." default="all-configs">
 
     <property name="output.dir" value="../${wildfly.build.output.dir}"/>
 
@@ -136,7 +136,7 @@
     </target>
 
 
-    <target name="all" depends="generate-configs"/>
+    <target name="all-configs" depends="generate-configs"/>
 
 	<macrodef name="generate-server-config">
       <attribute name="paramTemplateFile"/>

--- a/build/build.xml
+++ b/build/build.xml
@@ -23,12 +23,13 @@
 <project name="module-repository" basedir="." default="modules">
 
     <import file="lib.xml"/>
+    <import file="build-configs.xml"/>
 
     <property name="output.dir" value="../${wildfly.build.output.dir}"/>
 
     <target name="base" depends="clean-target, modules-minimalistic, copy-files, make-dirs"/>
 
-    <target name="copy-files">
+    <target name="copy-files" depends="all-configs">
         <copy todir="${output.dir}">
             <fileset dir="src/main/resources">
                 <include name="LICENSE.txt"/>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -47,63 +47,6 @@
         <generated.configs.src.dir>${basedir}/src/main/resources</generated.configs.src.dir>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <inherited>false</inherited>
-                <executions>
-                    <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-                    <execution>
-                        <id>generate-configs</id>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <target>
-                                <ant antfile="build-configs.xml" inheritRefs="true">
-                                    <target name="all"/>
-                                </ant>
-                            </target>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>build-dist</id>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <phase>package</phase>
-                        <configuration>
-                            <target>
-                                <ant antfile="build.xml" inheritRefs="true">
-                                    <target name="${ant.target}"/>
-                                </ant>
-                            </target>
-                        </configuration>
-                    </execution>
-                </executions>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jboss</groupId>
-                        <artifactId>jandex</artifactId>
-                        <version>${version.org.jboss.jandex}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.apache.ant</groupId>
-                        <artifactId>ant-apache-bsf</artifactId>
-                        <version>${version.org.apache.ant}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>rhino</groupId>
-                        <artifactId>js</artifactId>
-                        <version>${version.rhino.js}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
 
@@ -226,7 +169,9 @@
         <profile>
             <id>normal</id>
             <activation>
-                <property><name>!minimalistic</name></property>
+                <property>
+                    <name>!minimalistic</name>
+                </property>
             </activation>
 
             <dependencies>
@@ -2120,11 +2065,61 @@
         </profile>
 
         <profile>
+            <id>default-build</id>
+            <activation>
+                <property>
+                    <name>!release</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <inherited>false</inherited>
+                        <executions>
+                            <execution>
+                                <id>build-dist</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="build.xml" inheritRefs="true">
+                                            <target name="${ant.target}"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jboss</groupId>
+                                <artifactId>jandex</artifactId>
+                                <version>${version.org.jboss.jandex}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>org.apache.ant</groupId>
+                                <artifactId>ant-apache-bsf</artifactId>
+                                <version>${version.org.apache.ant}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>rhino</groupId>
+                                <artifactId>js</artifactId>
+                                <version>${version.rhino.js}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
             <id>release</id>
             <activation>
                 <property>
                     <name>release</name>
-                    <value>true</value>
                 </property>
             </activation>
             <build>
@@ -2169,7 +2164,22 @@
                                     </target>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>build-dist</id>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <phase>package</phase>
+                                <configuration>
+                                    <target>
+                                        <ant antfile="build.xml" inheritRefs="true">
+                                            <target name="${ant.target}"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
                         </executions>
+
                         <dependencies>
                             <dependency>
                                 <groupId>org.jboss</groupId>
@@ -2238,7 +2248,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>2.9</version>
+                        <version>${version.javadoc.plugin}</version>
                         <executions>
                             <execution>
                                 <id>javadocs-dist</id>

--- a/build/src/license/licenses.xml
+++ b/build/src/license/licenses.xml
@@ -308,8 +308,8 @@
       </licenses>
     </dependency>
     <dependency>
-      <groupId>javax.mail</groupId>
-      <artifactId>mail</artifactId>
+      <groupId>com.sun.mail</groupId>
+      <artifactId>javax.mail</artifactId>
       <licenses>
         <license>
           <name>Common Development and Distribution License</name>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
@@ -39,7 +39,7 @@
         Xalan is optional dependancy and would need to be present in cases where runtime code needs xslt transformation otherwise
         xslt parser will fallback to JDK provided xalan, which can cause issues.
          -->
-        <module name="org.apache.xalan" services="import"/>
+        <module name="org.apache.xalan" services="import" optional="true"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.codehaus.woodstox" services="import"/>        
         <module name="org.jboss.logmanager" services="import"/>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/FileUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/FileUtils.java
@@ -1,16 +1,14 @@
 package org.jboss.as.test.shared;
 
 import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 
 /**
  * Shared fs utils for the test suite.
@@ -83,26 +81,12 @@ public class FileUtils {
 
 
     public static void copyFile(final File src, final File dest) throws IOException {
-        final InputStream in = new BufferedInputStream(new FileInputStream(src));
-        try {
-            copyFile(in, dest);
-        } finally {
-            close(in);
-        }
+        Files.copy(src.toPath(),dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
     }
 
     public static void copyFile(final InputStream in, final File dest) throws IOException {
         dest.getParentFile().mkdirs();
-        final OutputStream out = new BufferedOutputStream(new FileOutputStream(dest));
-        try {
-            int i = in.read();
-            while (i != -1) {
-                out.write(i);
-                i = in.read();
-            }
-        } finally {
-            close(out);
-        }
+        Files.copy(in,dest.toPath(), StandardCopyOption.REPLACE_EXISTING);
     }
 
     /**


### PR DESCRIPTION
this way generated-configs contain full configuration that ParseAndMarshalModelsTestCase.java uses.
and also some small cleanup of ParseAndMarshalModelsTestCase test
