### PR TITLE
[WFLY-215] Clustering tests leave a hanging instance if they are run in ...

### DIFF
--- a/testsuite/integration/clust/pom.xml
+++ b/testsuite/integration/clust/pom.xml
@@ -85,9 +85,6 @@
                                 <phase>test</phase>
                                 <goals><goal>test</goal></goals>
                                 <configuration>
-                                    <!-- Force the order of tests -->
-                                    <runOrder>reversealphabetical</runOrder>
-
                                     <!-- Tests to execute. -->
                                     <includes>
                                         <include>org/jboss/as/test/clustering/cluster/**/*TestCase.java</include>


### PR DESCRIPTION
...opposite order

Forcing the order is a hack, running locally it seems the original issue was fixed. Lets see what brontes CI says now.
