### PR TITLE
WFLY-2441 Arquillian Protocol default is now Servlet 3.0

### DIFF
--- a/arquillian/common/pom.xml
+++ b/arquillian/common/pom.xml
@@ -63,6 +63,10 @@
           <artifactId>arquillian-container-test-impl-base</artifactId>
         </dependency>
         <dependency>
+          <groupId>org.jboss.arquillian.protocol</groupId>
+          <artifactId>arquillian-protocol-servlet</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-arquillian-testenricher-msc</artifactId>
         </dependency>

--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/CommonDeployableContainer.java
@@ -68,7 +68,7 @@ public abstract class CommonDeployableContainer<T extends CommonContainerConfigu
 
     @Override
     public ProtocolDescription getDefaultProtocol() {
-        return new ProtocolDescription("jmx-as7");
+        return new ProtocolDescription("Servlet 3.0");
     }
 
     @Override

--- a/arquillian/container-embedded/pom.xml
+++ b/arquillian/container-embedded/pom.xml
@@ -70,12 +70,6 @@
 			<artifactId>arquillian-junit-container</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.jboss.arquillian.protocol</groupId>
-			<artifactId>arquillian-protocol-servlet</artifactId>
-			<scope>test</scope>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/arquillian/container-embedded/src/test/resources/arquillian.xml
+++ b/arquillian/container-embedded/src/test/resources/arquillian.xml
@@ -3,8 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="Servlet 3.0" />
-
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">target/jbossas</property>

--- a/arquillian/container-managed-domain/src/test/resources/arquillian.xml
+++ b/arquillian/container-managed-domain/src/test/resources/arquillian.xml
@@ -3,6 +3,8 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProcotol type="jmx-as7" />
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">target/jbossas</property>

--- a/arquillian/container-managed/src/test/resources/arquillian.xml
+++ b/arquillian/container-managed/src/test/resources/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
 	<container qualifier="jboss" default="true">
 		<configuration>
                         <property name="jbossHome">target/jbossas</property>

--- a/arquillian/testng-integration/src/test/resources/arquillian.xml
+++ b/arquillian/testng-integration/src/test/resources/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
 	<container qualifier="jboss" default="true">
 		<configuration>
 			<property name="jbossHome">target/jbossas</property>

--- a/testsuite/compat/src/test/resources/arquillian.xml
+++ b/testsuite/compat/src/test/resources/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>

--- a/testsuite/integration/clust/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clust/src/test/config/arq/arquillian.xml
@@ -6,6 +6,8 @@
         <property name="deploymentExportPath">target/</property>
     </engine>
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="clustering-udp-single">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas-clustering-SYNC-tcp-0</property>

--- a/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <group qualifier="iiop">
 
         <!-- The server than invokes the exposed EJB's -->

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -2,6 +2,7 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
 
     <group qualifier="manual-mode">
         <container qualifier="default-jbossas" default="true" mode="manual">

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <group qualifier="multinode">
 
         <!-- The server than invokes the exposed EJB's via remote outbound connection -->

--- a/testsuite/integration/patching/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/patching/src/test/config/arq/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="jboss" default="true" mode="manual">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>

--- a/testsuite/integration/rbac/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/rbac/src/test/config/arq/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>

--- a/testsuite/integration/rts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/rts/src/test/config/arq/arquillian.xml
@@ -23,6 +23,8 @@
 <arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>

--- a/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+    
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>

--- a/testsuite/integration/xts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/xts/src/test/config/arq/arquillian.xml
@@ -2,6 +2,8 @@
 <arquillian xmlns="http://www.jboss.org/arquillian-1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.jboss.org/arquillian-1.0 http://jboss.org/schema/arquillian/arquillian-1.0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>


### PR DESCRIPTION
Replacing default protocol of Arquillian WF Adaptors to Servlet 3.0. Adding arquillian-servlet-protocol as a dependency. This simplifies usage of adaptor for Arquillian users.
