### PR TITLE
[WFLY-2838] Make "cpu" the default mod_cluster load metric

### DIFF
--- a/build/src/main/resources/configuration/subsystems/mod_cluster.xml
+++ b/build/src/main/resources/configuration/subsystems/mod_cluster.xml
@@ -5,7 +5,7 @@
     <subsystem xmlns="urn:jboss:domain:modcluster:1.2">
         <mod-cluster-config advertise-socket="modcluster" connector="ajp">
             <dynamic-load-provider>
-                <load-metric type="busyness"/>
+                <load-metric type="cpu"/>
             </dynamic-load-provider>
         </mod-cluster-config>
     </subsystem>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2838

Unless anyone has strong feelings against this change...
