### PR TITLE
[WFLY-2637] Only allow log files defined in known file handlers to be listed and read

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingMessages.java
@@ -717,11 +717,10 @@ public interface LoggingMessages {
     /**
      * Creates an exception indicating the user cannot read the file.
      *
-     * @param name              the name of the file that was not allowed to be read
-     * @param directoryProperty the name of the property used to resolved the log directory
+     * @param name the name of the file that was not allowed to be read
      *
      * @return an {@link OperationFailedException} for the error
      */
-    @Message(id = 11595, value = "Permission was denied to read file '%s' in the %s directory property.")
-    OperationFailedException readPermissionDenied(String name, String directoryProperty);
+    @Message(id = 11595, value = "File '%s' is not allowed to be read.")
+    OperationFailedException readNotAllowed(String name);
 }

--- a/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
+++ b/logging/src/main/resources/org/jboss/as/logging/LocalDescriptions.properties
@@ -4,15 +4,18 @@ logging.add=Add the logging subsystem.
 logging.remove=Remove the logging subsystem.
 
 # read-log-file operation
-logging.read-log-file=Reads the contents of a log file.
+logging.read-log-file=Reads the contents of a log file. The file must be in the jboss.server.log.dir and must be defined as a \
+  file-handler, periodic-rotating-file-handler or size-rotating-file-handler.
 logging.read-log-file.name=The name of the log file to read. This file must exist in the jboss.server.log.dir.
 logging.read-log-file.lines=The number of lines to read from the file. A value of -1 will read all log lines.
 logging.read-log-file.skip=The number of lines to skip before reading.
 logging.read-log-file.tail=Reads from the end of the file.
 
-logging.list-log-files=Lists the log files in the jboss.server.log.dir directory.
+logging.list-log-files=Lists the log files in the jboss.server.log.dir directory that are defined on a file-handler, \
+  periodic-rotating-file-handler or size-rotating-file-handler.
 logging.list-log-files.file-name=The name of the file.
 logging.list-log-files.file-size=The size of the log file in bytes.
+logging.list-log-files.last-modified-date=The date the file was last modified.
 
 # Root resource attributes
 logging.add-logging-api-dependencies=Indicates whether or not logging API dependencies should be added to deployments \

--- a/logging/src/test/resources/simple-subsystem.xml
+++ b/logging/src/test/resources/simple-subsystem.xml
@@ -29,10 +29,18 @@
         <file relative-to="jboss.server.log.dir" path="simple.log"/>
     </file-handler>
 
+    <file-handler name="ignore" autoflush="true">
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file path="${jboss.server.log.dir}/ignore.log"/>
+    </file-handler>
+
     <logger category="org.jboss.as.logging.test" use-parent-handlers="false">
         <level name="INFO"/>
         <handlers>
             <handler name="FILE"/>
+            <handler name="ignore"/>
         </handlers>
     </logger>
 
@@ -43,4 +51,35 @@
     <formatter name="PATTERN">
         <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
     </formatter>
+
+    <logging-profiles>
+        <logging-profile name="testProfile">
+
+            <file-handler name="FILE" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="profile-simple.log"/>
+            </file-handler>
+
+            <file-handler name="ignore" autoflush="true">
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file path="${jboss.server.log.dir}/profile-ignore.log"/>
+            </file-handler>
+
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="FILE"/>
+                    <handler name="ignore"/>
+                </handlers>
+            </root-logger>
+
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+            </formatter>
+        </logging-profile>
+    </logging-profiles>
 </subsystem>


### PR DESCRIPTION
Changes the `list-log-files` and `read-log-file` operations to only allow log files found in a `file-handler`, `periodic-rotating-file-handler` and `size-rotating-file-handler`. This eliminates the need to filter out files from an audit log configuration or the operations being used as a generic file viewer.
