### PR TITLE
[WFLY-1801] Improvements around worker-thread-pool/endpoint choice, plus WFLY-2865, WFLY-2589

### DIFF
--- a/build/src/main/resources/configuration/subsystems/remoting.xml
+++ b/build/src/main/resources/configuration/subsystems/remoting.xml
@@ -3,7 +3,7 @@
 <config>
    <extension-module>org.jboss.as.remoting</extension-module>
    <subsystem xmlns="urn:jboss:domain:remoting:2.0">
-       <endpoint/>
+       <endpoint worker="default"/>
        <http-connector name="http-remoting-connector" connector-ref="default" security-realm="ApplicationRealm"/>
    </subsystem>
 </config>

--- a/build/src/main/resources/docs/schema/wildfly-remoting_2_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-remoting_2_0.xsd
@@ -44,8 +44,22 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="worker-thread-pool" type="workerThreadsType" minOccurs="0"/>
-            <xs:element name="endpoint" type="endpointType" minOccurs="1" maxOccurs="1"/>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="worker-thread-pool" type="workerThreadsType">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                   Deprecated and replaced with the 'endpoint' configuration that can reference a worker from the IO subsystem.
+                   This is only supported for use in managed domain profiles whose servers are all running on
+                   previous versions that do not support the 'endpoint' configuration. Use in a server
+                   running a version after the introduction of the 'endpoint' configuration will result
+                   in an error.
+               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="endpoint" type="endpointType"></xs:element>
+            </xs:choice>
             <xs:element name="connector" type="connector" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="http-connector" type="http-connector" minOccurs="0" maxOccurs="unbounded"/>
             <xs:element name="outbound-connections" minOccurs="0" type="outbound-connectionsType" />
@@ -56,10 +70,9 @@
            <xs:annotation>
                <xs:documentation>
                    <![CDATA[
-                   The configuration of the worker thread pool.
+                   Deprecated configuration of the worker thread pool.
 
-                   Configuration of worker thread pool was deprecated and replaced with endpoint configuration that can reference worker from IO subsystem.
-                       This is only here to preserve backward compatibility
+                   Only supported for legacy servers in a managed domain.
                ]]>
                </xs:documentation>
            </xs:annotation>
@@ -76,14 +89,19 @@
         <xs:annotation>
             <xs:documentation>
             <![CDATA[
-                Configures endpoint
-
-
+                Configures the remoting endpoint.
             ]]>
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="worker" type="xs:string" default="default"/>
-
+        <xs:attribute name="worker" type="xs:string" default="default">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                The name of the IO subsystem worker the endpoint should use.
+            ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
 
         <xs:attribute name="authorize-id" type="xs:string">
             <xs:annotation>

--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -212,7 +212,7 @@ public class PersistentResourceXMLDescription {
 
             }
             for (Map.Entry<String, AttributeDefinition> def : attributes.entrySet()) {
-                def.getValue().getAttributeMarshaller().marshallAsAttribute(def.getValue(), model, false, writer);
+                def.getValue().getAttributeMarshaller().marshallAsAttribute(def.getValue(), model, true, writer);
             }
             persistChildren(writer, model);
 

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestLegacyControllerKernelServicesProxy.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestLegacyControllerKernelServicesProxy.java
@@ -270,6 +270,10 @@ public abstract class ModelTestLegacyControllerKernelServicesProxy {
         throw new IllegalStateException("Can only be called for the main controller");
     }
 
