### PR TITLE
[WFLY-2922] Document messaging XML schema

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-messaging_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_1_4.xsd
@@ -65,7 +65,13 @@
           <!-- no file system deployment in AS
           <xs:element maxOccurs="1" minOccurs="0" type="file-deployment-enabled"/>
            -->
-          <xs:element maxOccurs="1" minOccurs="0" name="persistence-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="persistence-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server will use the file based journal for persistence.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <!--  TODO use thread subsystem?  -->
           <xs:element maxOccurs="1" minOccurs="0" name="scheduled-thread-pool-max-size" type="xs:int">
               <xs:annotation>
@@ -81,39 +87,219 @@
                   </xs:documentation>
               </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="security-domain" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="security-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="security-invalidation-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="wild-card-routing-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="management-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="management-notification-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="cluster-user" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="cluster-password" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-domain" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The security domain to use to verify user and role information
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether security is enabled
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-invalidation-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long (in ms) to wait before invalidating the security cache.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="wild-card-routing-enabled" type="xs:boolean">
+               <xs:annotation>
+                   <xs:documentation>
+                       Whether the server supports wild card routing.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="management-address" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       Address to send management messages to.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="management-notification-address" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       The name of the address that consumers bind to  to receive management notifications.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-user" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The user used by cluster connections to communicate between the clustered nodes.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-password" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The password used by cluster connections to communicate between the clustered nodes.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <!-- no logging configuration for AS needed
           <xs:element maxOccurs="1" minOccurs="0" name="log-delegate-factory-class-name" type="xs:string" />
            -->
-          <xs:element maxOccurs="1" minOccurs="0" name="jmx-management-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="jmx-domain" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-sample-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-max-day-history" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl-override" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="async-connection-execution-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout-scan-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-scan-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-thread-priority" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="id-cache-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="persist-id-cache" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="remoting-interceptors" type="remoting-interceptorsType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="remoting-incoming-interceptors" type="remoting-interceptorsType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="remoting-outgoing-interceptors" type="remoting-interceptorsType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="backup" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="allow-failback" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="failback-delay" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-shutdown" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="shared-store" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="persist-delivery-count-before-delivery" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-management-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether HornetQ should expose its internal management API via JMX. This is not recommended, as accessing these MBeans can lead to inconsistent configuration.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-domain" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The JMX domain used to register internal HornetQ MBeans in the MBeanServer.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                    Whether gathering of statistics such as message counters are enabled.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-sample-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The sample period (in ms) to use for message counters.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-max-day-history" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many days to keep message counter history.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl-override" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      If set, this will override how long (in ms) to keep a connection alive without receiving a ping.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="async-connection-execution-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether incoming packets on the server should be handed off to a thread from the thread pool for processing. False if they should be handled on the remoting thread.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long (in ms) before a transaction can be removed from the resource manager after create time.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout-scan-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often (in ms) to scan for timeout transactions.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-scan-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often (in ms) to scan for expired messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-thread-priority" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The priority of the thread expiring messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="id-cache-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size of the cache for pre-creating message IDs.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-id-cache" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether IDs are persisted to the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Deprecated. Use remoting-incoming-interceptors instead
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-incoming-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The list of incoming interceptor classes used by this server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-outgoing-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The list of outgoing interceptor classes used by this server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="backup" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server is a backup server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="allow-failback" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server will automatically shutdown if the original live server comes back up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="failback-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long to wait before failback occurs on live server restart.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-shutdown" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this backup server (if it is a backup server) should come live on a normal server shutdown.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="shared-store" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server is using a shared store for failover.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-delivery-count-before-delivery" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the delivery count is persisted before delivery. False means that this only happens after a message has been cancelled.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="live-connector-ref" type="live-connectorType">
               <xs:annotation>
                   <xs:documentation>
@@ -121,29 +307,161 @@
                   </xs:documentation>
               </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="page-max-concurrent-io" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="create-bindings-dir" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="create-journal-dir" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-type" type="journalType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-size" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-transactional" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-non-transactional" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="log-journal-write-rate" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-file-size" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-min-files" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-percentage" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-min-files" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-max-io" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-saved-replicated-journal-size" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-concurrent-io" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of concurrent reads allowed on paging
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="create-bindings-dir" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server should create the bindings directory on start up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="create-journal-dir" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server should create the journal directory on start up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-type" type="journalType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The type of journal to use.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout (in nanoseconds) used to flush internal buffers on the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-size" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size of the internal buffer on the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-transactional" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to wait for transaction data to be synchronized to the journal before returning a response to the client.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-non-transactional" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to wait for non transaction data to be synced to the journal before returning a response to the client.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="log-journal-write-rate" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to periodically log the journal's write rate and flush rate.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-file-size" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size (in bytes) of each journal file.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-min-files" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many journal files to pre-create.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-percentage" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The percentage of live data on which we consider compacting the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-min-files" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimal number of journal data files before we can start compacting.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-max-io" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of write requests that can be in the AIO queue at any one time.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-saved-replicated-journal-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of backup journals to keep after failback occurs.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="perf-blast-pages" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="run-sync-speed-test" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="server-dump-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="memory-warning-threshold" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="memory-measure-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="check-for-live-server" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="backup-group-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="replication-clustername" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="run-sync-speed-test" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether on startup to perform a diagnostic test on how fast your disk can sync. Useful when determining performance issues.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="server-dump-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often to dump basic runtime information to the server log. A value less than 1 disables this feature.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-warning-threshold" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Percentage of available memory which if exceeded results in a warning log
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-measure-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Frequency to sample JVM memory in ms (or -1 to disable memory sampling)
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-for-live-server" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      If a replicated live server should check the current cluster to see if there is already a live server with the same node id
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="backup-group-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of a set of live/backups that should replicate with each other
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="replication-clustername" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of the cluster connection to replicate from if more than one cluster connection is configured
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
 
           <xs:element maxOccurs="1" minOccurs="0" name="paging-directory" type="directoryType" />
           <xs:element maxOccurs="1" minOccurs="0" name="bindings-directory" type="directoryType" />
@@ -243,12 +561,48 @@
     </xs:attribute>
     </xs:complexType>
 
-    <xs:element name="local-bind-address" type="xs:string"/>
-    <xs:element name="local-bind-port" type="xs:int"/>
-    <xs:element name="group-address" type="xs:string"/>
-    <xs:element name="group-port" type="xs:int"/>
-    <xs:element name="broadcast-period" type="xs:long"/>
-    <xs:element name="initial-wait-timeout" type="xs:int"/>
+    <xs:element name="local-bind-address" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="local-bind-port" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="group-address" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="group-port" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="broadcast-period" type="xs:long">
+        <xs:annotation>
+            <xs:documentation>
+                The period in milliseconds between consecutive broadcasts.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="initial-wait-timeout" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Period, in ms, to wait for an initial broadcast to give us at least one node in the cluster.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
 
     <xs:complexType name="broadcast-groupType">
        <xs:sequence>
@@ -261,10 +615,22 @@
                           </xs:documentation>
                       </xs:annotation>
                   </xs:element>
