### PR TITLE
[WFLY-2782] JMXConnector should be closed to avoid leaking endpoints in ...

### DIFF
--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -444,7 +444,8 @@ public class ManagementClient {
             try {
                 final HashMap<String, Object> env = new HashMap<String, Object>();
                 env.put(CallbackHandler.class.getName(), Authentication.getCallbackHandler());
-                connection = JMXConnectorFactory.connect(getRemoteJMXURL(), env).getMBeanServerConnection();
+                connector = JMXConnectorFactory.connect(getRemoteJMXURL(), env);
+                connection = connector.getMBeanServerConnection();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/MBeanServerConnectionProvider.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/MBeanServerConnectionProvider.java
@@ -16,6 +16,7 @@
  */
 package org.jboss.as.arquillian.container;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -26,6 +27,7 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 
 import org.jboss.logging.Logger;
+import org.xnio.IoUtils;
 
 /**
  * A provider for the JSR160 connection.
@@ -33,7 +35,7 @@ import org.jboss.logging.Logger;
  * @author Thomas.Diesler@jboss.com
  * @since 03-Dec-2010
  */
-public final class MBeanServerConnectionProvider {
+public final class MBeanServerConnectionProvider implements Closeable {
 
     private static final Logger log = Logger.getLogger(MBeanServerConnectionProvider.class);
     private final InetAddress hostAddr;
@@ -80,5 +82,10 @@ public final class MBeanServerConnectionProvider {
             }
         }
         throw new IllegalStateException("MBeanServerConnection not available");
+    }
+
+    @Override
+    public void close() throws IOException {
+        IoUtils.safeClose(jmxConnector);
     }
 }

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -348,7 +348,8 @@ public class ManagementClient implements AutoCloseable, Closeable {
                     // Only set this is there is a username as it disabled local authentication.
                     env.put(CallbackHandler.class.getName(), Authentication.getCallbackHandler());
                 }
-                connection = new MBeanConnectionProxy(JMXConnectorFactory.connect(getRemoteJMXURL(), env).getMBeanServerConnection());
+                connector = JMXConnectorFactory.connect(getRemoteJMXURL(), env);
+                connection = new MBeanConnectionProxy(connector.getMBeanServerConnection());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientTestCase.java
@@ -28,8 +28,10 @@ import org.jboss.as.arquillian.container.MBeanServerConnectionProvider;
 import org.jboss.as.arquillian.container.managed.archive.ConfigService;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
 
 /**
  * JBossASRemoteIntegrationTestCase
@@ -41,6 +43,7 @@ import org.junit.runner.RunWith;
 @RunAsClient
 @Ignore // Disable until JMX over Remoting is implemented
 public class ManagedAsClientTestCase extends AbstractContainerTestCase {
+    private MBeanServerConnectionProvider provider;
 
     @Deployment(testable = false)
     public static JavaArchive createDeployment() throws Exception {
@@ -54,7 +57,13 @@ public class ManagedAsClientTestCase extends AbstractContainerTestCase {
 
     @Override
     protected MBeanServerConnection getMBeanServer() throws Exception {
-        MBeanServerConnectionProvider provider = MBeanServerConnectionProvider.defaultProvider();
+        assert provider == null;
+        provider = MBeanServerConnectionProvider.defaultProvider();
         return provider.getConnection();
+    }
+
+    @After
+    public void closeProvider() {
+        IoUtils.safeClose(provider);
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
@@ -42,6 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import javax.xml.parsers.DocumentBuilder;
@@ -60,15 +61,14 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
+import org.xnio.IoUtils;
 
 /**
  * @author baranowb
@@ -88,6 +88,7 @@ public class JMXPropertyEditorsTestCase {
     private ManagementClient managementClient;
 
     private MBeanServerConnection connection;
+    private JMXConnector connector;
     private static final String USER_SYS_PROP = System.getProperty("os.name","linux").contains("indows")?"USERNAME":"USER";
 
     @Before
@@ -99,14 +100,13 @@ public class JMXPropertyEditorsTestCase {
     @After
     public void closeConnection() throws Exception {
         connection = null;
+        IoUtils.safeClose(connector);
     }
 
     private MBeanServerConnection getMBeanServerConnection() throws IOException {
         final String address = managementClient.getMgmtAddress()+":"+managementClient.getMgmtPort();
-//        return JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:remoting-jmx://localhost:9999"))
-//                .getMBeanServerConnection();
-        return JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:http-remoting-jmx://"+address))
-                .getMBeanServerConnection();
+        connector = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:http-remoting-jmx://"+address));
+        return connector.getMBeanServerConnection();
 
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/SarWithinEarTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/SarWithinEarTestCase.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -37,9 +38,11 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
 
 /**
  * Test that a service configured in a .sar within a .ear deployment works fine, both when the .ear contains a application.xml
@@ -58,6 +61,12 @@ public class SarWithinEarTestCase {
     @ContainerResource
     private ManagementClient managementClient;
 
+    private JMXConnector connector;
+
+    @After
+    public void closeConnector() {
+        IoUtils.safeClose(connector);
+    }
     /**
      * Create a .ear, without an application.xml, with a nested .sar deployment
      *
@@ -124,7 +133,8 @@ public class SarWithinEarTestCase {
     }
 
     private MBeanServerConnection getMBeanServerConnection() throws IOException {
-        return JMXConnectorFactory.connect(managementClient.getRemoteJMXURL()).getMBeanServerConnection();
+        connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        return connector.getMBeanServerConnection();
 
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/SarInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/SarInjectionTestCase.java
@@ -24,9 +24,9 @@ package org.jboss.as.test.integration.sar.injection;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 
-import org.junit.Assert;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -35,8 +35,10 @@ import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.sar.injection.pojos.A;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
 
 
 /**
@@ -61,14 +63,18 @@ public final class SarInjectionTestCase {
 
     @Test
     public void testMBean() throws Exception {
-        final MBeanServerConnection mbeanServer = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL()).getMBeanServerConnection();
-        final ObjectName objectName = new ObjectName("jboss:name=POJOService");
-        Assert.assertTrue(2 == (Integer) mbeanServer.getAttribute(objectName, "Count"));
-        Assert.assertTrue((Boolean) mbeanServer.getAttribute(objectName, "CreateCalled"));
-        Assert.assertTrue((Boolean) mbeanServer.getAttribute(objectName, "StartCalled"));
-        Assert.assertFalse((Boolean) mbeanServer.getAttribute(objectName, "StopCalled"));
-        Assert.assertFalse((Boolean) mbeanServer.getAttribute(objectName, "DestroyCalled"));
-
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        try {
+            final MBeanServerConnection mbeanServer = connector.getMBeanServerConnection();
+            final ObjectName objectName = new ObjectName("jboss:name=POJOService");
+            Assert.assertTrue(2 == (Integer) mbeanServer.getAttribute(objectName, "Count"));
+            Assert.assertTrue((Boolean) mbeanServer.getAttribute(objectName, "CreateCalled"));
+            Assert.assertTrue((Boolean) mbeanServer.getAttribute(objectName, "StartCalled"));
+            Assert.assertFalse((Boolean) mbeanServer.getAttribute(objectName, "StopCalled"));
+            Assert.assertFalse((Boolean) mbeanServer.getAttribute(objectName, "DestroyCalled"));
+        } finally {
+            IoUtils.safeClose(connector);
+        }
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/resource/SarResourceInjectionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/injection/resource/SarResourceInjectionTestCase.java
@@ -25,9 +25,8 @@ package org.jboss.as.test.integration.sar.injection.resource;
 import javax.annotation.Resource;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
-
-import org.junit.Assert;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -36,8 +35,10 @@ import org.jboss.as.arquillian.api.ContainerResource;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
 
 /**
  * [AS7-1699] Tests {@link Resource} injection on MBeans
@@ -60,10 +61,14 @@ public final class SarResourceInjectionTestCase {
 
     @Test
     public void testMBean() throws Exception {
-        final MBeanServerConnection mbeanServer = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL())
-                .getMBeanServerConnection();
-        final ObjectName objectName = new ObjectName("jboss:name=X");
-        Assert.assertTrue((Boolean) mbeanServer.invoke(objectName, "resourcesInjected", null, null));
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        try {
+            final MBeanServerConnection mbeanServer = connector.getMBeanServerConnection();
+            final ObjectName objectName = new ObjectName("jboss:name=X");
+            Assert.assertTrue((Boolean) mbeanServer.invoke(objectName, "resourcesInjected", null, null));
+        } finally {
+            IoUtils.safeClose(connector);
+        }
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/ServiceMBeanSupportTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/ServiceMBeanSupportTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.integration.sar.servicembean;
 
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 
 import org.jboss.arquillian.container.test.api.Deployer;
@@ -43,7 +44,7 @@ import org.junit.runner.RunWith;
 
 /**
  * Test MBeans which implement {@link ServiceMBean} and extend {@link ServiceMBeanSupport}.
- * 
+ *
  * @author Eduardo Martins
  */
 @RunWith(Arquillian.class)
@@ -77,14 +78,14 @@ public class ServiceMBeanSupportTestCase {
 
     /**
      * Tests that invocation on a service deployed within a .sar, inside a .ear without an application.xml, is successful.
-     * 
+     *
      * @throws Exception
      */
-    @Test    
+    @Test
     public void testSarWithServiceMBeanSupport() throws Exception {
         // get mbean server
-        final MBeanServerConnection mBeanServerConnection = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL())
-                .getMBeanServerConnection();
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        final MBeanServerConnection mBeanServerConnection = connector.getMBeanServerConnection();
         try {
             // deploy the unmanaged sar
             deployer.deploy(ServiceMBeanSupportTestCase.UNMANAGED_SAR_DEPLOYMENT_NAME);
@@ -112,7 +113,7 @@ public class ServiceMBeanSupportTestCase {
         attribute = "DestroyServiceInvoked";
         result = (Boolean) mBeanServerConnection.getAttribute(new ObjectName("jboss:name=service-mbean-support-test-result"),
                 attribute);
-        Assert.assertTrue("Unexpected result for " + attribute + ": " + result, result);        
+        Assert.assertTrue("Unexpected result for " + attribute + ": " + result, result);
     }
 
 }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/sar/SarTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/sar/SarTestCase.java
@@ -24,6 +24,7 @@ package org.jboss.as.test.smoke.sar;
 import javax.management.Attribute;
 import javax.management.MBeanServerConnection;
 import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -35,6 +36,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
 
 /**
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
@@ -57,10 +59,15 @@ public class SarTestCase {
 
     @Test
     public void testMBean() throws Exception {
-        MBeanServerConnection mbeanServer = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL()).getMBeanServerConnection();
-        ObjectName objectName = new ObjectName("jboss:name=test,type=config");
-        mbeanServer.getAttribute(objectName, "IntervalSeconds");
-        mbeanServer.setAttribute(objectName, new Attribute("IntervalSeconds", 2));
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        try {
+            MBeanServerConnection mbeanServer = connector.getMBeanServerConnection();
+            ObjectName objectName = new ObjectName("jboss:name=test,type=config");
+            mbeanServer.getAttribute(objectName, "IntervalSeconds");
+            mbeanServer.setAttribute(objectName, new Attribute("IntervalSeconds", 2));
+        } finally {
+            IoUtils.safeClose(connector);
+        }
     }
 
 }


### PR DESCRIPTION
...testsuite

https://issues.jboss.org/browse/WFLY-2782
