### PR TITLE
[WFLY-943] Use of elementFormDefault='unqualified' cannot validate some ...

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-deployment-dependencies-1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-deployment-dependencies-1_0.xsd
@@ -25,7 +25,7 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             targetNamespace="urn:jboss:deployment-dependencies:1.0"
             xmlns="urn:jboss:deployment-dependencies:1.0"
-            elementFormDefault="unqualified"
+            elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="1.0">
 

--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_0.xsd
@@ -24,7 +24,7 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             targetNamespace="urn:jboss:ejb-client:1.0"
             xmlns="urn:jboss:ejb-client:1.0"
-            elementFormDefault="unqualified"
+            elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="1.0">
 

--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_1.xsd
@@ -24,7 +24,7 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             targetNamespace="urn:jboss:ejb-client:1.1"
             xmlns="urn:jboss:ejb-client:1.1"
-            elementFormDefault="unqualified"
+            elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="1.1">
 

--- a/build/src/main/resources/docs/schema/jboss-ejb-client_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-ejb-client_1_2.xsd
@@ -25,7 +25,7 @@
 <xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
             targetNamespace="urn:jboss:ejb-client:1.2"
             xmlns="urn:jboss:ejb-client:1.2"
-            elementFormDefault="unqualified"
+            elementFormDefault="qualified"
             attributeFormDefault="unqualified"
             version="1.2">
 

--- a/build/src/main/resources/docs/schema/jboss-jpa_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-jpa_1_0.xsd
@@ -25,7 +25,7 @@
   <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
   targetNamespace="urn:jboss:jboss-jpa:1.0"     
   xmlns="urn:jboss:jboss-jpa:1.0"
-  elementFormDefault="unqualified" 
+  elementFormDefault="qualified"
   attributeFormDefault="unqualified" 
   version="1.0">
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/shallow/jboss-all.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/epcpropagation/shallow/jboss-all.xml
@@ -1,5 +1,5 @@
 <jboss>
     <jboss-jpa xmlns="http://www.jboss.com/xml/ns/javaee">
-    <extended-persistence inheritance="SHALLOW"/>
+        <extended-persistence inheritance="SHALLOW"/>
     </jboss-jpa>
 </jboss>


### PR DESCRIPTION
...documents

https://issues.jboss.org/browse/WFLY-943

The ejb-client XSDs need these, but jboss-jpa never uses it :-( [Looks like a parsing bug.](https://issues.jboss.org/browse/WFLY-943?focusedCommentId=12940782&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-12940782)