-                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name used by a JGroups channel to join a cluster.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
-                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The broadcast group socket binding.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
                   <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
@@ -298,9 +664,21 @@
                </xs:sequence>
            </xs:choice>
            <xs:element maxOccurs="1" minOccurs="0" ref="broadcast-period" />
-           <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string" />
+           <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       Specifies the names of connectors that will be broadcast.
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the broadcast group
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="discovery-groupType">
@@ -314,10 +692,22 @@
                           </xs:documentation>
                       </xs:annotation>
                   </xs:element>
-                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name used by a JGroups channel to join a cluster.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
-                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The discovery group socket binding.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
                   <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
@@ -343,10 +733,28 @@
                   </xs:element>
                </xs:sequence>
             </xs:choice>
-            <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int" />
-            <xs:element maxOccurs="1" minOccurs="0" ref="initial-wait-timeout" />
+            <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period the discovery group waits after receiving the last broadcast from a particular server before removing that server's connector pair entry from its list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element maxOccurs="1" minOccurs="0" ref="initial-wait-timeout">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period, in ms, to wait for an initial broadcast to give us at least one node in the cluster.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
-        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the discovery group
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="remoting-interceptorsType">
@@ -371,7 +779,13 @@
             </xs:documentation>
        </xs:annotation>
        <xs:sequence>
-          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                    The class name of the remoting incoming interceptor.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:sequence>
     </xs:complexType>
 
@@ -384,13 +798,31 @@
             </xs:documentation>
        </xs:annotation>
        <xs:sequence>
-          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The class name of the remoting outgoing interceptor.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="paramType">
-       <xs:attribute name="key" type="xs:string" use="required"/>
-       <xs:attribute name="value" type="xs:string" use="required"/>
+       <xs:attribute name="key" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The key of the parameter
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+       <xs:attribute name="value" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The value of the parameter
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="netty-connectorType">
@@ -403,7 +835,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-connectorType">
-             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+             <xs:attribute name="socket-binding" type="xs:string" use="required">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -418,7 +856,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-connectorType">
-             <xs:attribute name="server-id" type="xs:int" use="optional" />
+             <xs:attribute name="server-id" type="xs:int" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The connector server ID.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -435,9 +879,21 @@
        <xs:complexContent>
           <xs:extension base="base-connectorType">
              <xs:sequence>
-                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Class name of the factory class that can instantiate the connector.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
              </xs:sequence>
-             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+             <xs:attribute name="socket-binding" type="xs:string" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -446,7 +902,13 @@
        <xs:sequence>
           <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the connector
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="netty-acceptorType">
@@ -459,7 +921,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-acceptorType">
-             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+             <xs:attribute name="socket-binding" type="xs:string" use="required">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -474,7 +942,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-acceptorType">
-             <xs:attribute name="server-id" type="xs:int" use="optional" />
+             <xs:attribute name="server-id" type="xs:int" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The server id.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -491,9 +965,21 @@
        <xs:complexContent>
           <xs:extension base="base-acceptorType">
              <xs:sequence>
-                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Class name of the factory class that can instantiate the acceptor.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
              </xs:sequence>
-             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+             <xs:attribute name="socket-binding" type="xs:string" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding that the acceptor will use to accept connections.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -502,27 +988,105 @@
        <xs:sequence>
           <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="optional"/>
+       <xs:attribute name="name" type="xs:string" use="optional">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the acceptor
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="bridgeType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="1" name="queue-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="forwarding-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="ha" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="1" name="queue-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The unique name of the local queue that the bridge consumes from.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="forwarding-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The address on the target server that the message will be forwarded to. If a forwarding address is not specified then the original destination of the message will be retained.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="ha" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether or not this bridge should support high availability. True means it will connect to any available server in a cluster and support failover.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="filter">
              <xs:complexType>
-                <xs:attribute name="string" type="xs:string" use="required"/>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
              </xs:complexType>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long"  />
-          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      An optional filter string. If specified then only messages which match the filter expression specified will be forwarded. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimum size (in bytes) for a message before it is considered as a large message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period (in milliseconds) between client failure check.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum time (in milliseconds) for which the connections used by the bridges are considered alive (in the absence of heartbeat).
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period in milliseconds between subsequent reconnection attempts, if the connection to the target server has failed.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double">
+              <xs:annotation>
+                  <xs:documentation>
+                      A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum interval of time used to retry connections
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="failover-on-server-shutdown" type="xs:boolean">
              <xs:annotation>
                 <xs:documentation>
@@ -530,13 +1094,42 @@
                 </xs:documentation>
              </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the bridge will automatically insert a duplicate id property into each message that it forwards.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The confirmation-window-size to use for the connection used to forward messages to the target node.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The user name to use when creating the bridge connection to the remote server. If it is not specified the default cluster user specified by the cluster-user attribute in the root messaging subsystem resource will be used.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The password to use when creating the bridge connection to the remote server. If it is not specified the default cluster password specified by the cluster-password attribute in the root messaging subsystem resource will be used.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:choice>
              <xs:element maxOccurs="1" minOccurs="1" name="static-connectors">
                 <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation>
+                            A list of names of statically defined connectors used by this bridge. Must be undefined (null) if 'discovery-group-name' is defined.
+                        </xs:documentation>
+                    </xs:annotation>
                    <xs:sequence>
                       <xs:element maxOccurs="unbounded" minOccurs="1" name="connector-ref" type="xs:string"/>
                    </xs:sequence>
@@ -545,57 +1138,218 @@
              <xs:element maxOccurs="1" minOccurs="1" name="discovery-group-ref" type="discovery-group-refType" />
           </xs:choice>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the bridge
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="clusterConnectionType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="1" name="connector-ref" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="call-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="call-failover-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="forward-when-no-consumers" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-hops" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="notification-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="notification-attempts" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Each cluster connection only applies to messages sent to an address that starts with this value.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="connector-ref" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of connector to use for live connection
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period (in milliseconds) between client failure check.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum time (in milliseconds) for which the connections used by the cluster connections are considered alive (in the absence of heartbeat).
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimum size (in bytes) for a message before it is considered as a large message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="call-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout (in ms) for remote calls made by the cluster connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="call-failover-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout to use when fail over is in process (in ms) for remote calls made by the cluster connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period in milliseconds between subsequent attempts to reconnect to a target server, if the connection to the target server has failed.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double">
+              <xs:annotation>
+                  <xs:documentation>
+                      A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum interval of time used to retry connections
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the bridge will automatically insert a duplicate id property into each message that it forwards.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="forward-when-no-consumers" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether messages will be distributed round robin between other nodes of the cluster irrespective of whether there are matching or indeed any consumers on other nodes. If this is set to false (the default) then HornetQ will only forward messages to other nodes of the cluster if the address to which they are being forwarded has queues which have consumers, and if those consumers have message filters (selectors) at least one of those selectors must match the message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-hops" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of times a message can be forwarded. HornetQ can be configured to also load balance messages to nodes which might be connected to it only indirectly with other HornetQ servers as intermediates in a chain.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The confirmation-window-size to use for the connection used to forward messages to a target node.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often the cluster connection will broadcast itself
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many times the cluster connection will broadcast itself
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:choice>
              <xs:element maxOccurs="1" minOccurs="0" name="static-connectors">
                 <xs:complexType>
                    <xs:sequence>
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string"/>
                    </xs:sequence>
