### PR TITLE
Javadoc cleanup for the new public clustering API

### DIFF
--- a/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/Command.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/Command.java
@@ -25,14 +25,19 @@ import java.io.Serializable;
 
 /**
  * A command to invoke remotely.
+ *
+ * @param <C> the command context type
+ * @param <R> the command return type
  * @author Paul Ferraro
  */
 public interface Command<R, C> extends Serializable {
 
     /**
      * Execute this command with the specified context.
-     * @param context the execution context.
-     * @return the result of this command.
+     *
+     * @param context the execution context
+     * @return the result of this command
+     * @throws Exception exception that occurred during execution
      */
     R execute(C context) throws Exception;
 }

--- a/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/CommandDispatcher.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/CommandDispatcher.java
@@ -28,39 +28,48 @@ import org.wildfly.clustering.group.Node;
 
 /**
  * A dispatcher for remote invocation of commands.
+ *
+ * @param <C> the command context type
  * @author Paul Ferraro
  */
 public interface CommandDispatcher<C> extends AutoCloseable {
+
     /**
      * Execute the specified command on the specified node.
-     * @param <R> the return value type
+     *
+     * @param <R>     the return value type
      * @param command the command to execute
+     * @param node    the node to execute the command on
      * @return the result of the command execution
      */
     <R> CommandResponse<R> executeOnNode(Command<R, C> command, Node node);
 
     /**
      * Execute the specified command on all nodes in the group, excluding the specified nodes
-     * @param <R> the return value type
-     * @param command the command to execute
-     * @param nodes the set of nodes to exclude
-     * @return a map of command execution results per node.
+     *
+     * @param <R>           the return value type
+     * @param command       the command to execute
+     * @param excludedNodes the set of nodes to exclude
+     * @return a map of command execution results per node
      */
     <R> Map<Node, CommandResponse<R>> executeOnCluster(Command<R, C> command, Node... excludedNodes);
 
     /**
      * Submits the specified command on the specified node for execution.
-     * @param <R> the return value type
+     *
+     * @param <R>     the return value type
      * @param command the command to execute
+     * @param node    the node to execute the command on
      * @return the result of the command execution
      */
     <R> Future<R> submitOnNode(Command<R, C> command, Node node);
 
     /**
      * Submits the specified command on all nodes in the group, excluding the specified nodes.
-     * @param <R> the return value type
-     * @param command the command to execute
-     * @param nodes the set of nodes to exclude
+     *
+     * @param <R>           the return value type
+     * @param command       the command to execute
+     * @param excludedNodes the set of nodes to exclude
      * @return a map of command execution results per node.
      */
     <R> Map<Node, Future<R>> submitOnCluster(Command<R, C> command, Node... excludedNodes);

--- a/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/CommandDispatcherFactory.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/CommandDispatcherFactory.java
@@ -25,12 +25,14 @@ import org.wildfly.clustering.group.Group;
 
 /**
  * Factory for creating a command dispatcher.
+ *
  * @author Paul Ferraro
  */
 public interface CommandDispatcherFactory {
 
     /**
      * Returns the group upon which the this command dispatcher operates.
+     *
      * @return a group
      */
     Group getGroup();
@@ -38,7 +40,8 @@ public interface CommandDispatcherFactory {
     /**
      * Creates a new command dispatcher using the specified identifier and context..
      * The resulting {@link CommandDispatcher} will communicate with those dispatchers within the group sharing the same identifier.
-     * @param id a unique identifier for this dispatcher.
+     *
+     * @param id      a unique identifier for this dispatcher
      * @param context the context used for executing commands
      * @return a new command dispatcher
      */

--- a/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/package-info.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/package-info.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,21 +19,9 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.dispatcher;
-
-import java.util.concurrent.ExecutionException;
 
 /**
- * Remote command execution response.
- *
- * @param <R> the response type
- * @author Paul Ferraro
+ * Public clustering API which facilitates remote command execution
+ * on the cluster.
  */
-public interface CommandResponse<R> {
-
-    /**
-     * @return response of the remote command execution
-     * @throws ExecutionException exception that was raised during execution
-     */
-    R get() throws ExecutionException;
-}
+package org.wildfly.clustering.dispatcher;

--- a/clustering/api/src/main/java/org/wildfly/clustering/group/Group.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/group/Group.java
@@ -25,50 +25,70 @@ import java.util.List;
 
 /**
  * Represents a groups of nodes.
+ *
  * @author Paul Ferraro
  */
 public interface Group {
 
+    /**
+     * Listener for membership changes.
+     */
     interface Listener {
         /**
          * Indicates that the membership of the group has changed.
-         * @param previousMembers previous group members.
-         * @param members new group members
-         * @param merged indicates whether the membership change is the result of a merge view
+         *
+         * @param previousMembers previous group members
+         * @param members         new group members
+         * @param merged          indicates whether the membership change is the result of a merge view
          */
         void membershipChanged(List<Node> previousMembers, List<Node> members, boolean merged);
     }
 
+    /**
+     * Registers a membership listener for the group.
+     *
+     * @param listener listener to be added
+     */
     void addListener(Listener listener);
 
+    /**
+     * Removes a registered listener from the group.
+     *
+     * @param listener listener to be removed
+     */
     void removeListener(Listener listener);
 
     /**
      * Returns the name of this group.
+     *
      * @return the group name
      */
     String getName();
 
     /**
      * Indicates whether or not we are the group coordinator.
-     * @return true, if we are the group coordinator, false otherwise.
+     *
+     * @return true, if we are the group coordinator, false otherwise
      */
     boolean isCoordinator();
 
     /**
      * Returns the local node.
-     * @return the local node.
+     *
+     * @return the local node
      */
     Node getLocalNode();
 
     /**
-     * Returns the group coordinator.
-     * @return the group coordinator.
+     * Returns the group coordinator node.
+     *
+     * @return the group coordinator node
      */
     Node getCoordinatorNode();
 
     /**
      * Returns the list of nodes that are members of this group.
+     *
      * @return a list of nodes
      */
     List<Node> getNodes();

--- a/clustering/api/src/main/java/org/wildfly/clustering/group/Node.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/group/Node.java
@@ -25,17 +25,20 @@ import java.net.InetSocketAddress;
 
 /**
  * Identifies a member of a cluster.
+ *
  * @author Paul Ferraro
  */
 public interface Node {
     /**
      * Returns the logical name of this node.
+     *
      * @return a unique name
      */
     String getName();
 
     /**
      * Returns the unique socking binding address of this node.
+     *
      * @return a socket binding address
      */
     InetSocketAddress getSocketAddress();

--- a/clustering/api/src/main/java/org/wildfly/clustering/group/NodeFactory.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/group/NodeFactory.java
@@ -23,9 +23,16 @@ package org.wildfly.clustering.group;
 
 /**
  * Factory for creating nodes.
- * @author Paul Ferraro
+ *
  * @param <A> address type
+ * @author Paul Ferraro
  */
 public interface NodeFactory<A> {
+    /**
+     * Creates a node instance from the address.
+     *
+     * @param address address of a node to create
+     * @return node with the given address
+     */
     Node createNode(A address);
 }

--- a/clustering/api/src/main/java/org/wildfly/clustering/group/package-info.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/group/package-info.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,21 +19,8 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.dispatcher;
-
-import java.util.concurrent.ExecutionException;
 
 /**
- * Remote command execution response.
- *
- * @param <R> the response type
- * @author Paul Ferraro
+ * Public clustering API which represent cluster group and its members.
  */
-public interface CommandResponse<R> {
-
-    /**
-     * @return response of the remote command execution
-     * @throws ExecutionException exception that was raised during execution
-     */
-    R get() throws ExecutionException;
-}
+package org.wildfly.clustering.group;

--- a/clustering/api/src/main/java/org/wildfly/clustering/provider/ServiceProviderRegistration.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/provider/ServiceProviderRegistration.java
@@ -27,13 +27,18 @@ import org.wildfly.clustering.group.Node;
 
 /**
  * Registration of a provided service.
+ *
  * @author Paul Ferraro
  */
 public interface ServiceProviderRegistration extends AutoCloseable {
 
+    /**
+     * Listener for service provider changes.
+     */
     interface Listener {
         /**
          * Indicates that the set of nodes providing a given service has changed.
+         *
          * @param nodes the new set of nodes providing the given service
          */
         void providersChanged(Set<Node> nodes);
@@ -41,13 +46,15 @@ public interface ServiceProviderRegistration extends AutoCloseable {
 
     /**
      * The provided service.
+     *
      * @return a service identifier
      */
     Object getService();
 
     /**
      * Returns the set of nodes that can provide this service.
-     * @return a set of nodes.
+     *
+     * @return a set of nodes
      */
     Set<Node> getProviders();
 

--- a/clustering/api/src/main/java/org/wildfly/clustering/provider/ServiceProviderRegistrationFactory.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/provider/ServiceProviderRegistrationFactory.java
@@ -28,19 +28,22 @@ import org.wildfly.clustering.group.Node;
 
 /**
  * A factory for creating a service provider registration.
+ *
  * @author Paul Ferraro
  */
 public interface ServiceProviderRegistrationFactory {
 
     /**
      * Returns the group with which to register service providers.
+     *
      * @return a group
      */
     Group getGroup();
 
     /**
      * Registers the local node as providing the specified service, using the specified listener.
-     * @param id a service identifier
+     *
+     * @param service  a service to register
      * @param listener a registry listener
      * @return a new service provider registration
      */
@@ -48,8 +51,9 @@ public interface ServiceProviderRegistrationFactory {
 
     /**
      * Returns the set of nodes that provide the specified service.
-     * @param id a service identifier
-     * @return a set of nodes.
+     *
+     * @param service a service to obtain providers for
+     * @return a set of nodes
      */
     Set<Node> getProviders(Object service);
 }

--- a/clustering/api/src/main/java/org/wildfly/clustering/provider/package-info.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/provider/package-info.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,21 +19,8 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.dispatcher;
-
-import java.util.concurrent.ExecutionException;
 
 /**
- * Remote command execution response.
- *
- * @param <R> the response type
- * @author Paul Ferraro
+ * Public clustering API for registering services on a group of nodes.
  */
-public interface CommandResponse<R> {
-
-    /**
-     * @return response of the remote command execution
-     * @throws ExecutionException exception that was raised during execution
-     */
-    R get() throws ExecutionException;
-}
+package org.wildfly.clustering.provider;

--- a/clustering/api/src/main/java/org/wildfly/clustering/registry/Registry.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/registry/Registry.java
@@ -29,44 +29,70 @@ import org.wildfly.clustering.group.Node;
 
 /**
  * Clustered registry abstraction that stores a unique key/value per node.
+ *
+ * @param <K> the type of the registry entry key
+ * @param <V> the type of the registry entry value
  * @author Paul Ferraro
  */
 public interface Registry<K, V> extends AutoCloseable {
 
+    /**
+     * Listener for added, updated and removed entries.
+     */
     interface Listener<K, V> {
+        /**
+         * Called when new entries have been added.
+         *
+         * @param added a map of entries that have been added
+         */
         void addedEntries(Map<K, V> added);
 
+        /**
+         * Called when existing entries have been updated.
+         *
+         * @param updated a map of entries that have been updated
+         */
         void updatedEntries(Map<K, V> updated);
 
+        /**
+         * Called when entries have been removed.
+         *
+         * @param removed a map of entries that have been removed
+         */
         void removedEntries(Map<K, V> removed);
     }
 
     /**
      * Returns the group associated with this factory.
+     *
      * @return a group
      */
     Group getGroup();
 
     /**
-     * Adds a listener to this registry
+     * Adds a listener to this registry.
+     *
      * @param listener a registry listener
      */
     void addListener(Listener<K, V> listener);
 
     /**
-     * Adds a listener from this registry
+     * Adds a listener from this registry.
+     *
      * @param listener a registry listener
      */
     void removeListener(Listener<K, V> listener);
 
     /**
-     * Returns all registry entries in this group
-     * @return
+     * Returns all registry entries in this group.
+     *
+     * @return a map for entries
      */
     Map<K, V> getEntries();
 
     /**
-     * Returns the registry entry for the specified node
+     * Returns the registry entry for the specified node.
+     *
      * @param node a node
      * @return the node's registry entry, or null if undefined
      */
@@ -74,6 +100,7 @@ public interface Registry<K, V> extends AutoCloseable {
 
     /**
      * Refreshes and returns the local registry entry from the {@link RegistryEntryProvider}.
+     *
      * @return the registry entry of the local node
      */
     Map.Entry<K, V> getLocalEntry();

--- a/clustering/api/src/main/java/org/wildfly/clustering/registry/RegistryEntryProvider.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/registry/RegistryEntryProvider.java
@@ -23,22 +23,24 @@ package org.wildfly.clustering.registry;
 
 /**
  * Provides the registry entry for the local node.
- * @author Paul Ferraro
  *
  * @param <K> the type of the registry entry key
  * @param <V> the type of the registry entry value
+ * @author Paul Ferraro
  */
 public interface RegistryEntryProvider<K, V> {
 
     /**
      * Supplies the unique key for this node's registry entry.
-     * @return a registry entry key.
+     *
+     * @return a registry entry key
      */
     K getKey();
 
     /**
      * Supplies the value for this node's registry entry.
-     * @return a registry entry value.
+     *
+     * @return a registry entry value
      */
     V getValue();
 }

--- a/clustering/api/src/main/java/org/wildfly/clustering/registry/RegistryFactory.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/registry/RegistryFactory.java
@@ -23,12 +23,16 @@ package org.wildfly.clustering.registry;
 
 /**
  * Factory for creating a clustered registry.
+ *
+ * @param <K> the type of the registry entry key
+ * @param <V> the type of the registry entry value
  * @author Paul Ferraro
  */
 public interface RegistryFactory<K, V> {
 
     /**
      * Creates a registry for the group associated with this factory.
+     *
      * @param provider the provider of the local registry entry
      * @return a registry
      */

--- a/clustering/api/src/main/java/org/wildfly/clustering/registry/package-info.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/registry/package-info.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,21 +19,8 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.dispatcher;
-
-import java.util.concurrent.ExecutionException;
 
 /**
- * Remote command execution response.
- *
- * @param <R> the response type
- * @author Paul Ferraro
+ * Public clustering API for clustered registry that stores a unique key/value pair per node.
  */
-public interface CommandResponse<R> {
-
-    /**
-     * @return response of the remote command execution
-     * @throws ExecutionException exception that was raised during execution
-     */
-    R get() throws ExecutionException;
-}
+package org.wildfly.clustering.registry;


### PR DESCRIPTION
Javadoc cleanup for follow Javadoc rules and recommendations for the new public clustering API.
