### PR TITLE
WFLY-2774 Non-distributed, stateful web applications cannot be load balanced using sticky sessions

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
@@ -36,6 +36,7 @@
 
         <module name="io.undertow.core"/>
         <module name="io.undertow.servlet"/>
+        <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.msc"/>
         <module name="org.wildfly.clustering.web.spi"/>

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactory.java
@@ -34,12 +34,8 @@ import org.jboss.as.clustering.marshalling.SimpleMarshalledValueFactory;
 import org.jboss.as.clustering.marshalling.SimpleMarshallingContextFactory;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.modules.Module;
-import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.AbstractService;
-import org.jboss.msc.value.InjectedValue;
 import org.jboss.msc.value.Value;
-import org.wildfly.clustering.group.NodeFactory;
-import org.wildfly.clustering.registry.Registry;
 import org.wildfly.clustering.web.LocalContextFactory;
 import org.wildfly.clustering.web.infinispan.InfinispanWebMessages;
 import org.wildfly.clustering.web.infinispan.session.coarse.CoarseSessionCacheEntry;
@@ -64,8 +60,6 @@ public class InfinispanSessionManagerFactory extends AbstractService<SessionMana
     private final CacheInvoker invoker = new RetryingCacheInvoker(10, 100);
     private final Value<Cache> cache;
     private final Value<KeyAffinityServiceFactory> affinityFactory;
-    private final InjectedValue<NodeFactory> nodeFactory = new InjectedValue<>();
-    private final InjectedValue<Registry> registry = new InjectedValue<>();
 
     public InfinispanSessionManagerFactory(Module module, JBossWebMetaData metaData, Value<Cache> cache, Value<KeyAffinityServiceFactory> affinityFactory) {
         this.module = module;
@@ -81,7 +75,7 @@ public class InfinispanSessionManagerFactory extends AbstractService<SessionMana
 
     @Override
     public <L> SessionManager<L> createSessionManager(SessionContext context, SessionIdentifierFactory identifierFactory, LocalContextFactory<L> localContextFactory) {
-        return new InfinispanSessionManager<>(context, identifierFactory, this.cache.getValue(), this.<L>getSessionFactory(context, localContextFactory), this.affinityFactory.getValue(), this.registry.getOptionalValue(), this.nodeFactory.getOptionalValue(), this.metaData);
+        return new InfinispanSessionManager<>(context, identifierFactory, this.cache.getValue(), this.<L>getSessionFactory(context, localContextFactory), this.affinityFactory.getValue(), this.metaData);
     }
 
     private <L> SessionFactory<?, L> getSessionFactory(SessionContext context, LocalContextFactory<L> localContextFactory) {
@@ -105,13 +99,5 @@ public class InfinispanSessionManagerFactory extends AbstractService<SessionMana
                 throw InfinispanWebMessages.MESSAGES.unknownReplicationGranularity(this.metaData.getReplicationConfig().getReplicationGranularity());
             }
         }
