### PR TITLE
Fix transient failures in CommandDispatcherTestCase.

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ServiceCommandDispatcher.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ServiceCommandDispatcher.java
@@ -202,7 +202,7 @@ public abstract class ServiceCommandDispatcher<C> implements CommandDispatcher<C
     }
 
     private RequestOptions createRequestOptions() {
-        return new RequestOptions(ResponseMode.GET_ALL, this.timeout, false, FILTER, Message.Flag.DONT_BUNDLE);
+        return new RequestOptions(ResponseMode.GET_ALL, this.timeout, false, FILTER, Message.Flag.DONT_BUNDLE, Message.Flag.OOB);
     }
 
     static <R> CommandResponse<R> createCommandResponse(Rsp<R> response) {


### PR DESCRIPTION
Messages need to be flagged with _both_ DONT_BUNDLE and OOB to disable message batching on the receiver.
