### PR TITLE
[WFLY-2756] hard-coded connector for connection factory definition

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -211,4 +211,15 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 11615, value = "Registered HTTP upgrade handler for %s protocol")
     void registeredHTTPUpgradeHandler(String name);
+
+    /**
+     * Logs an warn message when no connectors were specified for a connection factory definition
+     * and one connector was picked up to be used.
+     *
+     * @param name the name of the connection factory definition
+     * @param connectorName the name of the connector that was picked
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11616, value = "No connectors were explicitly defined for the pooled connection factory %s. Using %s as the connector.")
+    void connectorForPooledConnectionFactory(String name, String connectorName);
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/DirectJMSConnectionFactoryInjectionSource.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/DirectJMSConnectionFactoryInjectionSource.java
@@ -180,8 +180,14 @@ public class DirectJMSConnectionFactoryInjectionSource extends InjectionSource {
             model.get(CommonAttributes.CLIENT_ID.getName()).set(clientId);
         }
 
-        String discoveryGroupName = model.hasDefined(DISCOVERY_GROUP_NAME.getName()) ? model.get(DISCOVERY_GROUP_NAME.getName()).asString() : null;
-        String jgroupsChannelName = model.hasDefined(JGROUPS_CHANNEL.getName()) ? model.get(JGROUPS_CHANNEL.getName()).asString() : null;
+        final String discoveryGroupName = properties.containsKey(DISCOVERY_GROUP_NAME.getName()) ? properties.get(DISCOVERY_GROUP_NAME.getName()) : null;
+        if (discoveryGroupName != null) {
+            model.get(DISCOVERY_GROUP_NAME.getName()).set(discoveryGroupName);
+        }
+        final String jgroupsChannelName = properties.containsKey(JGROUPS_CHANNEL.getName()) ? properties.get(JGROUPS_CHANNEL.getName()) : null;
+        if (jgroupsChannelName != null) {
+            model.get(JGROUPS_CHANNEL.getName()).set(jgroupsChannelName);
+        }
 
         List<PooledConnectionFactoryConfigProperties> adapterParams = getAdapterParams(model);
         String txSupport = transactional ? XA_TX : NO_TX;
@@ -191,7 +197,7 @@ public class DirectJMSConnectionFactoryInjectionSource extends InjectionSource {
         PooledConnectionFactoryService.installService(null, null, serviceTarget, pcfName, getHornetQServerName(), connectors,
                 discoveryGroupName, jgroupsChannelName, adapterParams,
                 bindInfo,
-                txSupport, minPoolSize, maxPoolSize);
+                txSupport, minPoolSize, maxPoolSize, true);
 
         final ServiceName referenceFactoryServiceName = ConnectionFactoryReferenceFactoryService.SERVICE_NAME_BASE
                 .append(bindInfo.getBinderServiceName());
@@ -209,9 +215,7 @@ public class DirectJMSConnectionFactoryInjectionSource extends InjectionSource {
 
     private List<String> getConnectors(Map<String, String> props) {
         List<String> connectors = new ArrayList<>();
-        if (!props.containsKey(CONNECTOR)) {
-            connectors.add("netty");
-        } else {
+        if (props.containsKey(CONNECTOR)) {
             String connectorsStr = properties.remove(CONNECTOR);
             for (String s : connectorsStr.split(",")) {
                 String connector = s.trim();
@@ -220,7 +224,7 @@ public class DirectJMSConnectionFactoryInjectionSource extends InjectionSource {
                 }
             }
         }
-        return  connectors;
+        return connectors;
     }
 
     void clearUnknownProperties(final Map<String, String> props) {


### PR DESCRIPTION
remove hard-coded "netty" connector when a connection factory definition
does not specified any connector and pick one instead from the runtime
hornetq server (and warns the users he should explicitly set it up)

JIRA: https://issues.jboss.org/browse/WFLY-2756
