### PR TITLE
WFLY-2813 testsuite/integration pom fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -168,6 +168,7 @@ main() {
             ## -s .../settings.xml - don't use our own.
             -s)      MVN_SETTINGS_XML_ARGS="";   ADDIT_PARAMS="$ADDIT_PARAMS $param";;
             -*)      ADDIT_PARAMS="$ADDIT_PARAMS '$param'";;
+            help*)   MVN_GOAL="$MVN_GOAL$param ";;
             clean)   MVN_GOAL="$MVN_GOAL$param ";;
             test)    MVN_GOAL="$MVN_GOAL$param ";;
             install) MVN_GOAL="$MVN_GOAL$param ";;

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -174,60 +174,6 @@
                 <module>patching</module>
             </modules>
         </profile>
-        <profile>
-            <id>help</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-help-plugin</artifactId>
-                        <inherited>true</inherited>
-                        <executions>
-                            <execution>
-                                <id>help.active-profiles</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>active-profiles</goal>
-                                </goals>
-                                <configuration>
-                                    <output>target/help.active-profiles.txt</output>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>help.effective-pom</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>effective-pom</goal>
-                                </goals>
-                                <configuration>
-                                    <output>target/help.effective-pom.txt</output>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>help.effective-settings</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>effective-settings</goal>
-                                </goals>
-                                <configuration>
-                                    <output>target/help.effective-settings.txt</output>
-                                </configuration>
-                            </execution>
-                            <execution>
-                                <id>help.system</id>
-                                <phase>initialize</phase>
-                                <goals>
-                                    <goal>system</goal>
-                                </goals>
-                                <configuration>
-                                    <output>target/help.system.txt</output>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
 
@@ -270,6 +216,11 @@
                 </executions>
             </plugin>
 
+            <!-- Setup standalone server IP and logging configuration -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>xml-maven-plugin</artifactId>
+            </plugin>
 
             <!-- General surefire configuration. Applies to submodules too. -->
             <plugin>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1220,6 +1220,7 @@
 
         <profile>
             <id>help</id>
+            <activation><property><name>ts.help</name></property></activation>
             <build>
                 <plugins>
                     <!-- Testsuite debugging info. -->


### PR DESCRIPTION
WFLY-2813
- enable help:\* goals in build.sh
- remove duplication and discrepancy of help profile between testsuite and testsuite/integration
- enable help profile by default in testsuite/pom.xml (why is it a profile at all btw?)
- fix inheritance of xml-maven-plugin in testsuite/integration module and submodules (fixes IP and logging configuration)
