### PR TITLE
[WFLY-2695] Corrected the order of the describe to place formatters before handlers

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingExtension.java
@@ -367,6 +367,14 @@ public class LoggingExtension implements Extension {
                     result = LESS;
                 } else if (CommonAttributes.LOGGING_PROFILE.equals(key2)) {
                     result = GREATER;
+                } else if (PatternFormatterResourceDefinition.PATTERN_FORMATTER.getName().equals(key1)) {
+                    result = LESS;
+                } else if (PatternFormatterResourceDefinition.PATTERN_FORMATTER.getName().equals(key2)) {
+                    result = GREATER;
+                } else if (CustomFormatterResourceDefinition.CUSTOM_FORMATTER.getName().equals(key1)) {
+                    result = LESS;
+                } else if (CustomFormatterResourceDefinition.CUSTOM_FORMATTER.getName().equals(key2)) {
+                    result = GREATER;
                 } else if (RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME.equals(key1)) {
                     result = GREATER;
                 } else if (RootLoggerResourceDefinition.ROOT_LOGGER_PATH_NAME.equals(key2)) {

--- a/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingOperations.java
@@ -82,7 +82,7 @@ final class LoggingOperations {
     }
 
     private static final class CommitOperationStepHandler implements OperationStepHandler {
-        private static AttachmentKey<Boolean> WRITTEN_KEY = AttachmentKey.create(Boolean.class);
+        private static final AttachmentKey<Boolean> WRITTEN_KEY = AttachmentKey.create(Boolean.class);
         private final ConfigurationPersistence configurationPersistence;
         private final boolean persistConfig;
 

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemAdd.java
@@ -114,6 +114,16 @@ class LoggingSubsystemAdd extends AbstractAddStepHandler {
             LoggingLogger.ROOT_LOGGER.tracef("Removing handler configuration for '%s'", name);
             logContextConfiguration.removeHandlerConfiguration(name);
         }
+
+        // Remove formatters
+        final List<String> configuredFormatters = logContextConfiguration.getFormatterNames();
+        configuredFormatters.removeAll(resource.getChildrenNames(PatternFormatterResourceDefinition.PATTERN_FORMATTER.getName()));
+        configuredFormatters.removeAll(resource.getChildrenNames(CustomFormatterResourceDefinition.CUSTOM_FORMATTER.getName()));
+        for (String name : configuredFormatters) {
+            LoggingLogger.ROOT_LOGGER.tracef("Removing formatter configuration for '%s'", name);
+            logContextConfiguration.removeFormatterConfiguration(name);
+        }
+
         LoggingOperations.addCommitStep(context, configurationPersistence);
         LoggingLogger.ROOT_LOGGER.trace("Logging subsystem has been added.");
     }


### PR DESCRIPTION
Some handlers were being added before the formatters causing errors when using named formatters. During the describe, formatters should be listed first.

A couple other minor changes/fixes too.
