### PR TITLE
[WFLY-2696] SyslogAuditLogProtocolResourceDefinition needs to use toUpperCase() for the protocol

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
@@ -106,7 +106,7 @@ public abstract class SyslogAuditLogProtocolResourceDefinition extends SimpleRes
     public static void createServerAddOperations(final List<ModelNode> addOps, final PathAddress protocolAddress, final ModelNode protocol) {
         addOps.add(createProtocolAddOperation(protocolAddress, protocol));
 
-        final SyslogAuditLogHandler.Transport transport = SyslogAuditLogHandler.Transport.valueOf(protocolAddress.getLastElement().getValue());
+        final SyslogAuditLogHandler.Transport transport = SyslogAuditLogHandler.Transport.valueOf(protocolAddress.getLastElement().getValue().toUpperCase());
         if (transport == SyslogAuditLogHandler.Transport.TLS){
             if (protocol.hasDefined(AUTHENTICATION)){
                 final ModelNode auth = protocol.get(AUTHENTICATION);
@@ -125,7 +125,7 @@ public abstract class SyslogAuditLogProtocolResourceDefinition extends SimpleRes
         protocolAdd.get(HOST.getName()).set(protocol.get(HOST.getName()));
         protocolAdd.get(PORT.getName()).set(protocol.get(PORT.getName()));
 
-        SyslogAuditLogHandler.Transport transport = SyslogAuditLogHandler.Transport.valueOf(protocolAddress.getLastElement().getValue());
+        SyslogAuditLogHandler.Transport transport = SyslogAuditLogHandler.Transport.valueOf(protocolAddress.getLastElement().getValue().toUpperCase());
         if (transport != SyslogAuditLogHandler.Transport.UDP){
             protocolAdd.get(Tcp.MESSAGE_TRANSFER.getName()).set(protocol.get(Tcp.MESSAGE_TRANSFER.getName()));
         }


### PR DESCRIPTION
Two occurrences of

SyslogAuditLogHandler.Transport.valueOf(protocolAddress.getLastElement().getValue());

Both need to be:

SyslogAuditLogHandler.Transport.valueOf(protocolAddress.getLastElement().getValue().toUpperCase());
