### PR TITLE
WFLY-2642 Add Resteasy Spring Integration

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -101,6 +101,8 @@
     <target name="create-ext-content">
         <mkdir dir="${output.dir}/modules/system/layers/base/org/jboss/integration/ext-content/main/bundled"/>
         <copy file="${org.jboss.seam.integration:jboss-seam-int-jbossas:jar}" tofile="${output.dir}/modules/system/layers/base/org/jboss/integration/ext-content/main/bundled/jboss-seam-int.jar"/>
+        <!-- resteasy spring integration -->
+        <copy file="${org.jboss.resteasy:resteasy-spring:jar}" tofile="${output.dir}/modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/bundled/resteasy-spring.jar"/>
 
         <!-- Copy the EJB specific schemas to the JBOSS_HOME/docs/schema folder -->
         <unzip src="${org.jboss.metadata:jboss-metadata-ejb:jar}" dest="${output.dir}/docs/schema/">
@@ -1287,6 +1289,8 @@
         <module-def name="org.jboss.resteasy.resteasy-multipart-provider">
             <maven-resource group="org.jboss.resteasy" artifact="resteasy-multipart-provider"/>
         </module-def>
+
+        <module-def name="org.jboss.resteasy.resteasy-spring"/>
 
         <module-def name="org.jboss.resteasy.resteasy-validator-provider-11">
             <maven-resource group="org.jboss.resteasy" artifact="resteasy-validator-provider-11"/>

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1550,6 +1550,11 @@
 
                 <dependency>
                     <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-spring</artifactId>
+                </dependency>
+
+                <dependency>
+                    <groupId>org.jboss.resteasy</groupId>
                     <artifactId>resteasy-atom-provider</artifactId>
                 </dependency>
 

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
@@ -56,6 +56,7 @@
         <module name="org.jboss.resteasy.resteasy-jettison-provider"/>
         <module name="org.jboss.resteasy.resteasy-jsapi"/>
         <module name="org.jboss.resteasy.resteasy-multipart-provider"/>
+        <module name="org.jboss.resteasy.resteasy-spring" />
         <module name="org.jboss.resteasy.resteasy-validator-provider-11"/>
         <module name="org.jboss.resteasy.resteasy-yaml-provider"/>
         <module name="org.jboss.staxmapper"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/module.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-spring">
+
+    <resources>
+        <!-- This module just contains the jar as a resource root. It cannot be depended on to get
+         access to the jar classes-->
+        <resource-root path="bundled"/>
+    </resources>
+
+    <dependencies>
+    </dependencies>
+</module>

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsMessages.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsMessages.java
@@ -94,5 +94,8 @@ public interface JaxrsMessages {
 
     @Message(id = 11235, value = "Invalid value for parameter %s: %s")
     DeploymentUnitProcessingException invalidParamValue(String param, String value);
+
+    @Message(id = 11236, value = "No spring integration jar found")
+    DeploymentUnitProcessingException noSpringIntegrationJar();
 }
 

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemAdd.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsSubsystemAdd.java
@@ -33,6 +33,7 @@ import org.jboss.as.jaxrs.deployment.JaxrsComponentDeployer;
 import org.jboss.as.jaxrs.deployment.JaxrsDependencyProcessor;
 import org.jboss.as.jaxrs.deployment.JaxrsIntegrationProcessor;
 import org.jboss.as.jaxrs.deployment.JaxrsScanningProcessor;