+    public ModelNode readTransformedModel(ModelVersion modelVersion, boolean includeDefaults) {
+        throw new IllegalStateException("Can only be called for the main controller");
+    }
+
 
     public ModelNode executeOperation(ModelVersion modelVersion, TransformedOperation op) {
         throw new IllegalStateException("Can only be called for the main controller");

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointAdd.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointAdd.java
@@ -24,13 +24,104 @@
 
 package org.jboss.as.remoting;
 
+import java.util.List;
+
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.NoSuchResourceException;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+import org.jboss.msc.service.ServiceController;
 
 /**
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
  */
 public class RemotingEndpointAdd extends AbstractAddStepHandler {
+
     public RemotingEndpointAdd() {
         super(RemotingEndpointResource.INSTANCE.getAttributes());
+    }
+
+    @Override
+    protected Resource createResource(OperationContext context) {
+        // If the resource is already there but empty, just use it
+        // We do this because RemotingSubsystemAdd/WorkerThreadPoolVsEndpointHandler will end up adding a resource if
+        // one isn't added in the same op. So if a user adds one in a separate op, we're forgiving about it.
+        // Mostly we do this to allow transformers tests to pass which call ModelTestUtils.checkFailedTransformedBootOperations
+        // which calls this OSH in a separate op from the one that calls RemotingSubystemAdd
+        try {
+            Resource existing = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
+            ModelNode existingModel = existing.getModel();
+            if (!existingModel.isDefined()) {
+                return existing;
+            } else {
+                boolean undefined = true;
+                for (Property prop : existingModel.asPropertyList()) {
+                    if (prop.getValue().isDefined()) {
+                        undefined = false;
+                        break;
+                    }
+                }
+                if (undefined) {
+                    return existing;
+                }
+            }
+        } catch (NoSuchResourceException ignored) {
+            //
+        }
+        return super.createResource(context);
+    }
+
+    @Override
+    protected void populateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.populateModel(context, operation, resource);
+
+        PathAddress pa = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
+        context.addStep(Util.createOperation("validate-endpoint", pa.subAddress(0, pa.size() - 1)),
+                WorkerThreadPoolVsEndpointHandler.INSTANCE, OperationContext.Stage.MODEL);
+    }
+
+    @Override
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        if (context.getAttachment(RemotingSubsystemAdd.RUNTIME_KEY) == null) {
+            // We're not running in the same op set as RemotingSubsystemAdd
+            // See if the config has changed from the default; if so reload is needed
+            boolean reload = false;
+            for (AttributeDefinition ad : RemotingEndpointResource.INSTANCE.getAttributes()) {
+                ModelNode node = model.get(ad.getName());
+                if (node.isDefined()) {
+                    ModelNode deflt = ad.getDefaultValue();
+                    if (!node.equals(deflt)) {
+                        reload = true;
+                        break;
+                    }
+                }
+            }
+            if (reload) {
+                context.reloadRequired();
+                // Signal rollbackRuntime
+                context.attach(RemotingSubsystemAdd.RUNTIME_KEY, Boolean.TRUE);
+            }
+        }
+    }
+
+    @Override
+    protected boolean requiresRuntimeVerification() {
+        return false;
+    }
+
+    @Override
+    protected void rollbackRuntime(OperationContext context, ModelNode operation, ModelNode model, List<ServiceController<?>> controllers) {
+        Boolean revert = context.getAttachment(RemotingSubsystemAdd.RUNTIME_KEY);
+        if (revert != null && revert.booleanValue()) {
+            context.revertReloadRequired();
+        }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointResource.java
@@ -58,8 +58,8 @@ public class RemotingEndpointResource extends PersistentResourceDefinition {
             .addOption(RemotingOptions.SEND_BUFFER_SIZE, "send-buffer-size", new ModelNode(RemotingOptions.DEFAULT_SEND_BUFFER_SIZE))
             .addOption(RemotingOptions.RECEIVE_BUFFER_SIZE, "receive-buffer-size", new ModelNode(RemotingOptions.DEFAULT_RECEIVE_BUFFER_SIZE))
             .addOption(RemotingOptions.BUFFER_REGION_SIZE, "buffer-region-size")
-            .addOption(RemotingOptions.TRANSMIT_WINDOW_SIZE, "transmit-window-size", new ModelNode(RemotingOptions.OUTGOING_CHANNEL_DEFAULT_RECEIVE_WINDOW_SIZE))
-            .addOption(RemotingOptions.RECEIVE_WINDOW_SIZE, "receive-window-size", new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE))
+            .addOption(RemotingOptions.TRANSMIT_WINDOW_SIZE, "transmit-window-size", new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE))
+            .addOption(RemotingOptions.RECEIVE_WINDOW_SIZE, "receive-window-size", new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_RECEIVE_WINDOW_SIZE))
             .addOption(RemotingOptions.MAX_OUTBOUND_CHANNELS, "max-outbound-channels", new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_CHANNELS))
             .addOption(RemotingOptions.MAX_INBOUND_CHANNELS, "max-inbound-channels", new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_CHANNELS))
             .addOption(RemotingOptions.AUTHORIZE_ID, "authorize-id")
