### PR TITLE
WFLY-2697 Base64 encode inter-process messages sent over stdin

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -45,7 +45,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.jboss.as.core-security"/>        
+        <module name="org.jboss.as.core-security"/>
         <module name="org.jboss.common-core"/>
         <module name="org.jboss.as.deployment-repository"/>
         <module name="org.jboss.as.domain-management"/>

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -45,6 +45,7 @@ import org.jboss.as.process.CommandLineArgumentUsageImpl;
 import org.jboss.as.process.CommandLineConstants;
 import org.jboss.as.process.ExitCodes;
 import org.jboss.as.process.protocol.StreamUtils;
+import org.jboss.as.process.stdin.Base64InputStream;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.logging.MDC;
 import org.jboss.logmanager.Level;
@@ -84,7 +85,7 @@ public final class Main {
 
         final byte[] authKey = new byte[16];
         try {
-            StreamUtils.readFully(System.in, authKey);
+            StreamUtils.readFully(new Base64InputStream(System.in), authKey);
         } catch (IOException e) {
             System.err.println(MESSAGES.failedToReadAuthenticationKey(e));
             fail();

--- a/process-controller/src/main/java/org/jboss/as/process/stdin/Base64.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/Base64.java
@@ -1,0 +1,451 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.process.stdin;
+
+/**
+ * Variant of the <a href="http://commons.apache.org/proper/commons-codec">Commons Codec</a> project's class
+ * of the same name. This varies from the original in the implementation of the
+ * {@link #decode(byte[], int, int, org.jboss.as.process.stdin.BaseNCodec.Context)} method, which does not treat
+ * the presence of the {@code =} character in the stream as indicating an end of stream. This makes
+ * {@link org.jboss.as.process.stdin.Base64InputStream} useful for continuous reading of multiple sets
+ * of data, with the {@code =} character in the stream indicating the end of a set, while the commons-codec
+ * variant is limited to a single read. It also varies from the original by removing constructor options not needed
+ * by the intended use cases for this WildFly package.
+ * <p>
+ * Provides Base64 encoding and decoding as defined by <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>.
+ * </p>
+ * <p>
+ * This class implements section <cite>6.8. Base64 Content-Transfer-Encoding</cite> from RFC 2045 <cite>Multipurpose
+ * Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</cite> by Freed and Borenstein.
+ * </p>
+ * <p>
+ * <p>
+ * Since this class operates directly on byte streams, and not character streams, it is hard-coded to only
+ * encode/decode character encodings which are compatible with the lower 127 ASCII chart (ISO-8859-1, Windows-1252,
+ * UTF-8, etc).
+ * </p>
+ * <p>
+ * This class is thread-safe.
+ * </p>
+ *
+ * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
+ */
+class Base64 extends BaseNCodec {
+
+    /**
+     * BASE32 characters are 6 bits in length.
+     * They are formed by taking a block of 3 octets to form a 24-bit string,
+     * which is converted into 4 BASE64 characters.
+     */
+    private static final int BITS_PER_ENCODED_BYTE = 6;
+    private static final int BYTES_PER_UNENCODED_BLOCK = 3;
+    private static final int BYTES_PER_ENCODED_BLOCK = 4;
+
+    /**
+     * Chunk separator per RFC 2045 section 2.1.
+     *
+     * <p>
+     * N.B. The next major release may break compatibility and make this field private.
+     * </p>
+     *
+     * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045 section 2.1</a>
+     */
+    static final byte[] CHUNK_SEPARATOR = {'\r', '\n'};
+
+    /**
+     * This array is a lookup table that translates 6-bit positive integer index values into their "Base64 Alphabet"
+     * equivalents as specified in Table 1 of RFC 2045.
+     *
+     * Thanks to "commons" project in ws.apache.org for this code.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     */
+    private static final byte[] STANDARD_ENCODE_TABLE = {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'
+    };
+
+    /**
+     * This is a copy of the STANDARD_ENCODE_TABLE above, but with + and /
+     * changed to - and _ to make the encoded Base64 results more URL-SAFE.
+     * This table is only used when the Base64's mode is set to URL-SAFE.
+     */
+    private static final byte[] URL_SAFE_ENCODE_TABLE = {
+            'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+            'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+            'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z',
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '_'
+    };
+
+    /**
+     * This array is a lookup table that translates Unicode characters drawn from the "Base64 Alphabet" (as specified
+     * in Table 1 of RFC 2045) into their 6-bit positive integer equivalents. Characters that are not in the Base64
+     * alphabet but fall within the bounds of the array are translated to -1.
+     *
+     * Note: '+' and '-' both decode to 62. '/' and '_' both decode to 63. This means decoder seamlessly handles both
+     * URL_SAFE and STANDARD base64. (The encoder, on the other hand, needs to know ahead of time what to emit).
+     *
+     * Thanks to "commons" project in ws.apache.org for this code.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     */
+    private static final byte[] DECODE_TABLE = {
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+            -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, 62, -1, 63, 52, 53, 54,
+            55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1, -1, 0, 1, 2, 3, 4,
+            5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+            24, 25, -1, -1, -1, -1, 63, -1, 26, 27, 28, 29, 30, 31, 32, 33, 34,
+            35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51
+    };
+
+    /**
+     * Base64 uses 6-bit fields.
+     */
+    /** Mask used to extract 6 bits, used when encoding */
+    private static final int MASK_6BITS = 0x3f;
+
+    // The static final fields above are used for the original static byte[] methods on Base64.
+    // The private member fields below are used with the new streaming approach, which requires
+    // some state be preserved between calls of encode() and decode().
+
+    /**
+     * Encode table to use: either STANDARD or URL_SAFE. Note: the DECODE_TABLE above remains static because it is able
+     * to decode both STANDARD and URL_SAFE streams, but the encodeTable must be a member variable so we can switch
+     * between the two modes.
+     */
+    private final byte[] encodeTable;
+
+    // Only one decode table currently; keep for consistency with Base32 code
+    private final byte[] decodeTable = DECODE_TABLE;
+
+    /**
+     * Line separator for encoding. Not used when decoding. Only used if lineLength > 0.
+     */
+    private final byte[] lineSeparator;
+
+    /**
+     * Convenience variable to help us determine when our buffer is going to run out of room and needs resizing.
+     * <code>decodeSize = 3 + lineSeparator.length;</code>
+     */
+    private final int decodeSize;
+
+    /**
+     * Convenience variable to help us determine when our buffer is going to run out of room and needs resizing.
+     * <code>encodeSize = 4 + lineSeparator.length;</code>
+     */
+    private final int encodeSize;
+
+    /**
+     * Creates a Base64 codec used for decoding (all modes) and encoding in URL-unsafe mode.
+     * <p>
+     * When encoding the line length and line separator are given in the constructor, and the encoding table is
+     * STANDARD_ENCODE_TABLE.
+     * </p>
+     * <p>
+     * Line lengths that aren't multiples of 4 will still essentially end up being multiples of 4 in the encoded data.
+     * </p>
+     * <p>
+     * When decoding all variants are supported.
+     * </p>
+     *
+     * @throws IllegalArgumentException
+     *             Thrown when the provided lineSeparator included some base64 characters.
+     * @since 1.4
+     */
+    Base64() {
+        super(BYTES_PER_ENCODED_BLOCK,-1, 0);
+        this.encodeSize = BYTES_PER_ENCODED_BLOCK;
+        this.lineSeparator = null;
+        this.decodeSize = this.encodeSize - 1;
+        this.encodeTable = STANDARD_ENCODE_TABLE;
+    }
+
+    /**
+     * Returns our current encode mode. True if we're URL-SAFE, false otherwise.
+     *
+     * @return true if we're in URL-SAFE mode, false otherwise.
+     * @since 1.4
+     */
+    public boolean isUrlSafe() {
+        return this.encodeTable == URL_SAFE_ENCODE_TABLE;
+    }
+
+    /**
+     * <p>
+     * Encodes all of the provided data, starting at inPos, for inAvail bytes. Must be called at least twice: once with
+     * the data to encode, and once with inAvail set to "-1" to alert encoder that EOF has been reached, to flush last
+     * remaining bytes (if not multiple of 3).
+     * </p>
+     * <p><b>Note: no padding is added when encoding using the URL-safe alphabet.</b></p>
+     * <p>
+     * Thanks to "commons" project in ws.apache.org for the bitwise operations, and general approach.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * </p>
+     *
+     * @param in
+     *            byte[] array of binary data to base64 encode.
+     * @param inPos
+     *            Position to start reading data from.
+     * @param inAvail
+     *            Amount of bytes available from input for encoding.
+     * @param context
+     *            the context to be used
+     */
+    @Override
+    void encode(final byte[] in, int inPos, final int inAvail, final Context context) {
+        if (context.eof) {
+            return;
+        }
+        // inAvail < 0 is how we're informed of EOF in the underlying data we're
+        // encoding.
+        if (inAvail < 0) {
+            context.eof = true;
+            if (0 == context.modulus && lineLength == 0) {
+                return; // no leftovers to process and not using chunking
+            }
+            final byte[] buffer = ensureBufferSize(encodeSize, context);
+            final int savedPos = context.pos;
+            switch (context.modulus) { // 0-2
+                case 0 : // nothing to do here
+                    break;
+                case 1 : // 8 bits = 6 + 2
+                    // top 6 bits:
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 2) & MASK_6BITS];
+                    // remaining 2:
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea << 4) & MASK_6BITS];
+                    // URL-SAFE skips the padding to further reduce size.
+                    if (encodeTable == STANDARD_ENCODE_TABLE) {
+                        buffer[context.pos++] = PAD;
+                        buffer[context.pos++] = PAD;
+                    }
+                    break;
+
+                case 2 : // 16 bits = 6 + 6 + 4
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 10) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 4) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea << 2) & MASK_6BITS];
+                    // URL-SAFE skips the padding to further reduce size.
+                    if (encodeTable == STANDARD_ENCODE_TABLE) {
+                        buffer[context.pos++] = PAD;
+                    }
+                    break;
+                default:
+                    throw new IllegalStateException("Impossible modulus "+context.modulus);
+            }
+            context.currentLinePos += context.pos - savedPos; // keep track of current line position
+            // if currentPos == 0 we are at the start of a line, so don't add CRLF
+            if (lineLength > 0 && context.currentLinePos > 0) {
+                System.arraycopy(lineSeparator, 0, buffer, context.pos, lineSeparator.length);
+                context.pos += lineSeparator.length;
+            }
+        } else {
+            for (int i = 0; i < inAvail; i++) {
+                final byte[] buffer = ensureBufferSize(encodeSize, context);
+                context.modulus = (context.modulus+1) % BYTES_PER_UNENCODED_BLOCK;
+                int b = in[inPos++];
+                if (b < 0) {
+                    b += 256;
+                }
+                context.ibitWorkArea = (context.ibitWorkArea << 8) + b; //  BITS_PER_BYTE
+                if (0 == context.modulus) { // 3 bytes = 24 bits = 4 * 6 bits to extract
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 18) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 12) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[(context.ibitWorkArea >> 6) & MASK_6BITS];
+                    buffer[context.pos++] = encodeTable[context.ibitWorkArea & MASK_6BITS];
+                    context.currentLinePos += BYTES_PER_ENCODED_BLOCK;
+                    if (lineLength > 0 && lineLength <= context.currentLinePos) {
+                        System.arraycopy(lineSeparator, 0, buffer, context.pos, lineSeparator.length);
+                        context.pos += lineSeparator.length;
+                        context.currentLinePos = 0;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * <p>
+     * Decodes all of the provided data, starting at inPos, for inAvail bytes. Should be called at least twice: once
+     * with the data to decode, and once with inAvail set to "-1" to alert decoder that EOF has been reached. The "-1"
+     * call is not necessary when decoding, but it doesn't hurt, either.
+     * </p>
+     * <p>
+     * Ignores all non-base64 characters. This is how chunked (e.g. 76 character) data is handled, since CR and LF are
+     * silently ignored, but has implications for other bytes, too. This method subscribes to the garbage-in,
+     * garbage-out philosophy: it will not check the provided data for validity.
+     * </p>
+     * <p>
+     * Thanks to "commons" project in ws.apache.org for the bitwise operations, and general approach.
+     * http://svn.apache.org/repos/asf/webservices/commons/trunk/modules/util/
+     * </p>
+     *
+     * @param in
+     *            byte[] array of ascii data to base64 decode.
+     * @param inPos
+     *            Position to start reading data from.
+     * @param inAvail
+     *            Amount of bytes available from input for encoding.
+     * @param context
+     *            the context to be used
+     */
+    @Override
+    void decode(final byte[] in, int inPos, final int inAvail, final Context context) {
+        if (context.eof) {
+            return;
+        }
+        if (inAvail < 0) {
+            context.eof = true;
+        }
+
+        for (int i = 0; i < inAvail; i++) {
+            final byte[] buffer = ensureBufferSize(decodeSize, context);
+            final byte b = in[inPos++];
+            if (b == PAD) {
+                // A chunk of data is done.
+
+                // NOTE: BES 2014/01/04 -- THIS BLOCK IS WHERE ALL THIS STUFF DIFFERS FROM commons-codec
+                // We don't set context.eof=true -- we output the data we have and continue on
+
+                // We have some spare bits remaining
+                // Output all whole multiples of 8 bits and ignore the rest
+                switch (context.modulus) {
+                    case 0 : // 2nd PAD case - ignore
+                        break;
+                    case 1 : // 6 bits - ignore entirely
+                        // TODO not currently tested; perhaps it is impossible?
+                        break;
+                    case 2 : // 12 bits = 8 + 4
+                        context.ibitWorkArea = context.ibitWorkArea >> 4; // dump the extra 4 bits
+                        buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
+                        break;
+                    case 3 : // 18 bits = 8 + 8 + 2
+                        context.ibitWorkArea = context.ibitWorkArea >> 2; // dump 2 bits
+                        buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
+                        buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
+                        break;
+                    default:
+                        throw new IllegalStateException("Impossible modulus "+context.modulus);
+                }
+                // Set the modulus to zero so further PAD (e.g. aB==) are ignored until we get a non-PAD
+                context.modulus = 0;
+            } else {
+                if (b >= 0 && b < DECODE_TABLE.length) {
+                    final int result = DECODE_TABLE[b];
+                    if (result >= 0) {
+                        context.modulus = (context.modulus+1) % BYTES_PER_ENCODED_BLOCK;
+                        context.ibitWorkArea = (context.ibitWorkArea << BITS_PER_ENCODED_BYTE) + result;
+                        if (context.modulus == 0) {
+                            buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 16) & MASK_8BITS);
+                            buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
+                            buffer[context.pos++] = (byte) (context.ibitWorkArea & MASK_8BITS);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Two forms of EOF as far as base64 decoder is concerned: actual
+        // EOF (-1) and first time '=' character is encountered in stream.
+        // This approach makes the '=' padding characters completely optional.
+        if (context.eof && context.modulus != 0) {
+            final byte[] buffer = ensureBufferSize(decodeSize, context);
+
+            // We have some spare bits remaining
+            // Output all whole multiples of 8 bits and ignore the rest
+            switch (context.modulus) {
+//              case 0 : // impossible, as excluded above
+                case 1 : // 6 bits - ignore entirely
+                    // TODO not currently tested; perhaps it is impossible?
+                    break;
+                case 2 : // 12 bits = 8 + 4
+                    context.ibitWorkArea = context.ibitWorkArea >> 4; // dump the extra 4 bits
+                    buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
+                    break;
+                case 3 : // 18 bits = 8 + 8 + 2
+                    context.ibitWorkArea = context.ibitWorkArea >> 2; // dump 2 bits
+                    buffer[context.pos++] = (byte) ((context.ibitWorkArea >> 8) & MASK_8BITS);
+                    buffer[context.pos++] = (byte) ((context.ibitWorkArea) & MASK_8BITS);
+                    break;
+                default:
+                    throw new IllegalStateException("Impossible modulus "+context.modulus);
+            }
+        }
+    }
+
+    /**
+     * Tests a given byte array to see if it contains only valid characters within the Base64 alphabet. Currently the
+     * method treats whitespace as valid.
+     *
+     * @param arrayOctet
+     *            byte array to test
+     * @return {@code true} if all bytes are valid characters in the Base64 alphabet or if the byte array is empty;
+     *         {@code false}, otherwise
+     * @deprecated 1.5 Use {@link #isBase64(byte[])}, will be removed in 2.0.
+     */
+    @Deprecated
+    public static boolean isArrayByteBase64(final byte[] arrayOctet) {
+        return isBase64(arrayOctet);
+    }
+
+    /**
+     * Returns whether or not the <code>octet</code> is in the base 64 alphabet.
+     *
+     * @param octet
+     *            The value to test
+     * @return {@code true} if the value is defined in the the base 64 alphabet, {@code false} otherwise.
+     * @since 1.4
+     */
+    public static boolean isBase64(final byte octet) {
+        return octet == PAD_DEFAULT || (octet >= 0 && octet < DECODE_TABLE.length && DECODE_TABLE[octet] != -1);
+    }
+
+    /**
+     * Tests a given byte array to see if it contains only valid characters within the Base64 alphabet. Currently the
+     * method treats whitespace as valid.
+     *
+     * @param arrayOctet
+     *            byte array to test
+     * @return {@code true} if all bytes are valid characters in the Base64 alphabet or if the byte array is empty;
+     *         {@code false}, otherwise
+     * @since 1.5
+     */
+    public static boolean isBase64(final byte[] arrayOctet) {
+        for (int i = 0; i < arrayOctet.length; i++) {
+            if (!isBase64(arrayOctet[i]) && !isWhiteSpace(arrayOctet[i])) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns whether or not the <code>octet</code> is in the Base64 alphabet.
+     *
+     * @param octet
+     *            The value to test
+     * @return {@code true} if the value is defined in the the Base64 alphabet {@code false} otherwise.
+     */
+    @Override
+    protected boolean isInAlphabet(final byte octet) {
+        return octet >= 0 && octet < decodeTable.length && decodeTable[octet] != -1;
+    }
+
+}

--- a/process-controller/src/main/java/org/jboss/as/process/stdin/Base64InputStream.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/Base64InputStream.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.process.stdin;
+
+import java.io.InputStream;
+
+/**
+ * Variant of the <a href="http://commons.apache.org/proper/commons-codec">Commons Codec</a> project's class
+ * of the same name. See {@link org.jboss.as.process.stdin.Base64} for an explanation of the rationale
+ * for creating the variants in this package.
+ * <p>
+ * Provides Base64 encoding and decoding in a streaming fashion (unlimited size).
+ * </p>
+ * <p>
+ * The behaviour of the Base64OutputStream is to ENCODE, whereas the  behaviour of the Base64InputStream
+ * is to DECODE.
+ * </p>
+ * <p>
+ * This class implements section <cite>6.8. Base64 Content-Transfer-Encoding</cite> from RFC 2045 <cite>Multipurpose
+ * Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</cite> by Freed and Borenstein.
+ * </p>
+ * <p>
+ * Since this class operates directly on byte streams, and not character streams, it is hard-coded to only encode/decode
+ * character encodings which are compatible with the lower 127 ASCII chart (ISO-8859-1, Windows-1252, UTF-8, etc).
+ * </p>
+ *
+ * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
+ */
+public class Base64InputStream extends BaseNCodecInputStream {
+
+    /**
+     * Creates a Base64InputStream such that all data read is Base64-decoded from the original
+     * provided InputStream.
+     *
+     * @param in
+     *            InputStream to wrap.
+     *
+     */
+    public Base64InputStream(final InputStream in) {
+        super(in, new Base64(), false);
+    }
+}

--- a/process-controller/src/main/java/org/jboss/as/process/stdin/Base64OutputStream.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/Base64OutputStream.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.process.stdin;
+
+import java.io.OutputStream;
+
+/**
+ * Variant of the <a href="http://commons.apache.org/proper/commons-codec">Commons Codec</a> project's class
+ * of the same name. See {@link org.jboss.as.process.stdin.Base64} for an explanation of the rationale
+ * for creating the variants in this package.
+ * <p>
+ * Provides Base64 encoding and decoding in a streaming fashion (unlimited size).
+ * </p>
+ * <p>
+ * The behaviour of the Base64OutputStream is to ENCODE, whereas the  behaviour of the Base64InputStream
+ * is to DECODE.
+ * </p>
+ * <p>
+ * This class implements section <cite>6.8. Base64 Content-Transfer-Encoding</cite> from RFC 2045 <cite>Multipurpose
+ * Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies</cite> by Freed and Borenstein.
+ * </p>
+ * <p>
+ * Since this class operates directly on byte streams, and not character streams, it is hard-coded to only encode/decode
+ * character encodings which are compatible with the lower 127 ASCII chart (ISO-8859-1, Windows-1252, UTF-8, etc).
+ * </p>
+ *
+ * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045</a>
+ */
+public class Base64OutputStream extends BaseNCodecOutputStream {
+
+    /**
+     * Creates a Base64OutputStream such that all data written is either Base64-encoded to the
+     * original provided OutputStream.
+     *
+     * @param out
+     *            OutputStream to wrap.
+     *
+     */
+    public Base64OutputStream(final OutputStream out) {
+        super(out, new Base64(), true);
+    }
+}

--- a/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodec.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodec.java
@@ -1,0 +1,311 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.process.stdin;
+
+import java.util.Arrays;
+
+/**
+ * Variant of the <a href="http://commons.apache.org/proper/commons-codec">Commons Codec</a> project's class
+ * of the same name. See {@link org.jboss.as.process.stdin.Base64} for an explanation of the rationale
+ * for creating the variants in this package. This class was modified from the commons-codec original
+ * solely to make it non-public and remove methods not used in this package.
+ * <p>
+ * Abstract superclass for Base-N encoders and decoders.
+ * </p>
+ * <p>
+ * TODO modify available() and readResults to make it possible for {@link Base64OutputStream#flush()}
+ * to flush all data, including partial bite triplets.
+ * </p>
+ * <p>
+ * This class is thread-safe.
+ * </p>
+ */
+abstract class BaseNCodec {
+
+    /**
+     * Holds thread context so classes can be thread-safe.
+     *
+     * This class is not itself thread-safe; each thread must allocate its own copy.
+     *
+     * @since 1.7
+     */
+    static class Context {
+
+        /**
+         * Place holder for the bytes we're dealing with for our based logic.
+         * Bitwise operations store and extract the encoding or decoding from this variable.
+         */
+        int ibitWorkArea;
+
+        /**
+         * Place holder for the bytes we're dealing with for our based logic.
+         * Bitwise operations store and extract the encoding or decoding from this variable.
+         */
+        long lbitWorkArea;
+
+        /**
+         * Buffer for streaming.
+         */
+        byte[] buffer;
+
+        /**
+         * Position where next character should be written in the buffer.
+         */
+        int pos;
+
+        /**
+         * Position where next character should be read from the buffer.
+         */
+        int readPos;
+
+        /**
+         * Boolean flag to indicate the EOF has been reached. Once EOF has been reached, this object becomes useless,
+         * and must be thrown away.
+         */
+        boolean eof;
+
+        /**
+         * Variable tracks how many characters have been written to the current line. Only used when encoding. We use
+         * it to make sure each encoded line never goes beyond lineLength (if lineLength > 0).
+         */
+        int currentLinePos;
+
+        /**
+         * Writes to the buffer only occur after every 3/5 reads when encoding, and every 4/8 reads when decoding. This
+         * variable helps track that.
+         */
+        int modulus;
+
+        Context() {
+        }
+
+        /**
+         * Returns a String useful for debugging (especially within a debugger.)
+         *
+         * @return a String useful for debugging.
+         */
+        @SuppressWarnings("boxing") // OK to ignore boxing here
+        @Override
+        public String toString() {
+            return String.format("%s[buffer=%s, currentLinePos=%s, eof=%s, ibitWorkArea=%s, lbitWorkArea=%s, " +
+                    "modulus=%s, pos=%s, readPos=%s]", this.getClass().getSimpleName(), Arrays.toString(buffer),
+                    currentLinePos, eof, ibitWorkArea, lbitWorkArea, modulus, pos, readPos);
+        }
+    }
+
+    /**
+     * EOF
+     *
+     * @since 1.7
+     */
+    static final int EOF = -1;
+
+    /**
+     *  MIME chunk size per RFC 2045 section 6.8.
+     *
+     * <p>
+     * The {@value} character limit does not count the trailing CRLF, but counts all other characters, including any
+     * equal signs.
+     * </p>
+     *
+     * @see <a href="http://www.ietf.org/rfc/rfc2045.txt">RFC 2045 section 6.8</a>
+     */
+    public static final int MIME_CHUNK_SIZE = 76;
+
+    private static final int DEFAULT_BUFFER_RESIZE_FACTOR = 2;
+
+    /**
+     * Defines the default buffer size - currently {@value}
+     * - must be large enough for at least one encoded block+separator
+     */
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
+
+    /** Mask used to extract 8 bits, used in decoding bytes */
+    protected static final int MASK_8BITS = 0xff;
+
+    /**
+     * Byte used to pad output.
+     */
+    protected static final byte PAD_DEFAULT = '='; // Allow static access to default
+
+    protected final byte PAD = PAD_DEFAULT; // instance variable just in case it needs to vary later
+
+    /**
+     * Chunksize for encoding. Not used when decoding.
+     * A value of zero or less implies no chunking of the encoded data.
+     * Rounded down to nearest multiple of encodedBlockSize.
+     */
+    protected final int lineLength;
+
+    /**
+     * Note <code>lineLength</code> is rounded down to the nearest multiple of {@code encodedBlockSize}
+     * If <code>chunkSeparatorLength</code> is zero, then chunking is disabled.
+     * @param encodedBlockSize the size of an encoded block (e.g. Base64 = 4)
+     * @param lineLength if &gt; 0, use chunking with a length <code>lineLength</code>
+     * @param chunkSeparatorLength the chunk separator length, if relevant
+     */
+    protected BaseNCodec(final int encodedBlockSize,
+                         final int lineLength, final int chunkSeparatorLength) {
+        final boolean useChunking = lineLength > 0 && chunkSeparatorLength > 0;
+        this.lineLength = useChunking ? (lineLength / encodedBlockSize) * encodedBlockSize : 0;
+    }
+
+    /**
+     * Returns true if this object has buffered data for reading.
+     *
+     * @param context the context to be used
+     * @return true if there is data still available for reading.
+     */
+    boolean hasData(final Context context) {  // package protected for access from I/O streams
+        return context.buffer != null;
+    }
+
+    /**
+     * Returns the amount of buffered data available for reading.
+     *
+     * @param context the context to be used
+     * @return The amount of buffered data available for reading.
+     */
+    int available(final Context context) {  // package protected for access from I/O streams
+        return context.buffer != null ? context.pos - context.readPos : 0;
+    }
+
+    /**
+     * Get the default buffer size. Can be overridden.
+     *
+     * @return {@link #DEFAULT_BUFFER_SIZE}
+     */
+    protected int getDefaultBufferSize() {
+        return DEFAULT_BUFFER_SIZE;
+    }
+
+    /**
+     * Increases our buffer by the {@link #DEFAULT_BUFFER_RESIZE_FACTOR}.
+     * @param context the context to be used
+     */
+    private byte[] resizeBuffer(final Context context) {
+        if (context.buffer == null) {
+            context.buffer = new byte[getDefaultBufferSize()];
+            context.pos = 0;
+            context.readPos = 0;
+        } else {
+            final byte[] b = new byte[context.buffer.length * DEFAULT_BUFFER_RESIZE_FACTOR];
+            System.arraycopy(context.buffer, 0, b, 0, context.buffer.length);
+            context.buffer = b;
+        }
+        return context.buffer;
+    }
+
+    /**
+     * Ensure that the buffer has room for <code>size</code> bytes
+     *
+     * @param size minimum spare space required
+     * @param context the context to be used
+     */
+    protected byte[] ensureBufferSize(final int size, final Context context){
+        if ((context.buffer == null) || (context.buffer.length < context.pos + size)){
+            return resizeBuffer(context);
+        }
+        return context.buffer;
+    }
+
+    /**
+     * Extracts buffered data into the provided byte[] array, starting at position bPos, up to a maximum of bAvail
+     * bytes. Returns how many bytes were actually extracted.
+     * <p>
+     * Package protected for access from I/O streams.
+     *
+     * @param b
+     *            byte[] array to extract the buffered data into.
+     * @param bPos
+     *            position in byte[] array to start extraction at.
+     * @param bAvail
+     *            amount of bytes we're allowed to extract. We may extract fewer (if fewer are available).
+     * @param context
+     *            the context to be used
+     * @return The number of bytes successfully extracted into the provided byte[] array.
+     */
+    int readResults(final byte[] b, final int bPos, final int bAvail, final Context context) {
+        if (context.buffer != null) {
+            final int len = Math.min(available(context), bAvail);
+            System.arraycopy(context.buffer, context.readPos, b, bPos, len);
+            context.readPos += len;
+            if (context.readPos >= context.pos) {
+                context.buffer = null; // so hasData() will return false, and this method can return -1
+            }
+            return len;
+        }
+        return context.eof ? EOF : 0;
+    }
+
+    /**
+     * Checks if a byte value is whitespace or not.
+     * Whitespace is taken to mean: space, tab, CR, LF
+     * @param byteToCheck
+     *            the byte to check
+     * @return true if byte is whitespace, false otherwise
+     */
+    protected static boolean isWhiteSpace(final byte byteToCheck) {
+        switch (byteToCheck) {
+            case ' ' :
+            case '\n' :
+            case '\r' :
+            case '\t' :
+                return true;
+            default :
+                return false;
+        }
+    }
+
+    // package protected for access from I/O streams
+    abstract void encode(byte[] pArray, int i, int length, Context context);
+
+    // package protected for access from I/O streams
+    abstract void decode(byte[] pArray, int i, int length, Context context);
+
+    /**
+     * Returns whether or not the <code>octet</code> is in the current alphabet.
+     * Does not allow whitespace or pad.
+     *
+     * @param value The value to test
+     *
+     * @return {@code true} if the value is defined in the current alphabet, {@code false} otherwise.
+     */
+    protected abstract boolean isInAlphabet(byte value);
+
+    /**
+     * Tests a given byte array to see if it contains any characters within the alphabet or PAD.
+     *
+     * Intended for use in checking line-ending arrays
+     *
+     * @param arrayOctet
+     *            byte array to test
+     * @return {@code true} if any byte is a valid character in the alphabet or PAD; {@code false} otherwise
+     */
+    protected boolean containsAlphabetOrPad(final byte[] arrayOctet) {
+        if (arrayOctet == null) {
+            return false;
+        }
+        for (final byte element : arrayOctet) {
+            if (PAD == element || isInAlphabet(element)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecInputStream.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecInputStream.java
@@ -1,0 +1,214 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.process.stdin;
+
+import static org.jboss.as.process.stdin.BaseNCodec.EOF;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.as.process.stdin.BaseNCodec.Context;
+
+/**
+ * Variant of the <a href="http://commons.apache.org/proper/commons-codec">Commons Codec</a> project's class
+ * of the same name. See {@link org.jboss.as.process.stdin.Base64} for an explanation of the rationale
+ * for creating the variants in this package. This class was modified from the commons-codec original
+ * solely to make it non-public and remove methods not used in this package.
+ * <p>
+ * Abstract superclass for Base-N input streams.
+ * </p>
+ */
+class BaseNCodecInputStream extends FilterInputStream {
+
+    private final BaseNCodec baseNCodec;
+
+    private final boolean doEncode;
+
+    private final byte[] singleByte = new byte[1];
+
+    private final Context context = new Context();
+
+    protected BaseNCodecInputStream(final InputStream in, final BaseNCodec baseNCodec, final boolean doEncode) {
+        super(in);
+        this.doEncode = doEncode;
+        this.baseNCodec = baseNCodec;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return <code>0</code> if the {@link InputStream} has reached <code>EOF</code>,
+     * <code>1</code> otherwise
+     * @since 1.7
+     */
+    @Override
+    public int available() throws IOException {
+        // Note: the logic is similar to the InflaterInputStream:
+        //       as long as we have not reached EOF, indicate that there is more
+        //       data available. As we do not know for sure how much data is left,
+        //       just return 1 as a safe guess.
+
+        return context.eof ? 0 : 1;
+    }
+
+    /**
+     * Marks the current position in this input stream.
+     * <p>The {@code mark} method of {@link BaseNCodecInputStream} does nothing.</p>
+     *
+     * @param readLimit the maximum limit of bytes that can be read before the mark position becomes invalid.
+     * @since 1.7
+     */
+    @Override
+    public synchronized void mark(final int readLimit) {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @return always returns <code>false</code>
+     */
+    @Override
+    public boolean markSupported() {
+        return false; // not an easy job to support marks
+    }
+
+    /**
+     * Reads one <code>byte</code> from this input stream.
+     *
+     * @return the byte as an integer in the range 0 to 255. Returns -1 if EOF has been reached.
+     * @throws IOException
+     *             if an I/O error occurs.
+     */
+    @Override
+    public int read() throws IOException {
+        int r = read(singleByte, 0, 1);
+        while (r == 0) {
+            r = read(singleByte, 0, 1);
+        }
+        if (r > 0) {
+            final byte b = singleByte[0];
+            return b < 0 ? 256 + b : b;
+        }
+        return EOF;
+    }
+
+    /**
+     * Attempts to read <code>len</code> bytes into the specified <code>b</code> array starting at <code>offset</code>
+     * from this InputStream.
+     *
+     * @param b
+     *            destination byte array
+     * @param offset
+     *            where to start writing the bytes
+     * @param len
+     *            maximum number of bytes to read
+     *
+     * @return number of bytes read
+     * @throws IOException
+     *             if an I/O error occurs.
+     * @throws NullPointerException
+     *             if the byte array parameter is null
+     * @throws IndexOutOfBoundsException
+     *             if offset, len or buffer size are invalid
+     */
+    @Override
+    public int read(final byte[] b, final int offset, final int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (offset < 0 || len < 0) {
+            throw new IndexOutOfBoundsException();
+        } else if (offset > b.length || offset + len > b.length) {
+            throw new IndexOutOfBoundsException();
+        } else if (len == 0) {
+            return 0;
+        } else {
+            int readLen = 0;
+            /*
+             Rationale for while-loop on (readLen == 0):
+             -----
+             Base32.readResults() usually returns > 0 or EOF (-1).  In the
+             rare case where it returns 0, we just keep trying.
+
+             This is essentially an undocumented contract for InputStream
+             implementors that want their code to work properly with
+             java.io.InputStreamReader, since the latter hates it when
+             InputStream.read(byte[]) returns a zero.  Unfortunately our
+             readResults() call must return 0 if a large amount of the data
+             being decoded was non-base32, so this while-loop enables proper
+             interop with InputStreamReader for that scenario.
+             -----
+             This is a fix for CODEC-101
+            */
+            while (readLen == 0) {
+                if (!baseNCodec.hasData(context)) {
+                    final byte[] buf = new byte[doEncode ? 4096 : 8192];
+                    final int c = in.read(buf);
+                    if (doEncode) {
+                        baseNCodec.encode(buf, 0, c, context);
+                    } else {
+                        baseNCodec.decode(buf, 0, c, context);
+                    }
+                }
+                readLen = baseNCodec.readResults(b, offset, len, context);
+            }
+            return readLen;
+        }
+    }
+
+    /**
+     * Repositions this stream to the position at the time the mark method was last called on this input stream.
+     * <p>
+     * The {@link #reset} method of {@link BaseNCodecInputStream} does nothing except throw an {@link IOException}.
+     *
+     * @throws IOException if this method is invoked
+     * @since 1.7
+     */
+    @Override
+    public synchronized void reset() throws IOException {
+        throw new IOException("mark/reset not supported");
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException if the provided skip length is negative
+     * @since 1.7
+     */
+    @Override
+    public long skip(final long n) throws IOException {
+        if (n < 0) {
+            throw new IllegalArgumentException("Negative skip length: " + n);
+        }
+
+        // skip in chunks of 512 bytes
+        final byte[] b = new byte[512];
+        long todo = n;
+
+        while (todo > 0) {
+            int len = (int) Math.min(b.length, todo);
+            len = this.read(b, 0, len);
+            if (len == EOF) {
+                break;
+            }
+            todo -= len;
+        }
+
+        return n - todo;
+    }
+}

--- a/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecOutputStream.java
+++ b/process-controller/src/main/java/org/jboss/as/process/stdin/BaseNCodecOutputStream.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.as.process.stdin;
+
+import static org.jboss.as.process.stdin.BaseNCodec.EOF;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.jboss.as.process.stdin.BaseNCodec.Context;
+
+/**
+ * Variant of the <a href="http://commons.apache.org/proper/commons-codec">Commons Codec</a> project's class
+ * of the same name. See {@link org.jboss.as.process.stdin.Base64} for an explanation of the rationale
+ * for creating the variants in this package. This class was modified from the commons-codec original
+ * solely to make it non-public and remove methods not used in this package.
+ * <p>
+ * Abstract superclass for Base-N output streams.
+ * </p>
+ * <p>
+ * TODO modify flush() to flush all data, including partial bite triplets.
+ * </p>
+ */
+class BaseNCodecOutputStream extends FilterOutputStream {
+
+    private final boolean doEncode;
+
+    private final BaseNCodec baseNCodec;
+
+    private final byte[] singleByte = new byte[1];
+
+    private final Context context = new Context();
+
+    BaseNCodecOutputStream(final OutputStream out, final BaseNCodec basedCodec, final boolean doEncode) {
+        super(out);
+        this.baseNCodec = basedCodec;
+        this.doEncode = doEncode;
+    }
+
+    /**
+     * Writes the specified <code>byte</code> to this output stream.
+     *
+     * @param i
+     *            source byte
+     * @throws IOException
+     *             if an I/O error occurs.
+     */
+    @Override
+    public void write(final int i) throws IOException {
+        singleByte[0] = (byte) i;
+        write(singleByte, 0, 1);
+    }
+
+    /**
+     * Writes <code>len</code> bytes from the specified <code>b</code> array starting at <code>offset</code> to this
+     * output stream.
+     *
+     * @param b
+     *            source byte array
+     * @param offset
+     *            where to start reading the bytes
+     * @param len
+     *            maximum number of bytes to write
+     *
+     * @throws IOException
+     *             if an I/O error occurs.
+     * @throws NullPointerException
+     *             if the byte array parameter is null
+     * @throws IndexOutOfBoundsException
+     *             if offset, len or buffer size are invalid
+     */
+    @Override
+    public void write(final byte[] b, final int offset, final int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException();
+        } else if (offset < 0 || len < 0) {
+            throw new IndexOutOfBoundsException();
+        } else if (offset > b.length || offset + len > b.length) {
+            throw new IndexOutOfBoundsException();
+        } else if (len > 0) {
+            if (doEncode) {
+                baseNCodec.encode(b, offset, len, context);
+            } else {
+                baseNCodec.decode(b, offset, len, context);
+            }
+            flush(false);
+        }
+    }
+
+    /**
+     * Flushes this output stream and forces any buffered output bytes to be written out to the stream. If propagate is
+     * true, the wrapped stream will also be flushed.
+     *
+     * @param propagate
+     *            boolean flag to indicate whether the wrapped OutputStream should also be flushed.
+     * @throws IOException
+     *             if an I/O error occurs.
+     */
+    private void flush(final boolean propagate) throws IOException {
+        final int avail = baseNCodec.available(context);
+        if (avail > 0) {
+            final byte[] buf = new byte[avail];
+            final int c = baseNCodec.readResults(buf, 0, avail, context);
+            if (c > 0) {
+                out.write(buf, 0, c);
+            }
+        }
+        if (propagate) {
+            out.flush();
+        }
+    }
+
+    /**
+     * Flushes this output stream and forces any buffered output bytes to be written out to the stream.
+     *
+     * @throws IOException
+     *             if an I/O error occurs.
+     */
+    @Override
+    public void flush() throws IOException {
+        flush(true);
+    }
+
+    /**
+     * Closes this output stream and releases any system resources associated with the stream.
+     *
+     * @throws IOException
+     *             if an I/O error occurs.
+     */
+    @Override
+    public void close() throws IOException {
+        // Notify encoder of EOF (-1).
+        if (doEncode) {
+            baseNCodec.encode(singleByte, 0, EOF, context);
+        } else {
+            baseNCodec.decode(singleByte, 0, EOF, context);
+        }
+        flush();
+        out.close();
+    }
+
+}

--- a/process-controller/src/test/java/org/jboss/as/process/stdin/Base64InputStreamTestCase.java
+++ b/process-controller/src/test/java/org/jboss/as/process/stdin/Base64InputStreamTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.process.stdin;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Test of {@link org.jboss.as.process.stdin.Base64InputStream}.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class Base64InputStreamTestCase {
+
+    private static final byte[] input = {(byte) 1, (byte) 2,(byte) 3, (byte) 4,(byte) 5,(byte) 6,
+            (byte) 7,(byte) 8,(byte) 9, (byte) 10};
+
+    @Test
+    public void testRemainOpenOnPad() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Base64OutputStream b64os = getOut(baos);
+        b64os.write(input, 0, 1);
+        b64os.close();
+        b64os = getOut(baos);
+        b64os.write(input, 1, 2);
+        b64os.close();
+        b64os = getOut(baos);
+        b64os.write(input, 3, 3);
+        b64os.close();
+        b64os = getOut(baos);
+        b64os.write(input, 6, 4);
+        b64os.close();
+
+        byte[] output = baos.toByteArray();
+
+        Base64InputStream b64is = getIn(output);
+        byte[] result = new byte[10];
+        Assert.assertEquals(10, b64is.read(result, 0, 10));
+        Assert.assertArrayEquals(input, result);
+
+        b64is = getIn(output);
+        result = new byte[10];
+        Assert.assertEquals(1, b64is.read(result, 0, 1));
+        byte[] correct = new byte[10];
+        correct[0] = (byte) 1;
+        Assert.assertArrayEquals(correct, result);
+
+        b64is = getIn(output);
+        result = new byte[10];
+        Assert.assertEquals(2, b64is.read(result, 0, 2));
+        correct[1] = (byte) 2;
+        Assert.assertArrayEquals(correct, result);
+
+        b64is = getIn(output);
+        result = new byte[10];
+        Assert.assertEquals(3, b64is.read(result, 0, 3));
+        correct[2] = (byte) 3;
+        Assert.assertArrayEquals(correct, result);
+
+        b64is = getIn(output);
+        result = new byte[10];
+        Assert.assertEquals(4, b64is.read(result, 0, 4));
+        correct[3] = (byte) 4;
+        Assert.assertArrayEquals(correct, result);
+
+        b64is = getIn(output);
+        result = new byte[10];
+        Assert.assertEquals(2, b64is.read(result, 0, 2));
+        Assert.assertEquals(5, b64is.read(result, 2, 5));
+        correct[4] = (byte) 5;
+        correct[5] = (byte) 6;
+        correct[6] = (byte) 7;
+        Assert.assertArrayEquals(correct, result);
+    }
+
+
+    private static Base64OutputStream getOut(OutputStream sink) {
+        return new Base64OutputStream(sink);
+    }
+
+    private static Base64InputStream getIn(byte[] source) {
+        ByteArrayInputStream bais = new ByteArrayInputStream(source);
+        return new Base64InputStream(bais);
+    }
+}

--- a/server/src/main/java/org/jboss/as/server/DomainServerMain.java
+++ b/server/src/main/java/org/jboss/as/server/DomainServerMain.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 
 import org.jboss.as.process.ExitCodes;
 import org.jboss.as.process.protocol.StreamUtils;
+import org.jboss.as.process.stdin.Base64InputStream;
 import org.jboss.as.server.mgmt.domain.HostControllerClient;
 import org.jboss.as.server.mgmt.domain.HostControllerConnectionService;
 import org.jboss.logmanager.Level;
@@ -71,7 +72,7 @@ public final class DomainServerMain {
      */
     public static void main(String[] args) {
 
-        final InputStream initialInput = System.in;
+        final InputStream initialInput = new Base64InputStream(System.in);
         final PrintStream initialError = System.err;
 
         // Make sure our original stdio is properly captured.
@@ -91,7 +92,7 @@ public final class DomainServerMain {
 
         final byte[] authKey = new byte[16];
         try {
-            org.jboss.as.process.protocol.StreamUtils.readFully(initialInput, authKey);
+            StreamUtils.readFully(initialInput, authKey);
         } catch (IOException e) {
             e.printStackTrace();
             System.exit(ExitCodes.FAILED);


### PR DESCRIPTION
IBM JDK 7 has issues on Windows with binary data sent by the ProcessController to a child process over stdin. Any byte whose high order bit is 1 (i.e. a negative signed byte) is garbled. It appears stdin is treated as a character stream and not a binary stream and there is some sort of encoding problem.

This patch avoids this problem by Base64 encoding all data sent via stdin.

I forked classes from commons-codec to do this. See the Base64 class, particularly the comment in its "decode" method for why I needed to fork it.