-                   <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional"/>
+                   <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional">
+                       <xs:annotation>
+                           <xs:documentation>
+                               Whether, if a node learns of the existence of a node that is more than 1 hop away, we do not create a bridge for direct cluster connection. Only relevant if 'static-connectors' is defined.
+                           </xs:documentation>
+                       </xs:annotation>
+                   </xs:attribute>
                 </xs:complexType>
              </xs:element>
              <xs:element maxOccurs="1" minOccurs="0" name="discovery-group-ref" type="discovery-group-refType" />
           </xs:choice>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the discovery group
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
-
     <xs:complexType name="divertType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="0" name="routing-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="1" name="forwarding-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="routing-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Routing name of the divert
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Address to divert from
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="forwarding-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Address to divert to
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="filter">
              <xs:complexType>
-                <xs:attribute name="string" type="xs:string" use="required"/>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            An optional filter string. If specified then only messages which match the filter expression specified will be diverted. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
              </xs:complexType>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="exclusive" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of a class used to transform the message's body or properties before it is diverted.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="exclusive" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   Whether the divert is exclusive, meaning that the message is diverted to the new address, and does not go to the old address at all.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="journalType">
@@ -608,9 +1362,21 @@
     <xs:complexType name="groupingHandlerType">
        <xs:sequence>
           <xs:element maxOccurs="1" minOccurs="1" name="type" type="groupingHandlerTypeType"/>
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string"/>
-          <xs:element maxOccurs="1" minOccurs="0" name="timeout" type="xs:int"/>
-           <xs:element maxOccurs="1" minOccurs="0" name="group-timeout" type="xs:long" >
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      A reference to a cluster connection and the address it uses.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="timeout" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long to wait for a handling decision to be made; an exception will be thrown during the send if this timeout is reached, ensuring that strict ordering is kept.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="group-timeout" type="xs:long" >
                <xs:annotation>
                    <xs:documentation>
                        How long a group binding will be used, -1 means for ever. Bindings are removed after this wait elapses (only valid for LOCAL handlers).
@@ -625,10 +1391,21 @@
                </xs:annotation>
            </xs:element>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the grouping handler.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="groupingHandlerTypeType">
+       <xs:annotation>
+           <xs:documentation>
+               Whether the handler is the single "Local" handler for the cluster, which makes handling decisions, or a "Remote" handler which converses with the local handler.
+           </xs:documentation>
+       </xs:annotation>
        <xs:restriction base="xs:token">
           <xs:enumeration value="LOCAL"/>
           <xs:enumeration value="REMOTE"/>
@@ -658,7 +1435,13 @@
              </xs:complexType>
           </xs:element>
        </xs:sequence>
-       <xs:attribute name="match" type="xs:string" use="required"/>
+       <xs:attribute name="match" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   Expression matched against a queue address.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="address-settingsType">
@@ -669,20 +1452,98 @@
 
     <xs:complexType name="address-settingType">
        <xs:all>
-          <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="page-size-bytes" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="page-max-cache-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="address-full-policy" type="addressFullMessagePolicyType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-history-day-limit" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="last-value-queue" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="redistribution-delay" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="send-to-dla-on-no-route" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The dead letter address
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines where to send a message that has expired.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how long to wait before attempting redelivery of a cancelled message
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how many time a cancelled message can be redelivered before sending to the dead-letter-address
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The max bytes size.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-size-bytes" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The paging size.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-cache-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The number of page files to keep in memory to optimize IO during paging navigation.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="address-full-policy" type="addressFullMessagePolicyType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Determines what happens when an address where max-size-bytes is specified becomes full. (PAGE, DROP or BLOCK)
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-history-day-limit" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Day limit for the message counter history.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="last-value-queue" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines whether a queue only uses last values or not
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="redistribution-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how long to wait when the last consumer is closed on a queue before redistributing any messages
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="send-to-dla-on-no-route" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      If this parameter is set to true for that address, if the message is not routed to any queues it will instead be sent to the dead letter address (DLA) for that address, if it exists.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:all>
-       <xs:attribute name="match" type="xs:string" use="required"/>
+       <xs:attribute name="match" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the address setting.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="queuesType">
@@ -693,15 +1554,39 @@
 
     <xs:complexType name="queueType">
        <xs:all>
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The queue address defines what address is used for routing messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="filter">
              <xs:complexType>
-                <xs:attribute name="string" type="xs:string" use="required"/>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A queue message filter definition. An undefined or empty filter will match all messages.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
              </xs:complexType>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="durable" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="durable" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines whether the queue is durable.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
         </xs:all>
-        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the queue.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="live-connectorType">
@@ -718,10 +1603,22 @@
 
     <xs:complexType name="connectorServiceType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Class name of the factory class that can instantiate the connector service.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="optional"/>
+       <xs:attribute name="name" type="xs:string" use="optional">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the connector service.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="directoryType">
@@ -774,32 +1671,188 @@
                </xs:sequence>
             </xs:complexType>
          </xs:element>
-         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
-         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the connection factory supports High Availability.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client failure check period.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The connection ttl.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The call time out.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The timeout to use when fail over is in process (in ms).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The confirmation window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether large messages should be compressed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to cache large messages.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The min large message size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The dups ok batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The transaction batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on non durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether or not message grouping is automatically used
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to pre-acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval multiplier.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The max retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The reconnect attempts.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to fail over on initial connection.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
              <xs:annotation>
                 <xs:documentation>
@@ -807,15 +1860,51 @@
                 </xs:documentation>
              </xs:annotation>
          </xs:element>
-         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use global pools.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The scheduled thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The group id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <!-- ============================================================= -->
          <!-- end of common elements                                        -->
       </xs:all>
-      <xs:attribute name="name" type="xs:string" />
+      <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the connection factory.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:simpleType name="connectionFactoryType">
@@ -836,28 +1925,112 @@
          <xs:element name="inbound-config" maxOccurs="1" minOccurs="0">
             <xs:complexType>
                <xs:sequence>
-                    <xs:element name="use-jndi" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="jndi-params" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="use-local-tx" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="setup-attempts" type="xs:integer" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="setup-interval" type="xs:long" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="use-jndi" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Use JNDI to locate the destination for incoming connections
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="jndi-params" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The JNDI params to use for locating the destination for incoming connections.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="use-local-tx" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Use a local transaction for incoming sessions
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="setup-attempts" type="xs:integer" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The number of times to set up an MDB endpoint
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="setup-interval" type="xs:long" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The interval between attempts at setting up an MDB endpoint.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
-         <xs:element name="transaction" type="transactionType" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="user" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="initial-message-packet-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="initial-connect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="transaction" type="transactionType" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     The type of transaction.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="user" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The default username to use with this connection factory. This is only needed when pointing the connection factory to a remote host.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The default password to use with this connection factory. This is only needed when pointing the connection factory to a remote host.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The minimum size for the pool
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum size for the pool
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use auto recovery.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="initial-message-packet-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The initial size of messages created through this factory.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="initial-connect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The number of attempts to connect initially with this factory.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <!-- ============================================================== -->
          <!-- end of JMS pooled-connection-factoryType specific elements     -->
 
          <!-- start of common elements                                       -->
          <!--  ============================================================= -->
