### PR TITLE
BZ-1061609: Expose underlying cause during InitialContextFactory instantiation

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -113,7 +113,7 @@ public class InitialContext extends InitialDirContext {
                     final Class<?> factoryClass = Class.forName(factoryClassName, true, classLoader);
                     defaultInitCtx = ((javax.naming.spi.InitialContextFactory)factoryClass.newInstance()).getInitialContext(myProps);
                 } catch (Exception e) {
-                    throw MESSAGES.failedToInstantiate("InitialContextFactory", factoryClassName, classLoader);
+                    throw MESSAGES.failedToInstantiate(e, "InitialContextFactory", factoryClassName, classLoader);
                 }
             }
             gotDefault = true;

--- a/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingMessages.java
@@ -195,7 +195,7 @@ public interface NamingMessages {
      * @return a {@link NamingException} for the error.
      */
     @Message(id = 11843, value = "Failed instantiate %s %s from classloader %s")
-    NamingException failedToInstantiate(String description, String className, ClassLoader classLoader);
+    NamingException failedToInstantiate(@Cause Throwable cause, String description, String className, ClassLoader classLoader);
 
     /**
      * A message indicating the context entries could not be read from the binding name represented by the


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2868
