### PR TITLE
[WFLY-475] Allow user to accept server certificate without needing a second connection attempt.

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CLIModelControllerClient.java
@@ -40,6 +40,7 @@ import org.jboss.as.cli.Util;
 import org.jboss.as.cli.impl.ModelControllerClientFactory.ConnectionCloseHandler;
 import org.jboss.as.controller.client.impl.AbstractModelControllerClient;
 import org.jboss.as.protocol.ProtocolChannelClient;
+import org.jboss.as.protocol.ProtocolTimeoutHandler;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.as.protocol.mgmt.ManagementChannelAssociation;
 import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
@@ -116,7 +117,8 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
     private boolean closed;
 
     CLIModelControllerClient(final ControllerAddress address, CallbackHandler handler, int connectionTimeout,
-            final ConnectionCloseHandler closeHandler, Map<String, String> saslOptions, SSLContext sslContext) throws IOException {
+            final ConnectionCloseHandler closeHandler, Map<String, String> saslOptions, SSLContext sslContext,
+            ProtocolTimeoutHandler timeoutHandler) throws IOException {
         this.handler = handler;
         this.sslContext = sslContext;
         this.closeHandler = closeHandler;
@@ -145,6 +147,7 @@ public class CLIModelControllerClient extends AbstractModelControllerClient {
             channelConfig.setConnectionTimeout(connectionTimeout);
         }
         channelConfig.setEndpoint(endpoint);
+        channelConfig.setTimeoutHandler(timeoutHandler);
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -149,6 +149,7 @@ import org.jboss.as.cli.operation.impl.DefaultPrefixFormatter;
 import org.jboss.as.cli.operation.impl.RolloutPlanCompleter;
 import org.jboss.as.cli.parsing.operation.OperationFormat;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.protocol.GeneralTimeoutHandler;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.aesh.console.settings.Settings;
@@ -216,6 +217,8 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     private BatchManager batchManager = new DefaultBatchManager();
     /** the default command completer */
     private final CommandCompleter cmdCompleter;
+    /** the timeout handler */
+    private final GeneralTimeoutHandler timeoutHandler = new GeneralTimeoutHandler();
 
     /** output target */
     private BufferedWriter outputTarget;
@@ -817,7 +820,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                     log.debug("connecting to " + address.getHost() + ':' + address.getPort() + " as " + username);
                 }
                 ModelControllerClient tempClient = ModelControllerClientFactory.CUSTOM.
-                        getClient(address, cbh, disableLocalAuth, sslContext, connectionTimeout, this);
+                        getClient(address, cbh, disableLocalAuth, sslContext, connectionTimeout, this, timeoutHandler);
                 retry = tryConnection(tempClient, address);
                 if(!retry) {
                     newClient = tempClient;
@@ -1366,7 +1369,35 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             this.digest = digest;
         }
 
