### PR TITLE
Remove legacy 9999 port from standalone configs

### DIFF
--- a/build/src/main/resources/configuration/standalone/template.xml
+++ b/build/src/main/resources/configuration/standalone/template.xml
@@ -41,9 +41,6 @@
             </logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket-binding native="management-native"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm" http-upgrade-enabled="true">
                 <socket-binding http="management-http"/>
             </http-interface>
@@ -81,7 +78,6 @@
     </interfaces>
 
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
-        <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
         <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/ClientCompatibilityUnitTestCase.java
@@ -29,19 +29,26 @@ import java.lang.reflect.Proxy;
 import java.security.SecureRandom;
 import java.util.Random;
 
+import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.controller.client.Operation;
 import org.jboss.as.controller.client.OperationBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.model.test.ChildFirstClassLoaderBuilder;
 import org.jboss.as.process.protocol.StreamUtils;
+import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -56,9 +63,8 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-//@ServerSetup(ClientCompatibilityUnitTestCase.ClientCompatibilityUnitTestCaseServerSetup.class)
+@ServerSetup(ClientCompatibilityUnitTestCase.ClientCompatibilityUnitTestCaseServerSetup.class)
 public class ClientCompatibilityUnitTestCase {
-    /* TODO: re-enable when the native interface is removed
     static class ClientCompatibilityUnitTestCaseServerSetup implements ServerSetupTask {
 
         @Override
@@ -83,8 +89,8 @@ public class ClientCompatibilityUnitTestCase {
 
         private ModelNode address() {
             return PathAddress.pathAddress()
-                    .append(CORE_SERVICE, MANAGEMENT)
-                    .append(MANAGEMENT_INTERFACE, NATIVE_INTERFACE).toModelNode();
+                    .append(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT)
+                    .append(ModelDescriptionConstants.MANAGEMENT_INTERFACE, ModelDescriptionConstants.NATIVE_INTERFACE).toModelNode();
         }
     }
 
@@ -93,7 +99,6 @@ public class ClientCompatibilityUnitTestCase {
     public static Archive fakeDeployment() {
         return ShrinkWrap.create(JavaArchive.class);
     }
-    */
 
     private static final String CONTROLLER_ADDRESS = System.getProperty("node0", "localhost");
 

--- a/testsuite/integration/patching/src/test/java/org/jboss/as/test/patching/NativeApiPatchingTestCase.java
+++ b/testsuite/integration/patching/src/test/java/org/jboss/as/test/patching/NativeApiPatchingTestCase.java
@@ -136,7 +136,7 @@ public class NativeApiPatchingTestCase extends AbstractPatchingTestCase {
     }
 
     private ModelControllerClient getControllerClient() throws UnknownHostException {
-        return ModelControllerClient.Factory.create(System.getProperty("node0", "127.0.0.1"), 9999);
+        return ModelControllerClient.Factory.create("http-remoting", System.getProperty("node0", "127.0.0.1"), 9990);
     }
 
 }


### PR DESCRIPTION
Part 1 of dropping the legacy port