@@ -75,7 +75,7 @@ public class RemotingEndpointResource extends PersistentResourceDefinition {
             .build();
 
     protected static final PathElement ENDPOINT_PATH = PathElement.pathElement("configuration", "endpoint");
-    protected static final Collection ATTRIBUTES;
+    protected static final Collection<AttributeDefinition> ATTRIBUTES;
 
     static final RemotingEndpointResource INSTANCE = new RemotingEndpointResource();
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingMessages.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingMessages.java
@@ -113,4 +113,7 @@ public interface RemotingMessages {
 
     @Message(id = 17132, value = "Worker configuration is no longer used, please use endpoint worker configuration")
     OperationFailedException workerConfigurationIgnored();
+
+    @Message(id = 17133, value = "Only one of '%s' configuration or '%s' configuration is allowed")
+    String workerThreadsEndpointConfigurationChoiceRequired(String workerThreads, String endpoint);
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem10Parser.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem10Parser.java
@@ -81,7 +81,6 @@ class RemotingSubsystem10Parser implements XMLStreamConstants, XMLElementReader<
                 }
             }
         }
-        list.add(Util.createAddOperation(address.append(RemotingEndpointResource.INSTANCE.getPathElement())));
     }
 
     /**

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem11Parser.java
@@ -92,7 +92,6 @@ class RemotingSubsystem11Parser extends RemotingSubsystem10Parser implements XML
                 }
             }
         }
-        list.add(Util.createAddOperation(address.append(RemotingEndpointResource.INSTANCE.getPathElement())));
     }
 
     void parseConnector(final XMLExtendedStreamReader reader, final ModelNode address, final List<ModelNode> list) throws XMLStreamException {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemRootResource.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceName;
@@ -69,7 +70,7 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
     public RemotingSubsystemRootResource(final ProcessType processType) {
         super(PATH,
                 RemotingExtension.getResourceDescriptionResolver(RemotingExtension.SUBSYSTEM_NAME),
-                processType.isServer() ? RemotingSubsystemAdd.SERVER : RemotingSubsystemAdd.DOMAIN,
+                RemotingSubsystemAdd.INSTANCE,
                 RemotingSubsystemRemove.INSTANCE);
         this.processType = processType;
     }
@@ -106,8 +107,7 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
         @Override
         protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel,
                                              ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-            RemotingSubsystemAdd addHandler = processType.isServer() ? RemotingSubsystemAdd.SERVER : RemotingSubsystemAdd.DOMAIN;
-            addHandler.launchServices(context, parentModel, verificationHandler, null);
+            RemotingSubsystemAdd.INSTANCE.launchServices(context, parentModel, verificationHandler, null);
         }
 
         @Override
@@ -118,6 +118,11 @@ public class RemotingSubsystemRootResource extends SimpleResourceDefinition {
         @Override
         protected void removeServices(final OperationContext context, final ServiceName parentService, final ModelNode parentModel) throws OperationFailedException {
             super.removeServices(context, parentService, parentModel);
+        }
+
+        @Override
+        protected void validateUpdatedModel(OperationContext context, Resource model) throws OperationFailedException {
+            context.addStep(WorkerThreadPoolVsEndpointHandler.INSTANCE, OperationContext.Stage.MODEL);
         }
     }
 }

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystemXMLPersister.java
@@ -54,9 +54,9 @@ class RemotingSubsystemXMLPersister implements XMLStreamConstants, XMLElementWri
 
         final ModelNode model = context.getModelNode();
 
-        RemotingSubsystem20Parser.ENDPOINT_PARSER.persist(writer, model);
-
         writeWorkerThreadPoolIfAttributesSet(writer, model);
+
+        writeEndpointIfAttributesSet(writer, model);
 
         if (model.hasDefined(CONNECTOR)) {
             final ModelNode connector = model.get(CONNECTOR);
@@ -132,6 +132,25 @@ class RemotingSubsystemXMLPersister implements XMLStreamConstants, XMLElementWri
             writer.writeEndElement();
         }
 
+    }
+
+    private void writeEndpointIfAttributesSet(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
+        ModelNode endpointConfig = model.get(RemotingEndpointResource.ENDPOINT_PATH.getKey(),
+                RemotingEndpointResource.ENDPOINT_PATH.getValue());
+        if (endpointConfig.isDefined()) {
+            boolean write = false;
+
+            for (Property prop : endpointConfig.asPropertyList()) {
+                if (prop.getValue().isDefined()) {
+                    write = true;
+                    break;
+                }
+            }
+
+            if (write) {
+                RemotingSubsystem20Parser.ENDPOINT_PARSER.persist(writer, model);
+            }
+        }
     }
 
     private void writeConnector(final XMLExtendedStreamWriter writer, final ModelNode node, final String name) throws XMLStreamException {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/WorkerThreadPoolVsEndpointHandler.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/WorkerThreadPoolVsEndpointHandler.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.remoting;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * Ensures that legacy worker thread configurations and newer endpoint configurations
+ * are properly used. Specifically:
+ * <ol>
+ *     <li>legacy worker thread pool attributes are not used on servers</li>
+ *     <li>legacy worker thread pool attributes and an endpoint configuration are not both used</li>
+ *     <li>adds default endpoint configuration if not present and worker thread pool attributes are not used</li>
+ * </ol>
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+class WorkerThreadPoolVsEndpointHandler implements OperationStepHandler {
+
+    static final OperationStepHandler INSTANCE = new WorkerThreadPoolVsEndpointHandler();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+        Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+        ModelNode model = resource.getModel();
+        Set<String> configuredAttributes = new HashSet<String>();
+        for (final AttributeDefinition attribute : RemotingSubsystemRootResource.ATTRIBUTES) {
+            String attrName = attribute.getName();
+            if (model.hasDefined(attrName)) {
+                configuredAttributes.add(attrName);
+            }
+        }
+
+        Resource endpointConfig = resource.getChild(RemotingEndpointResource.ENDPOINT_PATH);
+        if (configuredAttributes.size() > 0) {
+            if (context.getProcessType().isServer()) {
+                // worker-thread-pool not allowed on a server
+                throw RemotingMessages.MESSAGES.workerConfigurationIgnored();
+            } else if (endpointConfig != null) {
+                // Can't configure both worker-thread-pool and endpoint
+                ModelNode endpointModel = endpointConfig.getModel();
+                if (endpointModel.isDefined()) {
+                    for (Property prop : endpointModel.asPropertyList()) {
+                        if (prop.getValue().isDefined()) {
+                            throw new OperationFailedException(
+                                    RemotingMessages.MESSAGES.workerThreadsEndpointConfigurationChoiceRequired(
+                                            Element.WORKER_THREAD_POOL.getLocalName(), Element.ENDPOINT.getLocalName()
+                                    ));
+                        }
+                    }
+                }
+            }
+        } else if (endpointConfig == null) {
+            // User didn't configure either worker-thread-pool or endpoint. Add a default endpoint resource so
+            // users can read the default config attribute values
+            context.addResource(PathAddress.pathAddress(RemotingEndpointResource.ENDPOINT_PATH), Resource.Factory.create());
+        }
+
+        context.stepCompleted();
+    }
+}

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-bad-connector-property.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-bad-connector-property.xml
@@ -1,14 +1,6 @@
 <subsystem xmlns="urn:jboss:domain:remoting:1.0">
 
-   <worker-thread-pool
-	    read-threads="5"
-	    task-core-threads="6"
-	    task-keepalive="7"
-	    task-limit="8"
-	    task-max-threads="9"
-	    write-threads="10"
-	 />
-    <connector name="test-connector" socket-binding="test">
+   <connector name="test-connector" socket-binding="test">
       <properties>
          <property name="WORKER_ACCEPT_THREAD_BAD" value="1"/><!-- proper name is WORKER_ACCEPT_THREADS -->
       </properties>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-connector.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-connector.xml
@@ -1,0 +1,8 @@
+<subsystem xmlns="urn:jboss:domain:remoting:2.0">
+    <connector name="test-connector" socket-binding="test">
+        <properties>
+            <!-- This must be smaller than worker-read-threads -->
+            <property name="org.xnio.Options.WORKER_ACCEPT_THREADS" value="1"/>
+        </properties>
+    </connector>
+</subsystem>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-expressions-and-good-legacy-protocol.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-expressions-and-good-legacy-protocol.xml
@@ -1,4 +1,5 @@
 <subsystem xmlns="urn:jboss:domain:remoting:2.0">
+   <endpoint/>
    <connector name="remoting-connector" socket-binding="remoting">
       <properties>
          <property name="c1" value="${connector.prop:connector one}"/>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-expressions.xml
@@ -1,5 +1,12 @@
 <subsystem xmlns="urn:jboss:domain:remoting:2.0">
-    <endpoint />
+    <worker-thread-pool
+            read-threads="${worker.read.threads:5}"
+            task-core-threads="${worker.task.core.threads:6}"
+            task-keepalive="${worker.task.keepalive:7}"
+            task-limit="${worker.task.limit:8}"
+            task-max-threads="${worker.task.max.threads:9}"
+            write-threads="${worker.write.threads:10}"
+            />
     <connector name="remoting-connector" socket-binding="remoting">
       <properties>
          <property name="c1" value="${connector.prop:connector one}"/>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-threads.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-with-threads.xml
@@ -1,12 +1,12 @@
 <subsystem xmlns="urn:jboss:domain:remoting:1.0">
-   <!--<worker-thread-pool
+   <worker-thread-pool
        read-threads="5"
        task-core-threads="6"
        task-keepalive="7"
        task-limit="8"
        task-max-threads="9"
        write-threads="10"
-    />-->
+    />
     <connector name="test-connector" socket-binding="test">
       <properties>
          <!-- This must be smaller than worker-read-threads -->

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-without-expressions.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting-without-expressions.xml
@@ -1,12 +1,12 @@
 <subsystem xmlns="urn:jboss:domain:remoting:1.1">
-   <worker-thread-pool
+   <!--<worker-thread-pool
 	    read-threads="5"
 	    task-core-threads="6"
 	    task-keepalive="7"
 	    task-limit="8"
 	    task-max-threads="9"
 	    write-threads="10"
-	 />
+	 /> -->
    <connector name="remoting-connector" socket-binding="remoting">
       <properties>
          <property name="c1" value="connector one"/>

--- a/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
+++ b/remoting/tests/src/test/resources/org/jboss/as/remoting/remoting.xml
@@ -1,5 +1,24 @@
 <subsystem xmlns="urn:jboss:domain:remoting:2.0">
-    <endpoint worker="default-remoting" />
+    <endpoint
+        worker="default-remoting"
+        send-buffer-size="8191"
+        receive-buffer-size="8191"
+        buffer-region-size="1024"
+        transmit-window-size="131071"
+        receive-window-size="131071"
+        max-outbound-channels="41"
+        max-inbound-channels="41"
+        authorize-id="foo"
+        auth-realm="ApplicationRealm"
+        authentication-retries="4"
+        max-outbound-messages="65534"
+        max-inbound-messages="79"
+        heartbeat-interval="20000"
+        max-inbound-message-size="1000000"
+        max-outbound-message-size="1000000"
+        server-name="test"
+        sasl-protocol="bar"
+    />
     <connector name="remoting-connector" socket-binding="remoting">
         <authentication-provider name="blah"/>
         <properties>

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractKernelServicesImpl.java
@@ -110,6 +110,10 @@ public abstract class AbstractKernelServicesImpl extends ModelTestKernelServices
         return SubsystemDescriptionDump.readFullModelDescription(PathAddress.pathAddress(pathAddress), getRootRegistration().getSubModel(PathAddress.pathAddress(pathAddress)));
     }
 
+    @Override
+    public ModelNode readTransformedModel(ModelVersion modelVersion) {
+        return readTransformedModel(modelVersion, true);
+    }
 
     ExtensionRegistry getExtensionRegistry() {
         return extensionRegistry;

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemBaseTest.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemBaseTest.java
@@ -104,6 +104,10 @@ public abstract class AbstractSubsystemBaseTest extends AbstractSubsystemTest {
         standardSubsystemTest(configId, configIdResolvedModel, true);
     }
 
+    protected KernelServices standardSubsystemTest(final String configId, final String configIdResolvedModel, boolean compareXml) throws Exception {
+        return standardSubsystemTest(configId, configIdResolvedModel, compareXml, createAdditionalInitialization());
+    }
+
 
     /**
      * Tests the ability to create a model from an xml configuration, marshal the model back to xml,
@@ -122,12 +126,12 @@ public abstract class AbstractSubsystemBaseTest extends AbstractSubsystemTest {
      * @param compareXml if {@code true} a comparison of xml output to original input is performed. This can be
      *                   set to {@code false} if the original input is from an earlier xsd and the current
      *                   schema has a different output
+     * @param additionalInit service container and model initialization
      *
      * @throws Exception
      */
