### PR TITLE
[WFLY-2656] Restore support for legacy clustered-cache-ref

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
@@ -117,7 +117,14 @@
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="cache-ref" type="xs:string"/>
-        <xs:attribute name="clustered-cache-ref" type="xs:string" use="optional"/>
+        <xs:attribute name="clustered-cache-ref" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Deprecated. Not supported on current version servers; only allowed in managed domain profiles for use
+                    on servers running earlier versions.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="passivation-disabled-cache-ref" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -58,6 +58,7 @@ import javax.transaction.Transaction;
 import javax.transaction.xa.Xid;
 import javax.xml.stream.Location;
 
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentCreateServiceFactory;
@@ -2505,6 +2506,9 @@ public interface EjbMessages {
 
     @Message(id = 14588, value = "CMP Entity Beans are not supported")
     DeploymentUnitProcessingException cmpEntityBeansAreNotSupported();
+
+    @Message(id = 14589, value = "Attribute '%s' is not supported on current version servers; it is only allowed if its value matches '%s'")
+    OperationFailedException inconsistentAttributeNotSupported(String attributeName, String mustMatch);
 
     // STOP!!! Don't add message ids greater that 14599!!! If you need more first check what EjbLogger is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -355,7 +355,7 @@ public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>> 
                     break;
                 }
                 case CLUSTERED_CACHE_REF: {
-                    // Ignored
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
                     break;
                 }
                 default: {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
@@ -118,6 +118,10 @@ public class EJB3Subsystem20Parser extends EJB3Subsystem14Parser {
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
                     break;
                 }
+                case CLUSTERED_CACHE_REF: {
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    break;
+                }
                 case PASSIVATION_DISABLED_CACHE_REF: {
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
                     break;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDefaultCacheWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDefaultCacheWriteHandler.java
@@ -22,21 +22,24 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import java.util.List;
+
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.ejb3.cache.CacheFactoryBuilder;
+import org.jboss.as.ejb3.cache.CacheFactoryBuilderService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.InjectedValue;
-
-import java.util.List;
-import org.jboss.as.ejb3.cache.CacheFactoryBuilderService;
 
 /**
  * @author Paul Ferraro
@@ -50,6 +53,14 @@ public class EJB3SubsystemDefaultCacheWriteHandler extends AbstractWriteAttribut
     public static final EJB3SubsystemDefaultCacheWriteHandler SFSB_PASSIVATION_DISABLED_CACHE =
             new EJB3SubsystemDefaultCacheWriteHandler(CacheFactoryBuilderService.DEFAULT_PASSIVATION_DISABLED_CACHE_SERVICE_NAME,
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE);
+
+    public static final OperationStepHandler CLUSTERED_SFSB_CACHE =
+            new ModelOnlyWriteAttributeHandler(EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE) {
+                @Override
+                protected void validateUpdatedModel(final OperationContext context, final Resource model) throws OperationFailedException {
+                    context.addStep(new ValidateClusteredCacheRefHandler(), OperationContext.Stage.MODEL);
+                }
+            };
 
     private final ServiceName serviceName;
     private final AttributeDefinition attribute;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -46,6 +46,7 @@ public interface EJB3SubsystemModel {
     String DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS = "default-missing-method-permissions-deny-access";
     String DEFAULT_RESOURCE_ADAPTER_NAME = "default-resource-adapter-name";
     String DEFAULT_SFSB_CACHE = "default-sfsb-cache";
+    String DEFAULT_CLUSTERED_SFSB_CACHE = "default-clustered-sfsb-cache";
     String DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE = "default-sfsb-passivation-disabled-cache";
     String DEFAULT_SLSB_INSTANCE_POOL = "default-slsb-instance-pool";
     String INSTANCE_ACQUISITION_TIMEOUT = "timeout";

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -106,6 +106,12 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                     .setXmlName(EJB3SubsystemXMLAttribute.PASSIVATION_DISABLED_CACHE_REF.getLocalName())
                     .setAllowExpression(true)
                     .build();
+    static final SimpleAttributeDefinition DEFAULT_CLUSTERED_SFSB_CACHE =
+            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_CLUSTERED_SFSB_CACHE, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setAllowNull(true)
+                    .setDeprecated(ModelVersion.create(2))
+                    .build();
 
     static final SimpleAttributeDefinition ENABLE_STATISTICS =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.ENABLE_STATISTICS, ModelType.BOOLEAN, true)
@@ -161,6 +167,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     }
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {
+            DEFAULT_CLUSTERED_SFSB_CACHE,
             DEFAULT_ENTITY_BEAN_INSTANCE_POOL,
             DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING,
             DEFAULT_MDB_INSTANCE_POOL,
@@ -182,6 +189,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerReadWriteAttribute(DEFAULT_SFSB_CACHE, null, EJB3SubsystemDefaultCacheWriteHandler.SFSB_CACHE);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, null, EJB3SubsystemDefaultCacheWriteHandler.SFSB_PASSIVATION_DISABLED_CACHE);
+        resourceRegistration.registerReadWriteAttribute(DEFAULT_CLUSTERED_SFSB_CACHE, null, EJB3SubsystemDefaultCacheWriteHandler.CLUSTERED_SFSB_CACHE);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_SLSB_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.SLSB_POOL);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_MDB_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.MDB_POOL);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_ENTITY_BEAN_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.ENTITY_BEAN_POOL);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -80,6 +80,7 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         // <stateful> element
         if (model.hasDefined(EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT)
                 || model.hasDefined(EJB3SubsystemModel.DEFAULT_SFSB_CACHE)
+                || model.hasDefined(EJB3SubsystemModel.DEFAULT_CLUSTERED_SFSB_CACHE)
                 || model.hasDefined(EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)) {
             // <stateful>
             writer.writeStartElement(EJB3SubsystemXMLElement.STATEFUL.getLocalName());
@@ -345,6 +346,10 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         if (statefulBeanModel.hasDefined(DEFAULT_SFSB_CACHE)) {
             String cache = statefulBeanModel.get(DEFAULT_SFSB_CACHE).asString();
             writer.writeAttribute(EJB3SubsystemXMLAttribute.CACHE_REF.getLocalName(), cache);
+        }
+        if (statefulBeanModel.hasDefined(DEFAULT_CLUSTERED_SFSB_CACHE)) {
+            String cache = statefulBeanModel.get(DEFAULT_CLUSTERED_SFSB_CACHE).asString();
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.CLUSTERED_CACHE_REF.getLocalName(), cache);
         }
         EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.marshallAsAttribute(statefulBeanModel, writer);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ValidateClusteredCacheRefHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ValidateClusteredCacheRefHandler.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.ejb3.EjbMessages;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Validates that if {@link org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition#DEFAULT_CLUSTERED_SFSB_CACHE}
+ * is set on a server that it matches
+ * {@link org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition#DEFAULT_SFSB_CACHE}. Such a matched
+ * value implies the configuration may be being used on both WildFly servers and legacy servers, which
+ * still use the clustered cache ref.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+class ValidateClusteredCacheRefHandler implements OperationStepHandler {
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        if (context.getProcessType().isServer()) {
+            ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+            if (model.hasDefined(DEFAULT_CLUSTERED_SFSB_CACHE.getName())
+                && !model.get(DEFAULT_CLUSTERED_SFSB_CACHE.getName()).equals(model.get(DEFAULT_SFSB_CACHE.getName()))) {
+                throw EjbMessages.MESSAGES.inconsistentAttributeNotSupported(DEFAULT_CLUSTERED_SFSB_CACHE.getName(), DEFAULT_SFSB_CACHE.getName());
+            }
+        }
+        context.stepCompleted();
+    }
+}

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -4,6 +4,7 @@ ejb3.enable-statistics=If set to true, enable the collection of invocation stati
 ejb3.remove=Removes the ejb3 subsystem.
 ejb3.lite=Specifies whether the ejb3 container need only provide the "LITE" profile of the specification. This value should only be false when using the "everything" distro.
 ejb3.default-clustered-sfsb-cache=Name of the default stateful bean cache, which will be applicable to all clustered stateful EJBs, unless overridden at the deployment or bean level
+ejb3.default-clustered-sfsb-cache.deprecated=Not supported on current version servers; only allowed in managed domain profiles for use on servers running earlier versions.
 ejb3.default-sfsb-passivation-disabled-cache=Name of the default stateful bean cache, which will be applicable to all stateful EJBs which have passivation disabled. Each deployment or EJB can optionally override this cache name.
 ejb3.default-mdb-instance-pool=Name of the default MDB instance pool, which will be applicable to all MDBs, unless overridden at the deployment or bean level
 ejb3.default-entity-bean-instance-pool=Name of the default entity bean instance pool, which will be applicable to all entity beans, unless overridden at the deployment or bean level

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_1_0.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_1_0.xml
@@ -3,7 +3,7 @@
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
         </stateless>
-        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable"/>
+        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable" clustered-cache-ref="distributable"/>
         <singleton default-access-timeout="${prop.default-access-timeout:5000}"/>
     </session-bean>
     <entity-bean>

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_2_0.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_2_0.xml
@@ -3,7 +3,7 @@
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
         </stateless>
-        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable"/>
+        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable" clustered-cache-ref="distributable"/>
         <singleton default-access-timeout="${prop.default-access-timeout:5000}"/>
     </session-bean>
     <entity-bean>

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -69,13 +69,16 @@ import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 import org.xnio.IoUtils;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public abstract class SimpleMixedDomainTest  {
 
     MixedDomainTestSupport support;
@@ -93,13 +96,13 @@ public abstract class SimpleMixedDomainTest  {
     }
 
     @Test
-    public void testServerRunning() throws Exception {
+    public void test1ServerRunning() throws Exception {
         URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.slaveAddress) + ":8080").openConnection();
         connection.connect();
     }
 
     @Test
-    public void testVersioning() throws Exception {
+    public void test2Versioning() throws Exception {
 
         DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
         ModelNode masterModel;
@@ -122,7 +125,7 @@ public abstract class SimpleMixedDomainTest  {
     }
 
     @Test
-    public void testSecurityTransformers() throws Exception {
+    public void test9SecurityTransformers() throws Exception {
         final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
         final DomainClient slaveClient = support.getDomainSlaveLifecycleUtil().createDomainClient();
         try {

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -665,23 +665,23 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:infinispan:2.0">
                 <!-- In infinispan on 7.1.x the statistics are always on and not configurable, and need to be set to true on all cache-container and cache entries (the current default is false) -->
-                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics="true">
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="default" mode="SYNC" batching="true" statistics="true">
+                    <replicated-cache name="default" mode="SYNC" batching="true" statistics-enabled="true">
                         <locking isolation="REPEATABLE_READ"/>
                     </replicated-cache>
                 </cache-container>
-                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics="true">
+                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics="true">
+                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics-enabled="true">
                         <file-store/>
                     </replicated-cache>
-                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics="true">
+                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
                     <replicated-cache name="repl" mode="ASYNC" batching="true">
                         <eviction strategy="LRU" max-entries="10000"/>
@@ -691,25 +691,25 @@
                       ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
                       ~                 the socketbinding referenced by the EJB remoting connector 
                       -->
-                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <eviction strategy="LRU" max-entries="10000"/>
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics="true">
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <local-cache name="local-query" statistics="true">
+                    <local-cache name="local-query" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </local-cache>
-                    <invalidation-cache name="entity" mode="SYNC" statistics="true">
+                    <invalidation-cache name="entity" mode="SYNC" statistics-enabled="true">
                         <transaction mode="NON_XA"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </invalidation-cache>
-                    <replicated-cache name="timestamps" mode="ASYNC" statistics="true">
+                    <replicated-cache name="timestamps" mode="ASYNC" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="NONE"/>
                     </replicated-cache>
@@ -1176,25 +1176,25 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:infinispan:2.0">
                 <!-- In infinispan on 7.1.x the statistics are always on and not configurable, and need to be set to true on all cache-container and cache entries (the current default is false) -->
-                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics="true">
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="default" mode="SYNC" batching="true" statistics="true">
+                    <replicated-cache name="default" mode="SYNC" batching="true" statistics-enabled="true">
                         <locking isolation="REPEATABLE_READ"/>
                     </replicated-cache>
                 </cache-container>
-                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics="true">
+                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics="true">
+                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics-enabled="true">
                         <file-store/>
                     </replicated-cache>
-                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics="true">
+                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics="true">
+                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics-enabled="true">
                         <eviction strategy="LRU" max-entries="10000"/>
                         <file-store/>
                     </replicated-cache>
@@ -1202,25 +1202,25 @@
                       ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
                       ~                 the socketbinding referenced by the EJB remoting connector 
                       -->
-                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <eviction strategy="LRU" max-entries="10000"/>
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics="true">
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <local-cache name="local-query" statistics="true">
+                    <local-cache name="local-query" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </local-cache>
-                    <invalidation-cache name="entity" mode="SYNC" statistics="true">
+                    <invalidation-cache name="entity" mode="SYNC" statistics-enabled="true">
                         <transaction mode="NON_XA"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </invalidation-cache>
-                    <replicated-cache name="timestamps" mode="ASYNC" statistics="true">
+                    <replicated-cache name="timestamps" mode="ASYNC" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="NONE"/>
                     </replicated-cache>


### PR DESCRIPTION
Fixes the mixed-domain tests: http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=8245&tab=buildResultsDiv&buildTypeId=WF_MasterLinuxMixedDomain

Also fix some config issues that the previous mixed-domain test failures had hidden.
