### PR TITLE
https://issues.jboss.org/browse/WFLY-2745 Typo in jboss-cli help message...

### DIFF
--- a/cli/src/main/resources/help/connect.txt
+++ b/cli/src/main/resources/help/connect.txt
@@ -15,7 +15,7 @@ DESCRIPTION
 
   jboss-cli.sh controller=controller-host.net
 
-  In this case, the default port will be 9999 and the default protocol will be http.
+  In this case, the default port will be 9990 and the default protocol will be http.
 
   Note, specifying controller argument will only set the default host and port
   values for the connect command but will not automatically connect to the
@@ -43,4 +43,4 @@ ARGUMENTS
 
   host      - optional, default value is localhost.
 
-  port      - optional, default value is 9999.
+  port      - optional, default value is 9990.

--- a/cli/src/main/resources/help/help.txt
+++ b/cli/src/main/resources/help/help.txt
@@ -16,7 +16,7 @@ Usage:
  --controller    - the default controller host and port to connect to when
                    --connect option (described below) is specified or when the
                    connect command is issued w/o the arguments. The default
-                   controller host is localhost and the port is 9999.
+                   controller host is localhost and the port is 9990.
 
  --connect (-c)  - instructs the CLI to connect to the controller on start-up
                    (to avoid issuing a separate connect command later).


### PR DESCRIPTION
... (default port 9999 change to 9990)

Thanks,
Alexey