-         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0" />
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The discovery group name.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element name="connectors" maxOccurs="1" minOccurs="0">
             <xs:complexType>
                <xs:sequence>
@@ -873,32 +2046,188 @@
                </xs:sequence>
             </xs:complexType>
          </xs:element>
-         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
-         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the connection factory supports High Availability.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client failure check period.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The connection ttl.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The call time out.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The timeout to use when fail over is in process (in ms).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether large messages should be compressed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The confirmation window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to cache large messages.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The min large message size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The dups ok batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The transaction batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on non durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The autogroup.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to pre-acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval multiplier.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The max retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The reconnect attempts. By default, a pooled connection factory will try to reconnect infinitely to the messaging server(s).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to fail over on initial connection.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
              <xs:annotation>
                 <xs:documentation>
@@ -906,20 +2235,62 @@
                 </xs:documentation>
              </xs:annotation>
          </xs:element>
-         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use global pools.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The scheduled thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The group id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <!-- ============================================================= -->
          <!-- end of common elements                                        -->
       </xs:all>
-      <xs:attribute name="name" type="xs:string" />
+      <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the pooled connection factory.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
 
    <xs:complexType name="connector-refType">
-      <xs:attribute name="connector-name" type="xs:string" use="required" />
+      <xs:attribute name="connector-name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the connector.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="backup-connector-name" type="xs:string" use="optional">
           <xs:annotation>
               <xs:documentation>
@@ -930,11 +2301,23 @@
    </xs:complexType>
 
    <xs:complexType name="entryType">
-      <xs:attribute name="name" type="xs:string" use="required" />
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JNDI entry.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:complexType name="discovery-group-refType">
-      <xs:attribute name="discovery-group-name" type="xs:string" use="required" />
+      <xs:attribute name="discovery-group-name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the discovery group.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:complexType name="jmsQueueType">
@@ -942,19 +2325,43 @@
          <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
          <xs:element name="selector" maxOccurs="1" minOccurs="0">
             <xs:complexType>
-               <xs:attribute name="string" type="xs:string" use="required" />
+               <xs:attribute name="string" type="xs:string" use="required">
+                   <xs:annotation>
+                       <xs:documentation>
+                           The queue selector.
+                       </xs:documentation>
+                   </xs:annotation>
+               </xs:attribute>
             </xs:complexType>
          </xs:element>
-         <xs:element name="durable" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="durable" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the queue is durable or not.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
       </xs:sequence>
-      <xs:attribute name="name" type="xs:string" use="required" />
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JMS queue.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:complexType name="jmsTopicType">
       <xs:sequence>
          <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
       </xs:sequence>
-      <xs:attribute name="name" type="xs:string" use="required" />
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JMS Topic.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
     <xs:complexType name="transactionType">
@@ -965,17 +2372,23 @@
         <xs:restriction base="xs:token">
             <xs:enumeration value="xa">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>
+                        Use XA transaction.
+                    </xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="local">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>
+                        Use local transaction.
+                    </xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="none">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>
+                        Do not use transaction.
+                    </xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
         </xs:restriction>
@@ -990,18 +2403,77 @@
          </xs:documentation>
       </xs:annotation>
       <xs:all>
-         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType" />
-         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType" />
-         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType" />
-         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long" />
-         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int" />
-         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int" />
-         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long" />
-
+         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The source of the JMS bridge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The destination of the JMS bridge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The desired quality of service mode (AT_MOST_ONCE, DUPLICATES_OK or ONCE_AND_ONLY_ONCE).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long">
+             <xs:annotation>
+                 <xs:documentation>
+                     The amount of time in milliseconds to wait between trying to recreate connections to the source or target servers when the bridge has detected they have failed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int">
+             <xs:annotation>
+                 <xs:documentation>
+                     The number of times to attempt to recreate connections to the source or target servers when the bridge has detected they have failed. The bridge will give up after trying this number of times. -1 represents 'try forever'.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum number of messages to consume from the source destination before sending them in a batch to the target destination. Its value must >= 1.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum number of milliseconds to wait before sending a batch to target, even if the number of messages consumed has not reached max-batch-size. Its value must be -1 to represent 'wait forever', or >= 1 to specify an actual time.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element maxOccurs="1" minOccurs="0" name="selector" type="selectorType" />
-         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string" />
-         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string" />
-         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean" />
+         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The name of the subscription if it is durable and the source destination is a topic.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The JMS client ID to use when creating/looking up the subscription if it is durable and the source destination is a topic.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean">
+             <xs:annotation>
+                 <xs:documentation>
+                     If true, then the original message's message ID will be appended in the message sent to the destination in the header HORNETQ_BRIDGE_MSG_ID_LIST. If the message is bridged more than once, each message ID will be appended.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
       </xs:all>
       <xs:attribute name="name" type="xs:string" use="optional" default="default">
          <xs:annotation>
@@ -1073,7 +2545,13 @@
    </xs:complexType>
 
    <xs:complexType name="selectorType">
-      <xs:attribute name="string" type="xs:string" use="required" />
+      <xs:attribute name="string" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  A message selector.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:simpleType name="quality-of-serviceType">

--- a/build/src/main/resources/docs/schema/jboss-as-messaging_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-messaging_2_0.xsd
@@ -65,7 +65,13 @@
           <!-- no file system deployment in AS
           <xs:element maxOccurs="1" minOccurs="0" type="file-deployment-enabled"/>
            -->
-          <xs:element maxOccurs="1" minOccurs="0" name="persistence-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="persistence-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server will use the file based journal for persistence.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <!--  TODO use thread subsystem?  -->
           <xs:element maxOccurs="1" minOccurs="0" name="scheduled-thread-pool-max-size" type="xs:int">
               <xs:annotation>
@@ -81,20 +87,86 @@
                   </xs:documentation>
               </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="security-domain" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="security-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="security-invalidation-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="wild-card-routing-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="management-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="management-notification-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="cluster-user" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="cluster-password" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-domain" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The security domain to use to verify user and role information
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether security is enabled
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-invalidation-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long (in ms) to wait before invalidating the security cache.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="wild-card-routing-enabled" type="xs:boolean">
+               <xs:annotation>
+                   <xs:documentation>
+                       Whether the server supports wild card routing.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="management-address" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       Address to send management messages to.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="management-notification-address" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       The name of the address that consumers bind to  to receive management notifications.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-user" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The user used by cluster connections to communicate between the clustered nodes.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-password" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The password used by cluster connections to communicate between the clustered nodes.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <!-- no logging configuration for AS needed
           <xs:element maxOccurs="1" minOccurs="0" name="log-delegate-factory-class-name" type="xs:string" />
            -->
