### PR TITLE
Revert "Revert "[WFLY-2047] org.jboss.as.connector module needs sun.jdk module dependency""

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -32,6 +32,7 @@
     </resources>
 
     <dependencies>
+        <module name="sun.jdk"/>
         <module name="javax.api"/>
         <module name="javax.resource.api"/>
         <module name="javax.transaction.api"/>


### PR DESCRIPTION
This fix is harmless, even if not strictly "correct", and it solves real-world problems.  There was no good reason to revert this commit in the first place.

This reverts commit 9a3b000767c018a681a4858a84aae20a0b8c7310.
The original revert reverted 88756ddb1061660cb.
