### PR TITLE
CLI fixes

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-cli_2_0.xsd
@@ -202,6 +202,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
+            <xs:element name="vault" type="vaultType" minOccurs="0" />
             <xs:element name="key-store" type="xs:string" minOccurs="0" />
             <xs:element name="key-store-password" type="xs:string" minOccurs="0" />
             <xs:element name="alias" type="xs:string" minOccurs="0" />
@@ -219,4 +220,12 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="vaultType">
+        <xs:annotation>
+            <xs:documentation>
+                Element of this type points to a file with vault configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="file" type="xs:string" use="required"/>
+    </xs:complexType>
 </xs:schema>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -47,6 +47,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.threads"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.picketbox"/>
         <module name="javax.api"/>
     </dependencies>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -134,6 +134,11 @@
            <artifactId>jboss-vfs</artifactId>
         </dependency>
 
+        <dependency>
+           <groupId>org.picketbox</groupId>
+           <artifactId>picketbox</artifactId>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
@@ -229,10 +229,10 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
         try {
             response = client.execute(request);
         } catch (Exception e) {
-            throw new CommandFormatException("Failed to perform operation: " + e.getLocalizedMessage());
+            throw new CommandLineException("Failed to perform operation", e);
         }
         if (!Util.isSuccess(response)) {
-            throw new CommandFormatException(Util.getFailureDescription(response));
+            throw new CommandLineException(Util.getFailureDescription(response));
         }
         handleResponse(ctx, response, Util.COMPOSITE.equals(request.get(Util.OPERATION).asString()));
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/batch/BatchRunHandler.java
@@ -72,7 +72,8 @@ public class BatchRunHandler extends BaseOperationCommand {
             super.doHandle(ctx);
         } catch(CommandLineException e) {
             failed = true;
-            throw e;
+            throw new CommandLineException("The batch failed with the following error "
+                    + "(you are remaining in the batch editing mode to have a chance to correct the error)", e);
         } finally{
             if(!failed) {
                 if(ctx.getBatchManager().isBatchActive()) {

--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIVaultReader.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIVaultReader.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.impl;
+
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.regex.Pattern;
+
+import org.jboss.security.vault.SecurityVault;
+import org.jboss.security.vault.SecurityVaultException;
+import org.picketbox.plugins.vault.PicketBoxSecurityVault;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+class CLIVaultReader {
+
+    private static final Pattern VAULT_PATTERN = Pattern.compile("VAULT::.*::.*::.*");
+    private static final Charset CHARSET = Charset.forName("UTF-8");
+
+    private volatile SecurityVault vault;
+
+    CLIVaultReader() {
+    }
+
+    void init(Map<String, Object> options) throws SecurityVaultException {
+        vault = new PicketBoxSecurityVault();
+        vault.init(options);
+    }
+
+    String retrieve(String password) throws SecurityVaultException {
+        if(isVaultFormat(password)) {
+            char[] retrieved = getValue(password);
+            return retrieved != null ? new String(retrieved) : null;
+        }
+        return password;
+    }
+
+    boolean isVaultFormat(String str) {
+        return str != null && VAULT_PATTERN.matcher(str).matches();
+    }
+
+    private char[] getValue(String vaultString) throws SecurityVaultException {
+        if(vault == null) {
+            throw new SecurityVaultException("Vault has not been initialized.");
+        }
+        String[] tokens = tokens(vaultString);
+        byte[] sharedKey = null;
+        if (tokens.length > 2) {
+            // only in case of conversion of old vault implementation
+            sharedKey = tokens[3].getBytes(CHARSET);
+        }
+        return vault.retrieve(tokens[1], tokens[2], sharedKey);
+    }
+
+    private String[] tokens(String vaultString) {
+        StringTokenizer tokenizer = new StringTokenizer(vaultString, "::");
+        int length = tokenizer.countTokens();
+        String[] tokens = new String[length];
+
+        int index = 0;
+        while (tokenizer != null && tokenizer.hasMoreTokens()) {
+            tokens[index++] = tokenizer.nextToken();
+        }
+        return tokens;
+    }
+}

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -113,31 +113,49 @@ public class CliLauncher {
                         break;
                     }
                     if(commands != null) {
-                        argError = "Duplicate argument '--command'/'--commands'.";
+                        argError = "'" + arg +
+                                "' is assumed to be a command(s) but the commands to execute have been specified by another argument: " +
+                                commands;
                         break;
                     }
                     final String value = arg.startsWith("--") ? arg.substring(10) : arg.substring(8);
                     commands = Collections.singletonList(value);
-                } else if (arg.startsWith("--user=")) {
-                    username = arg.startsWith("--") ? arg.substring(7) : arg.substring(5);
-                    noLocalAuth = true;
-                } else if (arg.startsWith("--password=")) {
-                    password = (arg.startsWith("--") ? arg.substring(11) : arg.substring(9)).toCharArray();
+                } else if (arg.startsWith("--user")) {
+                    if(arg.length() > 6 && arg.charAt(6) == '=') {
+                        username = arg.substring(7);
+                        noLocalAuth = true;
+                    } else {
+                        argError = "'=' is missing after --user";
+                        break;
+                    }
+                } else if (arg.startsWith("--password")) {
+                    if(arg.length() > 10 && arg.charAt(10) == '=') {
+                        password = arg.substring(11).toCharArray();
+                    } else {
+                        argError = "'=' is missing after --password";
+                        break;
+                    }
                 } else if (arg.equals("--no-local-auth")) {
                     noLocalAuth = true;
-                } else if (arg.startsWith("--timeout=")) {
+                } else if (arg.startsWith("--timeout")) {
                     if (connectionTimeout > 0) {
                         argError = "Duplicate argument '--timeout'";
                         break;
                     }
-                    final String value = arg.substring(10);
-                    try {
-                        connectionTimeout = Integer.parseInt(value);
-                    } catch (final NumberFormatException e) {
-                        //
-                    }
-                    if (connectionTimeout <= 0) {
-                        argError = "The timeout must be a valid positive integer: '" + value + "'";
+                    if(arg.length() > 9 && arg.charAt(9) == '=') {
+                        final String value = arg.substring(10);
+                        try {
+                            connectionTimeout = Integer.parseInt(value);
+                        } catch (final NumberFormatException e) {
+                            //
+                        }
+                        if (connectionTimeout <= 0) {
+                            argError = "The timeout must be a valid positive integer: '" + value + "'";
+                            break;
+                        }
+                    } else {
+                        argError = "'=' is missing after --timeout";
+                        break;
                     }
                 } else if (arg.equals("--help") || arg.equals("-h")) {
                     commands = Collections.singletonList("help");
@@ -177,7 +195,9 @@ public class CliLauncher {
                         break;
                     }
                     if(commands != null) {
-                        argError = "Duplicate argument '--command'/'--commands'.";
+                        argError = "'" + arg +
+                                "' is assumed to be a command(s) but the commands to execute have been specified by another argument: " +
+                                commands;
                         break;
                     }
                     commands = Util.splitCommands(arg);

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliLauncher.java
@@ -198,43 +198,34 @@ public class CliLauncher {
 
             if(file != null) {
                 cmdCtx = initCommandContext(defaultController, username, password, noLocalAuth, false, connect, connectionTimeout);
-                try {
-                    runcom(cmdCtx);
-                    processFile(file, cmdCtx);
-                } finally {
-                    cmdCtx.terminateSession();
-                }
+                processFile(file, cmdCtx);
                 return;
             }
 
             if(commands != null) {
                 cmdCtx = initCommandContext(defaultController, username, password, noLocalAuth, false, connect, connectionTimeout);
-                try {
-                    runcom(cmdCtx);
-                    processCommands(commands, cmdCtx);
-                } finally {
-                    cmdCtx.terminateSession();
-                }
+                processCommands(commands, cmdCtx);
                 return;
             }
 
             if (gui) {
                 cmdCtx = initCommandContext(defaultController, username, password, noLocalAuth, false, true, connectionTimeout);
-                runcom(cmdCtx);
                 processGui(cmdCtx);
                 return;
             }
 
             // Interactive mode
             cmdCtx = initCommandContext(defaultController, username, password, noLocalAuth, true, connect, connectionTimeout);
-            runcom(cmdCtx);
             cmdCtx.interact();
         } catch(Throwable t) {
             t.printStackTrace();
             exitCode = 1;
         } finally {
-            if(cmdCtx != null && cmdCtx.getExitCode() != 0) {
-                exitCode = cmdCtx.getExitCode();
+            if(cmdCtx != null) {
+                cmdCtx.terminateSession();
+                if(cmdCtx.getExitCode() != 0) {
+                    exitCode = cmdCtx.getExitCode();
+                }
             }
             if (!gui) {
                 System.exit(exitCode);
@@ -292,7 +283,7 @@ public class CliLauncher {
     private static final String CURRENT_WORKING_DIRECTORY = "user.dir";
     private static final String JBOSS_CLI_RC_FILE = ".jbossclirc";
 
-    private static void runcom(CommandContext ctx) throws CliInitializationException {
+    static void runcom(CommandContext ctx) throws CliInitializationException {
         File jbossCliRcFile = null;
         // system property first
         String jbossCliRc = WildFlySecurityManager.getPropertyPrivileged(JBOSS_CLI_RC_PROPERTY, null);

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -258,6 +258,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         disableLocalAuth = false;
         initSSLContext();
         addShutdownHook();
+        CliLauncher.runcom(this);
     }
 
     CommandContextImpl(String username, char[] password, boolean disableLocalAuth) throws CliInitializationException {
@@ -298,6 +299,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         }
 
         addShutdownHook();
+        CliLauncher.runcom(this);
     }
 
     CommandContextImpl(String defaultController,
@@ -327,6 +329,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         this.operationCandidatesProvider = new DefaultOperationCandidatesProvider();
 
         addShutdownHook();
+        CliLauncher.runcom(this);
     }
 
     protected void addShutdownHook() {
@@ -661,10 +664,12 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
 
     @Override
     public void terminateSession() {
-        terminate = true;
-        disconnectController();
-        if(shutdownHook != null) {
-            CliShutdownHook.remove(shutdownHook);
+        if(!terminate) {
+            terminate = true;
+            disconnectController();
+            if (shutdownHook != null) {
+                CliShutdownHook.remove(shutdownHook);
+            }
         }
     }
 

--- a/cli/src/main/java/org/jboss/as/cli/impl/FileSystemPathArgument.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/FileSystemPathArgument.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.cli.impl;
 
+import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.handlers.CommandHandlerWithArguments;
 import org.jboss.as.cli.handlers.FilenameTabCompleter;
 import org.jboss.as.cli.operation.ParsedCommandLine;
@@ -46,7 +47,15 @@ public class FileSystemPathArgument extends ArgumentWithValue {
 
     @Override
     public String getValue(ParsedCommandLine args) {
-        String value = super.getValue(args);
+        return translatePath(super.getValue(args));
+    }
+
+    @Override
+    public String getValue(ParsedCommandLine args, boolean required) throws CommandFormatException {
+        return translatePath(super.getValue(args, required));
+    }
+
+    private String translatePath(String value) {
         if(value != null) {
             if(value.length() >= 0 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
                 value = value.substring(1, value.length() - 1);
@@ -57,5 +66,4 @@ public class FileSystemPathArgument extends ArgumentWithValue {
         }
         return value;
     }
-
 }

--- a/cli/src/main/java/org/jboss/as/cli/impl/FileSystemPathArgument.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/FileSystemPathArgument.java
@@ -46,11 +46,6 @@ public class FileSystemPathArgument extends ArgumentWithValue {
     }
 
     @Override
-    public String getValue(ParsedCommandLine args) {
-        return translatePath(super.getValue(args));
-    }
-
-    @Override
     public String getValue(ParsedCommandLine args, boolean required) throws CommandFormatException {
         return translatePath(super.getValue(args, required));
     }

--- a/cli/src/main/java/org/jboss/as/cli/impl/VaultConfig.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/VaultConfig.java
@@ -1,0 +1,142 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.impl;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.namespace.QName;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.jboss.as.protocol.StreamUtils;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLMapper;
+
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+class VaultConfig {
+
+    private final Map<String, Object> options = new HashMap<String, Object>();
+
+    static VaultConfig load(File f) throws XMLStreamException {
+        if(f == null) {
+            throw new IllegalArgumentException("File is null");
+        }
+        if(!f.exists()) {
+            throw new XMLStreamException("Failed to locate vault file " + f.getAbsolutePath());
+        }
+
+        final VaultConfig config = new VaultConfig();
+        BufferedInputStream input = null;
+        try {
+            final XMLMapper mapper = XMLMapper.Factory.create();
+            final XMLElementReader<VaultConfig> reader = new VaultConfigReader();
+            mapper.registerRootElement(new QName(VaultConfigReader.VAULT), reader);
+            FileInputStream is = new FileInputStream(f);
+            input = new BufferedInputStream(is);
+            XMLStreamReader streamReader = XMLInputFactory.newInstance().createXMLStreamReader(input);
+            mapper.parseDocument(config, streamReader);
+            streamReader.close();
+        } catch(FileNotFoundException e) {
+            throw new XMLStreamException("Vault file not found", e);
+        } catch(XMLStreamException t) {
+            throw t;
+        } finally {
+            StreamUtils.safeClose(input);
+        }
+        return config;
+    }
+
+    Map<String, Object> getOptions() {
+        return options;
+    }
+
+    void addOption(String name, String value) {
+        if(name == null || name.isEmpty()) {
+            throw new IllegalArgumentException("name is null or empty");
+        }
+        if(value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("value is null or empty");
+        }
+        options.put(name, value);
+    }
+
+    static class VaultConfigReader implements XMLElementReader<VaultConfig> {
+
+        static final String NAME = "name";
+        static final String VALUE = "value";
+        static final String VAULT = "vault";
+        static final String VAULT_OPTION = "vault-option";
+
+        @Override
+        public void readElement(XMLExtendedStreamReader reader, VaultConfig config) throws XMLStreamException {
+
+            String rootName = reader.getLocalName();
+            if (VAULT.equals(rootName) == false) {
+                throw new XMLStreamException("Unexpected element: " + rootName);
+            }
+
+            boolean done = false;
+            while (reader.hasNext() && done == false) {
+                int tag = reader.nextTag();
+                if(tag == XMLStreamConstants.START_ELEMENT) {
+                    final String localName = reader.getLocalName();
+                    if (localName.equals(VAULT_OPTION)) {
+                        final String name = reader.getAttributeValue(null, NAME);
+                        if(name == null) {
+                            throw new XMLStreamException("Attribute '" + NAME +
+                                    "' is not found for element '" +
+                                    VAULT_OPTION + "' at " + reader.getLocation());
+                        }
+                        final String value = reader.getAttributeValue(null, VALUE);
+                        if(value == null) {
+                            throw new XMLStreamException("Attribute '" + VALUE +
+                                    "' is not found for element " +
+                                    VAULT_OPTION + "' at " + reader.getLocation());
+                        }
+                        config.addOption(name.trim(), value.trim());
+                        CliConfigImpl.CliConfigReader.requireNoContent(reader);
+                    } else {
+                        throw new XMLStreamException("Unexpected element: " + localName);
+                    }
+                } else if(tag == XMLStreamConstants.END_ELEMENT) {
+                    final String localName = reader.getLocalName();
+                    if (localName.equals(VAULT)) {
+                        done = true;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/FilenameTabCompleterTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/FilenameTabCompleterTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.cli.parsing.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+import org.jboss.as.cli.CliInitializationException;
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.handlers.CommandHandlerWithArguments;
+import org.jboss.as.cli.handlers.DefaultFilenameTabCompleter;
+import org.jboss.as.cli.impl.FileSystemPathArgument;
+import org.jboss.as.cli.operation.impl.DefaultCallbackHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class FilenameTabCompleterTestCase {
+
+    private CommandContext ctx;
+    private FileSystemPathArgument arg;
+    private DefaultCallbackHandler parsedCmd;
+    
+    @Before
+    public void setup() throws CliInitializationException {
+        ctx = CommandContextFactory.getInstance().newCommandContext();
+        final DefaultFilenameTabCompleter completer = new DefaultFilenameTabCompleter(ctx);
+
+        final CommandHandlerWithArguments cmd = new CommandHandlerWithArguments(){
+
+            @Override
+            public boolean isAvailable(CommandContext ctx) {
+                // TODO Auto-generated method stub
+                return false;
+            }
+
+            @Override
+            public boolean isBatchMode(CommandContext ctx) {
+                // TODO Auto-generated method stub
+                return false;
+            }
+
+            @Override
+            public void handle(CommandContext ctx) throws CommandLineException {
+                // TODO Auto-generated method stub
+                
+            }};
+        
+        arg = new FileSystemPathArgument(cmd, completer, 0, "arg");
+        parsedCmd = new DefaultCallbackHandler();
+    }
+    
+    @After
+    public void tearDown() {
+        ctx.terminateSession();
+        ctx = null;
+        arg = null;
+        parsedCmd = null;
+    }
+    
+    @Test
+    public void testTranslateGetValue() throws Exception {
+        parsedCmd.parse(null, "cmd ~" + File.separator, ctx);
+        assertEquals(SecurityActions.getProperty("user.home") + File.separator, arg.getValue(parsedCmd));
+    }
+
+    @Test
+    public void testTranslateGetValueRequired() throws Exception {
+        parsedCmd.parse(null, "cmd ~" + File.separator, ctx);
+        assertEquals(SecurityActions.getProperty("user.home") + File.separator, arg.getValue(parsedCmd, true));
+    }
+}

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/SecurityActions.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/SecurityActions.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.cli.parsing.test;
+
+import org.wildfly.security.manager.action.GetSystemPropertiesAction;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+import static java.security.AccessController.doPrivileged;
+
+/**
+ * Package privileged actions
+ *
+ * @author Alexey Loubyansky
+ */
+class SecurityActions {
+    static String getProperty(String name) {
+        if (! WildFlySecurityManager.isChecking()) {
+            return System.getProperty(name);
+        } else {
+            return doPrivileged(GetSystemPropertiesAction.getInstance()).getProperty(name);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/CliScriptTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/CliScriptTestBase.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.jboss.as.cli.Util;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
@@ -73,7 +74,15 @@ public class CliScriptTestBase {
         return execute(TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), connect, cmd, logFailure);
     }
 
+    protected int execute(boolean connect, String cmd, boolean logFailure, Map<String,String> props) {
+        return execute(TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), connect, cmd, logFailure, props);
+    }
+
     protected int execute(String host, int port, boolean connect, String cmd, boolean logFailure) {
+        return execute(host, port, connect, cmd, logFailure, null);
+    }
+    
+    protected int execute(String host, int port, boolean connect, String cmd, boolean logFailure, Map<String,String> props) {
         cliOutput = null;
         final String jbossDist = TestSuiteEnvironment.getSystemProperty("jboss.dist");
         if (jbossDist == null) {
@@ -90,6 +99,11 @@ public class CliScriptTestBase {
         command.add(TestSuiteEnvironment.getJavaPath());
         TestSuiteEnvironment.getIpv6Args(command);
         command.add("-Djboss.cli.config=" + jbossDist + File.separator + "bin" + File.separator + "jboss-cli.xml");
+        if(props != null && !props.isEmpty()) {
+            for(String name : props.keySet()) {
+                command.add("-D" + name + "=" + props.get(name));
+            }
+        }
         command.add("-jar");
         command.add(jbossDist + File.separatorChar + "jboss-modules.jar");
         command.add("-mp");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/JBossclircTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/JBossclircTestCase.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Collections;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandContextFactory;
+import org.jboss.as.cli.Util;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * @author Alexey Loubyansky
+ *
+ */
+public class JBossclircTestCase extends CliScriptTestBase {
+
+    private static final String JBOSS_CLI_RC_PROP = "jboss.cli.rc";
+    private static final String VAR_NAME = "test_var_name";
+    private static final String VAR_VALUE = "test_var_value";
+    
+    private static final File TMP_JBOSS_CLI_RC;
+    static {
+        TMP_JBOSS_CLI_RC = new File(new File(TestSuiteEnvironment.getTmpDir()), ".tmp-jbossclirc");
+    }
+
+    @BeforeClass
+    public static void setup() {
+        ensureRemoved(TMP_JBOSS_CLI_RC);
+        BufferedWriter writer = null;
+        try {
+            writer = new BufferedWriter(new FileWriter(TMP_JBOSS_CLI_RC));
+            writer.write("set " + VAR_NAME + "=" + VAR_VALUE);
+            writer.newLine();
+        } catch(IOException e) {
+            fail(e.getLocalizedMessage());
+        } finally {
+            if(writer != null) {
+                try {
+                    writer.close();
+                } catch (IOException e) {}
+            }
+        }
+    }
+    
+    @AfterClass
+    public static void cleanUp() {
+        ensureRemoved(TMP_JBOSS_CLI_RC);
+    }
+    
+    @Before
+    public void beforeTest() {
+        TestSuiteEnvironment.setSystemProperty(JBOSS_CLI_RC_PROP, TMP_JBOSS_CLI_RC.getAbsolutePath());
+    }
+    
+    @After
+    public void afterTest() {
+        TestSuiteEnvironment.clearSystemProperty(JBOSS_CLI_RC_PROP);
+    }
+    
+    @Test
+    public void testAPI() throws Exception {
+        CommandContext ctx = null;
+        try {
+            ctx = CommandContextFactory.getInstance().newCommandContext();
+            assertEquals(VAR_VALUE, ctx.getVariable(VAR_NAME));
+        } finally {
+            if(ctx != null) {
+                ctx.terminateSession();
+            }
+        }
+    }
+
+    @Test
+    public void testScript() throws Exception {
+        assertEquals(0, execute(false, "echo $" + VAR_NAME, false,
+                Collections.singletonMap(JBOSS_CLI_RC_PROP, TMP_JBOSS_CLI_RC.getAbsolutePath())));
+        assertTrue(getLastCommandOutput().endsWith(Util.LINE_SEPARATOR + VAR_VALUE + Util.LINE_SEPARATOR));
+    }
+    
+    protected static void ensureRemoved(File f) {
+        if(f.exists()) {
+            if(!f.delete()) {
+                fail("Failed to delete " + f.getAbsolutePath());
+            }
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TestSuiteEnvironment.java
@@ -49,6 +49,14 @@ public class TestSuiteEnvironment {
         return System.getProperty(name);
     }
 
+    public static void setSystemProperty(String name, String value) {
+        System.setProperty(name, value);
+    }
+
+    public static void clearSystemProperty(String name) {
+        System.clearProperty(name);
+    }
+
     public static String getTmpDir() {
         return getSystemProperty("java.io.tmpdir");
     }


### PR DESCRIPTION
- addition to https://issues.jboss.org/browse/WFLY-1063 CLI variables: make sure .jbossclirc is also effective for CLI API clients
- https://issues.jboss.org/browse/WFLY-2636 cli should be able to use the vault to encrypt a keystore password
- https://issues.jboss.org/browse/WFLY-2794 FileSystemPathArgument doesn't translate paths in getValue(args, required)

Thanks,
Alexey
