### PR TITLE
[WFLY-2899] Capture System.out and System.err before jboss-stdio capture them

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
@@ -23,6 +23,7 @@ package org.jboss.as.appclient.subsystem;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -61,10 +62,13 @@ import static org.jboss.as.appclient.logging.AppClientMessages.MESSAGES;
  * @author Stuart Douglas
  */
 public final class Main {
+    // Capture System.out and System.err before they are redirected by STDIO
+    private static final PrintStream STDOUT = System.out;
+    private static final PrintStream STDERR = System.err;
 
 
     private static void usage() {
-        CommandLineArgumentUsageImpl.printUsage(System.out);
+        CommandLineArgumentUsageImpl.printUsage(STDOUT);
     }
 
     private Main() {
@@ -105,7 +109,7 @@ public final class Main {
             final List<String> clientArgs = options.clientArguments;
 
             if (clientArgs.isEmpty()) {
-                System.err.println(MESSAGES.appClientNotSpecified());
+                STDERR.println(MESSAGES.appClientNotSpecified());
                 usage();
                 abort(null);
             } else {
@@ -162,7 +166,7 @@ public final class Main {
     private static void abort(Throwable t) {
         try {
             if (t != null) {
-                t.printStackTrace(System.err);
+                t.printStackTrace(STDERR);
             }
         } finally {
             SystemExiter.exit(1);
@@ -187,7 +191,7 @@ public final class Main {
                 } else if (CommandLineConstants.VERSION.equals(arg) || CommandLineConstants.SHORT_VERSION.equals(arg)
                         || CommandLineConstants.OLD_VERSION.equals(arg) || CommandLineConstants.OLD_SHORT_VERSION.equals(arg)) {
                     productConfig = new ProductConfig(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), null);
-                    System.out.println(productConfig.getPrettyVersionString());
+                    STDOUT.println(productConfig.getPrettyVersionString());
                     return null;
                 } else if (CommandLineConstants.HELP.equals(arg) || CommandLineConstants.SHORT_HELP.equals(arg) || CommandLineConstants.OLD_HELP.equals(arg)) {
                     usage();
@@ -258,7 +262,7 @@ public final class Main {
                     appClientConfig = parseValue(arg, CommandLineConstants.APPCLIENT_CONFIG);
                 } else {
                     if (arg.startsWith("-")) {
-                        System.out.println(MESSAGES.unknownOption(arg));
+                        STDOUT.println(MESSAGES.unknownOption(arg));
                         usage();
 
                         return null;
@@ -267,7 +271,7 @@ public final class Main {
                     clientArguments.add(arg);
                 }
             } catch (IndexOutOfBoundsException e) {
-                System.err.println(MESSAGES.argumentExpected(arg));
+                STDERR.println(MESSAGES.argumentExpected(arg));
                 usage();
                 return null;
             }
@@ -298,11 +302,11 @@ public final class Main {
             props.load(url.openConnection().getInputStream());
             return true;
         } catch (MalformedURLException e) {
-            System.err.println(MESSAGES.malformedUrl(arg));
+            STDERR.println(MESSAGES.malformedUrl(arg));
             usage();
             return false;
         } catch (IOException e) {
-            System.err.println(MESSAGES.cannotLoadProperties(url));
+            STDERR.println(MESSAGES.cannotLoadProperties(url));
             usage();
             return false;
         }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/Main.java
@@ -66,6 +66,9 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Brian Stansberry
  */
 public final class Main {
+    // Capture System.out and System.err before they are redirected by STDIO
+    private static final PrintStream STDOUT = System.out;
+    private static final PrintStream STDERR = System.err;
 
     private static final String PROCESS_NAME = "-D[Host Controller]";
 
@@ -87,7 +90,7 @@ public final class Main {
         try {
             StreamUtils.readFully(new Base64InputStream(System.in), authKey);
         } catch (IOException e) {
-            System.err.println(MESSAGES.failedToReadAuthenticationKey(e));
+            STDERR.println(MESSAGES.failedToReadAuthenticationKey(e));
             fail();
             return;
         }
@@ -178,7 +181,7 @@ public final class Main {
     }
 
     private static void usage() {
-        CommandLineArgumentUsageImpl.printUsage(System.out);
+        CommandLineArgumentUsageImpl.printUsage(STDOUT);
     }
 
     /**
@@ -239,7 +242,7 @@ public final class Main {
                     try {
                         pmPort = Integer.valueOf(port);
                     } catch (NumberFormatException e) {
-                        System.err.println(MESSAGES.invalidValue(CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT, "Integer", port, usageNote()));
+                        STDERR.println(MESSAGES.invalidValue(CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT, "Integer", port, usageNote()));
                         return null;
                     }
                 } else if (arg.startsWith(CommandLineConstants.PROCESS_CONTROLLER_BIND_PORT)) {
@@ -257,7 +260,7 @@ public final class Main {
                     try {
                         pmAddress = InetAddress.getByName(addr);
                     } catch (UnknownHostException e) {
-                        System.err.println(MESSAGES.unknownHostValue(CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR, addr, usageNote()));
+                        STDERR.println(MESSAGES.unknownHostValue(CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR, addr, usageNote()));
                         return null;
                     }
                 } else if (arg.startsWith(CommandLineConstants.PROCESS_CONTROLLER_BIND_ADDR)) {
@@ -342,7 +345,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        System.err.println(MESSAGES.argumentExpected(arg, usageNote()));
+                        STDERR.println(MESSAGES.argumentExpected(arg, usageNote()));
                         return null;
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : checkValueIsNotAnArg(arg, args[++i]);
@@ -356,7 +359,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        System.err.println(MESSAGES.argumentExpected(arg, usageNote()));
+                        STDERR.println(MESSAGES.argumentExpected(arg, usageNote()));
                         return null;
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : args[++i];
@@ -387,7 +390,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        System.err.println(MESSAGES.argumentExpected(arg, usageNote()));
+                        STDERR.println(MESSAGES.argumentExpected(arg, usageNote()));
                         return null;
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : checkValueIsNotAnArg(arg, args[++i]);
@@ -411,7 +414,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        System.err.println(MESSAGES.argumentExpected(arg, usageNote()));
+                        STDERR.println(MESSAGES.argumentExpected(arg, usageNote()));
                         return null;
                     }
                     String value = idx > -1 ? arg.substring(idx + 1) : checkValueIsNotAnArg(arg, args[++i]);
@@ -427,11 +430,11 @@ public final class Main {
                         return null;
                     }
                 } else {
-                    System.err.println(MESSAGES.invalidOption(arg, usageNote()));
+                    STDERR.println(MESSAGES.invalidOption(arg, usageNote()));
                     return null;
                 }
             } catch (IndexOutOfBoundsException e) {
-                System.err.println(MESSAGES.argumentExpected(arg, usageNote()));
+                STDERR.println(MESSAGES.argumentExpected(arg, usageNote()));
                 return null;
             }
         }
@@ -444,7 +447,7 @@ public final class Main {
     private static String parseValue(final String arg, final String key) {
         int splitPos = key.length();
         if (arg.length() <= splitPos + 1 || arg.charAt(splitPos) != '=') {
-            System.err.println(MESSAGES.argumentHasNoValue(arg, usageNote()));
+            STDERR.println(MESSAGES.argumentHasNoValue(arg, usageNote()));
             return null;
         } else {
             return arg.substring(splitPos + 1);
@@ -462,7 +465,7 @@ public final class Main {
      */
     private static String checkValueIsNotAnArg(String argument, String value) {
         if (value.startsWith("-")) {
-            System.err.println(MESSAGES.argumentHasNoValue(argument, usageNote()));
+            STDERR.println(MESSAGES.argumentHasNoValue(argument, usageNote()));
             return null;
         }
         return value;
@@ -481,10 +484,10 @@ public final class Main {
              }
              return true;
          } catch (MalformedURLException e) {
-             System.err.println(MESSAGES.malformedUrl(arg, usageNote()));
+             STDERR.println(MESSAGES.malformedUrl(arg, usageNote()));
              return false;
          } catch (IOException e) {
-             System.err.println(MESSAGES.unableToLoadProperties(url, usageNote()));
+             STDERR.println(MESSAGES.unableToLoadProperties(url, usageNote()));
              return false;
          }
     }
@@ -493,7 +496,7 @@ public final class Main {
          try {
              return Integer.valueOf(value);
          } catch (NumberFormatException e) {
-             System.err.println(MESSAGES.invalidValue(key, "Integer", value, usageNote()));
+             STDERR.println(MESSAGES.invalidValue(key, "Integer", value, usageNote()));
              return null;
          }
     }
@@ -502,7 +505,7 @@ public final class Main {
         try {
             return InetAddress.getByName(value);
         } catch (UnknownHostException e) {
-            System.err.println(MESSAGES.unknownHostValue(key, value, usageNote()));
+            STDERR.println(MESSAGES.unknownHostValue(key, value, usageNote()));
             return null;
         }
     }
@@ -561,7 +564,7 @@ public final class Main {
                 }
             }
         } catch (Exception e) {
-            System.err.println(MESSAGES.cannotAccessJvmInputArgument(e));
+            STDERR.println(MESSAGES.cannotAccessJvmInputArgument(e));
         }
         return hostSystemProperties;
     }
@@ -666,7 +669,7 @@ public final class Main {
                 bindAddress = InetAddress.getByName(value);
             } catch (UnknownHostException e) {
                 parseFailed = true;
-                System.err.println(MESSAGES.invalidValue(key, "InetAddress", value, usageNote()));
+                STDERR.println(MESSAGES.invalidValue(key, "InetAddress", value, usageNote()));
             }
         }
     }

--- a/server/src/main/java/org/jboss/as/server/Main.java
+++ b/server/src/main/java/org/jboss/as/server/Main.java
@@ -24,6 +24,7 @@ package org.jboss.as.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
@@ -53,9 +54,12 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Anil Saldhana
  */
 public final class Main {
+    // Capture System.out and System.err before they are redirected by STDIO
+    private static final PrintStream STDOUT = System.out;
+    private static final PrintStream STDERR = System.err;
 
     private static void usage() {
-        CommandLineArgumentUsageImpl.printUsage(System.out);
+        CommandLineArgumentUsageImpl.printUsage(STDOUT);
     }
 
     private Main() {
@@ -103,7 +107,7 @@ public final class Main {
     private static void abort(Throwable t) {
         try {
             if (t != null) {
-                t.printStackTrace(System.err);
+                t.printStackTrace(STDERR);
             }
         } finally {
             SystemExiter.exit(ExitCodes.FAILED);
@@ -122,7 +126,7 @@ public final class Main {
                 if (CommandLineConstants.VERSION.equals(arg) || CommandLineConstants.SHORT_VERSION.equals(arg)
                         || CommandLineConstants.OLD_VERSION.equals(arg) || CommandLineConstants.OLD_SHORT_VERSION.equals(arg)) {
                     productConfig = new ProductConfig(Module.getBootModuleLoader(), WildFlySecurityManager.getPropertyPrivileged(ServerEnvironment.HOME_DIR, null), null);
-                    System.out.println(productConfig.getPrettyVersionString());
+                    STDOUT.println(productConfig.getPrettyVersionString());
                     return null;
                 } else if (CommandLineConstants.HELP.equals(arg) || CommandLineConstants.SHORT_HELP.equals(arg) || CommandLineConstants.OLD_HELP.equals(arg)) {
                     usage();
@@ -188,7 +192,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        System.err.println(ServerMessages.MESSAGES.noArgValue(arg));
+                        STDERR.println(ServerMessages.MESSAGES.noArgValue(arg));
                         usage();
                         return null;
                     }
@@ -210,7 +214,7 @@ public final class Main {
 
                     int idx = arg.indexOf('=');
                     if (idx == arg.length() - 1) {
-                        System.err.println(ServerMessages.MESSAGES.valueExpectedForCommandLineOption(arg));
+                        STDERR.println(ServerMessages.MESSAGES.valueExpectedForCommandLineOption(arg));
                         usage();
                         return null;
                     }
@@ -238,12 +242,12 @@ public final class Main {
                         }
                     }
                 } else {
-                    System.err.println(ServerMessages.MESSAGES.invalidCommandLineOption(arg));
+                    STDERR.println(ServerMessages.MESSAGES.invalidCommandLineOption(arg));
                     usage();
                     return null;
                 }
             } catch (IndexOutOfBoundsException e) {
-                System.err.println(ServerMessages.MESSAGES.valueExpectedForCommandLineOption(arg));
+                STDERR.println(ServerMessages.MESSAGES.valueExpectedForCommandLineOption(arg));
                 usage();
                 return null;
             }
@@ -275,11 +279,11 @@ public final class Main {
              systemProperties.load(url.openConnection().getInputStream());
              return true;
          } catch (MalformedURLException e) {
-             System.err.println(ServerMessages.MESSAGES.malformedCommandLineURL(urlSpec, arg));
+             STDERR.println(ServerMessages.MESSAGES.malformedCommandLineURL(urlSpec, arg));
              usage();
              return false;
          } catch (IOException e) {
-             System.err.println(ServerMessages.MESSAGES.unableToLoadProperties(url));
+             STDERR.println(ServerMessages.MESSAGES.unableToLoadProperties(url));
              usage();
              return false;
          }
@@ -317,7 +321,7 @@ public final class Main {
 
             int idx = token.indexOf('=');
             if (idx == token.length() - 1) {
-                System.err.println(ServerMessages.MESSAGES.valueExpectedForCommandLineOption(secProperties));
+                STDERR.println(ServerMessages.MESSAGES.valueExpectedForCommandLineOption(secProperties));
                 usage();
                 return;
             }


### PR DESCRIPTION
Captures `System.out` and `System.err` in the main entry programs before jboss-stdio captures the streams.

Replacement for #5899
