### PR TITLE
[WFLY-2808] correct method name typo, and HandleWrapper should be serializable

### DIFF
--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/BasicIIOPInvocationTestCase.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/BasicIIOPInvocationTestCase.java
@@ -118,7 +118,7 @@ public class BasicIIOPInvocationTestCase {
     @OperateOnDeployment("client")
     public void testWrappedHandle() throws IOException, NamingException {
         final ClientEjb ejb = client();
-        Assert.assertEquals("hello", ejb.getRemoteViaHandleMessage());
+        Assert.assertEquals("hello", ejb.getRemoteViaWrappedHandle());
     }
 
     @Test

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/HandleWrapper.java
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/HandleWrapper.java
@@ -1,14 +1,15 @@
 package org.jboss.as.test.iiop.basic;
 
-import org.jboss.ejb.client.EJBHandle;
+import java.io.Serializable;
 
 import javax.ejb.Handle;
 
 /**
  * @author Stuart Douglas
  */
-public class HandleWrapper {
+public class HandleWrapper implements Serializable{
 
+    private static final long serialVersionUID = 1L;
     private final Handle handle;
 
     public HandleWrapper(Handle handle) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2808
Accidentally see this method name typo, and HandleWrapper should be serializable.
