### PR TITLE
[WFLY-2954] Use TransactionSynchronizationRegistry in JMSContext

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/CDIDeploymentProcessor.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/CDIDeploymentProcessor.java
@@ -43,7 +43,6 @@ public class CDIDeploymentProcessor implements DeploymentUnitProcessor {
             WeldPortableExtensions extensions = WeldPortableExtensions.getPortableExtensions(parent);
             extensions.registerExtensionInstance(new JMSCDIExtension(), parent);
         }
-
     }
 
     public void undeploy(DeploymentUnit context) {


### PR DESCRIPTION
Register the sync object using the TransactionSynchronizationRegistry
instead of registering it directly on the Transaction.

JIRA: https://issues.jboss.org/browse/WFLY-2954