-          <xs:element maxOccurs="1" minOccurs="0" name="jmx-management-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="jmx-domain" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="statistics-enabled" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-management-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether HornetQ should expose its internal management API via JMX. This is not recommended, as accessing these MBeans can lead to inconsistent configuration.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-domain" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The JMX domain used to register internal HornetQ MBeans in the MBeanServer.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="statistics-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether gathering of statistics such as message counters are enabled.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="message-counter-enabled" type="xs:boolean">
               <xs:annotation>
                   <xs:documentation>
@@ -102,25 +174,139 @@
                   </xs:documentation>
               </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-sample-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-max-day-history" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl-override" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="async-connection-execution-enabled" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout-scan-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-scan-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-thread-priority" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="id-cache-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="persist-id-cache" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="remoting-interceptors" type="remoting-interceptorsType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="remoting-incoming-interceptors" type="remoting-interceptorsType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="remoting-outgoing-interceptors" type="remoting-interceptorsType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="backup" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="allow-failback" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="failback-delay" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-shutdown" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="shared-store" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="persist-delivery-count-before-delivery" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-sample-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The sample period (in ms) to use for message counters.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-max-day-history" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many days to keep message counter history.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl-override" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      If set, this will override how long (in ms) to keep a connection alive without receiving a ping.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="async-connection-execution-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether incoming packets on the server should be handed off to a thread from the thread pool for processing. False if they should be handled on the remoting thread.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long (in ms) before a transaction can be removed from the resource manager after create time.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout-scan-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often (in ms) to scan for timeout transactions.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-scan-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often (in ms) to scan for expired messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-thread-priority" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The priority of the thread expiring messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="id-cache-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size of the cache for pre-creating message IDs.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-id-cache" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether IDs are persisted to the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Deprecated. Use remoting-incoming-interceptors instead
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-incoming-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The list of incoming interceptor classes used by this server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-outgoing-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The list of outgoing interceptor classes used by this server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="backup" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server is a backup server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="allow-failback" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server will automatically shutdown if the original live server comes back up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="failback-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long to wait before failback occurs on live server restart.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-shutdown" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this backup server (if it is a backup server) should come live on a normal server shutdown.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="shared-store" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server is using a shared store for failover.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-delivery-count-before-delivery" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the delivery count is persisted before delivery. False means that this only happens after a message has been cancelled.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="live-connector-ref" type="live-connectorType">
               <xs:annotation>
                   <xs:documentation>
@@ -128,20 +314,104 @@
                   </xs:documentation>
               </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="page-max-concurrent-io" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="create-bindings-dir" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="create-journal-dir" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-type" type="journalType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-size" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-transactional" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-non-transactional" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="log-journal-write-rate" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-file-size" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-min-files" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-percentage" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-min-files" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="journal-max-io" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-concurrent-io" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of concurrent reads allowed on paging
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="create-bindings-dir" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server should create the bindings directory on start up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="create-journal-dir" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server should create the journal directory on start up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-type" type="journalType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The type of journal to use.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout (in nanoseconds) used to flush internal buffers on the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-size" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size of the internal buffer on the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-transactional" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to wait for transaction data to be synchronized to the journal before returning a response to the client.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-non-transactional" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to wait for non transaction data to be synced to the journal before returning a response to the client.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="log-journal-write-rate" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to periodically log the journal's write rate and flush rate.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-file-size" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size (in bytes) of each journal file.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-min-files" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many journal files to pre-create.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-percentage" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The percentage of live data on which we consider compacting the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-min-files" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimal number of journal data files before we can start compacting.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-max-io" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of write requests that can be in the AIO queue at any one time.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="max-saved-replicated-journal-size" type="xs:int">
               <xs:annotation>
                   <xs:documentation>
@@ -150,13 +420,55 @@
               </xs:annotation>
           </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="perf-blast-pages" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="run-sync-speed-test" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="server-dump-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="memory-warning-threshold" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="memory-measure-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="check-for-live-server" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="backup-group-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="replication-clustername" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="run-sync-speed-test" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether on startup to perform a diagnostic test on how fast your disk can sync. Useful when determining performance issues.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="server-dump-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often to dump basic runtime information to the server log. A value less than 1 disables this feature.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-warning-threshold" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Percentage of available memory which if exceeded results in a warning log
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-measure-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Frequency to sample JVM memory in ms (or -1 to disable memory sampling)
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-for-live-server" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      If a replicated live server should check the current cluster to see if there is already a live server with the same node id
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="backup-group-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of a set of live/backups that should replicate with each other
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="replication-clustername" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of the cluster connection to replicate from if more than one cluster connection is configured
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
 
           <xs:element maxOccurs="1" minOccurs="0" name="paging-directory" type="directoryType" />
           <xs:element maxOccurs="1" minOccurs="0" name="bindings-directory" type="directoryType" />
@@ -258,12 +570,48 @@
     </xs:attribute>
     </xs:complexType>
 
-    <xs:element name="local-bind-address" type="xs:string"/>
-    <xs:element name="local-bind-port" type="xs:int"/>
-    <xs:element name="group-address" type="xs:string"/>
-    <xs:element name="group-port" type="xs:int"/>
-    <xs:element name="broadcast-period" type="xs:long"/>
-    <xs:element name="initial-wait-timeout" type="xs:int"/>
+    <xs:element name="local-bind-address" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="local-bind-port" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="group-address" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="group-port" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="broadcast-period" type="xs:long">
+        <xs:annotation>
+            <xs:documentation>
+                The period in milliseconds between consecutive broadcasts.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="initial-wait-timeout" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Period, in ms, to wait for an initial broadcast to give us at least one node in the cluster.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
 
     <xs:complexType name="broadcast-groupType">
        <xs:sequence>
@@ -276,10 +624,22 @@
                           </xs:documentation>
                       </xs:annotation>
                   </xs:element>
-                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name used by a JGroups channel to join a cluster.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
-                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The broadcast group socket binding.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
                   <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
@@ -313,9 +673,21 @@
                </xs:sequence>
            </xs:choice>
            <xs:element maxOccurs="1" minOccurs="0" ref="broadcast-period" />
-           <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string" />
+           <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       Specifies the names of connectors that will be broadcast.
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the broadcast group
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="discovery-groupType">
@@ -329,10 +701,22 @@
                           </xs:documentation>
                       </xs:annotation>
                   </xs:element>
-                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name used by a JGroups channel to join a cluster.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
-                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string" />
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The discovery group socket binding.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
                </xs:sequence>
                <xs:sequence>
                   <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
@@ -358,10 +742,28 @@
                   </xs:element>
                </xs:sequence>
             </xs:choice>
