### PR TITLE
WFLY-2709 add missing resource key

### DIFF
--- a/connector/src/main/resources/org/jboss/as/connector/subsystems/resourceadapters/LocalDescriptions.properties
+++ b/connector/src/main/resources/org/jboss/as/connector/subsystems/resourceadapters/LocalDescriptions.properties
@@ -61,6 +61,7 @@ connection-definitions.background-validation-millis=The background-validation-mi
 connection-definitions.background-validation=An element to specify that connections should be validated on a background thread versus being validated prior to use. Changing this value requires a server restart.
 connection-definitions.blocking-timeout-wait-millis=The blocking-timeout-millis element specifies the maximum time, in milliseconds, to block while waiting for a connection before throwing an exception. Note that this blocks only while waiting for locking a connection, and will never throw an exception if creating a new connection takes an inordinately long time.
 connection-definitions.class-name=Specifies the fully qualified class name of a managed connection factory or admin object.
+connection-definitions.clear-statistics=Clear statistics values for this resource adapter's connection definitions.
 connection-definitions.config-properties=Custom defined config properties.
 connection-definitions.enabled=Specifies if the resource adapter should be enabled.
 connection-definitions.flush-all-connection-in-pool=Flushes all connections in the pool.


### PR DESCRIPTION
The connector subsystem is missing the resource key
“connection-definitions.clear-statistics”. This results in a exception
when looking at the connection definitions of a resource adapter in
VisualVM.
- add the resource key "connection-definitions.clear-statistics"

Issue: WFLY-2709
https://issues.jboss.org/browse/WFLY-2709
