### PR TITLE
WFLY-2610 vault tool can take an external password

### DIFF
--- a/security/src/main/java/org/jboss/as/security/vault/VaultSession.java
+++ b/security/src/main/java/org/jboss/as/security/vault/VaultSession.java
@@ -183,7 +183,9 @@ public final class VaultSession {
         if (vaultAlias == null) {
             throw VaultMessages.MESSAGES.vaultAliasNotSpecified();
         }
-        this.keystoreMaskedPassword = computeMaskedPassword();
+        this.keystoreMaskedPassword = (org.jboss.security.Util.isPasswordCommand(keystorePassword))
+                ? keystorePassword
+                : computeMaskedPassword();
         this.vaultAlias = vaultAlias;
         initSecurityVault();
     }


### PR DESCRIPTION
A small fix for Vault tool in order to get an external password as well.

https://issues.jboss.org/browse/WFLY-2610