-            <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int" />
-            <xs:element maxOccurs="1" minOccurs="0" ref="initial-wait-timeout" />
+            <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period the discovery group waits after receiving the last broadcast from a particular server before removing that server's connector pair entry from its list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element maxOccurs="1" minOccurs="0" ref="initial-wait-timeout">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period, in ms, to wait for an initial broadcast to give us at least one node in the cluster.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
         </xs:sequence>
-        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the discovery group
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="remoting-interceptorsType">
@@ -386,7 +788,13 @@
             </xs:documentation>
        </xs:annotation>
        <xs:sequence>
-          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                    The class name of the remoting incoming interceptor.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:sequence>
     </xs:complexType>
 
@@ -399,13 +807,31 @@
             </xs:documentation>
        </xs:annotation>
        <xs:sequence>
-          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The class name of the remoting outgoing interceptor.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:sequence>
     </xs:complexType>
 
     <xs:complexType name="paramType">
-       <xs:attribute name="key" type="xs:string" use="required"/>
-       <xs:attribute name="value" type="xs:string" use="required"/>
+       <xs:attribute name="key" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The key of the parameter
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+       <xs:attribute name="value" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The value of the parameter
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="http-connectorType">
@@ -441,7 +867,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-connectorType">
-             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+             <xs:attribute name="socket-binding" type="xs:string" use="required">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -456,7 +888,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-connectorType">
-             <xs:attribute name="server-id" type="xs:int" use="optional" />
+             <xs:attribute name="server-id" type="xs:int" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The connector server ID.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -473,9 +911,21 @@
        <xs:complexContent>
           <xs:extension base="base-connectorType">
              <xs:sequence>
-                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Class name of the factory class that can instantiate the connector.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
              </xs:sequence>
-             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+             <xs:attribute name="socket-binding" type="xs:string" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -484,7 +934,13 @@
        <xs:sequence>
           <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the connector
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="http-acceptorType">
@@ -520,7 +976,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-acceptorType">
-             <xs:attribute name="socket-binding" type="xs:string" use="required" />
+             <xs:attribute name="socket-binding" type="xs:string" use="required">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -535,7 +997,13 @@
        </xs:annotation>
        <xs:complexContent>
           <xs:extension base="base-acceptorType">
-             <xs:attribute name="server-id" type="xs:int" use="optional" />
+             <xs:attribute name="server-id" type="xs:int" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The server id.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -552,9 +1020,21 @@
        <xs:complexContent>
           <xs:extension base="base-acceptorType">
              <xs:sequence>
-                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Class name of the factory class that can instantiate the acceptor.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
              </xs:sequence>
-             <xs:attribute name="socket-binding" type="xs:string" use="optional" />
+             <xs:attribute name="socket-binding" type="xs:string" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding that the acceptor will use to accept connections.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
           </xs:extension>
        </xs:complexContent>
     </xs:complexType>
@@ -563,26 +1043,98 @@
        <xs:sequence>
           <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="optional"/>
+       <xs:attribute name="name" type="xs:string" use="optional">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the acceptor
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="bridgeType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="1" name="queue-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="forwarding-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="ha" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="1" name="queue-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The unique name of the local queue that the bridge consumes from.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="forwarding-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The address on the target server that the message will be forwarded to. If a forwarding address is not specified then the original destination of the message will be retained.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="ha" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether or not this bridge should support high availability. True means it will connect to any available server in a cluster and support failover.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="filter">
              <xs:complexType>
-                <xs:attribute name="string" type="xs:string" use="required"/>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
              </xs:complexType>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long"  />
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      An optional filter string. If specified then only messages which match the filter expression specified will be forwarded. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimum size (in bytes) for a message before it is considered as a large message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period (in milliseconds) between client failure check.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum time (in milliseconds) for which the connections used by the bridges are considered alive (in the absence of heartbeat).
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period in milliseconds between subsequent reconnection attempts, if the connection to the target server has failed.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double">
+              <xs:annotation>
+                  <xs:documentation>
+                      A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum interval of time used to retry connections
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="initial-connect-attempts" type="xs:int">
               <xs:annotation>
                   <xs:documentation>
@@ -590,8 +1142,20 @@
                   </xs:documentation>
               </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts-on-same-node" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts-on-same-node" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The total number of reconnect attempts on the same node the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="failover-on-server-shutdown" type="xs:boolean">
              <xs:annotation>
                 <xs:documentation>
@@ -599,13 +1163,42 @@
                 </xs:documentation>
              </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the bridge will automatically insert a duplicate id property into each message that it forwards.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The confirmation-window-size to use for the connection used to forward messages to the target node.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The user name to use when creating the bridge connection to the remote server. If it is not specified the default cluster user specified by the cluster-user attribute in the root messaging subsystem resource will be used.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The password to use when creating the bridge connection to the remote server. If it is not specified the default cluster password specified by the cluster-password attribute in the root messaging subsystem resource will be used.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:choice>
              <xs:element maxOccurs="1" minOccurs="1" name="static-connectors">
                 <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation>
+                            A list of names of statically defined connectors used by this bridge. Must be undefined (null) if 'discovery-group-name' is defined.
+                        </xs:documentation>
+                    </xs:annotation>
                    <xs:sequence>
                       <xs:element maxOccurs="unbounded" minOccurs="1" name="connector-ref" type="xs:string"/>
                    </xs:sequence>
@@ -614,21 +1207,87 @@
              <xs:element maxOccurs="1" minOccurs="1" name="discovery-group-ref" type="discovery-group-refType" />
           </xs:choice>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the bridge
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="clusterConnectionType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="1" name="connector-ref" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="call-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="call-failover-timeout" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long" />
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Each cluster connection only applies to messages sent to an address that starts with this value.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="connector-ref" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of connector to use for live connection
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period (in milliseconds) between client failure check.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum time (in milliseconds) for which the connections used by the cluster connections are considered alive (in the absence of heartbeat).
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimum size (in bytes) for a message before it is considered as a large message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="call-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout (in ms) for remote calls made by the cluster connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="call-failover-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout to use when fail over is in process (in ms) for remote calls made by the cluster connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period in milliseconds between subsequent attempts to reconnect to a target server, if the connection to the target server has failed.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double">
+              <xs:annotation>
+                  <xs:documentation>
+                      A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum interval of time used to retry connections
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="initial-connect-attempts" type="xs:int">
               <xs:annotation>
                   <xs:documentation>
@@ -636,41 +1295,137 @@
                   </xs:documentation>
               </xs:annotation>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="forward-when-no-consumers" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-hops" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="notification-interval" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="notification-attempts" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the bridge will automatically insert a duplicate id property into each message that it forwards.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="forward-when-no-consumers" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether messages will be distributed round robin between other nodes of the cluster irrespective of whether there are matching or indeed any consumers on other nodes. If this is set to false (the default) then HornetQ will only forward messages to other nodes of the cluster if the address to which they are being forwarded has queues which have consumers, and if those consumers have message filters (selectors) at least one of those selectors must match the message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-hops" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of times a message can be forwarded. HornetQ can be configured to also load balance messages to nodes which might be connected to it only indirectly with other HornetQ servers as intermediates in a chain.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The confirmation-window-size to use for the connection used to forward messages to a target node.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often the cluster connection will broadcast itself
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many times the cluster connection will broadcast itself
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:choice>
              <xs:element maxOccurs="1" minOccurs="0" name="static-connectors">
                 <xs:complexType>
                    <xs:sequence>
                       <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string"/>
                    </xs:sequence>
