### PR TITLE
[WFLY-2963] Overrid messaging connector's host property

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -194,7 +194,10 @@ class HornetQService implements Service<HornetQServer> {
                                 host = binding.getDestinationAddress().getHostAddress();
                             }
                         }
-                        tc.getParams().put(HOST, host);
+                        // [WFLY-2963] use the resolved host only if the HOST parameter is not already set
+                        if (!tc.getParams().containsKey(HOST)) {
+                            tc.getParams().put(HOST, host);
+                        }
                         tc.getParams().put(PORT, String.valueOf(port));
                     }
                 }


### PR DESCRIPTION
Use the host resolved from the socket-binding address only if the HOST
parameter is already set).
This allows the user to configure the HOST property to override it.

JIRA: https://issues.jboss.org/browse/WFLY-2963
