### PR TITLE
WFLY-2693 list-active-jsf-impls missing reply type

### DIFF
--- a/jsf/subsystem/src/main/java/org/jboss/as/jsf/subsystem/JSFImplListHandler.java
+++ b/jsf/subsystem/src/main/java/org/jboss/as/jsf/subsystem/JSFImplListHandler.java
@@ -24,9 +24,9 @@ import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.jsf.deployment.JSFModuleIdFactory;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 
 /**
  * Defines and handles the list-active-jsf-impls operation.
@@ -37,7 +37,10 @@ public class JSFImplListHandler implements OperationStepHandler {
     public static final String OPERATION_NAME = "list-active-jsf-impls";
 
     public static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, JSFExtension.getResourceDescriptionResolver())
-            .withFlags(OperationEntry.Flag.READ_ONLY, OperationEntry.Flag.RUNTIME_ONLY)
+            .setRuntimeOnly()
+            .setReadOnly()
+            .setReplyType(ModelType.LIST)
+            .setReplyValueType(ModelType.STRING)
             .build();
 
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {


### PR DESCRIPTION
The DMR operation "list-active-jsf-impls" of the JSF subsystem is
missing a reply type. Therefore the operation will show up as "Void"
in VisualVM and no result will be displayed.
- set the reply type to list
- set the reply value type to string

Issue: WFLY-2693
https://issues.jboss.org/browse/WFLY-2693