-                   <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional"/>
+                   <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional">
+                       <xs:annotation>
+                           <xs:documentation>
+                               Whether, if a node learns of the existence of a node that is more than 1 hop away, we do not create a bridge for direct cluster connection. Only relevant if 'static-connectors' is defined.
+                           </xs:documentation>
+                       </xs:annotation>
+                   </xs:attribute>
                 </xs:complexType>
              </xs:element>
              <xs:element maxOccurs="1" minOccurs="0" name="discovery-group-ref" type="discovery-group-refType" />
           </xs:choice>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the discovery group
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
     <xs:complexType name="divertType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="0" name="routing-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="1" name="forwarding-address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="0" name="routing-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Routing name of the divert
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Address to divert from
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="forwarding-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Address to divert to
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="filter">
              <xs:complexType>
-                <xs:attribute name="string" type="xs:string" use="required"/>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            An optional filter string. If specified then only messages which match the filter expression specified will be diverted. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
              </xs:complexType>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="exclusive" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of a class used to transform the message's body or properties before it is diverted.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="exclusive" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   Whether the divert is exclusive, meaning that the message is diverted to the new address, and does not go to the old address at all.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="journalType">
@@ -683,8 +1438,20 @@
     <xs:complexType name="groupingHandlerType">
        <xs:sequence>
           <xs:element maxOccurs="1" minOccurs="1" name="type" type="groupingHandlerTypeType"/>
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string"/>
-          <xs:element maxOccurs="1" minOccurs="0" name="timeout" type="xs:int"/>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      A reference to a cluster connection and the address it uses.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="timeout" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long to wait for a handling decision to be made; an exception will be thrown during the send if this timeout is reached, ensuring that strict ordering is kept.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="group-timeout" type="xs:long" >
                <xs:annotation>
                    <xs:documentation>
@@ -700,10 +1467,21 @@
                </xs:annotation>
            </xs:element>
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="required"/>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the grouping handler.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:simpleType name="groupingHandlerTypeType">
+       <xs:annotation>
+           <xs:documentation>
+               Whether the handler is the single "Local" handler for the cluster, which makes handling decisions, or a "Remote" handler which converses with the local handler.
+           </xs:documentation>
+       </xs:annotation>
        <xs:restriction base="xs:token">
           <xs:enumeration value="LOCAL"/>
           <xs:enumeration value="REMOTE"/>
@@ -733,7 +1511,13 @@
              </xs:complexType>
           </xs:element>
        </xs:sequence>
-       <xs:attribute name="match" type="xs:string" use="required"/>
+       <xs:attribute name="match" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   Expression matched against a queue address.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="address-settingsType">
@@ -744,21 +1528,105 @@
 
     <xs:complexType name="address-settingType">
        <xs:all>
-          <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string" />
-          <xs:element maxOccurs="1" minOccurs="0" name="expiry-delay" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="page-size-bytes" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="page-max-cache-size" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="address-full-policy" type="addressFullMessagePolicyType" />
-          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-history-day-limit" type="xs:int" />
-          <xs:element maxOccurs="1" minOccurs="0" name="last-value-queue" type="xs:boolean" />
-          <xs:element maxOccurs="1" minOccurs="0" name="redistribution-delay" type="xs:long" />
-          <xs:element maxOccurs="1" minOccurs="0" name="send-to-dla-on-no-route" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The dead letter address
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines where to send a message that has expired.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="expiry-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines the expiration time that will be used for messages using the default expiration time
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how long to wait before attempting redelivery of a cancelled message
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how many time a cancelled message can be redelivered before sending to the dead-letter-address
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The max bytes size.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-size-bytes" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The paging size.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-cache-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The number of page files to keep in memory to optimize IO during paging navigation.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="address-full-policy" type="addressFullMessagePolicyType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Determines what happens when an address where max-size-bytes is specified becomes full. (PAGE, DROP or BLOCK)
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-history-day-limit" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Day limit for the message counter history.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="last-value-queue" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines whether a queue only uses last values or not
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="redistribution-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how long to wait when the last consumer is closed on a queue before redistributing any messages
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="send-to-dla-on-no-route" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      If this parameter is set to true for that address, if the message is not routed to any queues it will instead be sent to the dead letter address (DLA) for that address, if it exists.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
        </xs:all>
-       <xs:attribute name="match" type="xs:string" use="required"/>
+       <xs:attribute name="match" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the address setting.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="queuesType">
@@ -769,15 +1637,39 @@
 
     <xs:complexType name="queueType">
        <xs:all>
-          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The queue address defines what address is used for routing messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="1" minOccurs="0" name="filter">
              <xs:complexType>
-                <xs:attribute name="string" type="xs:string" use="required"/>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A queue message filter definition. An undefined or empty filter will match all messages.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
              </xs:complexType>
           </xs:element>
-          <xs:element maxOccurs="1" minOccurs="0" name="durable" type="xs:boolean" />
+          <xs:element maxOccurs="1" minOccurs="0" name="durable" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines whether the queue is durable.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
         </xs:all>
-        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the queue.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="live-connectorType">
@@ -794,10 +1686,22 @@
 
     <xs:complexType name="connectorServiceType">
        <xs:sequence>
-          <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string" />
+          <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Class name of the factory class that can instantiate the connector service.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
           <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
        </xs:sequence>
-       <xs:attribute name="name" type="xs:string" use="optional"/>
+       <xs:attribute name="name" type="xs:string" use="optional">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the connector service.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="directoryType">
@@ -850,32 +1754,188 @@
                </xs:sequence>
             </xs:complexType>
          </xs:element>
-         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
-         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the connection factory supports High Availability.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client failure check period.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The connection ttl.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The call time out.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The timeout to use when fail over is in process (in ms).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The confirmation window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether large messages should be compressed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to cache large messages.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The min large message size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The dups ok batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The transaction batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on non durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether or not message grouping is automatically used
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to pre-acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval multiplier.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The max retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The reconnect attempts.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to fail over on initial connection.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
              <xs:annotation>
                 <xs:documentation>
@@ -883,15 +1943,51 @@
                 </xs:documentation>
              </xs:annotation>
          </xs:element>
-         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use global pools.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The scheduled thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The group id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <!-- ============================================================= -->
          <!-- end of common elements                                        -->
       </xs:all>
-      <xs:attribute name="name" type="xs:string" />
+      <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the connection factory.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:simpleType name="connectionFactoryType">
@@ -912,28 +2008,112 @@
          <xs:element name="inbound-config" maxOccurs="1" minOccurs="0">
             <xs:complexType>
                <xs:sequence>
