### PR TITLE
[WFLY-2637] Only allow log files defined in known file handlers to be listed and read

### DIFF
--- a/build/src/main/resources/configuration/subsystems/ejb3.xml
+++ b/build/src/main/resources/configuration/subsystems/ejb3.xml
@@ -4,15 +4,13 @@
    <extension-module>org.jboss.as.ejb3</extension-module>
    <subsystem xmlns="urn:jboss:domain:ejb3:2.0">
        <session-bean>
-           <stateless>
-               <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
-           </stateless>
            <?STATEFUL-BEAN?>
            <singleton default-access-timeout="5000"/>
        </session-bean>
        <?MDB?>
        <pools>
            <bean-instance-pools>
+               <!-- A sample strict max pool configuration -->
                <strict-max-pool name="slsb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
                <strict-max-pool name="mdb-strict-max-pool" max-pool-size="20" instance-acquisition-timeout="5" instance-acquisition-timeout-unit="MINUTES"/>
            </bean-instance-pools>

--- a/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-ejb3_2_0.xsd
@@ -117,7 +117,14 @@
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="cache-ref" type="xs:string"/>
-        <xs:attribute name="clustered-cache-ref" type="xs:string" use="optional"/>
+        <xs:attribute name="clustered-cache-ref" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Deprecated. Not supported on current version servers; only allowed in managed domain profiles for use
+                    on servers running earlier versions.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="passivation-disabled-cache-ref" type="xs:string" use="optional">
             <xs:annotation>
                 <xs:documentation>

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/RaDeploymentActivator.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/RaDeploymentActivator.java
@@ -57,7 +57,12 @@ import org.jboss.msc.service.ServiceTarget;
  * @author <a href="mailto:stefano.maestri@redhat.com">Stefano Maestri</a>
  */
 public class RaDeploymentActivator {
+    private final boolean appclient;
     private final MdrService mdrService = new MdrService();
+
+    public RaDeploymentActivator(final boolean appclient) {
+        this.appclient = appclient;
+    }
 
     public Collection<ServiceController<?>> activateServices(final ServiceTarget serviceTarget, final ServiceListener<Object>... listeners) {
         final List<ServiceController<?>> controllers = new ArrayList<ServiceController<?>>();
@@ -95,8 +100,9 @@ public class RaDeploymentActivator {
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_RA_DEPLOYMENT, new RaDeploymentParsingProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_IRON_JACAMAR_DEPLOYMENT,
                 new IronJacamarDeploymentParsingProcessor());
-        updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_RAR_CONFIG, new RarDependencyProcessor());
-        updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_RAR_SERVICES_DEPS, new RaXmlDependencyProcessor());
+        updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_RAR_CONFIG, new RarDependencyProcessor(appclient));
+                if (!appclient)
+                    updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_RAR_SERVICES_DEPS, new RaXmlDependencyProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_RA_NATIVE, new RaNativeProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_RA_DEPLOYMENT, new ParsedRaDeploymentProcessor());
         updateContext.addDeploymentProcessor(ResourceAdaptersExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_RA_XML_DEPLOYMENT, new RaXmlDeploymentProcessor(

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RarDependencyProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/RarDependencyProcessor.java
@@ -45,6 +45,13 @@ public class RarDependencyProcessor implements DeploymentUnitProcessor {
     private static ModuleIdentifier HIBERNATE_VALIDATOR_ID = ModuleIdentifier.create("org.hibernate.validator");
     private static ModuleIdentifier RESOURCE_API_ID = ModuleIdentifier.create("javax.resource.api");
 
+
+    private final boolean appclient;
+
+    public RarDependencyProcessor(final boolean appclient) {
+        this.appclient = appclient;
+    }
+
     /**
      * Add dependencies for modules required for ra deployments
      *
@@ -70,7 +77,8 @@ public class RarDependencyProcessor implements DeploymentUnitProcessor {
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, IRON_JACAMAR_ID, false, false, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, IRON_JACAMAR_IMPL_ID, false, true, false, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, HIBERNATE_VALIDATOR_ID, false, false, true, false));
-        phaseContext.addDeploymentDependency(ConnectorServices.RESOURCEADAPTERS_SUBSYSTEM_SERVICE, ResourceAdaptersSubsystemService.ATTACHMENT_KEY);
+        if (! appclient)
+            phaseContext.addDeploymentDependency(ConnectorServices.RESOURCEADAPTERS_SUBSYSTEM_SERVICE, ResourceAdaptersSubsystemService.ATTACHMENT_KEY);
     }
 
     public void undeploy(final DeploymentUnit context) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemAdd.java
@@ -33,6 +33,7 @@ import org.jboss.as.connector.services.transactionintegration.TransactionIntegra
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
@@ -60,8 +61,8 @@ class JcaSubsystemAdd extends AbstractBoottimeAddStepHandler {
     }
 
     protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) {
-        final RaDeploymentActivator raDeploymentActivator = new RaDeploymentActivator();
-
+        final boolean appclient = context.getProcessType() == ProcessType.APPLICATION_CLIENT;
+        final RaDeploymentActivator raDeploymentActivator = new RaDeploymentActivator(appclient);
         context.addStep(new AbstractDeploymentChainStep() {
             protected void execute(DeploymentProcessorTarget processorTarget) {
                 raDeploymentActivator.activateProcessors(processorTarget);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/EjbMessages.java
@@ -58,6 +58,7 @@ import javax.transaction.Transaction;
 import javax.transaction.xa.Xid;
 import javax.xml.stream.Location;
 
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentCreateServiceFactory;
@@ -2505,6 +2506,9 @@ public interface EjbMessages {
 
     @Message(id = 14588, value = "CMP Entity Beans are not supported")
     DeploymentUnitProcessingException cmpEntityBeansAreNotSupported();
+
+    @Message(id = 14589, value = "Attribute '%s' is not supported on current version servers; it is only allowed if its value matches '%s'")
+    OperationFailedException inconsistentAttributeNotSupported(String attributeName, String mustMatch);
 
     // STOP!!! Don't add message ids greater that 14599!!! If you need more first check what EjbLogger is
     // using and take more (lower) numbers from the available range for this module. If the range for the module is

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem12Parser.java
@@ -355,7 +355,7 @@ public class EJB3Subsystem12Parser implements XMLElementReader<List<ModelNode>> 
                     break;
                 }
                 case CLUSTERED_CACHE_REF: {
-                    // Ignored
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
                     break;
                 }
                 default: {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem20Parser.java
@@ -118,6 +118,10 @@ public class EJB3Subsystem20Parser extends EJB3Subsystem14Parser {
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
                     break;
                 }
+                case CLUSTERED_CACHE_REF: {
+                    EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
+                    break;
+                }
                 case PASSIVATION_DISABLED_CACHE_REF: {
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.parseAndSetParameter(value, ejb3SubsystemAddOperation, reader);
                     break;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDefaultCacheWriteHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemDefaultCacheWriteHandler.java
@@ -22,21 +22,24 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import java.util.List;
+
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.ejb3.cache.CacheFactoryBuilder;
+import org.jboss.as.ejb3.cache.CacheFactoryBuilderService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.InjectedValue;
-
-import java.util.List;
-import org.jboss.as.ejb3.cache.CacheFactoryBuilderService;
 
 /**
  * @author Paul Ferraro
@@ -50,6 +53,14 @@ public class EJB3SubsystemDefaultCacheWriteHandler extends AbstractWriteAttribut
     public static final EJB3SubsystemDefaultCacheWriteHandler SFSB_PASSIVATION_DISABLED_CACHE =
             new EJB3SubsystemDefaultCacheWriteHandler(CacheFactoryBuilderService.DEFAULT_PASSIVATION_DISABLED_CACHE_SERVICE_NAME,
                     EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE);
+
+    public static final OperationStepHandler CLUSTERED_SFSB_CACHE =
+            new ModelOnlyWriteAttributeHandler(EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE) {
+                @Override
+                protected void validateUpdatedModel(final OperationContext context, final Resource model) throws OperationFailedException {
+                    context.addStep(new ValidateClusteredCacheRefHandler(), OperationContext.Stage.MODEL);
+                }
+            };
 
     private final ServiceName serviceName;
     private final AttributeDefinition attribute;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -46,6 +46,7 @@ public interface EJB3SubsystemModel {
     String DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS = "default-missing-method-permissions-deny-access";
     String DEFAULT_RESOURCE_ADAPTER_NAME = "default-resource-adapter-name";
     String DEFAULT_SFSB_CACHE = "default-sfsb-cache";
+    String DEFAULT_CLUSTERED_SFSB_CACHE = "default-clustered-sfsb-cache";
     String DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE = "default-sfsb-passivation-disabled-cache";
     String DEFAULT_SLSB_INSTANCE_POOL = "default-slsb-instance-pool";
     String INSTANCE_ACQUISITION_TIMEOUT = "timeout";

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -106,6 +106,12 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
                     .setXmlName(EJB3SubsystemXMLAttribute.PASSIVATION_DISABLED_CACHE_REF.getLocalName())
                     .setAllowExpression(true)
                     .build();
+    static final SimpleAttributeDefinition DEFAULT_CLUSTERED_SFSB_CACHE =
+            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.DEFAULT_CLUSTERED_SFSB_CACHE, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setAllowNull(true)
+                    .setDeprecated(ModelVersion.create(2))
+                    .build();
 
     static final SimpleAttributeDefinition ENABLE_STATISTICS =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.ENABLE_STATISTICS, ModelType.BOOLEAN, true)
@@ -161,6 +167,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     }
 
     static final SimpleAttributeDefinition[] ATTRIBUTES = {
+            DEFAULT_CLUSTERED_SFSB_CACHE,
             DEFAULT_ENTITY_BEAN_INSTANCE_POOL,
             DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING,
             DEFAULT_MDB_INSTANCE_POOL,
@@ -182,6 +189,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerReadWriteAttribute(DEFAULT_SFSB_CACHE, null, EJB3SubsystemDefaultCacheWriteHandler.SFSB_CACHE);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE, null, EJB3SubsystemDefaultCacheWriteHandler.SFSB_PASSIVATION_DISABLED_CACHE);
+        resourceRegistration.registerReadWriteAttribute(DEFAULT_CLUSTERED_SFSB_CACHE, null, EJB3SubsystemDefaultCacheWriteHandler.CLUSTERED_SFSB_CACHE);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_SLSB_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.SLSB_POOL);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_MDB_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.MDB_POOL);
         resourceRegistration.registerReadWriteAttribute(DEFAULT_ENTITY_BEAN_INSTANCE_POOL, null, EJB3SubsystemDefaultPoolWriteHandler.ENTITY_BEAN_POOL);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -80,6 +80,7 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         // <stateful> element
         if (model.hasDefined(EJB3SubsystemModel.DEFAULT_STATEFUL_BEAN_ACCESS_TIMEOUT)
                 || model.hasDefined(EJB3SubsystemModel.DEFAULT_SFSB_CACHE)
+                || model.hasDefined(EJB3SubsystemModel.DEFAULT_CLUSTERED_SFSB_CACHE)
                 || model.hasDefined(EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)) {
             // <stateful>
             writer.writeStartElement(EJB3SubsystemXMLElement.STATEFUL.getLocalName());
@@ -345,6 +346,10 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
         if (statefulBeanModel.hasDefined(DEFAULT_SFSB_CACHE)) {
             String cache = statefulBeanModel.get(DEFAULT_SFSB_CACHE).asString();
             writer.writeAttribute(EJB3SubsystemXMLAttribute.CACHE_REF.getLocalName(), cache);
+        }
+        if (statefulBeanModel.hasDefined(DEFAULT_CLUSTERED_SFSB_CACHE)) {
+            String cache = statefulBeanModel.get(DEFAULT_CLUSTERED_SFSB_CACHE).asString();
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.CLUSTERED_CACHE_REF.getLocalName(), cache);
         }
         EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE.marshallAsAttribute(statefulBeanModel, writer);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ValidateClusteredCacheRefHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ValidateClusteredCacheRefHandler.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.subsystem;
+
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.DEFAULT_CLUSTERED_SFSB_CACHE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_CACHE;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.ejb3.EjbMessages;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Validates that if {@link org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition#DEFAULT_CLUSTERED_SFSB_CACHE}
+ * is set on a server that it matches
+ * {@link org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition#DEFAULT_SFSB_CACHE}. Such a matched
+ * value implies the configuration may be being used on both WildFly servers and legacy servers, which
+ * still use the clustered cache ref.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+class ValidateClusteredCacheRefHandler implements OperationStepHandler {
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        if (context.getProcessType().isServer()) {
+            ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+            if (model.hasDefined(DEFAULT_CLUSTERED_SFSB_CACHE.getName())
+                && !model.get(DEFAULT_CLUSTERED_SFSB_CACHE.getName()).equals(model.get(DEFAULT_SFSB_CACHE.getName()))) {
+                throw EjbMessages.MESSAGES.inconsistentAttributeNotSupported(DEFAULT_CLUSTERED_SFSB_CACHE.getName(), DEFAULT_SFSB_CACHE.getName());
+            }
+        }
+        context.stepCompleted();
+    }
+}

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -4,6 +4,7 @@ ejb3.enable-statistics=If set to true, enable the collection of invocation stati
 ejb3.remove=Removes the ejb3 subsystem.
 ejb3.lite=Specifies whether the ejb3 container need only provide the "LITE" profile of the specification. This value should only be false when using the "everything" distro.
 ejb3.default-clustered-sfsb-cache=Name of the default stateful bean cache, which will be applicable to all clustered stateful EJBs, unless overridden at the deployment or bean level
+ejb3.default-clustered-sfsb-cache.deprecated=Not supported on current version servers; only allowed in managed domain profiles for use on servers running earlier versions.
 ejb3.default-sfsb-passivation-disabled-cache=Name of the default stateful bean cache, which will be applicable to all stateful EJBs which have passivation disabled. Each deployment or EJB can optionally override this cache name.
 ejb3.default-mdb-instance-pool=Name of the default MDB instance pool, which will be applicable to all MDBs, unless overridden at the deployment or bean level
 ejb3.default-entity-bean-instance-pool=Name of the default entity bean instance pool, which will be applicable to all entity beans, unless overridden at the deployment or bean level

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_1_0.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_1_0.xml
@@ -3,7 +3,7 @@
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
         </stateless>
-        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable"/>
+        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable" clustered-cache-ref="distributable"/>
         <singleton default-access-timeout="${prop.default-access-timeout:5000}"/>
     </session-bean>
     <entity-bean>

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_2_0.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_2_0.xml
@@ -3,7 +3,7 @@
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
         </stateless>
-        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable"/>
+        <stateful default-access-timeout="${prop.default-access-timeout:5000}" cache-ref="distributable" clustered-cache-ref="distributable"/>
         <singleton default-access-timeout="${prop.default-access-timeout:5000}"/>
     </session-bean>
     <entity-bean>

--- a/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
@@ -717,11 +717,10 @@ public interface LoggingMessages {
     /**
      * Creates an exception indicating the user cannot read the file.
      *
-     * @param name              the name of the file that was not allowed to be read
-     * @param directoryProperty the name of the property used to resolved the log directory
+     * @param name the name of the file that was not allowed to be read
      *
      * @return an {@link OperationFailedException} for the error
      */
-    @Message(id = 11595, value = "Permission was denied to read file '%s' in the %s directory property.")
-    OperationFailedException readPermissionDenied(String name, String directoryProperty);
+    @Message(id = 11595, value = "File '%s' is not allowed to be read.")
+    OperationFailedException readNotAllowed(String name);
 }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
@@ -34,6 +34,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -42,6 +43,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationContext.ResultHandler;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
@@ -55,7 +57,9 @@ import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess.Flag;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.as.controller.services.path.PathResourceDefinition;
 import org.jboss.as.controller.transform.description.AttributeTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
@@ -63,6 +67,7 @@ import org.jboss.as.controller.transform.description.ResourceTransformationDescr
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
@@ -112,9 +117,15 @@ public class LoggingRootResource extends TransformerResourceDefinition {
             .build();
 
     static final SimpleAttributeDefinition FILE_NAME = SimpleAttributeDefinitionBuilder.create("file-name", ModelType.STRING, false)
+            .setAllowExpression(false)
             .build();
 
     static final SimpleAttributeDefinition FILE_SIZE = SimpleAttributeDefinitionBuilder.create("file-size", ModelType.LONG, false)
+            .setAllowExpression(false)
+            .build();
+
+    static final SimpleAttributeDefinition LAST_MODIFIED_DATE = SimpleAttributeDefinitionBuilder.create("last-modified-date", ModelType.LONG, false)
+            .setAllowExpression(false)
             .build();
 
     static final SimpleOperationDefinition READ_LOG_FILE = new SimpleOperationDefinitionBuilder("read-log-file", LoggingExtension.getResourceDescriptionResolver())
@@ -129,7 +140,7 @@ public class LoggingRootResource extends TransformerResourceDefinition {
     static final SimpleOperationDefinition LIST_LOG_FILES = new SimpleOperationDefinitionBuilder("list-log-files", LoggingExtension.getResourceDescriptionResolver())
             .addAccessConstraint(VIEW_SERVER_LOGS)
             .setReplyType(ModelType.LIST)
-            .setReplyParameters(FILE_NAME, FILE_SIZE)
+            .setReplyParameters(FILE_NAME, FILE_SIZE, LAST_MODIFIED_DATE)
             .setReadOnly()
             .setRuntimeOnly()
             .build();
@@ -195,24 +206,26 @@ public class LoggingRootResource extends TransformerResourceDefinition {
 
         @Override
         public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-            final String logDir = pathManager.getPathEntry(ServerEnvironment.SERVER_LOG_DIR).resolvePath();
-            final File[] logFiles = new File(logDir).listFiles(new FileFilter() {
-                @Override
-                public boolean accept(final File pathname) {
-                    return pathname.isFile() && pathname.canRead();
-                }
-            });
+            final List<File> logFiles = findFiles(pathManager, context);
             final ModelNode result = context.getResult().setEmptyList();
             for (File logFile : logFiles) {
                 final ModelNode fileInfo = new ModelNode();
                 fileInfo.get(FILE_NAME.getName()).set(logFile.getName());
                 fileInfo.get(FILE_SIZE.getName()).set(logFile.length());
+                fileInfo.get(LAST_MODIFIED_DATE.getName()).set(logFile.lastModified());
                 result.add(fileInfo);
             }
             context.completeStep(ResultHandler.NOOP_RESULT_HANDLER);
         }
     }
 
+
+    /**
+     * Reads a log file and returns the results.
+     * <p/>
+     * <i>Note: </i> If this operation ends up being repeatedly invoked, from the web console for instance, there could
+     * be a performance impact as the model is read and processed for file names during each invocation
+     */
     private static class ReadLogFileOperation implements OperationStepHandler {
 
         private final PathManager pathManager;
@@ -240,9 +253,10 @@ public class LoggingRootResource extends TransformerResourceDefinition {
             if (!path.exists()) {
                 throw LoggingMessages.MESSAGES.logFileNotFound(fileName, ServerEnvironment.SERVER_LOG_DIR);
             }
+            final List<File> logFiles = findFiles(pathManager, context);
             // User must have permissions to read the file
-            if (!path.canRead()) {
-                throw LoggingMessages.MESSAGES.readPermissionDenied(fileName, ServerEnvironment.SERVER_LOG_DIR);
+            if (!path.canRead() || !logFiles.contains(path)) {
+                throw LoggingMessages.MESSAGES.readNotAllowed(fileName);
             }
 
             // Read the contents of the log file
@@ -305,6 +319,83 @@ public class LoggingRootResource extends TransformerResourceDefinition {
             closeable.close();
         } catch (Throwable t) {
             LoggingLogger.ROOT_LOGGER.failedToCloseResource(t, closeable);
+        }
+    }
+
+    /**
+     * Finds all the files in the {@code jboss.server.log.dir} that are defined on a known file handler.
+     *
+     * @param pathManager the path manager used to resolve the {@code jboss.server.log.dir}
+     * @param context     the context used to read the model from
+     *
+     * @return a list of files or an empty list if no files were found
+     */
+    private static List<File> findFiles(final PathManager pathManager, final OperationContext context) {
+        final ModelNode model = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
+        final String logDir = pathManager.getPathEntry(ServerEnvironment.SERVER_LOG_DIR).resolvePath();
+        final File[] logFiles = new File(logDir).listFiles(AllowedFilesFilter.create(model));
+        final List<File> result;
+        if (logFiles == null) {
+            result = Collections.emptyList();
+        } else {
+            result = Arrays.asList(logFiles);
+            Collections.sort(result);
+        }
+        return result;
+    }
+
+    private static class AllowedFilesFilter implements FileFilter {
+        private static final List<String> FILE_HANDLER_TYPES = Arrays.asList(FileHandlerResourceDefinition.FILE_HANDLER,
+                PeriodicHandlerResourceDefinition.PERIODIC_ROTATING_FILE_HANDLER,
+                SizeRotatingHandlerResourceDefinition.SIZE_ROTATING_FILE_HANDLER);
+
+        private final List<String> allowedNames;
+
+        private AllowedFilesFilter(final List<String> allowedNames) {
+            this.allowedNames = allowedNames;
+        }
+
+        static AllowedFilesFilter create(final ModelNode subsystemModel) {
+            final List<String> allowedNames = new ArrayList<String>();
+            findFileNames(subsystemModel, allowedNames);
+            return new AllowedFilesFilter(allowedNames);
+        }
+
+        private static void findFileNames(final ModelNode model, final List<String> names) {
+            // Get all the file names from the model
+            for (Property resource : model.asPropertyList()) {
+                final String name = resource.getName();
+                if (CommonAttributes.LOGGING_PROFILE.equals(name)) {
+                    for (Property profileResource : resource.getValue().asPropertyList()) {
+                        findFileNames(profileResource.getValue(), names);
+                    }
+                } else if (FILE_HANDLER_TYPES.contains(name)) {
+                    for (Property handlerResource : resource.getValue().asPropertyList()) {
+                        final ModelNode handlerModel = handlerResource.getValue();
+                        // This should always exist, but better to be safe
+                        if (handlerModel.hasDefined(CommonAttributes.FILE.getName())) {
+                            final ModelNode fileModel = handlerModel.get(CommonAttributes.FILE.getName());
+                            if (fileModel.hasDefined(PathResourceDefinition.PATH.getName())) {
+                                names.add(fileModel.get(PathResourceDefinition.PATH.getName()).asString());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public boolean accept(final File pathname) {
+            if (pathname.canRead()) {
+                final String name = pathname.getName();
+                // Let's do a best guess on the file
+                for (String allowedName : allowedNames) {
+                    if (name.equals(allowedName) || name.startsWith(allowedName)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
         }
     }
 

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -4,15 +4,18 @@ logging.add=Add the logging subsystem.
 logging.remove=Remove the logging subsystem.
 
 # read-log-file operation
-logging.read-log-file=Reads the contents of a log file.
+logging.read-log-file=Reads the contents of a log file. The file must be in the jboss.server.log.dir and must be defined as a \
+  file-handler, periodic-rotating-file-handler or size-rotating-file-handler.
 logging.read-log-file.name=The name of the log file to read. This file must exist in the jboss.server.log.dir.
 logging.read-log-file.lines=The number of lines to read from the file. A value of -1 will read all log lines.
 logging.read-log-file.skip=The number of lines to skip before reading.
 logging.read-log-file.tail=Reads from the end of the file.
 
-logging.list-log-files=Lists the log files in the jboss.server.log.dir directory.
+logging.list-log-files=Lists the log files in the jboss.server.log.dir directory that are defined on a file-handler, \
+  periodic-rotating-file-handler or size-rotating-file-handler.
 logging.list-log-files.file-name=The name of the file.
 logging.list-log-files.file-size=The size of the log file in bytes.
+logging.list-log-files.last-modified-date=The date the file was last modified.
 
 # Root resource attributes
 logging.add-logging-api-dependencies=Indicates whether or not logging API dependencies should be added to deployments \

--- a/logging/src/test/resources/simple-subsystem.xml
+++ b/logging/src/test/resources/simple-subsystem.xml
@@ -29,10 +29,18 @@
         <file relative-to="jboss.server.log.dir" path="simple.log"/>
     </file-handler>
 
+    <file-handler name="ignore" autoflush="true">
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file path="${jboss.server.log.dir}/ignore.log"/>
+    </file-handler>
+
     <logger category="org.jboss.as.logging.test" use-parent-handlers="false">
         <level name="INFO"/>
         <handlers>
             <handler name="FILE"/>
+            <handler name="ignore"/>
         </handlers>
     </logger>
 
@@ -43,4 +51,35 @@
     <formatter name="PATTERN">
         <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
     </formatter>
+
+    <logging-profiles>
+        <logging-profile name="testProfile">
+
+            <file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="profile-simple.log"/>
+            </file-handler>
+
+            <file-handler name="ignore" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file path="${jboss.server.log.dir}/profile-ignore.log"/>
+            </file-handler>
+
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="FILE"/>
+                    <handler name="ignore"/>
+                </handlers>
+            </root-logger>
+
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            </formatter>
+        </logging-profile>
+    </logging-profiles>
 </subsystem>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptedNoProceedSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptedNoProceedSLSB.java
@@ -47,7 +47,7 @@ public class InterceptedNoProceedSLSB {
         postConstructCalled = true;
     }
 
-    public boolean isPostConstructCalled() {
+    public static boolean isPostConstructCalled() {
         return postConstructCalled;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptedWithProceedSLSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptedWithProceedSLSB.java
@@ -52,7 +52,7 @@ public class InterceptedWithProceedSLSB {
         postConstructCalled = true;
     }
 
-    public boolean isPostConstructCalled() {
+    public static boolean isPostConstructCalled() {
         return postConstructCalled;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptorLifecycleSFSBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/chains/InterceptorLifecycleSFSBTestCase.java
@@ -56,7 +56,7 @@ public class InterceptorLifecycleSFSBTestCase {
         InterceptedNoProceedSLSB bean = (InterceptedNoProceedSLSB)ctx.lookup("java:module/" + InterceptedNoProceedSLSB.class.getSimpleName());
         bean.doStuff();
         Assert.assertTrue(LifecycleInterceptorNoProceed.postConstruct);
-        Assert.assertFalse(bean.isPostConstructCalled());
+        Assert.assertFalse(InterceptedNoProceedSLSB.isPostConstructCalled());
     }
 
     @Test
@@ -65,7 +65,7 @@ public class InterceptorLifecycleSFSBTestCase {
         InterceptedWithProceedSLSB bean = (InterceptedWithProceedSLSB)ctx.lookup("java:module/" + InterceptedWithProceedSLSB.class.getSimpleName());
         bean.doStuff();
         Assert.assertTrue(LifecycleInterceptorWithProceed.postConstruct);
-        Assert.assertTrue(bean.isPostConstructCalled());
+        Assert.assertTrue(InterceptedWithProceedSLSB.isPostConstructCalled());
     }
 
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/ManagedStatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/ManagedStatelessBean.java
@@ -29,6 +29,7 @@ import javax.ejb.Stateless;
 import javax.ejb.Timeout;
 import javax.ejb.Timer;
 
+import org.jboss.ejb3.annotation.Pool;
 import org.jboss.ejb3.annotation.SecurityDomain;
 
 /**
@@ -40,6 +41,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @SecurityDomain("other")
 @DeclareRoles(value = {"Role1", "Role2", "Role3"})
 @RunAs("Role3")
+@Pool("slsb-strict-max-pool")
 public class ManagedStatelessBean extends AbstractManagedBean implements BusinessInterface {
     @Timeout
     @Schedule(second="15", persistent = false)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerStatelessBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/management/deployments/NoTimerStatelessBean.java
@@ -26,6 +26,7 @@ import javax.annotation.security.DeclareRoles;
 import javax.annotation.security.RunAs;
 import javax.ejb.Stateless;
 
+import org.jboss.ejb3.annotation.Pool;
 import org.jboss.ejb3.annotation.SecurityDomain;
 
 /**
@@ -37,6 +38,7 @@ import org.jboss.ejb3.annotation.SecurityDomain;
 @SecurityDomain("other")
 @DeclareRoles(value = {"Role1", "Role2", "Role3"})
 @RunAs("Role3")
+@Pool("slsb-strict-max-pool")
 public class NoTimerStatelessBean implements BusinessInterface {
 
     @Override

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -69,13 +69,16 @@ import org.jboss.dmr.Property;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.FixMethodOrder;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 import org.xnio.IoUtils;
 
 /**
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public abstract class SimpleMixedDomainTest  {
 
     MixedDomainTestSupport support;
@@ -93,13 +96,13 @@ public abstract class SimpleMixedDomainTest  {
     }
 
     @Test
-    public void testServerRunning() throws Exception {
+    public void test1ServerRunning() throws Exception {
         URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.slaveAddress) + ":8080").openConnection();
         connection.connect();
     }
 
     @Test
-    public void testVersioning() throws Exception {
+    public void test2Versioning() throws Exception {
 
         DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
         ModelNode masterModel;
@@ -122,7 +125,7 @@ public abstract class SimpleMixedDomainTest  {
     }
 
     @Test
-    public void testSecurityTransformers() throws Exception {
+    public void test9SecurityTransformers() throws Exception {
         final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
         final DomainClient slaveClient = support.getDomainSlaveLifecycleUtil().createDomainClient();
         try {

--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -665,23 +665,23 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:infinispan:2.0">
                 <!-- In infinispan on 7.1.x the statistics are always on and not configurable, and need to be set to true on all cache-container and cache entries (the current default is false) -->
-                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics="true">
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="default" mode="SYNC" batching="true" statistics="true">
+                    <replicated-cache name="default" mode="SYNC" batching="true" statistics-enabled="true">
                         <locking isolation="REPEATABLE_READ"/>
                     </replicated-cache>
                 </cache-container>
-                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics="true">
+                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics="true">
+                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics-enabled="true">
                         <file-store/>
                     </replicated-cache>
-                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics="true">
+                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
                     <replicated-cache name="repl" mode="ASYNC" batching="true">
                         <eviction strategy="LRU" max-entries="10000"/>
@@ -691,25 +691,25 @@
                       ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
                       ~                 the socketbinding referenced by the EJB remoting connector 
                       -->
-                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <eviction strategy="LRU" max-entries="10000"/>
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics="true">
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <local-cache name="local-query" statistics="true">
+                    <local-cache name="local-query" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </local-cache>
-                    <invalidation-cache name="entity" mode="SYNC" statistics="true">
+                    <invalidation-cache name="entity" mode="SYNC" statistics-enabled="true">
                         <transaction mode="NON_XA"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </invalidation-cache>
-                    <replicated-cache name="timestamps" mode="ASYNC" statistics="true">
+                    <replicated-cache name="timestamps" mode="ASYNC" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="NONE"/>
                     </replicated-cache>
@@ -1176,25 +1176,25 @@
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:infinispan:2.0">
                 <!-- In infinispan on 7.1.x the statistics are always on and not configurable, and need to be set to true on all cache-container and cache entries (the current default is false) -->
-                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics="true">
+                <cache-container name="server" aliases="singleton cluster" default-cache="default" module="org.wildfly.clustering.server" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="default" mode="SYNC" batching="true" statistics="true">
+                    <replicated-cache name="default" mode="SYNC" batching="true" statistics-enabled="true">
                         <locking isolation="REPEATABLE_READ"/>
                     </replicated-cache>
                 </cache-container>
-                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics="true">
+                <cache-container name="web" aliases="standard-session-cache" default-cache="repl" module="org.wildfly.clustering.web.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics="true">
+                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics-enabled="true">
                         <file-store/>
                     </replicated-cache>
-                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="sso" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics="true">
+                <cache-container name="ejb" aliases="sfsb sfsb-cache" default-cache="repl" module="org.jboss.as.clustering.ejb3.infinispan" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics="true">
+                    <replicated-cache name="repl" mode="ASYNC" batching="true" statistics-enabled="true">
                         <eviction strategy="LRU" max-entries="10000"/>
                         <file-store/>
                     </replicated-cache>
@@ -1202,25 +1202,25 @@
                       ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
                       ~                 the socketbinding referenced by the EJB remoting connector 
                       -->
-                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics="true"/>
-                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics="true">
+                    <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true" statistics-enabled="true"/>
+                    <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0" statistics-enabled="true">
                         <eviction strategy="LRU" max-entries="10000"/>
                         <file-store/>
                     </distributed-cache>
                 </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics="true">
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate" statistics-enabled="true">
                     <transport lock-timeout="60000"/>
-                    <local-cache name="local-query" statistics="true">
+                    <local-cache name="local-query" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </local-cache>
-                    <invalidation-cache name="entity" mode="SYNC" statistics="true">
+                    <invalidation-cache name="entity" mode="SYNC" statistics-enabled="true">
                         <transaction mode="NON_XA"/>
                         <eviction strategy="LRU" max-entries="10000"/>
                         <expiration max-idle="100000"/>
                     </invalidation-cache>
-                    <replicated-cache name="timestamps" mode="ASYNC" statistics="true">
+                    <replicated-cache name="timestamps" mode="ASYNC" statistics-enabled="true">
                         <transaction mode="NONE"/>
                         <eviction strategy="NONE"/>
                     </replicated-cache>


### PR DESCRIPTION
Changes the `list-log-files` and `read-log-file` operations to only allow log files found in a `file-handler`, `periodic-rotating-file-handler` and `size-rotating-file-handler`. This eliminates the need to filter out files from an audit log configuration or the operations being used as a generic file viewer.
