### PR TITLE
WFLY-2802 Component upgrade to Hibernate Search 4.5.0.CR1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,8 +155,8 @@
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
         <version.org.hibernate.validator>5.0.2.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-        <version.org.hibernate.hql>1.0.0.Alpha5</version.org.hibernate.hql>
-        <version.org.hibernate.search>4.5.0.Alpha2</version.org.hibernate.search>
+        <version.org.hibernate.hql>1.0.0.Alpha6</version.org.hibernate.hql>
+        <version.org.hibernate.search>4.5.0.CR1</version.org.hibernate.search>
         <version.org.hornetq>2.4.0.Final</version.org.hornetq>
         <version.org.infinispan>6.0.1.Final</version.org.infinispan>
         <version.org.jacorb>2.3.2-jbossorg-5</version.org.jacorb>


### PR DESCRIPTION
- Move to a stable version of Hibernate Search compatible with the Hibernate ORM version 4.3.1 (the one included in WildFly)
- The org.hibernate.hql package needs also to be upgraded to 1.0.0.Alpha6 to keep them compatible

https://issues.jboss.org/browse/WFLY-2802