-                    <xs:element name="use-jndi" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="jndi-params" type="xs:string" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="use-local-tx" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="setup-attempts" type="xs:integer" minOccurs="0" maxOccurs="1"/>
-                    <xs:element name="setup-interval" type="xs:long" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="use-jndi" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Use JNDI to locate the destination for incoming connections
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="jndi-params" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The JNDI params to use for locating the destination for incoming connections.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="use-local-tx" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Use a local transaction for incoming sessions
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="setup-attempts" type="xs:integer" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The number of times to set up an MDB endpoint
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="setup-interval" type="xs:long" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The interval between attempts at setting up an MDB endpoint.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
                </xs:sequence>
             </xs:complexType>
          </xs:element>
-         <xs:element name="transaction" type="transactionType" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="user" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="initial-message-packet-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="initial-connect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
+         <xs:element name="transaction" type="transactionType" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     The type of transaction.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="user" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The default username to use with this connection factory. This is only needed when pointing the connection factory to a remote host.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The default password to use with this connection factory. This is only needed when pointing the connection factory to a remote host.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The minimum size for the pool
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum size for the pool
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use auto recovery.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="initial-message-packet-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The initial size of messages created through this factory.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="initial-connect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The number of attempts to connect initially with this factory.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <!-- ============================================================== -->
          <!-- end of JMS pooled-connection-factoryType specific elements     -->
 
          <!-- start of common elements                                       -->
          <!--  ============================================================= -->
-         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0" />
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The discovery group name.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element name="connectors" maxOccurs="1" minOccurs="0">
             <xs:complexType>
                <xs:sequence>
@@ -949,32 +2129,188 @@
                </xs:sequence>
             </xs:complexType>
          </xs:element>
-         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1"/>
-         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0" />
-         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0" />
-         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the connection factory supports High Availability.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client failure check period.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The connection ttl.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The call time out.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The timeout to use when fail over is in process (in ms).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether large messages should be compressed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The confirmation window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to cache large messages.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The min large message size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The dups ok batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The transaction batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on non durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The autogroup.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to pre-acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval multiplier.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The max retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The reconnect attempts. By default, a pooled connection factory will try to reconnect infinitely to the messaging server(s).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to fail over on initial connection.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
              <xs:annotation>
                 <xs:documentation>
@@ -982,20 +2318,62 @@
                 </xs:documentation>
              </xs:annotation>
          </xs:element>
-         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0" />
-         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0" />
-         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0" />
-         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use global pools.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The scheduled thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The group id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <!-- ============================================================= -->
          <!-- end of common elements                                        -->
       </xs:all>
-      <xs:attribute name="name" type="xs:string" />
+      <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the pooled connection factory.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
 
    <xs:complexType name="connector-refType">
-      <xs:attribute name="connector-name" type="xs:string" use="required" />
+      <xs:attribute name="connector-name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the connector.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="backup-connector-name" type="xs:string" use="optional">
           <xs:annotation>
               <xs:documentation>
@@ -1006,11 +2384,23 @@
    </xs:complexType>
 
    <xs:complexType name="entryType">
-      <xs:attribute name="name" type="xs:string" use="required" />
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JNDI entry.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:complexType name="discovery-group-refType">
-      <xs:attribute name="discovery-group-name" type="xs:string" use="required" />
+      <xs:attribute name="discovery-group-name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the discovery group.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:complexType name="jmsQueueType">
@@ -1018,19 +2408,43 @@
          <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
          <xs:element name="selector" maxOccurs="1" minOccurs="0">
             <xs:complexType>
-               <xs:attribute name="string" type="xs:string" use="required" />
+               <xs:attribute name="string" type="xs:string" use="required">
+                   <xs:annotation>
+                       <xs:documentation>
+                           The queue selector.
+                       </xs:documentation>
+                   </xs:annotation>
+               </xs:attribute>
             </xs:complexType>
          </xs:element>
-         <xs:element name="durable" type="xs:boolean" maxOccurs="1" minOccurs="0" />
+         <xs:element name="durable" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the queue is durable or not.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
       </xs:sequence>
-      <xs:attribute name="name" type="xs:string" use="required" />
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JMS queue.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:complexType name="jmsTopicType">
       <xs:sequence>
          <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
       </xs:sequence>
-      <xs:attribute name="name" type="xs:string" use="required" />
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JMS Topic.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
     <xs:complexType name="transactionType">
@@ -1041,17 +2455,23 @@
         <xs:restriction base="xs:token">
             <xs:enumeration value="xa">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>
+                        Use XA transaction.
+                    </xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="local">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>
+                        Use local transaction.
+                    </xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="none">
                 <xs:annotation>
-                    <xs:documentation></xs:documentation>
+                    <xs:documentation>
+                        Do not use transaction.
+                    </xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
         </xs:restriction>
@@ -1066,18 +2486,77 @@
          </xs:documentation>
       </xs:annotation>
       <xs:all>
-         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType" />
-         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType" />
-         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType" />
-         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long" />
-         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int" />
-         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int" />
-         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long" />
-
+         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The source of the JMS bridge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The destination of the JMS bridge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The desired quality of service mode (AT_MOST_ONCE, DUPLICATES_OK or ONCE_AND_ONLY_ONCE).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long">
+             <xs:annotation>
+                 <xs:documentation>
+                     The amount of time in milliseconds to wait between trying to recreate connections to the source or target servers when the bridge has detected they have failed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int">
+             <xs:annotation>
+                 <xs:documentation>
+                     The number of times to attempt to recreate connections to the source or target servers when the bridge has detected they have failed. The bridge will give up after trying this number of times. -1 represents 'try forever'.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum number of messages to consume from the source destination before sending them in a batch to the target destination. Its value must >= 1.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum number of milliseconds to wait before sending a batch to target, even if the number of messages consumed has not reached max-batch-size. Its value must be -1 to represent 'wait forever', or >= 1 to specify an actual time.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
          <xs:element maxOccurs="1" minOccurs="0" name="selector" type="selectorType" />
-         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string" />
-         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string" />
-         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean" />
+         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The name of the subscription if it is durable and the source destination is a topic.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The JMS client ID to use when creating/looking up the subscription if it is durable and the source destination is a topic.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean">
+             <xs:annotation>
+                 <xs:documentation>
+                     If true, then the original message's message ID will be appended in the message sent to the destination in the header HORNETQ_BRIDGE_MSG_ID_LIST. If the message is bridged more than once, each message ID will be appended.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
       </xs:all>
       <xs:attribute name="name" type="xs:string" use="optional" default="default">
          <xs:annotation>
@@ -1149,7 +2628,13 @@
    </xs:complexType>
 
    <xs:complexType name="selectorType">
-      <xs:attribute name="string" type="xs:string" use="required" />
+      <xs:attribute name="string" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  A message selector.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
    </xs:complexType>
 
    <xs:simpleType name="quality-of-serviceType">


### PR DESCRIPTION
- add documentation annotation to messaging 1.4 & 2.0 XSD

There are no structural changes to the schema. I've only added annotation elements to document the element and attributes (using the same description that is in the management model).

JIRA: https://issues.jboss.org/browse/WFLY-2922