-    protected KernelServices standardSubsystemTest(final String configId, final String configIdResolvedModel, boolean compareXml) throws Exception {
-        final AdditionalInitialization additionalInit = createAdditionalInitialization();
-
+    protected KernelServices standardSubsystemTest(final String configId, final String configIdResolvedModel,
+                                                   boolean compareXml, final AdditionalInitialization additionalInit) throws Exception {
 
         // Parse the subsystem xml and install into the first controller
         final String subsystemXml = configId == null ? getSubsystemXml() : getSubsystemXml(configId);

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AbstractSubsystemTest.java
@@ -9,6 +9,7 @@ import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -260,8 +261,8 @@ public abstract class AbstractSubsystemTest {
      * @param modelVersion   the model version of the targetted legacy subsystem
      * @return the whole model of the legacy controller
      */
-    protected ModelNode checkSubsystemModelTransformation(KernelServices kernelServices, ModelVersion modelVersion) throws IOException {
-        return checkSubsystemModelTransformation(kernelServices, modelVersion, null);
+    protected ModelNode checkSubsystemModelTransformation(KernelServices kernelServices, ModelVersion modelVersion) throws IOException, OperationFailedException {
+        return checkSubsystemModelTransformation(kernelServices, modelVersion, null, true);
     }
 
     /**
@@ -273,8 +274,22 @@ public abstract class AbstractSubsystemTest {
      * @param legacyModelFixer use to touch up the model read from the legacy controller, use sparingly when the legacy model is just wrong. May be {@code null}
      * @return the whole model of the legacy controller
      */
-    protected ModelNode checkSubsystemModelTransformation(KernelServices kernelServices, ModelVersion modelVersion, ModelFixer legacyModelFixer) throws IOException {
-        return delegate.checkSubsystemModelTransformation(kernelServices, modelVersion, legacyModelFixer);
+    protected ModelNode checkSubsystemModelTransformation(KernelServices kernelServices, ModelVersion modelVersion, ModelFixer legacyModelFixer) throws IOException, OperationFailedException {
+        return checkSubsystemModelTransformation(kernelServices, modelVersion, legacyModelFixer, true);
+    }
+
+    /**
+     * Checks that the transformed model is the same as the model built up in the legacy subsystem controller via the transformed operations,
+     * and that the transformed model is valid according to the resource definition in the legacy subsystem controller.
+     *
+     * @param kernelServices the main kernel services
+     * @param modelVersion   the model version of the targetted legacy subsystem
+     * @param legacyModelFixer use to touch up the model read from the legacy controller, use sparingly when the legacy model is just wrong. May be {@code null}
+     * @return the whole model of the legacy controller
+     */
+    protected ModelNode checkSubsystemModelTransformation(KernelServices kernelServices, ModelVersion modelVersion,
+                                                          ModelFixer legacyModelFixer, boolean includeDefaults) throws IOException, OperationFailedException {
+        return delegate.checkSubsystemModelTransformation(kernelServices, modelVersion, legacyModelFixer, includeDefaults);
     }
 
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AdditionalInitialization.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/AdditionalInitialization.java
@@ -19,6 +19,13 @@ import org.jboss.msc.service.ServiceTarget;
 public class AdditionalInitialization extends AdditionalParsers {
     public static final AdditionalInitialization MANAGEMENT = new ManagementAdditionalInitialization();
 
+    public static final AdditionalInitialization ADMIN_ONLY_HC = new ManagementAdditionalInitialization() {
+        @Override
+        protected ProcessType getProcessType() {
+            return ProcessType.HOST_CONTROLLER;
+        }
+    };
+
     public static class ManagementAdditionalInitialization extends AdditionalInitialization implements Serializable {
         private static final long serialVersionUID = -509444465514822866L;
 

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KernelServices.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/KernelServices.java
@@ -35,6 +35,15 @@ public interface KernelServices extends ModelTestKernelServices<KernelServices> 
     ModelNode readTransformedModel(ModelVersion modelVersion);
 
     /**
+     * Transforms the model to the legacy subsystem model version
+     * @param modelVersion the target legacy subsystem model version
+     * @param includeDefaults {@code true} if default values for undefined attributes should be included
+     * @return the transformed model
+     * @throws IllegalStateException if this is not the test's main model controller
+     */
+    ModelNode readTransformedModel(ModelVersion modelVersion, boolean includeDefaults);
+
+    /**
      * Execute an operation in the  controller containg the passed in version of the subsystem.
      * The operation and results will be translated from the format for the main controller to the
      * legacy controller's format.

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/LegacyKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/LegacyKernelServicesImpl.java
@@ -56,7 +56,7 @@ public class LegacyKernelServicesImpl extends AbstractKernelServicesImpl impleme
     }
 
     @Override
-    public ModelNode readTransformedModel(ModelVersion modelVersion) {
+    public ModelNode readTransformedModel(ModelVersion modelVersion, boolean includeDefaults) {
         //Will throw an error since we are not the main controller
         checkIsMainController();
         return null;

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/MainKernelServicesImpl.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/MainKernelServicesImpl.java
@@ -24,11 +24,11 @@ package org.jboss.as.subsystem.test;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_DEFAULTS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_TRANSFORMED_RESOURCE_OPERATION;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 import java.io.IOException;
@@ -107,13 +107,14 @@ class MainKernelServicesImpl extends AbstractKernelServicesImpl {
      * @return the transformed model
      * @throws IllegalStateException if this is not the test's main model controller
      */
-    public ModelNode readTransformedModel(ModelVersion modelVersion) {
+    @Override
+    public ModelNode readTransformedModel(ModelVersion modelVersion, boolean includeDefaults) {
         getLegacyServices(modelVersion);//Checks we are the main controller
         ModelNode op = new ModelNode();
         op.get(OP).set(READ_TRANSFORMED_RESOURCE_OPERATION);
         op.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
-        op.get(RECURSIVE).set(true);
         op.get(SUBSYSTEM).set(mainSubsystemName);
+        op.get(INCLUDE_DEFAULTS).set(includeDefaults);
         ModelNode result = internalExecute(op, new ReadTransformedResourceOperation(getTransformersRegistry(), getCoreModelVersionByLegacyModelVersion(modelVersion), modelVersion));
         return ModelTestUtils.checkResultAndGetContents(result);
     }

--- a/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
+++ b/subsystem-test/framework/src/main/java/org/jboss/as/subsystem/test/ReadTransformedResourceOperation.java
@@ -24,11 +24,13 @@
 
 package org.jboss.as.subsystem.test;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_DEFAULTS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_TRANSFORMED_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -85,7 +87,8 @@ class ReadTransformedResourceOperation implements OperationStepHandler {
 
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-        final String subsystem = operation.get(ModelDescriptionConstants.SUBSYSTEM).asString();
+        final String subsystem = operation.get(SUBSYSTEM).asString();
+        final boolean includeDefaults = operation.get(INCLUDE_DEFAULTS).asBoolean(true);
         // Add a step to transform the result of a READ_RESOURCE.
         // Do this first, Stage.IMMEDIATE
         final ModelNode readResourceResult = new ModelNode();
@@ -103,6 +106,7 @@ class ReadTransformedResourceOperation implements OperationStepHandler {
         op.get(OP).set(READ_RESOURCE_OPERATION);
         op.get(OP_ADDR).set(PathAddress.EMPTY_ADDRESS.toModelNode());
         op.get(RECURSIVE).set(true);
+        op.get(INCLUDE_DEFAULTS).set(includeDefaults);
         context.addStep(readResourceResult, op, ReadResourceHandler.INSTANCE, OperationContext.Stage.MODEL, true);
         context.stepCompleted();
     }


### PR DESCRIPTION
Improves handling of legacy 'worker-thread-pool' config vs new 'endpoint' config, plus brings in 2 commits related to improving management transformation that are needed to handle this correctly
- Make worker-thread-pool/endpoint configs a choice in xsd
- Don't count on parser to add a default endpoint resource; do it in OSHs
- Have an OSH validate that both worker-thread-pool and endpoint aren't configured
  *Transformation improvements:
  -- same transformation for all previous versions
  -- reject if any endpoint attributes are configured (requires WFLY-2865)
- Some test rationalization and improvement, plus restore a test previously removed
