### PR TITLE
[WFLY-2211] For domain management we may have http, https or both.

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HttpManagementAddHandler.java
@@ -158,14 +158,19 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
                 .install();
 
         if(httpUpgrade) {
-
-
             ServiceName serverCallbackService = ServiceName.JBOSS.append("host", "controller", "server-inventory", "callback");
             ServiceName tmpDirPath = ServiceName.JBOSS.append("server", "path", "jboss.domain.temp.dir");
             ManagementRemotingServices.installSecurityServices(serviceTarget, ManagementRemotingServices.HTTP_CONNECTOR, securityRealm, serverCallbackService, tmpDirPath, verificationHandler, newControllers);
 
             NativeManagementServices.installRemotingServicesIfNotInstalled(serviceTarget, hostControllerInfo.getLocalHostName(), verificationHandler, null, serviceRegistry,onDemand);
-            RemotingHttpUpgradeService.installServices(serviceTarget, ManagementRemotingServices.HTTP_CONNECTOR, ManagementRemotingServices.HTTP_CONNECTOR, ManagementRemotingServices.MANAGEMENT_ENDPOINT, OptionMap.EMPTY, verificationHandler, newControllers);
+            final String httpConnectorName;
+            if (port > -1 || securePort < 0) {
+                httpConnectorName = ManagementRemotingServices.HTTP_CONNECTOR;
+            } else {
+                httpConnectorName = ManagementRemotingServices.HTTPS_CONNECTOR;
+            }
+
+            RemotingHttpUpgradeService.installServices(serviceTarget, ManagementRemotingServices.HTTP_CONNECTOR, httpConnectorName, ManagementRemotingServices.MANAGEMENT_ENDPOINT, OptionMap.EMPTY, verificationHandler, newControllers);
         }
 
     }

--- a/remoting/src/main/java/org/jboss/as/remoting/HttpConnectorAdd.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/HttpConnectorAdd.java
@@ -72,10 +72,7 @@ public class HttpConnectorAdd extends AbstractAddStepHandler {
 
         final ServiceTarget target = context.getServiceTarget();
         final String connectorRef = HttpConnectorResource.CONNECTOR_REF.resolveModelAttribute(context, model).asString();
+
         RemotingHttpUpgradeService.installServices(target, connectorName, connectorRef, RemotingServices.SUBSYSTEM_ENDPOINT, optionMap, verificationHandler, newControllers);
-
-        //TODO: install upgrade service
-
-
     }
 }

--- a/remoting/src/main/java/org/jboss/as/remoting/RemotingConnectorBindingInfoService.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/RemotingConnectorBindingInfoService.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 package org.jboss.as.remoting;
 
 import org.jboss.as.network.SocketBinding;

--- a/remoting/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
+++ b/remoting/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
@@ -70,6 +70,7 @@ public final class ManagementRemotingServices extends RemotingServices {
 
     public static final String MANAGEMENT_CONNECTOR = "management";
     public static final String HTTP_CONNECTOR = "http-management";
+    public static final String HTTPS_CONNECTOR = "https-management";
 
     /**
      * Installs a remoting stream server for a domain instance

--- a/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/HttpManagementAddHandler.java
@@ -263,11 +263,17 @@ public class HttpManagementAddHandler extends AbstractAddStepHandler {
         if(httpUpgrade) {
             final String hostName = WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.NODE_NAME, null);
 
-
             ServiceName tmpDirPath = ServiceName.JBOSS.append("server", "path", "jboss.server.temp.dir");
             RemotingServices.installSecurityServices(serviceTarget, ManagementRemotingServices.HTTP_CONNECTOR, securityRealm, null, tmpDirPath, verificationHandler, newControllers);
             NativeManagementServices.installRemotingServicesIfNotInstalled(serviceTarget, hostName, verificationHandler, null, context.getServiceRegistry(false));
-            RemotingHttpUpgradeService.installServices(serviceTarget, ManagementRemotingServices.HTTP_CONNECTOR, ManagementRemotingServices.HTTP_CONNECTOR, ManagementRemotingServices.MANAGEMENT_ENDPOINT, OptionMap.EMPTY, verificationHandler, newControllers);
+            final String httpConnectorName;
+            if (port > -1 || socketBindingServiceName != null || (securePort < 0 && secureSocketBindingServiceName == null)) {
+                httpConnectorName = ManagementRemotingServices.HTTP_CONNECTOR;
+            } else {
+                httpConnectorName = ManagementRemotingServices.HTTPS_CONNECTOR;
+            }
+
+            RemotingHttpUpgradeService.installServices(serviceTarget, ManagementRemotingServices.HTTP_CONNECTOR, httpConnectorName, ManagementRemotingServices.MANAGEMENT_ENDPOINT, OptionMap.EMPTY, verificationHandler, newControllers);
         }
 
     }


### PR DESCRIPTION
This commit corrects an issue where a NullPointerException was encountered when only https was defined.