-    }
-
-    Injector<NodeFactory> getNodeFactoryInjector() {
-        return this.nodeFactory;
-    }
-
-    Injector<Registry> getRegistryInjector() {
-        return this.registry;
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteLocatorBuilder.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteLocatorBuilder.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,27 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
+package org.wildfly.clustering.web.infinispan.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
-
-import io.undertow.server.session.SessionListeners;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.Value;
+import org.wildfly.clustering.web.session.RouteLocator;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Builds a {@link RouteLocator} service.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
-    /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
-     */
-    SessionListeners getSessionListeners();
+public class RouteLocatorBuilder implements org.wildfly.clustering.web.session.RouteLocatorBuilder {
 
-    /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
-     */
-    SessionManager<LocalSessionContext> getSessionManager();
+    @Override
+    public ServiceBuilder<RouteLocator> build(ServiceTarget target, ServiceName name, ServiceName deploymentServiceName) {
+        return RouteLocatorService.build(target, name, deploymentServiceName);
+    }
+
+    @Override
+    public ServiceBuilder<?> buildServerDependency(ServiceTarget target, final Value<? extends Value<String>> route) {
+        return target.addService(RouteRegistryEntryProviderService.SERVICE_NAME, new RouteRegistryEntryProviderService(route));
+    }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteLocatorService.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteLocatorService.java
@@ -1,0 +1,110 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.clustering.web.infinispan.session;
+
+import java.util.Map;
+
+import org.infinispan.Cache;
+import org.infinispan.distribution.DistributionManager;
+import org.infinispan.remoting.transport.Address;
+import org.jboss.as.clustering.infinispan.CacheContainer;
+import org.jboss.msc.inject.Injector;
+import org.jboss.msc.service.AbstractService;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.group.Node;
+import org.wildfly.clustering.group.NodeFactory;
+import org.wildfly.clustering.registry.Registry;
+import org.wildfly.clustering.web.session.RouteLocator;
+
+/**
+ * Service providing a {@link RouteLocator}.
+ * Uses Infinispan's {@link DistributionManager} to determine the best node (i.e. the primary lock owner) to handle a given session.
+ * The {@link Address} is then converted to a route using a {@link Registry}, which maps the route identifier per node.
+ * @author Paul Ferraro
+ */
+public class RouteLocatorService extends AbstractService<RouteLocator> implements RouteLocator {
+
+    public static final ServiceName REGISTRY_SERVICE_NAME = ServiceName.JBOSS.append("clustering", "registry", InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER, CacheContainer.DEFAULT_CACHE_ALIAS);
+    public static final ServiceName NODE_FACTORY_SERVICE_NAME = ServiceName.JBOSS.append("clustering", "nodes", InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER, CacheContainer.DEFAULT_CACHE_ALIAS, "entry");
+
+    @SuppressWarnings({ "unchecked", "rawtypes", "deprecation" })
+    public static ServiceBuilder<RouteLocator> build(ServiceTarget target, ServiceName name, ServiceName deploymentServiceName) {
+        RouteLocatorService service = new RouteLocatorService();
+        return target.addService(name, service)
+                // These services are only available if the cache is non-local.
+                .addDependency(ServiceBuilder.DependencyType.OPTIONAL, NODE_FACTORY_SERVICE_NAME, NodeFactory.class, (Injector) service.nodeFactory)
+                .addDependency(ServiceBuilder.DependencyType.OPTIONAL, REGISTRY_SERVICE_NAME, Registry.class, service.registry)
+                .addDependency(RouteRegistryEntryProviderService.SERVICE_NAME, RouteRegistryEntryProvider.class, service.provider)
+                .addDependency(getCacheServiceName(deploymentServiceName), Cache.class, service.cache)
+        ;
+    }
+
+    public static ServiceName getCacheServiceName(ServiceName deploymentServiceName) {
+        return deploymentServiceName.append("web", "cache");
+    }
+
+    private final InjectedValue<NodeFactory<Address>> nodeFactory = new InjectedValue<>();
+    private final InjectedValue<Registry<String, Void>> registry = new InjectedValue<>();
+    private final InjectedValue<RouteRegistryEntryProvider> provider = new InjectedValue<>();
+    private final InjectedValue<Cache<String, ?>> cache = new InjectedValue<>();
+
+    private RouteLocatorService() {
+        // Hide
+    }
+
+    @Override
+    public RouteLocator getValue() {
+        return this;
+    }
+
+    @Override
+    public String locate(String sessionId) {
+        Registry<String, Void> registry = this.registry.getOptionalValue();
+        if (registry == null) {
+            // Return local route
+            return this.provider.getValue().getKey();
+        }
+        Map.Entry<String, Void> entry = null;
+        Address location = this.locatePrimaryOwner(sessionId);
+        if (location != null) {
+            NodeFactory<Address> nodeFactory = this.nodeFactory.getOptionalValue();
+            if (nodeFactory != null) {
+                Node node = nodeFactory.createNode(location);
+                entry = registry.getEntry(node);
+            }
+        }
+        if (entry == null) {
+            // Accommodate mod_cluster's lazy route auto-generation
+            entry = registry.getLocalEntry();
+        }
+        return (entry != null) ? entry.getKey() : null;
+    }
+
+    private Address locatePrimaryOwner(String sessionId) {
+        Cache<?, ?> cache = this.cache.getValue();
+        DistributionManager dist = cache.getAdvancedCache().getDistributionManager();
+        return (dist != null) ? dist.getPrimaryLocation(sessionId) : cache.getCacheManager().getAddress();
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteRegistryEntryProvider.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteRegistryEntryProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,30 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
+package org.wildfly.clustering.web.infinispan.session;
 
-import io.undertow.server.session.SessionIdGenerator;
-
-import org.wildfly.clustering.web.session.SessionIdentifierFactory;
+import org.jboss.msc.value.Value;
+import org.wildfly.clustering.registry.RegistryEntryProvider;
 
 /**
- * Adapts a {@link SessionIdGenerator} to a {@link SessionIdentifierFactory}.
+ * Provides the local {@link Registry} entry containing the route identifier.
  * @author Paul Ferraro
  */
-public class SessionIdentifierFactoryAdapter implements SessionIdentifierFactory {
+public class RouteRegistryEntryProvider implements RegistryEntryProvider<String, Void> {
 
-    private final SessionIdGenerator generator;
+    private final Value<String> route;
 
-    public SessionIdentifierFactoryAdapter(SessionIdGenerator generator) {
-        this.generator = generator;
+    public RouteRegistryEntryProvider(Value<String> route) {
+        this.route = route;
     }
 
     @Override
-    public String createSessionId() {
-        return this.generator.createSessionId();
+    public String getKey() {
+        return this.route.getValue();
+    }
+
+    @Override
+    public Void getValue() {
+        return null;
     }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteRegistryEntryProviderService.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteRegistryEntryProviderService.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,30 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
+package org.wildfly.clustering.web.infinispan.session;
 
-import io.undertow.server.session.SessionListeners;
+import org.jboss.msc.service.AbstractService;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.value.Value;
+import org.wildfly.clustering.registry.RegistryEntryProvider;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Service that provides the {@link RegistryEntryProvider} for the routing {@link Registry}.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
-    /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
-     */
-    SessionListeners getSessionListeners();
+public class RouteRegistryEntryProviderService extends AbstractService<RegistryEntryProvider<String, Void>> {
 
-    /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
-     */
-    SessionManager<LocalSessionContext> getSessionManager();
+    public static final ServiceName SERVICE_NAME = RouteLocatorService.REGISTRY_SERVICE_NAME.append("entry");
+
+    private final Value<? extends Value<String>> route;
+
+    public RouteRegistryEntryProviderService(Value<? extends Value<String>> route) {
+        this.route = route;
+    }
+
+    @Override
+    public RegistryEntryProvider<String, Void> getValue() {
+        return new RouteRegistryEntryProvider(this.route.getValue());
+    }
 }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesCacheKey.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/SessionAttributesCacheKey.java
@@ -21,8 +21,6 @@
  */
 package org.wildfly.clustering.web.infinispan.session.coarse;
 
-import org.infinispan.distribution.group.Group;
-
 /**
  * Cache key for session attributes.
  * @author Paul Ferraro
@@ -36,7 +34,6 @@ public class SessionAttributesCacheKey {
     }
 
     @Override
-    @Group
     public String toString() {
         return this.id;
     }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeCacheKey.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/SessionAttributeCacheKey.java
@@ -48,7 +48,7 @@ public class SessionAttributeCacheKey {
 
     @Override
     public int hashCode() {
-        return this.id.hashCode();
+        return this.id.hashCode() ^ this.attribute.hashCode();
     }
 
     @Override

--- a/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.web.session.RouteLocatorBuilder
+++ b/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.web.session.RouteLocatorBuilder
@@ -1,0 +1,1 @@
+org.wildfly.clustering.web.infinispan.session.RouteLocatorBuilder

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocator.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocator.java
@@ -21,6 +21,10 @@
  */
 package org.wildfly.clustering.web.session;
 
+/**
+ * Locates the route appropriate for a given session identifier.
+ * @author Paul Ferraro
+ */
 public interface RouteLocator {
     /**
      * Returns the route identifier most appropriate for the specified session identifier.

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocatorBuilder.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocatorBuilder.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,32 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
+package org.wildfly.clustering.web.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
-
-import io.undertow.server.session.SessionListeners;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.Value;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Builds a {@link RouteLocator} service.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
+public interface RouteLocatorBuilder {
     /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
+     * Builds a {@link RouteLocator} service.
+     * @param target the service target
+     * @param name the service name of the route locator service
+     * @param deploymentServiceName the service name of the web deployment
+     * @return a service builder
      */
-    SessionListeners getSessionListeners();
+    ServiceBuilder<RouteLocator> build(ServiceTarget target, ServiceName name, ServiceName deploymentServiceName);
 
     /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
+     * Builds the server dependencies to be made available to every deployment.
+     * @param target the service target
+     * @param route the injected route source
+     * @return a service builder
      */
-    SessionManager<LocalSessionContext> getSessionManager();
+    ServiceBuilder<?> buildServerDependency(ServiceTarget target, Value<? extends Value<String>> route);
 }

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocatorBuilderValue.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/RouteLocatorBuilderValue.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,37 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
+package org.wildfly.clustering.web.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
+import java.util.ServiceLoader;
 
-import io.undertow.server.session.SessionListeners;
+import org.jboss.msc.value.Value;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Dynamically loads the {@link RouteLocatorBuilder} provider via {@link ServiceLoader}.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
-    /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
-     */
-    SessionListeners getSessionListeners();
+public class RouteLocatorBuilderValue implements Value<RouteLocatorBuilder> {
 
-    /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
-     */
-    SessionManager<LocalSessionContext> getSessionManager();
+    private static RouteLocatorBuilder load() {
+        for (RouteLocatorBuilder builder: ServiceLoader.load(RouteLocatorBuilder.class, RouteLocatorBuilder.class.getClassLoader())) {
+            return builder;
+        }
+        return null;
+    }
+
+    private final RouteLocatorBuilder builder;
+
+    public RouteLocatorBuilderValue() {
+        this(load());
+    }
+
+    public RouteLocatorBuilderValue(RouteLocatorBuilder builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public RouteLocatorBuilder getValue() {
+        return this.builder;
+    }
 }

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManager.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.wildfly.clustering.web.Batcher;
 
-public interface SessionManager<L> extends SessionIdentifierFactory, RouteLocator {
+public interface SessionManager<L> extends SessionIdentifierFactory {
     /**
      * Invoked prior to applicaion deployment.
      */

--- a/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManagerFactoryBuilder.java
+++ b/clustering/web/spi/src/main/java/org/wildfly/clustering/web/session/SessionManagerFactoryBuilder.java
@@ -26,7 +26,6 @@ import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.Value;
 
 /**
  * Interface for building a session manager factory.
@@ -34,6 +33,4 @@ import org.jboss.msc.value.Value;
  */
 public interface SessionManagerFactoryBuilder {
     ServiceBuilder<SessionManagerFactory> buildDeploymentDependency(ServiceTarget target, ServiceName name, ServiceName deploymentServiceName, Module module, JBossWebMetaData metaData);
-
-    ServiceBuilder<?> buildServerDependency(ServiceTarget target, Value<String> instanceId);
 }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/AbstractDistributableSession.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/AbstractDistributableSession.java
@@ -32,7 +32,7 @@ import io.undertow.server.session.Session;
  * Abstract Undertow adapter for a session.
  * @author Paul Ferraro
  */
-public abstract class AbstractSessionAdapter<S extends ImmutableSession> implements Session {
+public abstract class AbstractDistributableSession<S extends ImmutableSession> implements Session {
 
     /**
      * Returns a reference to the delegate session.

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableImmutableSession.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableImmutableSession.java
@@ -31,12 +31,12 @@ import io.undertow.server.session.SessionManager;
  * Undertow adapter for an {@link ImmutableSession}.
  * @author Paul Ferraro
  */
-public class ImmutableSessionAdapter extends AbstractSessionAdapter<ImmutableSession> {
+public class DistributableImmutableSession extends AbstractDistributableSession<ImmutableSession> {
 
     private final SessionManager manager;
     private final ImmutableSession session;
 
-    public ImmutableSessionAdapter(SessionManager manager, ImmutableSession session) {
+    public DistributableImmutableSession(SessionManager manager, ImmutableSession session) {
         this.manager = manager;
         this.session = session;
     }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodec.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodec.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.undertow.session;
+
+import org.jboss.as.web.session.RoutingSupport;
+import org.jboss.as.web.session.SessionIdentifierCodec;
+import org.wildfly.clustering.web.session.RouteLocator;
+
+/**
+ * {@link SessionIdentifierCodec} that encodes the route determined by the a {@link RouteLocator}.
+ * @author Paul Ferraro
+ */
+public class DistributableSessionIdentifierCodec implements SessionIdentifierCodec {
+
+    private final RouteLocator locator;
+    private final RoutingSupport routing;
+
+    public DistributableSessionIdentifierCodec(RouteLocator locator, RoutingSupport routing) {
+        this.locator = locator;
+        this.routing = routing;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String encode(String sessionId) {
+        String route = this.locator.locate(sessionId);
+        return (route != null) ? this.routing.format(sessionId, route) : sessionId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String decode(String encodedSessionId) {
+        return this.routing.parse(encodedSessionId).getKey();
+    }
+}

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecBuilder.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecBuilder.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.clustering.web.undertow.session;
+
+import org.jboss.as.web.session.SessionIdentifierCodec;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.web.session.RouteLocatorBuilder;
+import org.wildfly.clustering.web.session.RouteLocatorBuilderValue;
+import org.wildfly.extension.undertow.session.RouteValue;
+import org.wildfly.extension.undertow.session.RouteValueService;
+
+/**
+ * Builds a distributable {@link SessionIdentifierCodec} service.
+ * @author Paul Ferraro
+ */
+public class DistributableSessionIdentifierCodecBuilder implements org.wildfly.extension.undertow.session.DistributableSessionIdentifierCodecBuilder {
+
+    private final RouteLocatorBuilder builder;
+
+    public DistributableSessionIdentifierCodecBuilder() {
+        this(new RouteLocatorBuilderValue().getValue());
+    }
+
+    public DistributableSessionIdentifierCodecBuilder(RouteLocatorBuilder builder) {
+        this.builder = builder;
+    }
+
+    @Override
+    public ServiceBuilder<SessionIdentifierCodec> build(ServiceTarget target, ServiceName name, ServiceName deploymentServiceName) {
+        ServiceName locatorServiceName = deploymentServiceName.append("locator");
+        this.builder.build(target, locatorServiceName, deploymentServiceName)
+                .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                .install()
+        ;
+        return DistributableSessionIdentifierCodecService.build(target, name, locatorServiceName);
+    }
+
+    @Override
+    public ServiceBuilder<?> buildServerDependency(ServiceTarget target) {
+        final InjectedValue<RouteValue> route = new InjectedValue<>();
+        return this.builder.buildServerDependency(target, route)
+                .addDependency(RouteValueService.SERVICE_NAME, RouteValue.class, route)
+        ;
+    }
+}

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecService.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecService.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.undertow.session;
+
+import org.jboss.as.web.session.RoutingSupport;
+import org.jboss.as.web.session.SessionIdentifierCodec;
+import org.jboss.as.web.session.SimpleRoutingSupport;
+import org.jboss.msc.service.AbstractService;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.web.session.RouteLocator;
+
+/**
+ * Service providing a distributable {@link SessionIdentifierCodec}.
+ * @author Paul Ferraro
+ */
+public class DistributableSessionIdentifierCodecService extends AbstractService<SessionIdentifierCodec> {
+
+    public static ServiceBuilder<SessionIdentifierCodec> build(ServiceTarget target, ServiceName name, ServiceName locatorServiceName) {
+        DistributableSessionIdentifierCodecService service = new DistributableSessionIdentifierCodecService();
+        ServiceBuilder<SessionIdentifierCodec> builder = target.addService(name, service)
+                .addDependency(locatorServiceName, RouteLocator.class, service.locator)
+        ;
+        return builder;
+    }
+
+    private final InjectedValue<RouteLocator> locator = new InjectedValue<>();
+    private final RoutingSupport routing = new SimpleRoutingSupport();
+
+    private DistributableSessionIdentifierCodecService() {
+        // Hide
+    }
+
+    @Override
+    public SessionIdentifierCodec getValue() {
+        return new DistributableSessionIdentifierCodec(this.locator.getValue(), this.routing);
+    }
+}

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerFactory.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSessionManagerFactory.java
@@ -30,24 +30,22 @@ import io.undertow.server.session.SecureRandomSessionIdGenerator;
 import io.undertow.servlet.api.Deployment;
 
 /**
- * Factory for creating a distributable session manager.
+ * Factory for creating a {@link DistributableSessionManager}.
  * @author Paul Ferraro
  */
-public class SessionManagerAdapterFactory implements io.undertow.servlet.api.SessionManagerFactory {
+public class DistributableSessionManagerFactory implements io.undertow.servlet.api.SessionManagerFactory {
 
     private final SessionManagerFactory factory;
-    private final String deploymentName;
 
-    public SessionManagerAdapterFactory(SessionManagerFactory factory, String deploymentName) {
+    public DistributableSessionManagerFactory(SessionManagerFactory factory) {
         this.factory = factory;
-        this.deploymentName = deploymentName;
     }
 
     @Override
     public io.undertow.server.session.SessionManager createSessionManager(Deployment deployment) {
-        SessionContext context = new SessionContextAdapter(deployment);
-        SessionIdentifierFactory factory = new SessionIdentifierFactoryAdapter(new SecureRandomSessionIdGenerator());
+        SessionContext context = new UndertowSessionContext(deployment);
+        SessionIdentifierFactory factory = new UndertowSessionIdentifierFactory(new SecureRandomSessionIdGenerator());
         SessionManager<LocalSessionContext> manager = this.factory.createSessionManager(context, factory, new LocalSessionContextFactory());
-        return new SessionManagerAdapter(deploymentName, manager);
+        return new DistributableSessionManager(deployment.getDeploymentInfo().getDeploymentName(), manager);
     }
 }

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/UndertowSessionContext.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/UndertowSessionContext.java
@@ -35,14 +35,14 @@ import javax.servlet.http.HttpSessionListener;
 import org.wildfly.clustering.web.session.SessionContext;
 
 /**
- * Adapts a {@link Deployment} to a {@link SessionContext}
+ * {@link SessionContext} that delegate to a {@link Deployment}.
  * @author Paul Ferraro
  */
-public class SessionContextAdapter implements SessionContext {
+public class UndertowSessionContext implements SessionContext {
 
     private final Deployment deployment;
 
-    public SessionContextAdapter(Deployment deployment) {
+    public UndertowSessionContext(Deployment deployment) {
         this.deployment = deployment;
     }
 

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/UndertowSessionIdentifierFactory.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/UndertowSessionIdentifierFactory.java
@@ -21,24 +21,24 @@
  */
 package org.wildfly.clustering.web.undertow.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
+import io.undertow.server.session.SessionIdGenerator;
 
-import io.undertow.server.session.SessionListeners;
+import org.wildfly.clustering.web.session.SessionIdentifierFactory;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * {@link SessionIdentifierFactory} that delegates to a {@link SessionIdGenerator}.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
-    /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
-     */
-    SessionListeners getSessionListeners();
+public class UndertowSessionIdentifierFactory implements SessionIdentifierFactory {
 
-    /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
-     */
-    SessionManager<LocalSessionContext> getSessionManager();
+    private final SessionIdGenerator generator;
+
+    public UndertowSessionIdentifierFactory(SessionIdGenerator generator) {
+        this.generator = generator;
+    }
+
+    @Override
+    public String createSessionId() {
+        return this.generator.createSessionId();
+    }
 }

--- a/clustering/web/undertow/src/main/resources/META-INF/services/org.wildfly.extension.undertow.session.DistributableSessionIdentifierCodecBuilder
+++ b/clustering/web/undertow/src/main/resources/META-INF/services/org.wildfly.extension.undertow.session.DistributableSessionIdentifierCodecBuilder
@@ -1,0 +1,1 @@
+org.wildfly.clustering.web.undertow.session.DistributableSessionIdentifierCodecBuilder

--- a/clustering/web/undertow/src/main/resources/META-INF/services/org.wildfly.extension.undertow.session.DistributableSessionManagerFactoryBuilder
+++ b/clustering/web/undertow/src/main/resources/META-INF/services/org.wildfly.extension.undertow.session.DistributableSessionManagerFactoryBuilder
@@ -1,1 +1,1 @@
-org.wildfly.clustering.web.undertow.session.SessionManagerAdapterFactoryBuilder
+org.wildfly.clustering.web.undertow.session.DistributableSessionManagerFactoryBuilder

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionIdentifierCodecTestCase.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.clustering.web.undertow.session;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+
+import org.jboss.as.web.session.RoutingSupport;
+import org.jboss.as.web.session.SessionIdentifierCodec;
+import org.junit.Test;
+import org.wildfly.clustering.web.session.RouteLocator;
+
+/**
+ * Unit test for {@link DistributableSessionIdentifierCodec}.
+ * @author Paul Ferraro
+ */
+public class DistributableSessionIdentifierCodecTestCase {
+    private final RoutingSupport routing = mock(RoutingSupport.class);
+    private final RouteLocator locator = mock(RouteLocator.class);
+
+    private SessionIdentifierCodec codec = new DistributableSessionIdentifierCodec(this.locator, this.routing);
+
+    @Test
+    public void encode() {
+        String sessionId = "session";
+
+        when(this.locator.locate(sessionId)).thenReturn(null);
+
+        String result = this.codec.encode(sessionId);
+
+        assertSame(sessionId, result);
+
+        String route = "route";
+        String encodedSessionId = "session.route";
+
+        when(this.locator.locate(sessionId)).thenReturn(route);
+        when(this.routing.format(sessionId, route)).thenReturn(encodedSessionId);
+
+        result = this.codec.encode(sessionId);
+
+        assertSame(encodedSessionId, result);
+    }
+
+    @Test
+    public void decode() {
+        String encodedSessionId = "session.route";
+        String sessionId = "session";
+        String route = "route";
+
+        when(this.routing.parse(encodedSessionId)).thenReturn(new SimpleImmutableEntry<>(sessionId, route));
+
+        String result = this.codec.decode(encodedSessionId);
+
+        assertSame(sessionId, result);
+    }
+}

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionTestCase.java
@@ -46,16 +46,16 @@ import org.wildfly.clustering.web.session.Session;
 import org.wildfly.clustering.web.session.SessionAttributes;
 import org.wildfly.clustering.web.session.SessionManager;
 import org.wildfly.clustering.web.session.SessionMetaData;
-import org.wildfly.clustering.web.undertow.session.SessionAdapter;
+import org.wildfly.clustering.web.undertow.session.DistributableSession;
 import org.wildfly.clustering.web.undertow.session.UndertowSessionManager;
 
-public class SessionAdapterTestCase {
+public class DistributableSessionTestCase {
     private final UndertowSessionManager manager = mock(UndertowSessionManager.class);
     private final SessionConfig config = mock(SessionConfig.class);
     private final Session<LocalSessionContext> session = mock(Session.class);
     private final Batch batch = mock(Batch.class);
 
-    private final io.undertow.server.session.Session adapter = new SessionAdapter(this.manager, this.session, this.config, this.batch);
+    private final io.undertow.server.session.Session adapter = new DistributableSession(this.manager, this.session, this.config, this.batch);
     
     @Test
     public void getId() {
@@ -348,7 +348,7 @@ public class SessionAdapterTestCase {
         SessionListeners listeners = new SessionListeners();
         listeners.addSessionListener(listener);
         String sessionId = "session";
-        
+
         when(this.manager.getSessionListeners()).thenReturn(listeners);
         when(this.session.getId()).thenReturn(sessionId);
         when(this.manager.getSessionManager()).thenReturn(manager);
@@ -379,8 +379,6 @@ public class SessionAdapterTestCase {
         LocalSessionContext oldContext = mock(LocalSessionContext.class);
         LocalSessionContext newContext = mock(LocalSessionContext.class);
         String sessionId = "session";
-        String route = "route";
-        String routedSessionid = "session:route";
         String name = "name";
         Object value = new Object();
         Date date = new Date();
@@ -401,11 +399,9 @@ public class SessionAdapterTestCase {
         when(oldMetaData.getLastAccessedTime()).thenReturn(date);
         when(oldMetaData.getMaxInactiveInterval(capturedUnit.capture())).thenReturn(interval);
         when(session.getId()).thenReturn(sessionId);
-        when(manager.locate(sessionId)).thenReturn(route);
         when(this.session.getLocalContext()).thenReturn(oldContext);
         when(session.getLocalContext()).thenReturn(newContext);
         when(oldContext.getAuthenticatedSession()).thenReturn(authenticatedSession);
-        when(this.manager.format(sessionId, route)).thenReturn(routedSessionid);
         
         String result = this.adapter.changeSessionId(exchange, config);
         
@@ -413,7 +409,7 @@ public class SessionAdapterTestCase {
         
         verify(newMetaData).setLastAccessedTime(date);
         verify(newMetaData).setMaxInactiveInterval(interval, capturedUnit.getValue());
-        verify(config).setSessionId(exchange, routedSessionid);
+        verify(config).setSessionId(exchange, sessionId);
         verify(newContext).setAuthenticatedSession(same(authenticatedSession));
     }
 }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/UndertowSessionContextTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/UndertowSessionContextTestCase.java
@@ -47,9 +47,9 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.wildfly.clustering.web.session.SessionContext;
 
-public class SessionContextAdapterTestCase {
+public class UndertowSessionContextTestCase {
     private final Deployment deployment = mock(Deployment.class);
-    private final SessionContext context = new SessionContextAdapter(this.deployment);
+    private final SessionContext context = new UndertowSessionContext(this.deployment);
 
     @Test
     public void getServletContext() {

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/UndertowSessionIdentifierFactoryTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/UndertowSessionIdentifierFactoryTestCase.java
@@ -28,9 +28,9 @@ import io.undertow.server.session.SessionIdGenerator;
 import org.junit.Test;
 import org.wildfly.clustering.web.session.SessionIdentifierFactory;
 
-public class SessionIdentifierFactoryAdapterTestCase {
+public class UndertowSessionIdentifierFactoryTestCase {
     private final SessionIdGenerator generator = mock(SessionIdGenerator.class);
-    private final SessionIdentifierFactory factory = new SessionIdentifierFactoryAdapter(this.generator);
+    private final SessionIdentifierFactory factory = new UndertowSessionIdentifierFactory(this.generator);
     
     @Test
     public void test() {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
@@ -53,7 +53,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Validate the <distributable/> works for a two-node cluster.
+ * Validate that <distributable/> works for a two-node cluster.
  *
  * @author Paul Ferraro
  * @author Radoslav Husar

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering.cluster.web;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.HttpClientUtils;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
+import org.jboss.as.test.clustering.single.web.SimpleServlet;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Validate that non-distributable web applications play nicely with a load balancer using sticky sessions.
+ *
+ * @author Paul Ferraro
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class NonDistributableTestCase extends ClusterAbstractTestCase {
+
+    @Deployment(name = DEPLOYMENT_1, managed = false)
+    @TargetsContainer(CONTAINER_1)
+    public static Archive<?> deployment0() {
+        return getDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false)
+    @TargetsContainer(CONTAINER_2)
+    public static Archive<?> deployment1() {
+        return getDeployment();
+    }
+
+    private static Archive<?> getDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "non-distributable.war");
+        war.addClass(SimpleServlet.class);
+        log.info(war.toString(true));
+        return war;
+    }
+
+    @Test
+    public void test(@ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
+                     @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2) throws IOException, URISyntaxException {
+        URI uri1 = SimpleServlet.createURI(baseURL1);
+        URI uri2 = SimpleServlet.createURI(baseURL2);
+
+        DefaultHttpClient client = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
+        try {
+            HttpResponse response = client.execute(new HttpGet(uri1));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                // Session identifier should contain the route for this node
+                Assert.assertEquals(NODE_1, entry.getValue());
+                // Session identifier seen by servlet should *not* contain the route
+                Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            response = client.execute(new HttpGet(uri1));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                Assert.assertNull(entry);
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            response = client.execute(new HttpGet(uri2));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                // Session should not be replicated
+                Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                // Session identifier should contain the route for this node
+                Assert.assertEquals(NODE_2, entry.getValue());
+                // Session identifier seen by servlet should *not* contain the route
+                Assert.assertEquals(entry.getKey(), response.getFirstHeader(SimpleServlet.SESSION_ID_HEADER).getValue());
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+
+            response = client.execute(new HttpGet(uri2));
+            try {
+                Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+                Assert.assertEquals(2, Integer.parseInt(response.getFirstHeader(SimpleServlet.VALUE_HEADER).getValue()));
+                Map.Entry<String, String> entry = parseSessionRoute(response);
+                Assert.assertNull(entry);
+            } finally {
+                HttpClientUtils.closeQuietly(response);
+            }
+        } finally {
+            HttpClientUtils.closeQuietly(client);
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/single/web/SimpleServlet.java
@@ -45,6 +45,7 @@ public class SimpleServlet extends HttpServlet {
     public static final String REQUEST_DURATION_PARAM = "requestduration";
     public static final String HEADER_SERIALIZED = "serialized";
     public static final String VALUE_HEADER = "value";
+    public static final String SESSION_ID_HEADER = "sessionId";
     private static final String ATTRIBUTE = "test";
 
     public static URI createURI(URL baseURL) throws URISyntaxException {
@@ -54,6 +55,7 @@ public class SimpleServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         HttpSession session = req.getSession(true);
+        resp.addHeader(SESSION_ID_HEADER, session.getId());
         Mutable custom = (Mutable) session.getAttribute(ATTRIBUTE);
         if (custom == null) {
             custom = new Mutable(1);

--- a/undertow/pom.xml
+++ b/undertow/pom.xml
@@ -94,6 +94,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.logging</groupId>
             <artifactId>jboss-logging-annotations</artifactId>
             <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemAdd.java
@@ -39,7 +39,6 @@ import org.jboss.as.web.common.SharedTldsMetaDataBuilder;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
-import org.jboss.msc.value.ImmediateValue;
 import org.wildfly.extension.undertow.deployment.EarContextRootProcessor;
 import org.wildfly.extension.undertow.deployment.JBossWebParsingDeploymentProcessor;
 import org.wildfly.extension.undertow.deployment.ServletContainerInitializerDeploymentProcessor;
@@ -55,8 +54,9 @@ import org.wildfly.extension.undertow.deployment.WarStructureDeploymentProcessor
 import org.wildfly.extension.undertow.deployment.WebFragmentParsingDeploymentProcessor;
 import org.wildfly.extension.undertow.deployment.WebJBossAllParser;
 import org.wildfly.extension.undertow.deployment.WebParsingDeploymentProcessor;
-import org.wildfly.extension.undertow.session.DistributableSessionManagerFactoryBuilder;
-import org.wildfly.extension.undertow.session.DistributableSessionManagerFactoryBuilderValue;
+import org.wildfly.extension.undertow.session.DistributableSessionIdentifierCodecBuilder;
+import org.wildfly.extension.undertow.session.DistributableSessionIdentifierCodecBuilderValue;
+import org.wildfly.extension.undertow.session.RouteValueService;
 
 
 /**
@@ -142,9 +142,10 @@ class UndertowSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
         UndertowLogger.ROOT_LOGGER.serverStarting(Version.getVersionString());
 
-        DistributableSessionManagerFactoryBuilder builder = new DistributableSessionManagerFactoryBuilderValue().getValue();
+        DistributableSessionIdentifierCodecBuilder builder = new DistributableSessionIdentifierCodecBuilderValue().getValue();
         if (builder != null) {
-            newControllers.add(builder.buildServerDependency(target, new ImmediateValue<>(instanceId)).setInitialMode(ServiceController.Mode.ON_DEMAND).install());
+            newControllers.add(builder.buildServerDependency(target).setInitialMode(ServiceController.Mode.ON_DEMAND).install());
         }
+        newControllers.add(RouteValueService.build(target).setInitialMode(ServiceController.Mode.ON_DEMAND).install());
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/CodecSessionConfig.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/CodecSessionConfig.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.undertow.session;
+
+import org.jboss.as.web.session.SessionIdentifierCodec;
+
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.session.SessionConfig;
+
+/**
+ * {@link SessionConfig} decorator that performs encoding/decoding of the session identifier.
+ * In this way, routing is completely opaque to the request, session, and session manager.
+ * @author Paul Ferraro
+ */
+public class CodecSessionConfig implements SessionConfig {
+
+    private final SessionConfig config;
+    private final SessionIdentifierCodec codec;
+
+    public CodecSessionConfig(SessionConfig config, SessionIdentifierCodec codec) {
+        this.config = config;
+        this.codec = codec;
+    }
+
+    @Override
+    public void setSessionId(HttpServerExchange exchange, String sessionId) {
+        this.config.setSessionId(exchange, this.codec.encode(sessionId));
+    }
+
+    @Override
+    public void clearSession(HttpServerExchange exchange, String sessionId) {
+        this.config.clearSession(exchange, this.codec.encode(sessionId));
+    }
+
+    @Override
+    public String findSessionId(HttpServerExchange exchange) {
+        String encodedSessionId = this.config.findSessionId(exchange);
+        if (encodedSessionId == null) return null;
+        String sessionId = this.codec.decode(encodedSessionId);
+        // Check if the encoding for this session has changed
+        String reencodedSessionId = this.codec.encode(sessionId);
+        if (!reencodedSessionId.equals(encodedSessionId)) {
+            this.config.setSessionId(exchange, reencodedSessionId);
+        }
+        return sessionId;
+    }
+
+    @Override
+    public SessionCookieSource sessionCookieSource(HttpServerExchange exchange) {
+        return this.config.sessionCookieSource(exchange);
+    }
+
+    @Override
+    public String rewriteUrl(String originalUrl, String sessionId) {
+        return this.config.rewriteUrl(originalUrl, this.codec.encode(sessionId));
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/CodecSessionConfigWrapper.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/CodecSessionConfigWrapper.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,27 +19,29 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.session;
 
-import java.util.Map;
+package org.wildfly.extension.undertow.session;
+
+import org.jboss.as.web.session.SessionIdentifierCodec;
+
+import io.undertow.server.session.SessionConfig;
+import io.undertow.servlet.api.Deployment;
+import io.undertow.servlet.api.SessionConfigWrapper;
 
 /**
- * Exposes the mechanism for parsing and formation routing information from/into a requested session identifier.
+ * Adds session identifier encoding/decoding to a {@link SessionConfig}.
  * @author Paul Ferraro
  */
-public interface RoutingSupport extends RouteLocator {
-    /**
-     * Parses the routing information from the specified session identifier.
-     * @param requestedSessionId the requested session identifier.
-     * @return a map entry containing the key as the session ID, and value as the routing information.
-     */
-    Map.Entry<String, String> parse(String requestedSessionId);
+public class CodecSessionConfigWrapper implements SessionConfigWrapper {
 
-    /**
-     * Formats the specified session identifier and route identifier into a single identifier.
-     * @param sessionId a session identifier
-     * @param instanceId an instance identifier.
-     * @return a single identifier containing the specified session identifier and routing identifier.
-     */
-    String format(String sessionId, String routeId);
+    private final SessionIdentifierCodec codec;
+
+    public CodecSessionConfigWrapper(SessionIdentifierCodec codec) {
+        this.codec = codec;
+    }
+
+    @Override
+    public SessionConfig wrap(SessionConfig config, Deployment deployment) {
+        return new CodecSessionConfig(config, this.codec);
+    }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/DistributableSessionIdentifierCodecBuilder.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/DistributableSessionIdentifierCodecBuilder.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,31 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
+package org.wildfly.extension.undertow.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
-
-import io.undertow.server.session.SessionListeners;
+import org.jboss.as.web.session.SessionIdentifierCodec;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Builds a {@link SessionIdentifierCodec} service.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
+public interface DistributableSessionIdentifierCodecBuilder {
     /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
+     * Builds a {@link SessionIdentifierCodec} service.
+     * @param target a service target
+     * @param name a service name
+     * @param deploymentServiceName the service name of the deployment
+     * @return a service builder
      */
-    SessionListeners getSessionListeners();
+    ServiceBuilder<SessionIdentifierCodec> build(ServiceTarget target, ServiceName name, ServiceName deploymentServiceName);
 
     /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
+     * Builds cross-deployment dependencies needed for route handling
+     * @param target the service target
+     * @return a service builder
      */
-    SessionManager<LocalSessionContext> getSessionManager();
+    ServiceBuilder<?> buildServerDependency(ServiceTarget target);
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/DistributableSessionIdentifierCodecBuilderValue.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/DistributableSessionIdentifierCodecBuilderValue.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -26,31 +26,30 @@ import java.util.ServiceLoader;
 import org.jboss.msc.value.Value;
 
 /**
- * Uses a service loader to load a {@link DistributableSessionManagerFactoryBuilder} implementation.
- * This serves to decouple the undertow subsystem from the clustering modules.
+ * Dynamically loads the {@link DistributableSessionIdentifierCodecBuilder} provider via {@link ServiceLoader}.
  * @author Paul Ferraro
  */
-public class DistributableSessionManagerFactoryBuilderValue implements Value<DistributableSessionManagerFactoryBuilder> {
+public class DistributableSessionIdentifierCodecBuilderValue implements Value<DistributableSessionIdentifierCodecBuilder> {
 
-    private final DistributableSessionManagerFactoryBuilder builder;
+    private final DistributableSessionIdentifierCodecBuilder builder;
 
-    public DistributableSessionManagerFactoryBuilderValue() {
+    public DistributableSessionIdentifierCodecBuilderValue() {
         this(load());
     }
 
-    public DistributableSessionManagerFactoryBuilderValue(DistributableSessionManagerFactoryBuilder builder) {
+    public DistributableSessionIdentifierCodecBuilderValue(DistributableSessionIdentifierCodecBuilder builder) {
         this.builder = builder;
     }
 
-    private static DistributableSessionManagerFactoryBuilder load() {
-        for (DistributableSessionManagerFactoryBuilder builder: ServiceLoader.load(DistributableSessionManagerFactoryBuilder.class, DistributableSessionManagerFactoryBuilder.class.getClassLoader())) {
+    private static DistributableSessionIdentifierCodecBuilder load() {
+        for (DistributableSessionIdentifierCodecBuilder builder: ServiceLoader.load(DistributableSessionIdentifierCodecBuilder.class, DistributableSessionIdentifierCodecBuilder.class.getClassLoader())) {
             return builder;
         }
         return null;
     }
 
     @Override
-    public DistributableSessionManagerFactoryBuilder getValue() {
+    public DistributableSessionIdentifierCodecBuilder getValue() {
         return this.builder;
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/RouteValue.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/RouteValue.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,26 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
+package org.wildfly.extension.undertow.session;
 
-import io.undertow.server.session.SessionListeners;
+import org.jboss.msc.value.Value;
+import org.wildfly.extension.undertow.UndertowService;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Exposes Undertow's instance id as a {@link Value}.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
-    /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
-     */
-    SessionListeners getSessionListeners();
+public class RouteValue implements Value<String> {
 
-    /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
-     */
-    SessionManager<LocalSessionContext> getSessionManager();
+    private final UndertowService service;
+
+    public RouteValue(UndertowService service) {
+        this.service = service;
+    }
+
+    @Override
+    public String getValue() {
+        return this.service.getInstanceId();
+    }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/RouteValueService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/RouteValueService.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -21,27 +21,36 @@
  */
 package org.wildfly.extension.undertow.session;
 
-import io.undertow.servlet.api.SessionManagerFactory;
-
-import org.jboss.metadata.web.jboss.JBossWebMetaData;
-import org.jboss.modules.Module;
+import org.jboss.msc.service.AbstractService;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.undertow.UndertowService;
 
 /**
- * SPI for building a factory for creating a distributable session manager.
+ * Service that exposes instance id of the server as the route.
  * @author Paul Ferraro
  */
-public interface DistributableSessionManagerFactoryBuilder {
-    /**
-     * Builds a {@link SessionManagerFactory} service.
-     * @param target the service target
-     * @param name the service name of the {@link SessionManagerFactory} service
-     * @param deploymentServiceName service name of the web application
-     * @param module the deployment module
-     * @param metaData the web application meta data
-     * @return a session manager factory service builder
-     */
-    ServiceBuilder<SessionManagerFactory> build(ServiceTarget target, ServiceName name, ServiceName deploymentServiceName, Module module, JBossWebMetaData metaData);
+public class RouteValueService extends AbstractService<RouteValue> {
+
+    public static final ServiceName SERVICE_NAME = UndertowService.SERVER.append("route");
+
+    public static ServiceBuilder<RouteValue> build(ServiceTarget target) {
+        RouteValueService service = new RouteValueService();
+        return target.addService(SERVICE_NAME, service)
+                .addDependency(UndertowService.UNDERTOW, UndertowService.class, service.service)
+        ;
+    }
+
+    private final InjectedValue<UndertowService> service = new InjectedValue<>();
+
+    private RouteValueService() {
+        // Hide
+    }
+
+    @Override
+    public RouteValue getValue() {
+        return new RouteValue(this.service.getValue());
+    }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/session/SimpleSessionIdentifierCodecService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/session/SimpleSessionIdentifierCodecService.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow.session;
+
+import org.jboss.as.web.session.RoutingSupport;
+import org.jboss.as.web.session.SessionIdentifierCodec;
+import org.jboss.as.web.session.SimpleRoutingSupport;
+import org.jboss.as.web.session.SimpleSessionIdentifierCodec;
+import org.jboss.msc.service.AbstractService;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.value.InjectedValue;
+
+/**
+ * Service providing a non-distributable {@link SessionIdentifierCodec} implementation.
+ * @author Paul Ferraro
+ */
+public class SimpleSessionIdentifierCodecService extends AbstractService<SessionIdentifierCodec> {
+
+    public static ServiceBuilder<SessionIdentifierCodec> build(ServiceTarget target, ServiceName name) {
+        SimpleSessionIdentifierCodecService service = new SimpleSessionIdentifierCodecService();
+        return target.addService(name, service)
+                .addDependency(RouteValueService.SERVICE_NAME, RouteValue.class, service.route)
+        ;
+    }
+
+    private final InjectedValue<RouteValue> route = new InjectedValue<>();
+    private final RoutingSupport routing = new SimpleRoutingSupport();
+
+    private SimpleSessionIdentifierCodecService() {
+        // Hide
+    }
+
+    @Override
+    public SessionIdentifierCodec getValue() {
+        return new SimpleSessionIdentifierCodec(this.routing, this.route.getValue());
+    }
+}

--- a/undertow/src/test/java/org/wildfly/extension/undertow/session/CodecSessionConfigTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/session/CodecSessionConfigTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow.session;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.server.session.SessionConfig;
+
+import org.jboss.as.web.session.SessionIdentifierCodec;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link CodecSessionConfig}
+ * @author Paul Ferraro
+ */
+public class CodecSessionConfigTestCase {
+
+    private final SessionConfig config = mock(SessionConfig.class);
+    private final SessionIdentifierCodec codec = mock(SessionIdentifierCodec.class);
+
+    private final SessionConfig subject = new CodecSessionConfig(this.config, this.codec);
+
+    @Test
+    public void findSessionId() {
+        HttpServerExchange exchange = new HttpServerExchange(null);
+
+        when(this.config.findSessionId(exchange)).thenReturn(null);
+
+        String result = this.subject.findSessionId(exchange);
+
+        assertNull(result);
+
+        String encodedSessionId = "session.route1";
+        String sessionId = "session";
+
+        when(this.config.findSessionId(exchange)).thenReturn(encodedSessionId);
+        when(this.codec.decode(encodedSessionId)).thenReturn(sessionId);
+        when(this.codec.encode(sessionId)).thenReturn(encodedSessionId);
+
+        result = this.subject.findSessionId(exchange);
+
+        assertSame(sessionId, result);
+
+        verify(this.config, never()).setSessionId(same(exchange), anyString());
+
+        String reencodedSessionId = "session.route2";
+
+        when(this.codec.encode(sessionId)).thenReturn(reencodedSessionId);
+
+        result = this.subject.findSessionId(exchange);
+
+        assertSame(sessionId, result);
+
+        verify(this.config).setSessionId(exchange, reencodedSessionId);
+    }
+
+    @Test
+    public void setSessionId() {
+        HttpServerExchange exchange = new HttpServerExchange(null);
+        String encodedSessionId = "session.route";
+        String sessionId = "session";
+
+        when(this.codec.encode(sessionId)).thenReturn(encodedSessionId);
+
+        this.subject.setSessionId(exchange, sessionId);
+
+        verify(this.config).setSessionId(exchange, encodedSessionId);
+    }
+
+    @Test
+    public void clearSession() {
+        HttpServerExchange exchange = new HttpServerExchange(null);
+        String encodedSessionId = "session.route";
+        String sessionId = "session";
+
+        when(this.codec.encode(sessionId)).thenReturn(encodedSessionId);
+
+        this.subject.clearSession(exchange, sessionId);
+
+        verify(this.config).clearSession(exchange, encodedSessionId);
+    }
+
+    @Test
+    public void rewriteUrl() {
+        String url = "http://test";
+        String encodedUrl = "http://test/session";
+        String encodedSessionId = "session.route";
+        String sessionId = "session";
+
+        when(this.codec.encode(sessionId)).thenReturn(encodedSessionId);
+        when(this.config.rewriteUrl(url, encodedSessionId)).thenReturn(encodedUrl);
+
+        String result = this.subject.rewriteUrl(url, sessionId);
+
+        assertSame(encodedUrl, result);
+    }
+
+    @Test
+    public void sessionCookieSource() {
+        HttpServerExchange exchange = new HttpServerExchange(null);
+        SessionConfig.SessionCookieSource expected = SessionConfig.SessionCookieSource.OTHER;
+
+        when(this.config.sessionCookieSource(exchange)).thenReturn(expected);
+
+        SessionConfig.SessionCookieSource result = this.subject.sessionCookieSource(exchange);
+
+        assertSame(expected, result);
+    }
+}

--- a/web-common/pom.xml
+++ b/web-common/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.jboss.msc</groupId>

--- a/web-common/src/main/java/org/jboss/as/web/session/RoutingSupport.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/RoutingSupport.java
@@ -19,26 +19,27 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
+package org.jboss.as.web.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
-
-import io.undertow.server.session.SessionListeners;
+import java.util.Map;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Exposes the mechanism for parsing and formation routing information from/into a requested session identifier.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
+public interface RoutingSupport {
     /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
+     * Parses the routing information from the specified session identifier.
+     * @param requestedSessionId the requested session identifier.
+     * @return a map entry containing the session ID and routing information as the key and value, respectively.
      */
-    SessionListeners getSessionListeners();
+    Map.Entry<String, String> parse(String requestedSessionId);
 
     /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
+     * Formats the specified session identifier and route identifier into a single identifier.
+     * @param sessionId a session identifier
+     * @param route a route identifier.
+     * @return a single identifier containing the specified session identifier and routing identifier.
      */
-    SessionManager<LocalSessionContext> getSessionManager();
+    String format(String sessionId, String route);
 }

--- a/web-common/src/main/java/org/jboss/as/web/session/SessionIdentifierCodec.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/SessionIdentifierCodec.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.as.web.session;
+
+/**
+ * Encapsulates logic to encode/decode additional information in/from a session identifier.
+ * Both the {@link #encode(String)} and {@link #decode(String)} methods should be idempotent.
+ * The codec methods should also be symmetrical.  i.e. the result of
+ * <code>decode(encode(x))</code> should yield <code>x</code>, just as the result of
+ * <code>encode(decode(y))</code> should yield <code>y</code>.
+ * @author Paul Ferraro
+ */
+public interface SessionIdentifierCodec {
+    /**
+     * Encodes the specified session identifier
+     * @param sessionId a session identifier
+     * @return an encoded session identifier
+     */
+    String encode(String sessionId);
+
+    /**
+     * Decodes the specified session identifier encoded via {@link #encode(String)}.
+     * @param encodedSessionId an encoded session identifier
+     * @return the decoded session identifier
+     */
+    String decode(String encodedSessionId);
+}

--- a/web-common/src/main/java/org/jboss/as/web/session/SimpleRoutingSupport.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/SimpleRoutingSupport.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.web.session;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+import java.util.Map;
+
+/**
+ * Implements logic for parsing/appending routing information from/to a session identifier.
+ * @author Paul Ferraro
+ */
+public class SimpleRoutingSupport implements RoutingSupport {
+
+    public static final String DEFAULT_DELIMITER = ".";
+
+    private final String delimiter;
+
+    public SimpleRoutingSupport() {
+        this(DEFAULT_DELIMITER);
+    }
+
+    public SimpleRoutingSupport(String delimiter) {
+        this.delimiter = delimiter;
+    }
+
+    @Override
+    public Map.Entry<String, String> parse(String id) {
+        int index = (id != null) ? id.indexOf(this.delimiter) : -1;
+        return (index < 0) ? new SimpleImmutableEntry<String, String>(id, null) : new SimpleImmutableEntry<>(id.substring(0, index), id.substring(index + this.delimiter.length()));
+    }
+
+    @Override
+    public String format(String sessionId, String routeId) {
+        return ((routeId != null) && !routeId.isEmpty()) ? String.format("%s%s%s", sessionId, this.delimiter, routeId) : sessionId;
+    }
+}

--- a/web-common/src/main/java/org/jboss/as/web/session/SimpleSessionIdentifierCodec.java
+++ b/web-common/src/main/java/org/jboss/as/web/session/SimpleSessionIdentifierCodec.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,26 +19,32 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.web.undertow.session;
+package org.jboss.as.web.session;
 
-import org.wildfly.clustering.web.session.SessionManager;
-
-import io.undertow.server.session.SessionListeners;
+import org.jboss.msc.value.Value;
 
 /**
- * Exposes additional session manager aspects to a session.
+ * Simple codec implementation that uses a static route source.
  * @author Paul Ferraro
  */
-public interface UndertowSessionManager extends io.undertow.server.session.SessionManager {
-    /**
-     * Returns the configured session listeners for this web application
-     * @return the session listeners
-     */
-    SessionListeners getSessionListeners();
+public class SimpleSessionIdentifierCodec implements SessionIdentifierCodec {
 
-    /**
-     * Returns underlying distributable session manager implementation.
-     * @return a session manager
-     */
-    SessionManager<LocalSessionContext> getSessionManager();
+    private final Value<String> route;
+    private final RoutingSupport routing;
+
+    public SimpleSessionIdentifierCodec(RoutingSupport routing, Value<String> route) {
+        this.routing = routing;
+        this.route = route;
+    }
+
+    @Override
+    public String encode(String sessionId) {
+        String route = this.route.getValue();
+        return (route != null) ? this.routing.format(sessionId, route) : sessionId;
+    }
+
+    @Override
+    public String decode(String encodedSessionId) {
+        return (encodedSessionId != null) ? this.routing.parse(encodedSessionId).getKey() : null;
+    }
 }

--- a/web-common/src/test/java/org/jboss/as/web/session/SimpleRoutingSupportTestCase.java
+++ b/web-common/src/test/java/org/jboss/as/web/session/SimpleRoutingSupportTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.web.session;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+/**
+ * Unit test for {@link SimpleRoutingSupport}.
+ * @author Paul Ferraro
+ */
+public class SimpleRoutingSupportTestCase {
+
+    private final RoutingSupport routing = new SimpleRoutingSupport();
+
+    @Test
+    public void parse() {
+        Map.Entry<String, String> result = this.routing.parse("session1.route1");
+        assertEquals("session1", result.getKey());
+        assertEquals("route1", result.getValue());
+
+        result = this.routing.parse("session2");
+        assertEquals("session2", result.getKey());
+        assertNull(result.getValue());
+
+        result = this.routing.parse(null);
+        assertNull(result.getKey());
+        assertNull(result.getValue());
+    }
+
+    @Test
+    public void format() {
+        assertEquals("session1.route1", this.routing.format("session1", "route1"));
+        assertEquals("session2", this.routing.format("session2", ""));
+        assertEquals("session3", this.routing.format("session3", null));
+        assertNull(this.routing.format(null, null));
+    }
+}

--- a/web-common/src/test/java/org/jboss/as/web/session/SimpleSessionIdentifierCodecTestCase.java
+++ b/web-common/src/test/java/org/jboss/as/web/session/SimpleSessionIdentifierCodecTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.web.session;
+
+import static org.mockito.Mockito.*;
+import static org.junit.Assert.*;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+
+import org.jboss.msc.value.Value;
+import org.junit.Test;
+
+/**
+ * Unit test for {@link SimpleSessionIdentifierCodec}.
+ * @author Paul Ferraro
+ */
+public class SimpleSessionIdentifierCodecTestCase {
+
+    private final Value<String> route = mock(Value.class);
+    private final RoutingSupport routing = mock(RoutingSupport.class);
+
+    private final SessionIdentifierCodec codec = new SimpleSessionIdentifierCodec(this.routing, this.route);
+
+    @Test
+    public void encode() {
+        String result = this.codec.encode(null);
+
+        assertNull(result);
+
+        String sessionId = "session";
+
+        when(this.route.getValue()).thenReturn(null);
+
+        result = this.codec.encode(sessionId);
+
+        assertSame(sessionId, result);
+
+        String route = "route";
+        String encodedSessionId = "session.route";
+
+        when(this.route.getValue()).thenReturn(route);
+        when(this.routing.format(sessionId, route)).thenReturn(encodedSessionId);
+
+        result = this.codec.encode(sessionId);
+
+        assertSame(encodedSessionId, result);
+    }
+
+    @Test
+    public void decode() {
+        String result = this.codec.decode(null);
+
+        assertNull(result);
+
+        String sessionId = "session";
+
+        when(this.routing.parse(sessionId)).thenReturn(new SimpleImmutableEntry<String, String>(sessionId, null));
+
+        result = this.codec.decode(sessionId);
+
+        assertSame(sessionId, result);
+
+        String route = "route";
+        String encodedSessionId = "session.route";
+
+        when(this.routing.parse(encodedSessionId)).thenReturn(new SimpleImmutableEntry<>(sessionId, route));
+
+        result = this.codec.decode(encodedSessionId);
+
+        assertSame(sessionId, result);
+    }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2774
https://issues.jboss.org/browse/WFLY-2853

Implements session routing in Undertow via a SessionConfigWrapper.  Create SessionIdentifierCodec abstraction that is responsible for encoding/decoding the session identifier.  Distributable SessionIdentifierCodec implementation uses a RouteLocator, which has been decoupled from the SessionManager in org.wildfly.clustering.web modules.

Add integration tests that validate session routing for both distributable and non-distributable web applications.
