### PR TITLE
[WFLY-2584] Throw an IllegalArgumentException is a user attempts to swit...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/access/rbac/RunAsRoleMapper.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/rbac/RunAsRoleMapper.java
@@ -40,7 +40,7 @@ import org.jboss.dmr.ModelType;
 
 /**
  * A {@link RoleMapper} that allows clients to specify the roles they desire to run as. By default this {@link RoleMapper} Reads
- * the set of roles from a request headers in the operation, allowing the test to completely control the mapping. Roles are
+ * the set of roles from a request headers in the operation, allowing the client to completely control the mapping. Roles are
  * stored as a ModelNode of type ModelType.LIST, elements of ModelType.STRING, under operation.get("operation-headers",
  * "roles"). If no such header is found, the user is SUPERUSER. IF the list is empty, the user has no permissions.
  *

--- a/controller/src/main/java/org/jboss/as/controller/access/rbac/StandardRoleMapper.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/rbac/StandardRoleMapper.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.access.AuthorizerConfiguration;
 import org.jboss.as.controller.access.Caller;
@@ -70,8 +71,23 @@ public class StandardRoleMapper implements RoleMapper {
 
     @Override
     public boolean canRunAs(Set<String> mappedRoles, String runAsRole) {
-        return runAsRole != null && mappedRoles.contains(StandardRole.SUPERUSER.toString())
-                && authorizerConfiguration.hasRole(runAsRole);
+        if (runAsRole == null) {
+            return false;
+        }
+
+        boolean hasRole = authorizerConfiguration.hasRole(runAsRole);
+        boolean isSuperUser = mappedRoles.contains(StandardRole.SUPERUSER.toString());
+
+        /*
+         * We only allow users to specify roles to run as if they are SuperUser, if the user is not SuperUser we need to be
+         * careful to not provide a way for the user to test which roles actually exist.
+         */
+
+        if (isSuperUser && hasRole == false) {
+            throw ControllerMessages.MESSAGES.unknownRole(runAsRole);
+        }
+
+        return hasRole && isSuperUser;
     }
 
     private Set<String> mapRoles(final Caller caller) {

--- a/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/access/rbac/BasicRbacTestCase.java
@@ -25,6 +25,7 @@ package org.jboss.as.controller.access.rbac;
 import static org.jboss.as.controller.PathAddress.pathAddress;
 import static org.jboss.as.controller.PathElement.pathElement;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 
@@ -431,6 +432,15 @@ public class BasicRbacTestCase extends AbstractRbacTestBase {
         permitted(READWRITE_OPERATION, pathAddress(SENSITIVE_READ_ONLY_RESOURCE, BAR), StandardRole.SUPERUSER);
         permitted(READWRITE_OPERATION, pathAddress(APPLICATION_CONSTRAINED_RESOURCE, BAR), StandardRole.SUPERUSER);
         permitted(READWRITE_OPERATION, ACCESS_AUDIT_ADDR, StandardRole.AUDITOR);
+    }
+
+    // Bad role
+
+    @Test
+    public void testBadRole() throws Exception {
+        ModelNode operation = Util.createOperation(READONLY_OPERATION, pathAddress(UNCONSTRAINED_RESOURCE, FOO));
+        operation.get(OPERATION_HEADERS, "roles").add("Minataur");
+        executeForFailure(operation);
     }
 
     // model definition


### PR DESCRIPTION
...ch to a role that does not exist.

Note: This is only thrown for users that would have the ability to switch roles if the role actually existed - other users it still fails silently to stop them from using this to discover which roles actually exist.
