### PR TITLE
WFLY-2853 JSFFailoverTestCase fails since latest session changes in Undertow

### DIFF
--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -115,7 +115,9 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
         Header setCookie = response.getFirstHeader("Set-Cookie");
         if (setCookie != null) {
             String setCookieValue = setCookie.getValue();
-            state.sessionId = setCookieValue.substring(setCookieValue.indexOf('=') + 1, setCookieValue.indexOf(';'));
+            String encodedSessionId = setCookieValue.substring(setCookieValue.indexOf('=') + 1, setCookieValue.indexOf(';'));
+            int index = encodedSessionId.indexOf('.');
+            state.sessionId = (index > 0) ? encodedSessionId.substring(0, index) : encodedSessionId;
         } else if (sessionId != null) {
             // We don't get a cookie back if we have sent it, so just set it to whatever we had before
             state.sessionId = sessionId;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2853

This is just a workaround for more extensive changes to come tomorrow (i.e. WFLY-2774).  This fix is required for the Undertow 1.0.0.CR2 update.
