### PR TITLE
WFLY-2319: fixes usage of InitialLdapContext

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -34,7 +34,7 @@ import javax.naming.NameClassPair;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
-import javax.naming.directory.InitialDirContext;
+import javax.naming.ldap.InitialLdapContext;
 import javax.naming.spi.NamingManager;
 import javax.naming.spi.ObjectFactory;
 
@@ -47,7 +47,7 @@ import static org.jboss.as.naming.NamingMessages.MESSAGES;
  * @author Eduardo Martins
  * @author John Bailey
  */
-public class InitialContext extends InitialDirContext {
+public class InitialContext extends InitialLdapContext {
 
     /**
      * Map of any additional naming schemes
@@ -87,7 +87,7 @@ public class InitialContext extends InitialDirContext {
     }
 
     public InitialContext(Hashtable environment) throws NamingException {
-        super(environment);
+        super(environment, null);
     }
 
     @Override


### PR DESCRIPTION
WFLY-2319 was reopen due to an issue when app code uses InitialLdapContext and then invokes one of it's signature methods. Those methods fail due to our InitialContext not extending InitialLdapContext
