### PR TITLE
[WFLY-2959] Downgrade Jackson2 to align with RESTEasy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <version.asm>3.3.1</version.asm>
         <version.ch.qos.cal10n>0.8.1</version.ch.qos.cal10n>
         <version.com.fasterxml.classmate>1.0.0</version.com.fasterxml.classmate>
-        <version.com.fasterxml.jackson>2.3.0</version.com.fasterxml.jackson>
+        <version.com.fasterxml.jackson>2.2.3</version.com.fasterxml.jackson>
         <version.com.github.relaxng>2011.1</version.com.github.relaxng>
         <version.com.google.guava>16.0.1</version.com.google.guava>
         <version.com.h2database>1.3.173</version.com.h2database>


### PR DESCRIPTION
There is more information on the JIRA https://issues.jboss.org/browse/WFLY-2959.
