### PR TITLE
WFLY-2827: Upgrade to HAL 2.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <version.org.jboss.aesh>0.33.11</version.org.jboss.aesh>
         <version.org.jboss.arquillian.core>1.1.2.Final</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.osgi>2.1.0.CR2</version.org.jboss.arquillian.osgi>
-        <version.org.jboss.hal.release-stream>2.1.0.Final</version.org.jboss.hal.release-stream>
+        <version.org.jboss.hal.release-stream>2.1.1.Final</version.org.jboss.hal.release-stream>
         <version.org.jboss.byteman>2.1.4</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.0.4.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.common.jboss-common-beans>1.1.0.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
Final HAL console release for WildFly 8.0.0.Final. 

https://issues.jboss.org/browse/WFLY-2827
