### PR TITLE
[WFLY-1712] Stop the name attribute from being added when adding handlers

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/HandlerOperations.java
@@ -142,14 +142,14 @@ final class HandlerOperations {
                     context.reloadRequired();
                 }
             }
-            performRuntime(context, configuration, name, model);
+            performRuntime(context, configuration, operation, name, model);
 
             // It's important that properties are written in the correct order, reorder the properties if
             // needed before the commit.
             addOrderPropertiesStep(context, propertySorter, configuration);
         }
 
-        public void performRuntime(final OperationContext context, final HandlerConfiguration configuration, final String name, final ModelNode model) throws OperationFailedException {
+        public void performRuntime(final OperationContext context, final HandlerConfiguration configuration, final ModelNode operation, final String name, final ModelNode model) throws OperationFailedException {
             // No-op by default
         }
     }
@@ -451,14 +451,13 @@ final class HandlerOperations {
     static final OperationStepHandler ADD_SUBHANDLER = new HandlerUpdateOperationStepHandler() {
         @Override
         public void updateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-            HANDLER_NAME.validateAndSet(operation, model);
             model.get(SUBHANDLERS.getName()).add(operation.get(HANDLER_NAME.getName()));
         }
 
         @Override
-        public void performRuntime(final OperationContext context, final HandlerConfiguration configuration, final String name, final ModelNode model) throws OperationFailedException {
+        public void performRuntime(final OperationContext context, final HandlerConfiguration configuration, final ModelNode operation, final String name, final ModelNode model) throws OperationFailedException {
             // Get the handler name
-            final String handlerName = HANDLER_NAME.resolveModelAttribute(context, model).asString();
+            final String handlerName = HANDLER_NAME.resolveModelAttribute(context, operation).asString();
             if (name.equals(handlerName)) {
                 throw createOperationFailure(LoggingMessages.MESSAGES.cannotAddHandlerToSelf(configuration.getName()));
             }
@@ -475,8 +474,7 @@ final class HandlerOperations {
     static final OperationStepHandler REMOVE_SUBHANDLER = new HandlerUpdateOperationStepHandler() {
         @Override
         public void updateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-            HANDLER_NAME.validateAndSet(operation, model);
-            final String handlerName = model.get(HANDLER_NAME.getName()).asString();
+            final String handlerName = operation.get(HANDLER_NAME.getName()).asString();
             // Create a new handler list for the model
             boolean found = false;
             final List<ModelNode> handlers = model.get(SUBHANDLERS.getName()).asList();
@@ -494,8 +492,8 @@ final class HandlerOperations {
         }
 
         @Override
-        public void performRuntime(final OperationContext context, final HandlerConfiguration configuration, final String name, final ModelNode model) throws OperationFailedException {
-            configuration.removeHandlerName(HANDLER_NAME.resolveModelAttribute(context, model).asString());
+        public void performRuntime(final OperationContext context, final HandlerConfiguration configuration, final ModelNode operation, final String name, final ModelNode model) throws OperationFailedException {
+            configuration.removeHandlerName(HANDLER_NAME.resolveModelAttribute(context, operation).asString());
         }
     };
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggerOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggerOperations.java
@@ -199,14 +199,13 @@ final class LoggerOperations {
 
         @Override
         public void updateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-            HANDLER_NAME.validateAndSet(operation, model);
             model.get(HANDLERS.getName()).add(operation.get(HANDLER_NAME.getName()));
         }
 
         @Override
         public void performRuntime(final OperationContext context, final ModelNode operation, final LoggerConfiguration configuration, final String name, final ModelNode model) throws OperationFailedException {
             // Get the handler name
-            final String handlerName = HANDLER_NAME.resolveModelAttribute(context, model).asString();
+            final String handlerName = HANDLER_NAME.resolveModelAttribute(context, operation).asString();
             final String loggerName = getLogManagerLoggerName(name);
             if (configuration.getHandlerNames().contains(handlerName)) {
                 throw createOperationFailure(LoggingMessages.MESSAGES.handlerAlreadyDefined(handlerName));
@@ -223,8 +222,7 @@ final class LoggerOperations {
 
         @Override
         public void updateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-            HANDLER_NAME.validateAndSet(operation, model);
-            final String handlerName = model.get(HANDLER_NAME.getName()).asString();
+            final String handlerName = operation.get(HANDLER_NAME.getName()).asString();
             // Create a new handler list for the model
             boolean found = false;
             final List<ModelNode> handlers = model.get(HANDLERS.getName()).asList();
@@ -243,7 +241,7 @@ final class LoggerOperations {
 
         @Override
         public void performRuntime(final OperationContext context, final ModelNode operation, final LoggerConfiguration configuration, final String name, final ModelNode model) throws OperationFailedException {
-            configuration.removeHandlerName(HANDLER_NAME.resolveModelAttribute(context, model).asString());
+            configuration.removeHandlerName(HANDLER_NAME.resolveModelAttribute(context, operation).asString());
         }
     };
 

--- a/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
+++ b/logging/src/test/java/org/jboss/as/logging/AbstractLoggingSubsystemTest.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.logging;
 
+import static org.junit.Assert.*;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,6 +33,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
@@ -46,6 +49,7 @@ import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.SubsystemOperations;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
 import org.jboss.logmanager.LogContext;
 import org.jboss.logmanager.config.FormatterConfiguration;
 import org.jboss.logmanager.config.HandlerConfiguration;
@@ -434,6 +438,28 @@ public abstract class AbstractLoggingSubsystemTest extends AbstractSubsystemBase
                 }
             }
         }
+    }
+
+    /**
+     * Validates that there are no extra attributes on the resource.
+     *
+     * @param resource   the resource to check for additional attributes
+     * @param attributes the attributes that should be on the resource
+     */
+    protected void validateResourceAttributes(final ModelNode resource, final AttributeDefinition[] attributes) {
+        final List<String> validAttributes = new ArrayList<String>();
+        for (AttributeDefinition attribute : attributes) {
+            validAttributes.add(attribute.getName());
+        }
+        // Get the attribute names from the resource
+        final List<String> resourceAttributes = new ArrayList<String>();
+        for (Property property : resource.asPropertyList()) {
+            resourceAttributes.add(property.getName());
+        }
+
+        // Remove all the known attributes
+        resourceAttributes.removeAll(validAttributes);
+        assertTrue(String.format("Additional attributes (%s) found on the resource %s", resourceAttributes, resource), resourceAttributes.isEmpty());
     }
 
     protected ModelNode findHandlerModel(final ModelNode model, final String name) {

--- a/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/HandlerOperationsTestCase.java
@@ -309,6 +309,14 @@ public class HandlerOperationsTestCase extends AbstractOperationsTestCase {
                 .asList()
                 .isEmpty());
 
+        // Ensure the model doesn't contain any erroneous attributes
+        op = SubsystemOperations.createReadResourceOperation(address);
+        result = executeOperation(kernelServices, op);
+        final ModelNode asyncHandlerResource = SubsystemOperations.readResult(result);
+        validateResourceAttributes(asyncHandlerResource, Logging.join(AsyncHandlerResourceDefinition.ATTRIBUTES, CommonAttributes.NAME, CommonAttributes.FILTER));
+        // The name attribute should be the same as the last path element of the address
+        assertEquals(asyncHandlerResource.get(CommonAttributes.NAME.getName()).asString(), PathAddress.pathAddress(address).getLastElement().getValue());
+
         // Clean-up
         executeOperation(kernelServices, SubsystemOperations.createRemoveOperation(consoleAddress));
         verifyRemoved(kernelServices, consoleAddress);


### PR DESCRIPTION
The `add-handler` and `remove-handler` operations for loggers and the async-handler were adding a `name` attribute to the model. This caused issues with composite operations when trying to add multiple handlers.