-        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+        @Override
+        public void handle(final Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+            try {
+                timeoutHandler.suspendAndExecute(new Runnable() {
+
+                    @Override
+                    public void run() {
+
+                        try {
+                            dohandle(callbacks);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        } catch (UnsupportedCallbackException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof IOException) {
+                    throw (IOException) e.getCause();
+                } else if (e.getCause() instanceof UnsupportedCallbackException) {
+                    throw (UnsupportedCallbackException) e.getCause();
+                }
+                throw e;
+            }
+
+        }
+
+        private void dohandle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
             // Special case for anonymous authentication to avoid prompting user for their name.
             if (callbacks.length == 1 && callbacks[0] instanceof NameCallback) {
                 ((NameCallback) callbacks[0]).setName("anonymous CLI user");

--- a/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CommandContextImpl.java
@@ -810,28 +810,21 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     public void connectController(String controller) throws CommandLineException {
         ControllerAddress address = addressResolver.resolveAddress(controller);
 
-        boolean retry;
-        do {
-            retry = false;
-            try {
-                ModelControllerClient newClient = null;
-                CallbackHandler cbh = new AuthenticationCallbackHandler(username, password);
-                if(log.isDebugEnabled()) {
-                    log.debug("connecting to " + address.getHost() + ':' + address.getPort() + " as " + username);
-                }
-                ModelControllerClient tempClient = ModelControllerClientFactory.CUSTOM.
-                        getClient(address, cbh, disableLocalAuth, sslContext, connectionTimeout, this, timeoutHandler);
-                retry = tryConnection(tempClient, address);
-                if(!retry) {
-                    newClient = tempClient;
-                }
-                initNewClient(newClient, address);
-            } catch (RedirectException e) {
-                throw new CommandLineException("Server at " + address.getHost() + ":" + address.getPort() + " does not support " + address.getProtocol());
-            } catch (IOException e) {
-                throw new CommandLineException("Failed to resolve host '" + address.getHost() + "'",e);
+        try {
+            CallbackHandler cbh = new AuthenticationCallbackHandler(username, password);
+            if (log.isDebugEnabled()) {
+                log.debug("connecting to " + address.getHost() + ':' + address.getPort() + " as " + username);
             }
-        } while (retry);
+            ModelControllerClient tempClient = ModelControllerClientFactory.CUSTOM.getClient(address, cbh, disableLocalAuth,
+                    sslContext, connectionTimeout, this, timeoutHandler);
+            tryConnection(tempClient, address);
+            initNewClient(tempClient, address);
+        } catch (RedirectException re) {
+            throw new CommandLineException("Server at " + address.getHost() + ":" + address.getPort() + " does not support "
+                    + address.getProtocol());
+        } catch (IOException e) {
+            throw new CommandLineException("Failed to resolve host '" + address.getHost() + "'", e);
+        }
     }
 
     @Override
@@ -879,14 +872,10 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     /**
      * Handle the last SSL failure, prompting the user to accept or reject the certificate of the remote server.
      *
-     * @return true if the connection should be retried.
+     * @return true if the certificate validation should be retried.
      */
-    private boolean handleSSLFailure() throws CommandLineException {
-        Certificate[] lastChain;
-        if (trustManager == null || (lastChain = trustManager.getLastFailedCertificateChain()) == null) {
-            return false;
-        }
-        printLine("Unable to connect due to unrecognised server certificate");
+    private boolean handleSSLFailure(Certificate[] lastChain) throws CommandLineException {
+        error("Unable to connect due to unrecognised server certificate");
         for (Certificate current : lastChain) {
             if (current instanceof X509Certificate) {
                 X509Certificate x509Current = (X509Certificate) current;
@@ -922,7 +911,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                             trustManager.storeChainPermenantly(lastChain);
                             return true;
                         }
-
                 }
             }
         }
@@ -965,7 +953,7 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
     /**
      * Used to make a call to the server to verify that it is possible to connect.
      */
-    private boolean tryConnection(final ModelControllerClient client, ControllerAddress address) throws CommandLineException, RedirectException {
+    private void tryConnection(final ModelControllerClient client, ControllerAddress address) throws CommandLineException, RedirectException {
         try {
             DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
             builder.setOperationName(Util.READ_ATTRIBUTE);
@@ -974,7 +962,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
             client.execute(builder.buildRequest());
             // We don't actually care what the response is we just want to be sure the ModelControllerClient
             // does not throw an Exception.
-            return false;
         } catch (Exception e) {
             try {
                 Throwable current = e;
@@ -983,14 +970,13 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
                         throw new CommandLineException("Unable to authenticate against controller at " + address.getHost() + ":" + address.getPort(), current);
                     }
                     if (current instanceof SSLException) {
-                        if (!handleSSLFailure()) {
-                            throw new CommandLineException("Unable to negotiate SSL connection with controller at " + address.getHost() + ":" + address.getPort());
-                        } else {
-                            return true;
-                        }
+                        throw new CommandLineException("Unable to negotiate SSL connection with controller at "+ address.getHost() + ":" + address.getPort());
                     }
                     if (current instanceof RedirectException) {
                         throw (RedirectException) current;
+                    }
+                    if (current instanceof CommandLineException) {
+                        throw (CommandLineException) current;
                     }
                     current = current.getCause();
                 }
@@ -1479,7 +1465,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         private final boolean modifyTrustStore;
 
         private Set<X509Certificate> temporarilyTrusted = new HashSet<X509Certificate>();
-        private Certificate[] lastFailedCert;
         private X509TrustManager delegate;
 
         LazyDelagatingTrustManager(String trustStore, String trustStorePassword, boolean modifyTrustStore) {
@@ -1494,19 +1479,6 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
 
         boolean isModifyTrustStore() {
             return modifyTrustStore;
-        }
-
-        void setFailedCertChain(final Certificate[] chain) {
-            this.lastFailedCert = chain;
-        }
-
-        Certificate[] getLastFailedCertificateChain() {
-            try {
-                return lastFailedCert;
-            } finally {
-                // Only one chance to accept it.
-                lastFailedCert = null;
-            }
         }
 
         synchronized void storeChainTemporarily(final Certificate[] chain) {
@@ -1608,13 +1580,36 @@ class CommandContextImpl implements CommandContext, ModelControllerClientFactory
         }
 
         @Override
-        public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-            try {
-                getDelegate().checkServerTrusted(chain, authType);
-            } catch (CertificateException ce) {
-                setFailedCertChain(chain);
-                throw ce;
-            }
+        public void checkServerTrusted(final X509Certificate[] chain, String authType) throws CertificateException {
+            boolean retry;
+            do {
+                retry = false;
+                try {
+                    getDelegate().checkServerTrusted(chain, authType);
+                } catch (CertificateException ce) {
+                    if (retry == false) {
+                        timeoutHandler.suspendAndExecute(new Runnable() {
+
+                            @Override
+                            public void run() {
+                                try {
+                                    handleSSLFailure(chain);
+                                } catch (CommandLineException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            }
+                        });
+
+                        if (delegate == null) {
+                            retry = true;
+                        } else {
+                            throw ce;
+                        }
+                    } else {
+                        throw ce;
+                    }
+                }
+            } while (retry);
         }
 
         @Override

--- a/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ModelControllerClientFactory.java
@@ -30,6 +30,7 @@ import javax.security.auth.callback.CallbackHandler;
 
 import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.protocol.ProtocolTimeoutHandler;
 
 /**
  * @author Alexey Loubyansky
@@ -49,13 +50,14 @@ public interface ModelControllerClientFactory {
 
     ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
             boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
-            ConnectionCloseHandler closeHandler) throws IOException;
+            ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler) throws IOException;
 
     ModelControllerClientFactory DEFAULT = new ModelControllerClientFactory() {
         @Override
         public ModelControllerClient getClient(ControllerAddress address, CallbackHandler handler,
                 boolean disableLocalAuth, SSLContext sslContext, int connectionTimeout,
-                ConnectionCloseHandler closeHandler) throws IOException {
+                ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler) throws IOException {
+            // TODO - Make use of the ProtocolTimeoutHandler
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
             return ModelControllerClient.Factory.create(address.getProtocol(), address.getHost(), address.getPort(), handler, sslContext, connectionTimeout, saslOptions);
         }
@@ -66,9 +68,9 @@ public interface ModelControllerClientFactory {
         @Override
         public ModelControllerClient getClient(ControllerAddress address,
                 final CallbackHandler handler, boolean disableLocalAuth, final SSLContext sslContext,
-                final int connectionTimeout, final ConnectionCloseHandler closeHandler) throws IOException {
+                final int connectionTimeout, final ConnectionCloseHandler closeHandler, ProtocolTimeoutHandler timeoutHandler) throws IOException {
             Map<String, String> saslOptions = disableLocalAuth ? DISABLED_LOCAL_AUTH : ENABLED_LOCAL_AUTH;
-            return new CLIModelControllerClient(address, handler, connectionTimeout, closeHandler, saslOptions, sslContext);
+            return new CLIModelControllerClient(address, handler, connectionTimeout, closeHandler, saslOptions, sslContext, timeoutHandler);
         }};
 
 }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
@@ -24,6 +24,7 @@ package org.jboss.as.controller.client.impl;
 
 import java.security.AccessControlContext;
 import org.jboss.as.controller.client.ModelControllerClientConfiguration;
+import org.jboss.as.protocol.ProtocolTimeoutHandler;
 import org.jboss.threads.JBossThreadFactory;
 
 import javax.net.ssl.SSLContext;

--- a/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/impl/ClientConfigurationImpl.java
@@ -24,7 +24,6 @@ package org.jboss.as.controller.client.impl;
 
 import java.security.AccessControlContext;
 import org.jboss.as.controller.client.ModelControllerClientConfiguration;
-import org.jboss.as.protocol.ProtocolTimeoutHandler;
 import org.jboss.threads.JBossThreadFactory;
 
 import javax.net.ssl.SSLContext;

--- a/protocol/src/main/java/org/jboss/as/protocol/GeneralTimeoutHandler.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/GeneralTimeoutHandler.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.protocol;
+
+import java.util.concurrent.TimeUnit;
+
+import org.xnio.IoFuture;
+import org.xnio.IoFuture.Status;
+
+/**
+ * A general implementation of {@link ProtocolTimeoutHandler} that takes into account the time taken for {@link Runnable} tasks
+ * to be executed.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public class GeneralTimeoutHandler implements ProtocolTimeoutHandler {
+
+    private volatile boolean thinking = false;
+    private volatile long thinkTime = 0;
+
+    public void suspendAndExecute(final Runnable runnable) {
+        thinking = true;
+        long startThinking = System.currentTimeMillis();
+        try {
+            runnable.run();
+        } finally {
+            thinkTime += System.currentTimeMillis() - startThinking;
+            thinking = false;
+        }
+    }
+
+    @Override
+    public Status await(IoFuture<?> future, long timeoutMillis) {
+        final long startTime = System.currentTimeMillis();
+
+        IoFuture.Status status = future.await(timeoutMillis, TimeUnit.MILLISECONDS);
+        while (status == IoFuture.Status.WAITING) {
+            if (thinking) {
+                status = future.await(timeoutMillis, TimeUnit.MILLISECONDS);
+            } else {
+                long timeToWait = (timeoutMillis + thinkTime) - (System.currentTimeMillis() - startTime);
+                if (timeToWait > 0) {
+                    status = future.await(timeToWait, TimeUnit.MILLISECONDS);
+                } else {
+                    return status;
+                }
+            }
+        }
+
+        return status;
+    }
+
+}

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionConfiguration.java
@@ -52,6 +52,7 @@ public class ProtocolConnectionConfiguration {
     private Map<String, String> saslOptions = Collections.emptyMap();
     private SSLContext sslContext;
     private String clientBindAddress;
+    private ProtocolTimeoutHandler timeoutHandler;
 
     protected ProtocolConnectionConfiguration() {
         // TODO AS7-6223 propagate clientBindAddress configuration up to end user level and get rid of this system property
@@ -134,6 +135,14 @@ public class ProtocolConnectionConfiguration {
         this.clientBindAddress = clientBindAddress;
     }
 
+    public ProtocolTimeoutHandler getTimeoutHandler() {
+        return timeoutHandler;
+    }
+
+    public void setTimeoutHandler(ProtocolTimeoutHandler timeoutHandler) {
+        this.timeoutHandler = timeoutHandler;
+    }
+
     public ProtocolConnectionConfiguration copy() {
         return copy(this);
     }
@@ -160,6 +169,7 @@ public class ProtocolConnectionConfiguration {
         configuration.saslOptions = old.saslOptions;
         configuration.sslContext = old.sslContext;
         configuration.clientBindAddress = old.clientBindAddress;
+        configuration.timeoutHandler = old.timeoutHandler;
         return configuration;
     }
 

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolConnectionUtils.java
@@ -45,7 +45,6 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Protocol Connection utils.
@@ -93,34 +92,24 @@ public class ProtocolConnectionUtils {
      * @throws IOException
      */
     public static Connection connectSync(final ProtocolConnectionConfiguration configuration) throws IOException {
-        final CallbackHandler handler = configuration.getCallbackHandler();
-        final CallbackHandler actualHandler = handler != null ? handler : new AnonymousCallbackHandler();
-        final WrapperCallbackHandler wrapperHandler = new WrapperCallbackHandler(actualHandler);
-        final IoFuture<Connection> future = connect(wrapperHandler, configuration);
         long timeoutMillis = configuration.getConnectionTimeout();
-        IoFuture.Status status = future.await(timeoutMillis, TimeUnit.MILLISECONDS);
-        while (status == IoFuture.Status.WAITING) {
-            if (wrapperHandler.isInCall()) {
-                // If there is currently an interaction with the user just wait again.
-                status = future.await(timeoutMillis, TimeUnit.MILLISECONDS);
-            } else {
-                long lastInteraction = wrapperHandler.getCallFinished();
-                if (lastInteraction > 0) {
-                    long now = System.currentTimeMillis();
-                    long timeSinceLast = now - lastInteraction;
-                    if (timeSinceLast < timeoutMillis) {
-                        // As this point we are setting the timeout based on the time of the last interaction
-                        // with the user, if there is any time left we will wait for that time but dont wait for
-                        // a full timeout.
-                        status = future.await(timeoutMillis - timeSinceLast, TimeUnit.MILLISECONDS);
-                    } else {
-                        status = null;
-                    }
-                } else {
-                    status = null; // Just terminate status processing.
-                }
-            }
+        CallbackHandler handler = configuration.getCallbackHandler();
+        final CallbackHandler actualHandler;
+        ProtocolTimeoutHandler timeoutHandler = configuration.getTimeoutHandler();
+        // Note: If a client supplies a ProtocolTimeoutHandler it is taking on full responsibility for timeout management.
+        if (timeoutHandler == null) {
+            GeneralTimeoutHandler defaultTimeoutHandler = new GeneralTimeoutHandler();
+            // No point wrapping our AnonymousCallbackHandler.
+            actualHandler = handler != null ? new WrapperCallbackHandler(defaultTimeoutHandler, handler)
+                    : new AnonymousCallbackHandler();
+            timeoutHandler = defaultTimeoutHandler;
+        } else {
+            actualHandler = handler != null ? handler : new AnonymousCallbackHandler();
         }
+
+        final IoFuture<Connection> future = connect(actualHandler, configuration);
+
+        IoFuture.Status status = timeoutHandler.await(future, timeoutMillis);
 
         if (status == IoFuture.Status.DONE) {
             return future.get();
@@ -215,35 +204,40 @@ public class ProtocolConnectionUtils {
 
     private static final class WrapperCallbackHandler implements CallbackHandler {
 
-        private volatile boolean inCall = false;
-
-        private volatile long callFinished = -1;
-
+        private final GeneralTimeoutHandler timeoutHandler;
         private final CallbackHandler wrapped;
 
-        WrapperCallbackHandler(final CallbackHandler toWrap) {
+        WrapperCallbackHandler(final GeneralTimeoutHandler timeoutHandler, final CallbackHandler toWrap) {
+            this.timeoutHandler = timeoutHandler;
             this.wrapped = toWrap;
         }
 
-        public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
-            inCall = true;
+        public void handle(final Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+
             try {
-                wrapped.handle(callbacks);
-            } finally {
-                // Set the time first so if a read is made between these two calls it will say inCall=true until
-                // callFinished is set.
-                callFinished = System.currentTimeMillis();
-                inCall = false;
+                timeoutHandler.suspendAndExecute(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        try {
+                            wrapped.handle(callbacks);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        } catch (UnsupportedCallbackException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof IOException) {
+                    throw (IOException) e.getCause();
+                } else if (e.getCause() instanceof UnsupportedCallbackException) {
+                    throw (UnsupportedCallbackException) e.getCause();
+                }
+                throw e;
             }
         }
 
-        boolean isInCall() {
-            return inCall;
-        }
-
-        long getCallFinished() {
-            return callFinished;
-        }
     }
 
     private static final class AnonymousCallbackHandler implements CallbackHandler {

--- a/protocol/src/main/java/org/jboss/as/protocol/ProtocolTimeoutHandler.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/ProtocolTimeoutHandler.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.protocol;
+
+import org.xnio.IoFuture;
+
+/**
+ * An implementation of this interface can be provided by calling clients where they wish to supply their own implementation to
+ * handle timeouts whilst establishing a connection.
+ *
+ * The general purpose of this is for clients that wish to take into account additional factors during connection such as user
+ * think time / value entry.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public interface ProtocolTimeoutHandler {
+
+    /**
+     * Wait for the specified time on the supplied {@link IoFuture}, taking into account that some of this time could actually
+     * not be related to the establishment of the connection but instead some local task such as user think time.
+     *
+     * @param future - The {@link IoFuture} to wait on.
+     * @param timeoutMillis - The configures timeout in milliseconds.
+     * @return The {@link IoFuture.Status} when available or at the time the timeout is reached - whichever is soonest.
+     */
+    IoFuture.Status await(IoFuture<?> future, long timeoutMillis);
+
+}


### PR DESCRIPTION
This change expands on the CallbackHandler that was used previously to ignore timeouts where the user is making a decision to a more generic ProtocolTimeoutHandler that we now use both for CallbackHandler interaction and for TrustManager interactions.
