### PR TITLE
[WFLY-2790] Upgrade netty-xnio-transport to 0.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version.org.jboss.mod_cluster>1.3.0.Alpha1</version.org.jboss.mod_cluster>
         <version.org.jboss.modules.jboss-modules>1.3.0.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.0.CR1</version.org.jboss.msc.jboss-msc>
-        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.1.CR2</version.org.jboss.xnio.netty.netty-xnio-transport>
+        <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.1.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.osgi.metadata>3.0.1.Final</version.org.jboss.osgi.metadata>
         <version.org.jboss.remote-naming>2.0.0.Beta2</version.org.jboss.remote-naming>
         <version.org.jboss.remoting>4.0.0.Beta3</version.org.jboss.remoting>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-2790
