### PR TITLE
WFLY-130 make add-user.sh work under cygwin environment

### DIFF
--- a/build/src/main/resources/bin/add-user.sh
+++ b/build/src/main/resources/bin/add-user.sh
@@ -11,7 +11,7 @@ DIRNAME=`dirname "$0"`
 # OS specific support (must be 'true' or 'false').
 cygwin=false;
 if  [ `uname|grep -i CYGWIN` ]; then
-    cygwin = true;
+    cygwin=true;
 fi
 
 # For Cygwin, ensure paths are in UNIX format before anything is touched


### PR DESCRIPTION
this is a simple bash syntax fix from "var = value" to "var=value"

Actually this is a partial fix for WFLY-130, the other part I'll file a separate issue with AESH
