### PR TITLE
Initial linux based server killer implementation

### DIFF
--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolClientExtension.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/JMXProtocolClientExtension.java
@@ -32,5 +32,6 @@ public class JMXProtocolClientExtension implements LoadableExtension {
     public void register(ExtensionBuilder builder) {
         builder.service(Protocol.class, JMXProtocolAS7.class);
         builder.observer(ArquillianServiceDeployer.class);
+        builder.observer(ServerKillerExtension.class);
     }
 }

--- a/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/ServerKillerExtension.java
+++ b/arquillian/protocol-jmx/src/main/java/org/jboss/as/arquillian/protocol/jmx/ServerKillerExtension.java
@@ -1,0 +1,109 @@
+package org.jboss.as.arquillian.protocol.jmx;
+
+import org.jboss.arquillian.container.spi.event.container.BeforeSetup;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ *
+ * Massive hack that attempts to improve test suite reliability by killing servers between runs
+ *
+ * This means that if a server fails to stop it will not affect later runs
+ *
+ *
+ * @author Stuart Douglas
+ */
+public class ServerKillerExtension {
+
+    public static final String ORG_WILDFLY_TEST_KILL_SERVERS_BEFORE_TEST = "org.wildfly.test.kill-servers-before-test";
+
+    private static volatile String errorProcessTable;
+
+    private static boolean runOncePerSuite = true;
+
+    public void beforeSuite(@Observes BeforeSetup start) {
+        if(runOncePerSuite) {
+            killServers();
+        }
+    }
+
+    public void killServers() {
+        if(!Boolean.getBoolean(ORG_WILDFLY_TEST_KILL_SERVERS_BEFORE_TEST)) {
+            return;
+        }
+        runOncePerSuite = false;
+
+        //server is running and port is open.
+        Runtime rt = Runtime.getRuntime();
+        if (System.getProperty("os.name").toLowerCase().indexOf("windows") > -1) {
+            //rt.exec("taskkill " +....); //windows not supported yet
+        } else {
+            killLinux(rt);
+        }
+    }
+
+    public void throwErrpr(@Observes AfterSuite start) {
+        runOncePerSuite = true;
+        String result = errorProcessTable;
+        errorProcessTable = null;
+        if(result != null) {
+            throw new RuntimeException("There was a server running at the start of the test run execution. jstack output was \n" + result);
+        }
+    }
+
+
+    private void killLinux(Runtime rt) {
+        try {
+
+            //get a jstack of all the processes
+            Process process = rt.exec(new String[]{"/bin/sh", "-c", "ps -eaf --columns 20000 | grep org.jboss.as | grep jboss-modules.jar | grep -v -w grep | awk '{ print $2; }' | xargs --no-run-if-empty jstack"});
+            InputStream in = process.getInputStream();
+            String processTable = readString(in);
+            if(!processTable.isEmpty()) {
+                readString(rt.exec(new String[]{"/bin/sh", "-c", "ps -eaf --columns 20000 | grep org.jboss.as | grep jboss-modules.jar | grep -v -w grep | awk '{ print $2; }' | xargs --no-run-if-empty kill -9"}).getInputStream());
+                errorProcessTable = processTable;
+            }
+            long end = System.currentTimeMillis() + 5000;
+            while (System.currentTimeMillis() < end) {
+                String running = readString(rt.exec(new String[]{"/bin/sh", "-c", "ps -eaf --columns 20000 | grep org.jboss.as | grep jboss-modules.jar | grep -v -w grep | awk '{ print $2; }'"}).getInputStream());
+                if(running.isEmpty()) {
+                    break;
+                } else {
+                    Thread.sleep(100);
+                }
+            }
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String readString(InputStream file) {
+        BufferedInputStream stream = null;
+        try {
+            stream = new BufferedInputStream(file);
+            byte[] buff = new byte[1024];
+            StringBuilder builder = new StringBuilder();
+            int read = -1;
+            while ((read = stream.read(buff)) != -1) {
+                builder.append(new String(buff, 0, read));
+            }
+            return builder.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            if (stream != null) {
+                try {
+                    stream.close();
+                } catch (IOException e) {
+                    //ignore
+                }
+            }
+        }
+    }
+
+}

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -151,6 +151,9 @@
         <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>
         <surefire.forked.process.timeout>1500</surefire.forked.process.timeout>
 
+        <!-- If servers should be killed before the test suite is run-->
+        <org.wildfly.test.kill-servers-before-test>false</org.wildfly.test.kill-servers-before-test>
+
         <!-- Arquillian dependency versions -->
         <version.arquillian_wildfly>${project.parent.version}</version.arquillian_wildfly>
         <version.saxon>8.7</version.saxon>
@@ -355,6 +358,7 @@
                            <jboss.dist>${jboss.dist}</jboss.dist>
                            <jboss.home>${basedir}/target/jbossas</jboss.home>
                            <module.path>${jboss.dist}/modules${path.separator}${basedir}/target/modules</module.path>
+                           <org.wildfly.test.kill-servers-before-test>${org.wildfly.test.kill-servers-before-test}</org.wildfly.test.kill-servers-before-test>
                        </systemPropertyVariables>
                        <!-- Arquillian's config files. -->
                        <additionalClasspathElements combine.children="append">


### PR DESCRIPTION
This allows us to kill all running servers before a suite starts, which means that if a server fails to stop it will not hose the rest of the test suite run. 

The build will still be failed, and the jstack output of the problematic process included in the failure exception, which will hopefully make it easier to figure out why the process did not stop.
