### PR TITLE
complete WFLY-1995, String type property substitution for other ejb3 annotations 

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/MessageDrivenComponentDescriptionFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/MessageDrivenComponentDescriptionFactory.java
@@ -104,13 +104,13 @@ public class MessageDrivenComponentDescriptionFactory extends EJBComponentDescri
             if (!assertMDBClassValidity(beanClassInfo)) {
                 continue;
             }
+            final boolean replacement = deploymentUnit.getAttachment(Attachments.EJB_ANNOTATION_PROPERTY_REPLACEMENT);
             final String ejbName = beanClassInfo.name().local();
             final AnnotationValue nameValue = messageBeanAnnotation.value("name");
-            final String beanName = nameValue == null || nameValue.asString().isEmpty() ? ejbName : nameValue.asString();
+            final String beanName = nameValue == null || nameValue.asString().isEmpty() ? ejbName : (replacement ? PropertiesValueResolver.replaceProperties(nameValue.asString()) : nameValue.asString());
             final MessageDrivenBeanMetaData beanMetaData = getEnterpriseBeanMetaData(deploymentUnit, beanName, MessageDrivenBeanMetaData.class);
             final String beanClassName;
             final String messageListenerInterfaceName;
-            boolean replacement = deploymentUnit.getAttachment(Attachments.EJB_ANNOTATION_PROPERTY_REPLACEMENT);
             final Properties activationConfigProperties = getActivationConfigProperties(messageBeanAnnotation, replacement);
             final String messagingType;
             if (beanMetaData != null) {
@@ -256,7 +256,7 @@ public class MessageDrivenComponentDescriptionFactory extends EJBComponentDescri
             String propertyName = propAnnotation.value("propertyName").asString();
             String propertyValue = propAnnotation.value("propertyValue").asString();
             if(replacement)
-                props.put(propertyName, PropertiesValueResolver.replaceProperties(propertyValue));
+                props.put(PropertiesValueResolver.replaceProperties(propertyName), PropertiesValueResolver.replaceProperties(propertyValue));
             else
                 props.put(propertyName, propertyValue);
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
@@ -23,6 +23,7 @@
 package org.jboss.as.ejb3.deployment.processors;
 
 import org.jboss.as.ee.metadata.MetadataCompleteMarker;
+import org.jboss.as.ee.structure.Attachments;
 import org.jboss.as.ejb3.EjbLogger;
 import org.jboss.as.ejb3.EjbMessages;
 import org.jboss.as.ejb3.component.session.SessionBeanComponentDescription;
@@ -30,6 +31,7 @@ import org.jboss.as.ejb3.component.singleton.SingletonComponentDescription;
 import org.jboss.as.ejb3.component.stateful.StatefulComponentDescription;
 import org.jboss.as.ejb3.component.stateless.StatelessComponentDescription;
 import org.jboss.as.ejb3.deployment.EjbJarDescription;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.EjbDeploymentMarker;
@@ -109,6 +111,7 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
 
         final EjbJarDescription ejbJarDescription = getEjbJarDescription(deploymentUnit);
         final ServiceName deploymentUnitServiceName = deploymentUnit.getServiceName();
+        final boolean replacement = deploymentUnit.getAttachment(Attachments.EJB_ANNOTATION_PROPERTY_REPLACEMENT);
 
         // process these session bean annotations and create component descriptions out of it
         for (final AnnotationInstance sessionBeanAnnotation : sessionBeanAnnotations) {
@@ -125,7 +128,7 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
             }
             final String ejbName = sessionBeanClassInfo.name().local();
             final AnnotationValue nameValue = sessionBeanAnnotation.value("name");
-            final String beanName = nameValue == null || nameValue.asString().isEmpty() ? ejbName : nameValue.asString();
+            final String beanName = nameValue == null || nameValue.asString().isEmpty() ? ejbName : (replacement ? PropertiesValueResolver.replaceProperties(nameValue.asString()) : nameValue.asString());
             final SessionBeanMetaData beanMetaData = getEnterpriseBeanMetaData(deploymentUnit, beanName, SessionBeanMetaData.class);
             final SessionBeanComponentDescription.SessionBeanType sessionBeanType;
             final String beanClassName;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/CacheAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/CacheAnnotationInformationFactory.java
@@ -23,6 +23,7 @@ package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
 import org.jboss.as.ejb3.cache.CacheInfo;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.ejb3.annotation.Cache;
 import org.jboss.jandex.AnnotationInstance;
 
@@ -38,6 +39,9 @@ public class CacheAnnotationInformationFactory extends ClassAnnotationInformatio
     @Override
     protected CacheInfo fromAnnotation(AnnotationInstance annotationInstance, boolean replacement) {
         String value = annotationInstance.value().asString();
-        return new CacheInfo(value);
+        if (replacement)
+            return new CacheInfo(PropertiesValueResolver.replaceProperties(value));
+        else
+            return new CacheInfo(value);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DeclareRolesAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DeclareRolesAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.jandex.AnnotationInstance;
 
 import javax.annotation.security.DeclareRoles;
@@ -37,6 +38,12 @@ public class DeclareRolesAnnotationInformationFactory extends ClassAnnotationInf
 
     @Override
     protected String[] fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
-        return annotationInstance.value().asStringArray();
+        if (replacement) {
+            String[] values = annotationInstance.value().asStringArray();
+            for (int i = 0; i < values.length; i++)
+                values[i] = PropertiesValueResolver.replaceProperties(values[i]);
+            return values;
+        } else
+            return annotationInstance.value().asStringArray();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DependsOnAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/DependsOnAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.jandex.AnnotationInstance;
 
 import javax.ejb.DependsOn;
@@ -37,6 +38,13 @@ public class DependsOnAnnotationInformationFactory extends ClassAnnotationInform
 
     @Override
     protected String[] fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
-        return annotationInstance.value().asStringArray();
+        if (replacement) {
+            String[] values = annotationInstance.value().asStringArray();
+            for (int i = 0; i < values.length; i++)
+                values[i] = PropertiesValueResolver.replaceProperties(values[i]);
+            return values;
+        } else {
+            return annotationInstance.value().asStringArray();
+        }
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/InitAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/InitAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 
@@ -42,6 +43,9 @@ public class InitAnnotationInformationFactory extends ClassAnnotationInformation
         if (value == null) {
             return null;
         }
-        return value.asString();
+        if (replacement)
+            return PropertiesValueResolver.replaceProperties(value.asString());
+        else
+            return value.asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/PoolAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/PoolAnnotationInformationFactory.java
@@ -26,6 +26,7 @@ package org.jboss.as.ejb3.deployment.processors.annotation;
 import static org.jboss.as.ee.EeMessages.MESSAGES;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.ejb3.annotation.Pool;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -47,6 +48,9 @@ public class PoolAnnotationInformationFactory extends ClassAnnotationInformation
         if (value == null || value.asString().isEmpty()) {
             throw MESSAGES.annotationAttributeMissing("@Pool", "value");
         }
-        return value.asString();
+        if (replacement)
+            return PropertiesValueResolver.replaceProperties(value.asString());
+        else
+            return value.asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RolesAllowedAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RolesAllowedAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.jandex.AnnotationInstance;
 
 import javax.annotation.security.RolesAllowed;
@@ -37,6 +38,12 @@ public class RolesAllowedAnnotationInformationFactory extends ClassAnnotationInf
 
     @Override
     protected String[] fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
-        return annotationInstance.value().asStringArray();
+        if (replacement) {
+            String[] values = annotationInstance.value().asStringArray();
+            for (int i = 0; i < values.length; i++)
+                values[i] = PropertiesValueResolver.replaceProperties(values[i]);
+            return values;
+        } else
+            return annotationInstance.value().asStringArray();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.jandex.AnnotationInstance;
 
 import javax.annotation.security.RunAs;
@@ -39,6 +40,9 @@ public class RunAsAnnotationInformationFactory extends ClassAnnotationInformatio
 
     @Override
     protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
-        return annotationInstance.value().asString();
+        if (replacement)
+            return PropertiesValueResolver.replaceProperties(annotationInstance.value().asString());
+        else
+            return annotationInstance.value().asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsPrincipalAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/RunAsPrincipalAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.ejb3.annotation.RunAsPrincipal;
 import org.jboss.jandex.AnnotationInstance;
 
@@ -39,6 +40,9 @@ public class RunAsPrincipalAnnotationInformationFactory extends ClassAnnotationI
 
     @Override
     protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
-        return annotationInstance.value().asString();
+        if (replacement)
+            return PropertiesValueResolver.replaceProperties(annotationInstance.value().asString());
+        else
+            return annotationInstance.value().asString();
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ScheduleAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ScheduleAnnotationInformationFactory.java
@@ -23,11 +23,13 @@ package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
 import org.jboss.as.ejb3.timerservice.AutoTimer;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 
 import javax.ejb.Schedule;
 import javax.ejb.Schedules;
+
 import static org.jboss.as.ejb3.EjbMessages.MESSAGES;
 /**
  * {@link org.jboss.as.ee.metadata.ClassAnnotationInformation} for Schedule annotation
@@ -134,7 +136,7 @@ public class ScheduleAnnotationInformationFactory extends ClassAnnotationInforma
                 if (value == null) {
                     setString(timer, defaultStringValue);
                 } else {
-                    setString(timer, value.asString());
+                    setString(timer, PropertiesValueResolver.replaceProperties(value.asString()));
                 }
             }
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/SecurityDomainAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/SecurityDomainAnnotationInformationFactory.java
@@ -22,6 +22,7 @@
 package org.jboss.as.ejb3.deployment.processors.annotation;
 
 import org.jboss.as.ee.metadata.ClassAnnotationInformationFactory;
+import org.jboss.as.ejb3.util.PropertiesValueResolver;
 import org.jboss.ejb3.annotation.SecurityDomain;
 import org.jboss.jandex.AnnotationInstance;
 
@@ -38,6 +39,9 @@ public class SecurityDomainAnnotationInformationFactory extends ClassAnnotationI
 
     @Override
     protected String fromAnnotation(final AnnotationInstance annotationInstance, final boolean replacement) {
-        return annotationInstance.value().asString();
+        if (replacement)
+            return PropertiesValueResolver.replaceProperties(annotationInstance.value().asString());
+        else
+            return annotationInstance.value().asString();
     }
 }


### PR DESCRIPTION
According to discussion on https://issues.jboss.org/browse/WFLY-1995 
besides @ActivationConfigProperty and @ResourceAdapter, this commit includes String type property substitution of other ejb3 annotation in javax.ejb, javax.annotation.security and jboss-ejb3-ext-api.

For annotations without a property and non-string type property, the substitution is not applicable. 
