### PR TITLE
WFLY-2860 adding regression tests for WFLY-2319

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -34,7 +34,7 @@ import javax.naming.NameClassPair;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
-import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
 import javax.naming.spi.NamingManager;
 import javax.naming.spi.ObjectFactory;
 
@@ -47,7 +47,7 @@ import static org.jboss.as.naming.NamingMessages.MESSAGES;
  * @author Eduardo Martins
  * @author John Bailey
  */
-public class InitialContext extends InitialDirContext {
+public class InitialContext extends InitialLdapContext {
 
     /**
      * Map of any additional naming schemes
@@ -87,7 +87,7 @@ public class InitialContext extends InitialDirContext {
     }
 
     public InitialContext(Hashtable environment) throws NamingException {
-        super(environment);
+        super(environment, null);
     }
 
     @Override

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
@@ -52,7 +52,6 @@ import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -111,7 +110,6 @@ public class LdapUrlInSearchBaseTestCase {
      * @throws Exception
      */
     @Test
-    @Ignore("bz-1060275")
     public void testLdap() throws Exception {
         final URL servletURL = new URL(webAppURL.toExternalForm() + "?" + LdapUrlTestServlet.PARAM_HOST + "="
                 + URLEncoder.encode(Utils.getSecondaryTestAddress(mgmtClient), "UTF-8") + "&" + LdapUrlTestServlet.PARAM_LDAP

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlInSearchBaseTestCase.java
@@ -1,0 +1,233 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.naming.ldap;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.security.Security;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.directory.server.annotations.CreateLdapServer;
+import org.apache.directory.server.annotations.CreateTransport;
+import org.apache.directory.server.core.annotations.AnnotationUtils;
+import org.apache.directory.server.core.annotations.ContextEntry;
+import org.apache.directory.server.core.annotations.CreateDS;
+import org.apache.directory.server.core.annotations.CreateIndex;
+import org.apache.directory.server.core.annotations.CreatePartition;
+import org.apache.directory.server.core.api.DirectoryService;
+import org.apache.directory.server.core.factory.DSAnnotationProcessor;
+import org.apache.directory.server.factory.ServerAnnotationProcessor;
+import org.apache.directory.server.ldap.LdapServer;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Regression test for LDAP related issues.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ LdapUrlInSearchBaseTestCase.LDAPServerSetupTask.class })
+@RunAsClient
+public class LdapUrlInSearchBaseTestCase {
+
+    private static Logger LOGGER = Logger.getLogger(LdapUrlInSearchBaseTestCase.class);
+
+    @ArquillianResource
+    ManagementClient mgmtClient;
+
+    @ArquillianResource
+    URL webAppURL;
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     * Creates {@link WebArchive} with the {@link OKServlet}.
+     *
+     * @return
+     */
+    @Deployment
+    public static WebArchive deployment() {
+        LOGGER.info("Creating deployment");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "ldap-test.war");
+        war.addClasses(LdapUrlTestServlet.class);
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(war.toString(true));
+        }
+        return war;
+    }
+
+    /**
+     * Tests if it's possible to have searchBase prefixed with LDAP URL, InitialDirContext is used.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDir() throws Exception {
+        final URL servletURL = new URL(webAppURL.toExternalForm() + "?" + LdapUrlTestServlet.PARAM_HOST + "="
+                + URLEncoder.encode(Utils.getSecondaryTestAddress(mgmtClient), "UTF-8"));
+        assertEquals("cn=Java Duke", Utils.makeCallWithBasicAuthn(servletURL, null, null, 200));
+    }
+
+    /**
+     * Tests if it's possible to have searchBase prefixed with LDAP URL, InitialLdapContext is used.
+     *
+     * @throws Exception
+     */
+    @Test
+    @Ignore("bz-1060275")
+    public void testLdap() throws Exception {
+        final URL servletURL = new URL(webAppURL.toExternalForm() + "?" + LdapUrlTestServlet.PARAM_HOST + "="
+                + URLEncoder.encode(Utils.getSecondaryTestAddress(mgmtClient), "UTF-8") + "&" + LdapUrlTestServlet.PARAM_LDAP
+                + "=");
+        assertEquals("cn=Java Duke", Utils.makeCallWithBasicAuthn(servletURL, null, null, 200));
+    }
+
+    /**
+     * To test the behavior outside of the AS (i.e. org.jboss.as.naming.InitialContext is not used).
+     *
+     * @param args
+     * @throws Exception
+     */
+    public static void main(String[] args) throws Exception {
+        LDAPServerSetupTask ldapSetup = new LDAPServerSetupTask();
+        ldapSetup.setup(null, null);
+        System.out.println("InitialDirContext used:");
+        System.out.println(LdapUrlTestServlet.runSearch(null, false));
+        System.out.println("InitialLdapContext used:");
+        System.out.println(LdapUrlTestServlet.runSearch(null, true));
+        ldapSetup.tearDown(null, null);
+    }
+
+    // Embedded classes ------------------------------------------------------
+
+    /**
+     * A server setup task which configures and starts LDAP server.
+     */
+    //@formatter:off
+    @CreateDS(
+        name = "JBossDS",
+        partitions =
+        {
+            @CreatePartition(
+                name = "jboss",
+                suffix = "dc=jboss,dc=org",
+                contextEntry = @ContextEntry(
+                    entryLdif =
+                        "dn: dc=jboss,dc=org\n" +
+                        "dc: jboss\n" +
+                        "objectClass: top\n" +
+                        "objectClass: domain\n\n" ),
+                indexes =
+                {
+                    @CreateIndex( attribute = "objectClass" ),
+                    @CreateIndex( attribute = "dc" ),
+                    @CreateIndex( attribute = "ou" )
+                })
+        })
+    @CreateLdapServer (
+        transports =
+        {
+            @CreateTransport( protocol = "LDAP",  port = 10389, address = "0.0.0.0" ),
+        })
+    //@formatter:on
+    static class LDAPServerSetupTask implements ServerSetupTask {
+
+        private DirectoryService directoryService;
+        private LdapServer ldapServer;
+        private boolean removeBouncyCastle = false;
+
+        /**
+         * Creates directory services and starts LDAP server
+         *
+         * @param managementClient
+         * @param containerId
+         * @throws Exception
+         * @see org.jboss.as.arquillian.api.ServerSetupTask#setup(org.jboss.as.arquillian.container.ManagementClient,
+         *      java.lang.String)
+         */
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            try {
+                if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+                    Security.addProvider(new BouncyCastleProvider());
+                    removeBouncyCastle = true;
+                }
+            } catch (SecurityException ex) {
+                LOGGER.warn("Cannot register BouncyCastleProvider", ex);
+            }
+            directoryService = DSAnnotationProcessor.getDirectoryService();
+            DSAnnotationProcessor.injectEntries(directoryService, "dn: uid=jduke,dc=jboss,dc=org\n" //
+                    + "objectclass: top\n" //
+                    + "objectclass: uidObject\n" //
+                    + "objectclass: person\n" //
+                    + "uid: jduke\n" //
+                    + "cn: Java Duke\n" //
+                    + "sn: Duke\n" //
+                    + "userPassword: theduke\n");
+            final ManagedCreateLdapServer createLdapServer = new ManagedCreateLdapServer(
+                    (CreateLdapServer) AnnotationUtils.getInstance(CreateLdapServer.class));
+            Utils.fixApacheDSTransportAddress(createLdapServer, Utils.getSecondaryTestAddress(managementClient, false));
+            ldapServer = ServerAnnotationProcessor.instantiateLdapServer(createLdapServer, directoryService);
+            ldapServer.start();
+        }
+
+        /**
+         * Stops LDAP server and shuts down the directory service.
+         *
+         * @param managementClient
+         * @param containerId
+         * @throws Exception
+         * @see org.jboss.as.arquillian.api.ServerSetupTask#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+         *      java.lang.String)
+         */
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            ldapServer.stop();
+            directoryService.shutdown();
+            FileUtils.deleteDirectory(directoryService.getInstanceLayout().getInstanceDirectory());
+            if (removeBouncyCastle) {
+                try {
+                    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+                } catch (SecurityException ex) {
+                    LOGGER.warn("Cannot deregister BouncyCastleProvider", ex);
+                }
+            }
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlTestServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/ldap/LdapUrlTestServlet.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.naming.ldap;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.NamingEnumeration;
+import javax.naming.directory.Attributes;
+import javax.naming.directory.DirContext;
+import javax.naming.directory.InitialDirContext;
+import javax.naming.directory.SearchControls;
+import javax.naming.directory.SearchResult;
+import javax.naming.ldap.InitialLdapContext;
+import javax.naming.ldap.LdapContext;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * A servlet which tries to do a search in LDAP server. Default call use InitialDirContext. You can add parameter
+ * {@link #PARAM_LDAP} to your request and then InitialLdapContext is used.
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(urlPatterns = { LdapUrlTestServlet.SERVLET_PATH })
+public class LdapUrlTestServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/*";
+    public static final String PARAM_HOST = "host";
+    public static final String PARAM_LDAP = "ldapctx";
+
+    /**
+     * Writes simple text response.
+     *
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        final PrintWriter writer = resp.getWriter();
+        try {
+            String host = req.getParameter(PARAM_HOST);
+            writer.write(runSearch(host, req.getParameter(PARAM_LDAP) != null));
+        } catch (Exception e) {
+            throw new ServletException(e);
+        }
+        writer.close();
+    }
+
+    /**
+     * Try to search in LDAP with search base containing URL. Also try to retrieve RequestControls from LdapContext.
+     *
+     * @param hostname
+     * @return
+     * @throws Exception
+     */
+    public static String runSearch(final String hostname, boolean testLdapCtx) throws Exception {
+        final StringBuilder result = new StringBuilder();
+        final String ldapUrl = "ldap://" + (hostname == null ? "localhost" : hostname) + ":10389";
+
+        final Hashtable<String, String> env = new Hashtable<String, String>();
+        env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
+        env.put(Context.SECURITY_AUTHENTICATION, "simple");
+        env.put(Context.PROVIDER_URL, ldapUrl);
+        env.put(Context.SECURITY_PRINCIPAL, "uid=admin,ou=system");
+        env.put(Context.SECURITY_CREDENTIALS, "secret");
+
+        final SearchControls ctl = new SearchControls();
+        ctl.setReturningAttributes(new String[] { "cn" });
+
+        DirContext dirCtx = null;
+        if (testLdapCtx) {
+            // LdapContext must also work
+            LdapContext ldapCtx = new InitialLdapContext(env, null);
+            // next line tests if the LdapContext works
+            ldapCtx.getRequestControls();
+            dirCtx = ldapCtx;
+        } else {
+            dirCtx = new InitialDirContext(env);
+        }
+        final NamingEnumeration<SearchResult> nenum = dirCtx.search(ldapUrl + "/dc=jboss,dc=org", "(uid=jduke)", ctl);
+
+        while (nenum.hasMore()) {
+            SearchResult sr = nenum.next();
+            Attributes attrs = sr.getAttributes();
+            result.append("cn=").append(attrs.get("cn").get());
+        }
+        dirCtx.close();
+
+        return result.toString();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapLoginModuleTestCase.java
@@ -26,13 +26,11 @@ import static org.junit.Assert.assertEquals;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.net.URL;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
 import org.apache.directory.api.ldap.model.entry.DefaultEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifEntry;
 import org.apache.directory.api.ldap.model.ldif.LdifReader;
@@ -62,7 +60,6 @@ import org.jboss.as.test.categories.CommonCriteria;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
 import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
 import org.jboss.as.test.integration.security.common.ManagedCreateLdapServer;
-import org.jboss.as.test.integration.security.common.ManagedCreateTransport;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
@@ -112,7 +109,6 @@ public class LdapLoginModuleTestCase {
      * Creates {@link WebArchive} with the {@link OKServlet}.
      *
      * @return
-     * @throws SQLException
      */
     @Deployment(name = SECURITY_DOMAIN_LDAP)
     public static WebArchive deploymentLdap() {
@@ -123,7 +119,6 @@ public class LdapLoginModuleTestCase {
      * Creates {@link WebArchive} with the {@link OKServlet}.
      *
      * @return
-     * @throws SQLException
      */
     @Deployment(name = SECURITY_DOMAIN_LDAPS)
     public static WebArchive deploymentLdaps() {
@@ -231,59 +226,76 @@ public class LdapLoginModuleTestCase {
         protected SecurityDomain[] getSecurityDomains() throws Exception {
             Map<String, String> moduleOptions = new HashMap<String, String>();
 
-            //InitialContextFactory implementation class name. This defaults to the Sun LDAP provider implementation com.sun.jndi.ldap.LdapCtxFactory.
+            // InitialContextFactory implementation class name. This defaults to the Sun LDAP provider implementation
+            // com.sun.jndi.ldap.LdapCtxFactory.
             moduleOptions.put("java.naming.factory.initial", INITIAL_CONTEXT_FACTORY);
 
-            //LDAP URL for the LDAP server.
+            // LDAP URL for the LDAP server.
             moduleOptions.put("java.naming.provider.url", "ldap://" + Utils.getSecondaryTestAddress(managementClient) + ":"
                     + LDAP_PORT);
 
-            //Security level to use. This defaults to simple.
+            // Security level to use. This defaults to simple.
             moduleOptions.put("java.naming.security.authentication", SECURITY_AUTHENTICATION);
 
-            //Transport protocol to use for secure access, such as, SSL.
-            //            moduleOptions.put("java.naming.security.protocol","");
+            // Transport protocol to use for secure access, such as, SSL.
+            // moduleOptions.put("java.naming.security.protocol","");
 
-            //Principal for authenticating the caller to the service. This is built from other properties as described below.
+            // Principal for authenticating the caller to the service. This is built from other properties as described below.
             moduleOptions.put("java.naming.security.principal", SECURITY_PRINCIPAL);
 
-            //Authentication scheme to use. For example, hashed password, clear-text password, key, certificate, and so on.
+            // Authentication scheme to use. For example, hashed password, clear-text password, key, certificate, and so on.
             moduleOptions.put("java.naming.security.credentials", SECURITY_CREDENTIALS);
 
-            //Prefix added to the username to form the user distinguished name. See principalDNSuffix for more info.
+            // Prefix added to the username to form the user distinguished name. See principalDNSuffix for more info.
             moduleOptions.put("principalDNPrefix", "uid=");
 
-            //Suffix added to the username when forming the user distinguished name. This is useful if you prompt a user for a username and you don't want the user to have to enter the fully distinguished name. Using this property and principalDNSuffix the userDN will be formed as principalDNPrefix + username + principalDNSuffix
+            // Suffix added to the username when forming the user distinguished name. This is useful if you prompt a user for a
+            // username and you don't want the user to have to enter the fully distinguished name. Using this property and
+            // principalDNSuffix the userDN will be formed as principalDNPrefix + username + principalDNSuffix
             moduleOptions.put("principalDNSuffix", ",ou=People,dc=jboss,dc=org");
 
-            //Value that indicates the credential should be obtained as an opaque Object using the org.jboss.security.auth.callback.ObjectCallback type of Callback rather than as a char[] password using a JAAS PasswordCallback. This allows for passing non-char[] credential information to the LDAP server. The available values are true and false.
-            //            moduleOptions.put("useObjectCredential","");
+            // Value that indicates the credential should be obtained as an opaque Object using the
+            // org.jboss.security.auth.callback.ObjectCallback type of Callback rather than as a char[] password using a JAAS
+            // PasswordCallback. This allows for passing non-char[] credential information to the LDAP server. The available
+            // values are true and false.
+            // moduleOptions.put("useObjectCredential","");
 
-            //Fixed, distinguished name to the context to search for user roles.
+            // Fixed, distinguished name to the context to search for user roles.
             moduleOptions.put("rolesCtxDN", "ou=Roles,dc=jboss,dc=org");
 
-            //Name of an attribute in the user object that contains the distinguished name to the context to search for user roles. This differs from rolesCtxDN in that the context to search for a user's roles can be unique for each user.
-            //            moduleOptions.put("userRolesCtxDNAttributeName","");
+            // Name of an attribute in the user object that contains the distinguished name to the context to search for user
+            // roles. This differs from rolesCtxDN in that the context to search for a user's roles can be unique for each user.
+            // moduleOptions.put("userRolesCtxDNAttributeName","");
 
-            //Name of the attribute containing the user roles. If not specified, this defaults to roles.
-            //            moduleOptions.put("roleAttributeID","");
+            // Name of the attribute containing the user roles. If not specified, this defaults to roles.
+            // moduleOptions.put("roleAttributeID","");
 
-            // Flag indicating whether the roleAttributeID contains the fully distinguished name of a role object, or the role name. The role name is taken from the value of the roleNameAttributeId attribute of the context name by the distinguished name.
-            //If true, the role attribute represents the distinguished name of a role object. If false, the role name is taken from the value of roleAttributeID. The default is false.
-            //Note: In certain directory schemas (e.g., MS ActiveDirectory), role attributes in the user object are stored as DNs to role objects instead of simple names. For implementations that use this schema type, roleAttributeIsDN must be set to true.
+            // Flag indicating whether the roleAttributeID contains the fully distinguished name of a role object, or the role
+            // name. The role name is taken from the value of the roleNameAttributeId attribute of the context name by the
+            // distinguished name.
+            // If true, the role attribute represents the distinguished name of a role object. If false, the role name is taken
+            // from the value of roleAttributeID. The default is false.
+            // Note: In certain directory schemas (e.g., MS ActiveDirectory), role attributes in the user object are stored as
+            // DNs to role objects instead of simple names. For implementations that use this schema type, roleAttributeIsDN
+            // must be set to true.
             moduleOptions.put("roleAttributeIsDN", "false");
 
             // Name of the attribute containing the user roles. If not specified, this defaults to roles.
             moduleOptions.put("roleAttributeID", "cn");
 
-            //Name of the attribute in the object containing the user roles that corresponds to the userid. This is used to locate the user roles. If not specified this defaults to uid.
+            // Name of the attribute in the object containing the user roles that corresponds to the userid. This is used to
+            // locate the user roles. If not specified this defaults to uid.
             moduleOptions.put("uidAttributeID", "member");
 
-            //Flag that specifies whether the search for user roles should match on the user's fully distinguished name. If true, the full userDN is used as the match value. If false, only the username is used as the match value against the uidAttributeName attribute. The default value is false.
+            // Flag that specifies whether the search for user roles should match on the user's fully distinguished name. If
+            // true, the full userDN is used as the match value. If false, only the username is used as the match value against
+            // the uidAttributeName attribute. The default value is false.
             moduleOptions.put("matchOnUserDN", "true");
 
-            //A flag indicating if empty (length 0) passwords should be passed to the LDAP server. An empty password is treated as an anonymous login by some LDAP servers and this may not be a desirable feature. To reject empty passwords, set this to false. If set to true, the LDAP server will validate the empty password. The default is true.
-            //            moduleOptions.put("allowEmptyPasswords","");
+            // A flag indicating if empty (length 0) passwords should be passed to the LDAP server. An empty password is treated
+            // as an anonymous login by some LDAP servers and this may not be a desirable feature. To reject empty passwords,
+            // set this to false. If set to true, the LDAP server will validate the empty password. The default is true.
+            // moduleOptions.put("allowEmptyPasswords","");
 
             final SecurityDomain sdLdap = new SecurityDomain.Builder()
                     .name(SECURITY_DOMAIN_LDAP)
@@ -371,23 +383,9 @@ public class LdapLoginModuleTestCase {
             IOUtils.copy(getClass().getResourceAsStream(KEYSTORE_FILENAME), fos);
             fos.close();
             createLdapServer.setKeyStore(KEYSTORE_FILE.getAbsolutePath());
-            fixTransportAddress(createLdapServer, StringUtils.strip(Utils.getSecondaryTestAddress(managementClient), "[]"));
+            Utils.fixApacheDSTransportAddress(createLdapServer, Utils.getSecondaryTestAddress(managementClient, false));
             ldapServer = ServerAnnotationProcessor.instantiateLdapServer(createLdapServer, directoryService);
             ldapServer.start();
-        }
-
-        /**
-         * Fixes bind address in the CreateTransport annotation.
-         *
-         * @param createLdapServer
-         */
-        private void fixTransportAddress(ManagedCreateLdapServer createLdapServer, String address) {
-            final CreateTransport[] createTransports = createLdapServer.transports();
-            for (int i = 0; i < createTransports.length; i++) {
-                final ManagedCreateTransport mgCreateTransport = new ManagedCreateTransport(createTransports[i]);
-                mgCreateTransport.setAddress(address);
-                createTransports[i] = mgCreateTransport;
-            }
         }
 
         /**

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -48,6 +48,7 @@ import javax.security.auth.login.LoginException;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.directory.server.annotations.CreateTransport;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
@@ -827,5 +828,21 @@ public class Utils {
      */
     public static String stripSquareBrackets(final String str) {
         return StringUtils.strip(str, "[]");
+    }
+
+    /**
+     * Fixes/replaces LDAP bind address in the CreateTransport annotation of ApacheDS.
+     *
+     * @param createLdapServer
+     * @param address
+     */
+    public static void fixApacheDSTransportAddress(ManagedCreateLdapServer createLdapServer, String address) {
+        final CreateTransport[] createTransports = createLdapServer.transports();
+        for (int i = 0; i < createTransports.length; i++) {
+            final ManagedCreateTransport mgCreateTransport = new ManagedCreateTransport(createTransports[i]);
+            // localhost is a default used in original CreateTransport annotation. We use it as a fallback.
+            mgCreateTransport.setAddress(address != null ? address : "localhost");
+            createTransports[i] = mgCreateTransport;
+        }
     }
 }


### PR DESCRIPTION
The test method org.jboss.as.test.integration.naming.ldap.LdapUrlInSearchBaseTestCase.testLdap() is ignored, because of a new issue introduced by original fix for WFLY-2319 (cf https://bugzilla.redhat.com/show_bug.cgi?id=1060275)

The second test method - testDir() - should pass.