+import org.jboss.as.jaxrs.deployment.JaxrsSpringProcessor;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
@@ -57,6 +58,7 @@ class JaxrsSubsystemAdd extends AbstractBoottimeAddStepHandler {
         context.addStep(new AbstractDeploymentChainStep() {
             public void execute(DeploymentProcessorTarget processorTarget) {
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_JAXRS_ANNOTATIONS, new JaxrsAnnotationProcessor());
+                processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_JAXRS_SPRING, new JaxrsSpringProcessor());
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_JAXRS, new JaxrsDependencyProcessor());
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_JAXRS_SCANNING, new JaxrsScanningProcessor());
                 processorTarget.addDeploymentProcessor(JaxrsExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_JAXRS_COMPONENT, new JaxrsComponentDeployer());

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jaxrs.deployment;
+
+import org.jboss.as.jaxrs.JaxrsMessages;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.deployment.module.ModuleRootMarker;
+import org.jboss.as.server.deployment.module.MountHandle;
+import org.jboss.as.server.deployment.module.ResourceRoot;
+import org.jboss.as.server.deployment.module.TempFileProviderService;
+import org.jboss.as.web.common.WarMetaData;
+import org.jboss.metadata.javaee.spec.ParamValueMetaData;
+import org.jboss.metadata.web.jboss.JBossServletMetaData;
+import org.jboss.metadata.web.jboss.JBossWebMetaData;
+import org.jboss.metadata.web.spec.ListenerMetaData;
+import org.jboss.vfs.VFS;
+import org.jboss.vfs.VirtualFile;
+
+import java.io.Closeable;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Recognize Spring deployment and add the JAX-RS integration to it
+ */
+public class JaxrsSpringProcessor implements DeploymentUnitProcessor {
+
+
+    public static final String SPRING_INT_JAR = "resteasy-spring.jar";
+    public static final String SPRING_LISTENER = "org.resteasy.plugins.spring.SpringContextLoaderListener";
+    public static final String SPRING_SERVLET = "org.springframework.web.servlet.DispatcherServlet";
+    public static final String DISABLE_PROPERTY = "org.jboss.as.jaxrs.disableSpringIntegration";
+
+
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        if (deploymentUnit.getParent() != null) {
+            return;
+        }
+
+        final List<DeploymentUnit> deploymentUnits = new ArrayList<DeploymentUnit>();
+        deploymentUnits.add(deploymentUnit);
+        deploymentUnits.addAll(deploymentUnit.getAttachmentList(Attachments.SUB_DEPLOYMENTS));
+
+        boolean found = false;
+        for (DeploymentUnit unit : deploymentUnits) {
+
+            WarMetaData warMetaData = unit.getAttachment(WarMetaData.ATTACHMENT_KEY);
+            if (warMetaData == null) {
+                continue;
+            }
+            JBossWebMetaData md = warMetaData.getMergedJBossWebMetaData();
+            if (md == null) {
+                continue;
+            }
+            if (md.getContextParams() != null) {
+                boolean skip = false;
+                for (ParamValueMetaData prop : md.getContextParams()) {
+                    if (prop.getParamName().equals(DISABLE_PROPERTY) && "true".equals(prop.getParamValue())) {
+                        skip = true;
+                    }
+                }
+                if (skip) {
+                    continue;
+                }
+            }
+
+            if (md.getListeners() != null) {
+                for (ListenerMetaData listener : md.getListeners()) {
+                    if (SPRING_LISTENER.equals(listener.getListenerClass())) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if(md.getServlets() != null) {
+                for (JBossServletMetaData servlet : md.getServlets()) {
+                    if (SPRING_SERVLET.equals(servlet.getServletClass())) {
+                        found = true;
+                        break;
+                    }
+                }
+            }
+            if (found) {
+                try {
+                    URL url = this.getClass().getClassLoader().getResource(SPRING_INT_JAR);
+                    if (url == null) {
+                        throw JaxrsMessages.MESSAGES.noSpringIntegrationJar();
+                    }
+
+                    File file = new File(url.toURI());
+                    VirtualFile vf = VFS.getChild(file.toURI());
+                    final Closeable mountHandle = VFS.mountZip(file, vf, TempFileProviderService.provider());
+
+                    MountHandle mh = new MountHandle(mountHandle); // actual close is done by the MSC service above
+                    ResourceRoot resourceRoot = new ResourceRoot(vf, mh);
+                    ModuleRootMarker.mark(resourceRoot);
+                    deploymentUnit.addToAttachmentList(Attachments.RESOURCE_ROOTS, resourceRoot);
+                } catch (Exception e) {
+                    throw new DeploymentUnitProcessingException(e);
+                }
+                return;
+            }
+        }
+    }
+
+
+    public void undeploy(DeploymentUnit context) {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -5090,6 +5090,18 @@
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
+                <artifactId>resteasy-spring</artifactId>
+                <version>${version.org.jboss.resteasy}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss.spec.javax.annotation</groupId>
+                        <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>resteasy-cdi</artifactId>
                 <version>${version.org.jboss.resteasy}</version>
                 <exclusions>

--- a/server/src/main/java/org/jboss/as/server/deployment/Phase.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/Phase.java
@@ -353,6 +353,7 @@ public enum Phase {
     public static final int DEPENDENCIES_WS                             = 0x0C00;
     public static final int DEPENDENCIES_SECURITY                       = 0x0C50;
     public static final int DEPENDENCIES_JAXRS                          = 0x0D00;
+    public static final int DEPENDENCIES_JAXRS_SPRING                   = 0x0D80;
     public static final int DEPENDENCIES_SUB_DEPLOYMENTS                = 0x0E00;
     public static final int DEPENDENCIES_PERSISTENCE_ANNOTATION         = 0x0F00;
     public static final int DEPENDENCIES_JPA                            = 0x1000;


### PR DESCRIPTION
This will add the resteasy-spring.jar as a resource root, if either of the
SpringContextLoaderListener or Spring DispatcherServlet is present in the deployment.

This integration can be disabled by setting a context param
in web.xml with a name of org.jboss.as.jaxrs.disableSpringIntegration
and a value of true.
