### PR TITLE
WFLY-2968 Allow configuration of default IOR settings in the subsystem

### DIFF
--- a/build/src/main/resources/configuration/subsystems/jacorb.xml
+++ b/build/src/main/resources/configuration/subsystems/jacorb.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
    <extension-module>org.jboss.as.jacorb</extension-module>
-   <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+   <subsystem xmlns="urn:jboss:domain:jacorb:1.4">
        <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
            <initializers transactions="spec" security="identity"/>
        </orb>

--- a/build/src/main/resources/docs/schema/jboss-as-jacorb_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-jacorb_1_4.xsd
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:jacorb:1.4"
+           xmlns="urn:jboss:domain:jacorb:1.4"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.4">
+
+    <!-- The jacorb subsystem root element -->
+    <xs:element name="subsystem" type="jacorbSubsystemType"/>
+
+    <xs:complexType name="jacorbSubsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The jacorbSubsystemType specifies the elements that can be used to configure the various aspects of the
+                jacorb subsystem.
+
+                - orb: holds the attributes used to configure the Object Request Broker (ORB).
+                - poa: holds the attributes used to configure the Portable Object Adapters (POA).
+                - naming: holds the attributes used to configure the CORBA Naming Service.
+                - interop: holds the attributes that control the ORB interoperability features.
+                - security: holds the attributes that control the ORB security features.
+                - properties: allows for the specification of generic name/value properties.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="orb" minOccurs="0" maxOccurs="1" type="orbConfigType"/>
+            <xs:element name="poa" minOccurs="0" maxOccurs="1" type="poaConfigType"/>
+            <xs:element name="naming" minOccurs="0" maxOccurs="1" type="namingConfigType"/>
+            <xs:element name="interop" minOccurs="0" maxOccurs="1" type="interopConfigType"/>
+            <xs:element name="security" minOccurs="0" maxOccurs="1" type="securityConfigType"/>
+            <xs:element name="properties" minOccurs="0" maxOccurs="1" type="genericPropertiesType"/>
+            <xs:element name="ior-settings" minOccurs="0" maxOccurs="1" type="iorSettingsType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="orbConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                the orbConfigType specifies the elements and attributes that can be used to configure the behavior of the
+                Object Request Broker (ORB).
+
+                - connection: this element allows for the configuration of the connection properties.
+                - naming: this element allows for the configuration of the naming initial reference.
+
+                * name: the name of the running ORB.
+                * print-version: indicates whether the version number should be printed during ORB startup (on) or not (off).
+                * use-imr: indicates whether the implementation repository should be used (on) or not (off).
+                * use-bom: indicates whether GIOP 1.2 byte order markers should be used (on) or not (off).
+                * cache-typecodes: indicates whether typecodes should be cached (on) or not (off).
+                * cache-poa-names: indicates whether POA names should be cached (on) or not (off).
+                * giop-minor-version: the GIOP minor version to be used.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="connection" minOccurs="0" maxOccurs="1" type="orbConnectionConfigType"/>
+            <xs:element name="initializers" minOccurs="0" maxOccurs="1" type="orbInitializersConfigType"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="optional" default="JBoss"/>
+        <xs:attribute name="print-version" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="use-imr" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="use-bom" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="cache-typecodes" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="cache-poa-names" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="giop-minor-version" type="xs:integer" use="optional" default="2"/>
+        <xs:attribute name="socket-binding" type="xs:string" use="optional" default="jacorb"/>
+        <xs:attribute name="ssl-socket-binding" type="xs:string" use="optional" default="jacorb-ssl"/>
+    </xs:complexType>
+
+    <xs:complexType name="orbConnectionConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The orbConnectionConfigType specifies the attributes used to configure the ORB connections.
+
+                * retries: the number of retries if connections cannot be promptly established.
+                * retry-interval: the interval in milliseconds between retries.
+                * client-timeout: the client-side connection timeout value in milliseconds. A value of zero indicates that
+                                  the connection never times out.
+                * server-timeout: the server-side connection timeout value in milliseconds. A value of zero indicates that
+                                  the connection never times out.
+                * max-server-connections: the maximum number of connections accepted by the server.
+                * max-managed-buf-size: the log2 of maximum size managed by the internal buffer manager.
+                * outbuf-size: the size of the network buffers for outgoing messages.
+                * outbuf-cache-timeout: the buffer cache timeout in milliseconds.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="retries" type="xs:integer" use="optional" default="5"/>
+        <xs:attribute name="retry-interval" type="xs:integer" use="optional" default="500"/>
+        <xs:attribute name="client-timeout" type="xs:integer" use="optional" default="0"/>
+        <xs:attribute name="server-timeout" type="xs:integer" use="optional" default="0"/>
+        <xs:attribute name="max-server-connections" type="xs:integer" use="optional"/>
+        <xs:attribute name="max-managed-buf-size" type="xs:integer" use="optional" default="24"/>
+        <xs:attribute name="outbuf-size" type="xs:integer" use="optional" default="2048"/>
+        <xs:attribute name="outbuf-cache-timeout" type="xs:integer" use="optional" default="-1"/>
+    </xs:complexType>
+
+    <xs:complexType name="orbInitializersConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The orbInitializersConfigType specifies the attributes used to configure the ORB initializers.
+
+                * security: indicates whether the security (SAS and CSIv2) initializers should be installed. There are three possibilities:
+                    client   - The client interceptor will be installed. Remote calls from this server will propagate
+                               by sending the current username and password
+                    identity - The server will just send the current username. The recieving server must trust this
+                               server.
+                    off      - Security interceptors are not installed
+                * transactions: indicates which transaction initializers should be installed. There are three possibilities:
+                    on   - This requires JTS to be enabled in the transactions subsystem config, and will enable full transaction
+                           interaoprability with other JBoss AS instances.
+                    spec - This does not require JTS to be enabled, but will install the minimum set of transaction interceptors
+                           required for EJB spec compliance. These interceptors detect an incoming transaction and throw an
+                           exception if the invocation should be run in the incoming transaction context.
+                    off  - No transaction initalizers will be installed.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="security" type="securityEnabledType" use="optional" default="off"/>
+        <xs:attribute name="transactions" type="transactionEnabledType" use="optional" default="off"/>
+    </xs:complexType>
+
+    <xs:complexType name="poaConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The poaConfigType specifies the elements and attributes used to configure the Portable Object Adapterss (POA).
+
+                - request-processors: element that allows for the configuration of the POA request processors.
+
+                * monitoring: indicates whether the monitoring GUI should be displayed (on) or not (off).
+                * queue-wait: indicates whether requests that exceed the maximum queue size should wait (on) or not (off).
+                              When disabled, a TRANSIENT exception is thrown if the queue is full.
+                * queue-min: the size of the queue for notifying waiting requests. In other words, blocked requests are
+                             only notified when the queue has no more than queue-min requests.
+                * queue-max: the maximum number of requests that can be queued. If new requests arrive and queue-wait is
+                             on, the exceeding requests will be blocked until the queue reaches its minimum value.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="request-processors" minOccurs="0" maxOccurs="1" type="poaRequestProcessorsConfigType"/>
+        </xs:sequence>
+        <xs:attribute name="monitoring" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="queue-wait" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="queue-min" type="xs:integer" use="optional" default="10"/>
+        <xs:attribute name="queue-max" type="xs:integer" use="optional" default="100"/>
+    </xs:complexType>
+
+    <xs:complexType name="poaRequestProcessorsConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The poaRequestProcessorsConfigType specifies the attributes used to configure the POA request processors.
+
+                * pool-size: the size of the request processors thread-pool. Threads that finish processing a request are
+                             placed back in the pool if the pool is not full and discarded otherwise.
+                * max-threads: the maximum number of active request processor threads. Threads are first obtained from
+                               the pool and once the pool is exhausted new threads are created until the number of threads
+                               reaches this limit. New requests will wait until an active thread finishes its job.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pool-size" type="xs:integer" use="optional" default="5"/>
+        <xs:attribute name="max-threads" type="xs:integer" use="optional" default="32"/>
+    </xs:complexType>
+
+    <xs:complexType name="namingConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The namingConfigType specifies the attributes used to configure the naming service.
+
+                * root-context: the naming service root context.
+                * export-corbaloc: indicates whether the root context should be exported as corbaloc::address:port/NameService
+                                   (on) or not (off).
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="root-context" type="xs:string" use="optional" default="JBoss/Naming/root"/>
+        <xs:attribute name="export-corbaloc" type="onOffType" use="optional" default="on"/>
+    </xs:complexType>
+
+    <xs:complexType name="interopConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The interopConfigType specifies the attributes used to configure the ORB interoperability features.
+
+                * sun: indicates whether interoperability with Sun's ORB is enabled (on) or not (off).
+                * comet: indicates whether interoperability with Comet's ORB is enabled (on) or not (off).
+                * iona: indicates whether interoperability with IONA's ASP is enabled (on) or not (off).
+                * chunk-custom-rmi-valuetypes: indicates whether custom RMI valuetypes should be encoded as chunks (on)
+                                               or not (off).
+                * lax-boolean-encoding: indicates whether any non-zero CDR encoded boolean value should be interpreted as
+                                        true (on) or not (off).
+                * indirection-encoding-disabled: indicates whether indirection encoding for repeated typecodes should be
+                                                 disabled (on) or not (off).
+                * strict-check-on-tc-creation: indicates whether the method create_abstract_interface_tc should perform
+                                               a validation check on the name parameter (on) or not (off).
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="sun" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="comet" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="iona" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="chunk-custom-rmi-valuetypes" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="lax-boolean-encoding" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="indirection-encoding-disable" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="strict-check-on-tc-creation" type="onOffType" use="optional" default="off"/>
+    </xs:complexType>
+
+    <xs:complexType name="securityConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The securityConfigType specifies the attributes used to configure the ORB security features.
+
+                * support-ssl: indicates whether SSL is to be supported (on) or not (off).
+                * security-domain: the name of the security domain that holds the key and trust stores that will be used
+                                   to establish SSL connections.
+                * add-component-via-interceptor: indicates whether SSL components should be added by an IOR interceptor
+                                                 (on) or not (off).
+                * client-supports: value that indicates the client SSL supported parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * client-requires: value that indicates the client SSL required parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * server-supports: value that indicates the server SSL supported parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                * server-requires: value that indicates the server SSL required parameters (None, ServerAuth, ClientAuth.
+                                   MutualAuth)
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="support-ssl" type="onOffType" use="optional" default="off"/>
+        <xs:attribute name="security-domain" type="xs:string" use="optional"/>
+        <xs:attribute name="add-component-via-interceptor" type="onOffType" use="optional" default="on"/>
+        <xs:attribute name="client-supports" type="sslConfigType" use="optional" default="MutualAuth"/>
+        <xs:attribute name="client-requires" type="sslConfigType" use="optional" default="None"/>
+        <xs:attribute name="server-supports" type="sslConfigType" use="optional" default="MutualAuth"/>
+        <xs:attribute name="server-requires" type="sslConfigType" use="optional" default="None"/>
+    </xs:complexType>
+
+    <xs:complexType name="iorSettingsType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iorSettingsType specifies the elements that can be used to configure settings that are to be applied
+                to all generated IORs.
+
+                - transport-config: holds the attributes used to configure the IOR transport settings.
+                - as-context: holds the attributes used to configure the IOR Authentication Service (AS) settings.
+                - sas-context: holds the attributes used to configure the IOR Secure Attribute Service (SAS) settings.
+                        ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="transport-config" minOccurs="0" maxOccurs="1" type="iorTransportConfigType"/>
+            <xs:element name="as-context" minOccurs="0" maxOccurs="1" type="iorASContextType"/>
+            <xs:element name="sas-context" minOccurs="0" maxOccurs="1" type="iorSASContextType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="iorTransportConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iorTransportconfigType specifies the attributes used to setup the IOR transport settings.
+
+                * integrity: indicates whether the transport must require integrity protection or not. Valid values are
+                             "none", "supported" and "required".
+                * confidentiality: indicates whether the transport must require confidentiality protection or not. Valid
+                             values are "none", "supported" and "required".
+                * trust-in-target: indicates if the transport must require trust in target to be established. Valid values
+                             are "none" and "supported".
+                * trust-in-client: indicates if the transport must require trust in client to be established. Valid values
+                             are "none", "supported" and "required".
+                * detect-replay: indicates whether the transport must require replay detection or not. Valid values are
+                             "none", "supported" and "required".
+                * detect-misordering: indicates whether the transport must require misordering detection or not. Valid
+                             values are "none", "supported" and "required".
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="integrity" type="xs:string" use="optional"/>
+        <xs:attribute name="confidentiality" type="xs:string" use="optional"/>
+        <xs:attribute name="trust-in-target" type="xs:string" use="optional"/>
+        <xs:attribute name="trust-in-client" type="xs:string" use="optional"/>
+        <xs:attribute name="detect-replay" type="xs:string" use="optional"/>
+        <xs:attribute name="detect-misordering" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="iorASContextType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iorASContextType specifies the attributes used to setup the IOR Authentication Service settings.
+
+                * auth-method: the authentication method. Valid values are "none" and "username_password".
+                * realm: the Authentication Service realm name. If not provided it will be set to "Default".
+                * requires: indicates if authentication is required (true) or not (false).
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="auth-method" type="xs:string" use="optional"/>
+        <xs:attribute name="realm" type="xs:string" use="optional"/>
+        <xs:attribute name="required" type="xs:boolean" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="iorSASContextType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The iorSASContextType specifies the attributes used to setup the IOR Secure Attribute Service settings.
+
+                * caller-propagation: indicates whether the caller should be propagated in the SAS context or not. Valid
+                                      values are "none" and "supported".
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="caller-propagation" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="genericPropertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+               Enclosing element for a list of generic properties.
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="property" minOccurs="0" maxOccurs="unbounded" type="genericPropertyType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="genericPropertyType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+               The property element allows for the specification of generic name/value properties. It is useful to specify
+               configuration attributes that have not been covered in this schema.
+             ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="value" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:simpleType name="onOffType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                    Enumeration of allowed values for the standard JacORB attributes.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="transactionEnabledType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the transaction interceptor config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="on"/>
+            <xs:enumeration value="off"/>
+            <xs:enumeration value="spec"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="securityEnabledType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the security interceptor config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="identity"/>
+            <xs:enumeration value="client"/>
+            <xs:enumeration value="off"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <xs:simpleType name="sslConfigType">
+        <xs:annotation>
+            <xs:documentation>
+                Enumeration of allowed values for the SSL config.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="None"/>
+            <xs:enumeration value="ServerAuth"/>
+            <xs:enumeration value="ClientAuth"/>
+            <xs:enumeration value="MutualAuth"/>
+        </xs:restriction>
+    </xs:simpleType>
+
+</xs:schema>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
@@ -56,6 +56,7 @@ import org.jboss.as.jacorb.rmi.marshal.strategy.SkeletonStrategy;
 import org.jboss.as.jacorb.service.CorbaNamingService;
 import org.jboss.as.jacorb.service.CorbaORBService;
 import org.jboss.as.jacorb.service.CorbaPOAService;
+import org.jboss.as.jacorb.service.IORSecConfigMetaDataService;
 import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -68,6 +69,7 @@ import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
 import org.jboss.as.server.moduleservice.ServiceModuleLoader;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.metadata.ejb.jboss.IIOPMetaData;
+import org.jboss.metadata.ejb.jboss.IORSecurityConfigMetaData;
 import org.jboss.metadata.ejb.spec.EjbJarMetaData;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceBuilder;
@@ -255,6 +257,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
         builder.addDependency(POARegistry.SERVICE_NAME, POARegistry.class, service.getPoaRegistry());
         builder.addDependency(CorbaPOAService.INTERFACE_REPOSITORY_SERVICE_NAME, POA.class, service.getIrPoa());
         builder.addDependency(CorbaNamingService.SERVICE_NAME, NamingContextExt.class, service.getCorbaNamingContext());
+        builder.addDependency(IORSecConfigMetaDataService.SERVICE_NAME, IORSecurityConfigMetaData.class, service.getIORSecConfigMetaDataInjectedValue());
         builder.addDependency(Services.JBOSS_SERVICE_MODULE_LOADER, ServiceModuleLoader.class, service.getServiceModuleLoaderInjectedValue());
 
         //we need the arjunta transaction manager to be up, as it performs some initialization that is required by the orb interceptors

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPService.java
@@ -209,6 +209,11 @@ public class EjbIIOPService implements Service<EjbIIOPService> {
     private final InjectedValue<POA> irPoa = new InjectedValue<POA>();
 
     /**
+     * Default IOR security config metadata (defined in the jacorb subsystem).
+     */
+    private final InjectedValue<IORSecurityConfigMetaData> iorSecConfigMetaData = new InjectedValue<IORSecurityConfigMetaData>();
+
+    /**
      * The IIOP metadata, configured in the assembly descriptor.
      */
     private IIOPMetaData iiopMetaData;
@@ -273,8 +278,8 @@ public class EjbIIOPService implements Service<EjbIIOPService> {
                 EjbLogger.ROOT_LOGGER.cobraInterfaceRepository(name, orb.object_to_string(iri.getReference()));
             }
 
-            IORSecurityConfigMetaData iorSecurityConfigMetaData = null;
-            if (this.iiopMetaData != null)
+            IORSecurityConfigMetaData iorSecurityConfigMetaData = this.iorSecConfigMetaData.getOptionalValue();
+            if (this.iiopMetaData != null && this.iiopMetaData.getIorSecurityConfigMetaData() != null)
                 iorSecurityConfigMetaData = this.iiopMetaData.getIorSecurityConfigMetaData();
 
             // Create security policies if security metadata has been provided.
@@ -568,5 +573,9 @@ public class EjbIIOPService implements Service<EjbIIOPService> {
 
     public InjectedValue<ServiceModuleLoader> getServiceModuleLoaderInjectedValue() {
         return serviceModuleLoaderInjectedValue;
+    }
+
+    public InjectedValue<IORSecurityConfigMetaData> getIORSecConfigMetaDataInjectedValue() {
+        return iorSecConfigMetaData;
     }
 }

--- a/jacorb/src/main/java/org/jboss/as/jacorb/IORASContextDefinition.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/IORASContextDefinition.java
@@ -1,0 +1,140 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jacorb;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
+import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.metadata.ejb.jboss.IORASContextMetaData;
+
+/**
+ * <p>
+ * Defines a resource that encompasses the attributes used to configure the authentication service (AS) settings in
+ * generated IORs.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class IORASContextDefinition extends PersistentResourceDefinition {
+
+    static final AttributeDefinition AUTH_METHOD =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_AS_CONTEXT_AUTH_METHOD, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode(AuthMethodValues.USERNAME_PASSWORD.toString()))
+                    .setValidator(new EnumValidator<AuthMethodValues>(AuthMethodValues.class, true, true))
+                    .setAllowExpression(true)
+                    .build();
+
+    static final AttributeDefinition REALM =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_AS_CONTEXT_REALM, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setAccessConstraints(SensitiveTargetAccessConstraintDefinition.SECURITY_REALM_REF)
+                    .setAllowExpression(true)
+                    .build();
+
+    static final AttributeDefinition REQUIRED =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_AS_CONTEXT_REQUIRED, ModelType.BOOLEAN, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode(false))
+                    .setAllowExpression(true)
+                    .build();
+
+    static final Collection<AttributeDefinition> ATTRIBUTES = Arrays.asList(AUTH_METHOD, REALM, REQUIRED);
+
+    static final IORASContextDefinition INSTANCE = new IORASContextDefinition();
+
+    private IORASContextDefinition() {
+        super(PathElement.pathElement(JacORBSubsystemConstants.SETTING, JacORBSubsystemConstants.IOR_AS_CONTEXT),
+                JacORBExtension.getResourceDescriptionResolver(JacORBSubsystemConstants.IOR_SETTINGS,
+                        JacORBSubsystemConstants.IOR_AS_CONTEXT),
+                new AbstractAddStepHandler(ATTRIBUTES),
+                ReloadRequiredRemoveStepHandler.INSTANCE);
+    }
+
+    @Override
+    public List<AccessConstraintDefinition> getAccessConstraints() {
+        return Collections.singletonList((AccessConstraintDefinition)JacORBSubsystemDefinitions.JACORB_SECURITY_DEF);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return ATTRIBUTES;
+    }
+
+    private enum AuthMethodValues {
+
+        NONE("none"), USERNAME_PASSWORD("username_password");
+
+        private String name;
+
+        AuthMethodValues(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    /**
+     * <p>
+     * Builds a {@code IORASContextMetaData} using the specified {@code OperationContext} and {@code ModelNode}.
+     * </p>
+     *
+     * @param context a reference to the {@code OperationContext}.
+     * @param model a {@code ModelNode} containing the configured authentication service (AS) metadata.
+     * @return the constructed {@code IORASContextMetaData} or {@code null} if the specified model is undefined.
+     * @throws OperationFailedException if an error occurs while creating the transport metadata,
+     */
+    protected IORASContextMetaData getIORASContextMetaData(final OperationContext context, final ModelNode model)
+            throws OperationFailedException {
+
+        if (!model.isDefined())
+            return null;
+
+        IORASContextMetaData metaData = new IORASContextMetaData();
+        metaData.setAuthMethod(AUTH_METHOD.resolveModelAttribute(context, model).asString());
+        if (model.hasDefined(REALM.getName())) {
+            metaData.setRealm(REALM.resolveModelAttribute(context, model).asString());
+        }
+        metaData.setRequired(REQUIRED.resolveModelAttribute(context, model).asBoolean());
+        return metaData;
+    }
+}

--- a/jacorb/src/main/java/org/jboss/as/jacorb/IORSASContextDefinition.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/IORSASContextDefinition.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jacorb;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.metadata.ejb.jboss.IORSASContextMetaData;
+
+/**
+ * <p>
+ * Defines a resource that encompasses the attributes used to configure the secure attribute service (SAS) settings in
+ * generated IORs.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class IORSASContextDefinition extends PersistentResourceDefinition {
+
+    static final AttributeDefinition CALLER_PROPAGATION =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_SAS_CONTEXT_CALLER_PROPAGATION, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode(CallerPropagationValues.NONE.toString()))
+                    .setValidator(new EnumValidator<CallerPropagationValues>(CallerPropagationValues.class, true, true))
+                    .setAllowExpression(true)
+                    .build();
+
+    static final Collection<AttributeDefinition> ATTRIBUTES = Arrays.asList(CALLER_PROPAGATION);
+
+    static final IORSASContextDefinition INSTANCE = new IORSASContextDefinition();
+
+    private IORSASContextDefinition() {
+        super(PathElement.pathElement(JacORBSubsystemConstants.SETTING, JacORBSubsystemConstants.IOR_SAS_CONTEXT),
+                JacORBExtension.getResourceDescriptionResolver(JacORBSubsystemConstants.IOR_SETTINGS,
+                        JacORBSubsystemConstants.IOR_SAS_CONTEXT),
+                new AbstractAddStepHandler(ATTRIBUTES),
+                ReloadRequiredRemoveStepHandler.INSTANCE);
+    }
+
+    @Override
+    public List<AccessConstraintDefinition> getAccessConstraints() {
+        return Collections.singletonList((AccessConstraintDefinition) JacORBSubsystemDefinitions.JACORB_SECURITY_DEF);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return ATTRIBUTES;
+    }
+
+    private enum CallerPropagationValues {
+
+        NONE("none"), SUPPORTED("supported");
+
+        private String name;
+
+        CallerPropagationValues(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    /**
+     * <p>
+     * Builds a {@code IORSASContextMetaData} using the specified {@code OperationContext} and {@code ModelNode}.
+     * </p>
+     *
+     * @param context a reference to the {@code OperationContext}.
+     * @param model a {@code ModelNode} containing the configured secure attribute service (SAS) metadata.
+     * @return the constructed {@code IORSASContextMetaData} or {@code null} if the specified model is undefined.
+     * @throws OperationFailedException if an error occurs while creating the transport metadata,
+     */
+    protected IORSASContextMetaData getIORSASContextMetaData(final OperationContext context, final ModelNode model)
+            throws OperationFailedException {
+
+        if (!model.isDefined())
+            return null;
+
+        IORSASContextMetaData metaData = new IORSASContextMetaData();
+        metaData.setCallerPropagation(CALLER_PROPAGATION.resolveModelAttribute(context, model).asString());
+        return metaData;
+    }
+}

--- a/jacorb/src/main/java/org/jboss/as/jacorb/IORSettingsDefinition.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/IORSettingsDefinition.java
@@ -1,0 +1,44 @@
+package org.jboss.as.jacorb;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+
+/**
+ * <p>
+ * Defines a resource that encompasses all the settings that are to be applied when generating IORs.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+class IORSettingsDefinition extends PersistentResourceDefinition {
+
+    static final IORSettingsDefinition INSTANCE = new IORSettingsDefinition();
+
+    private static final List<PersistentResourceDefinition> CHILDREN = Collections.unmodifiableList(
+            Arrays.asList(IORTransportConfigDefinition.INSTANCE, IORASContextDefinition.INSTANCE,
+                    IORSASContextDefinition.INSTANCE));
+
+    private IORSettingsDefinition() {
+        super(PathElement.pathElement(JacORBSubsystemConstants.IOR_SETTINGS, JacORBSubsystemConstants.DEFAULT),
+                JacORBExtension.getResourceDescriptionResolver(JacORBSubsystemConstants.IOR_SETTINGS),
+                new AbstractAddStepHandler(), ReloadRequiredRemoveStepHandler.INSTANCE);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    protected List<? extends PersistentResourceDefinition> getChildren() {
+        return CHILDREN;
+    }
+}

--- a/jacorb/src/main/java/org/jboss/as/jacorb/IORSettingsParser.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/IORSettingsParser.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jacorb;
+
+import java.util.List;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * <p>
+ * This class implements a parser for the {@code IORSettingsDefinition} resource.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+class IORSettingsParser implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<ModelNode> {
+
+    static final IORSettingsParser INSTANCE = new IORSettingsParser();
+
+    static final PersistentResourceXMLDescription xmlDescription = builder(IORSettingsDefinition.INSTANCE)
+                .setXmlElementName(JacORBSubsystemConstants.IOR_SETTINGS)
+                .addChild(builder(IORTransportConfigDefinition.INSTANCE)
+                        .addAttribute(IORTransportConfigDefinition.INTEGRITY)
+                        .addAttribute(IORTransportConfigDefinition.CONFIDENTIALITY)
+                        .addAttribute(IORTransportConfigDefinition.TRUST_IN_CLIENT)
+                        .addAttribute(IORTransportConfigDefinition.TRUST_IN_TARGET)
+                        .addAttribute(IORTransportConfigDefinition.DETECT_REPLAY)
+                        .addAttribute(IORTransportConfigDefinition.DETECT_MISORDERING)
+                )
+                .addChild(builder(IORASContextDefinition.INSTANCE)
+                        .addAttribute(IORASContextDefinition.AUTH_METHOD)
+                        .addAttribute(IORASContextDefinition.REALM)
+                        .addAttribute(IORASContextDefinition.REQUIRED)
+                )
+                .addChild(builder(IORSASContextDefinition.INSTANCE)
+                        .addAttribute(IORSASContextDefinition.CALLER_PROPAGATION)
+                )
+                .build();
+
+    private IORSettingsParser() {
+    }
+
+    @Override
+    public void readElement(final XMLExtendedStreamReader xmlExtendedStreamReader, final List<ModelNode> modelNodes) throws XMLStreamException {
+        xmlDescription.parse(xmlExtendedStreamReader, PathAddress.pathAddress(JacORBSubsystemResource.INSTANCE.getPathElement()), modelNodes);
+    }
+
+    @Override
+    public void writeContent(final XMLExtendedStreamWriter xmlExtendedStreamWriter, final ModelNode modelNode) throws XMLStreamException {
+        ModelNode model = new ModelNode();
+        model.get(IORSettingsDefinition.INSTANCE.getPathElement().getKeyValuePair()).set(modelNode);
+        xmlDescription.persist(xmlExtendedStreamWriter, model);
+    }
+}

--- a/jacorb/src/main/java/org/jboss/as/jacorb/IORTransportConfigDefinition.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/IORTransportConfigDefinition.java
@@ -1,0 +1,174 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jacorb;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PersistentResourceDefinition;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.access.management.AccessConstraintDefinition;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.metadata.ejb.jboss.IORTransportConfigMetaData;
+
+/**
+ * <p>
+ * Defines a resource that encompasses the attributes used to configure the transport settings in generated IORs.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+class IORTransportConfigDefinition extends PersistentResourceDefinition {
+
+    static final ParameterValidator VALIDATOR = new EnumValidator<IORTransportConfigValues>(
+            IORTransportConfigValues.class, true, true);
+
+    static final ModelNode DEFAULT_VALUE = new ModelNode(IORTransportConfigValues.NONE.toString());
+
+    static final AttributeDefinition INTEGRITY =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_INTEGRITY, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(DEFAULT_VALUE)
+                    .setValidator(VALIDATOR)
+                    .setAllowExpression(true)
+                    .build();
+
+    static final AttributeDefinition CONFIDENTIALITY =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_CONFIDENTIALITY, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(DEFAULT_VALUE)
+                    .setValidator(VALIDATOR)
+                    .setAllowExpression(true)
+                    .build();
+
+    static final AttributeDefinition TRUST_IN_TARGET =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_TRUST_IN_TARGET, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(DEFAULT_VALUE)
+                    .setValidator(new EnumValidator<IORTransportConfigValues>(IORTransportConfigValues.class, true, true,
+                            IORTransportConfigValues.NONE, IORTransportConfigValues.SUPPORTED))
+                    .setAllowExpression(true)
+                    .build();
+
+    static final AttributeDefinition TRUST_IN_CLIENT =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_TRUST_IN_CLIENT, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(DEFAULT_VALUE)
+                    .setValidator(VALIDATOR)
+                    .setAllowExpression(true)
+                    .build();
+
+    static final AttributeDefinition DETECT_REPLAY =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_DETECT_REPLAY, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(DEFAULT_VALUE)
+                    .setValidator(VALIDATOR)
+                    .setAllowExpression(true)
+                    .build();
+
+    static final SimpleAttributeDefinition DETECT_MISORDERING =
+            new SimpleAttributeDefinitionBuilder(JacORBSubsystemConstants.IOR_TRANSPORT_DETECT_MISORDERING, ModelType.STRING, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(DEFAULT_VALUE)
+                    .setValidator(VALIDATOR)
+                    .setAllowExpression(true)
+                    .build();
+
+    static final Collection<AttributeDefinition> ATTRIBUTES = Arrays.asList(INTEGRITY, CONFIDENTIALITY, TRUST_IN_TARGET,
+            TRUST_IN_CLIENT, DETECT_REPLAY, DETECT_MISORDERING);
+
+    static final IORTransportConfigDefinition INSTANCE = new IORTransportConfigDefinition();
+
+    private IORTransportConfigDefinition() {
+        super(PathElement.pathElement(JacORBSubsystemConstants.SETTING, JacORBSubsystemConstants.IOR_TRANSPORT_CONFIG),
+                JacORBExtension.getResourceDescriptionResolver(JacORBSubsystemConstants.IOR_SETTINGS,
+                        JacORBSubsystemConstants.IOR_TRANSPORT_CONFIG),
+                new AbstractAddStepHandler(ATTRIBUTES),
+                ReloadRequiredRemoveStepHandler.INSTANCE);
+    }
+
+    @Override
+    public List<AccessConstraintDefinition> getAccessConstraints() {
+        return Collections.singletonList((AccessConstraintDefinition) JacORBSubsystemDefinitions.JACORB_SECURITY_DEF);
+    }
+
+    @Override
+    public Collection<AttributeDefinition> getAttributes() {
+        return ATTRIBUTES;
+    }
+
+    private enum IORTransportConfigValues {
+
+        NONE("none"), SUPPORTED("supported"), REQUIRED("required");
+
+        private String name;
+
+        IORTransportConfigValues(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return this.name;
+        }
+    }
+
+    /**
+     * <p>
+     * Builds a {@code IORTransportConfigMetaData} using the specified {@code OperationContext} and {@code ModelNode}.
+     * </p>
+     *
+     * @param context a reference to the {@code OperationContext}.
+     * @param model a {@code ModelNode} containing the configured transport metadata.
+     * @return the constructed {@code IORTransportConfigMetaData} or {@code null} if the specified model is undefined.
+     * @throws OperationFailedException if an error occurs while creating the transport metadata,
+     */
+    protected IORTransportConfigMetaData getTransportConfigMetaData(final OperationContext context, final ModelNode model)
+            throws OperationFailedException {
+
+        if (!model.isDefined())
+            return null;
+
+        IORTransportConfigMetaData metaData = new IORTransportConfigMetaData();
+        metaData.setIntegrity(INTEGRITY.resolveModelAttribute(context, model).asString());
+        metaData.setConfidentiality(CONFIDENTIALITY.resolveModelAttribute(context, model).asString());
+        metaData.setEstablishTrustInTarget(TRUST_IN_TARGET.resolveModelAttribute(context, model).asString());
+        metaData.setEstablishTrustInClient(TRUST_IN_CLIENT.resolveModelAttribute(context, model).asString());
+        metaData.setDetectMisordering(DETECT_MISORDERING.resolveModelAttribute(context, model).asString());
+        metaData.setDetectReplay(DETECT_REPLAY.resolveModelAttribute(context, model).asString());
+        return metaData;
+    }
+}

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemConstants.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemConstants.java
@@ -99,6 +99,23 @@ public final class JacORBSubsystemConstants {
     public static final String PROPERTY_KEY = "key";
     public static final String PROPERTY_VALUE = "value";
 
+    public static final String SETTING = "setting";
+    public static final String DEFAULT = "default";
+    public static final String IOR_SETTINGS = "ior-settings";
+    public static final String IOR_TRANSPORT_CONFIG = "transport-config";
+    public static final String IOR_TRANSPORT_INTEGRITY = "integrity";
+    public static final String IOR_TRANSPORT_CONFIDENTIALITY = "confidentiality";
+    public static final String IOR_TRANSPORT_TRUST_IN_TARGET = "trust-in-target";
+    public static final String IOR_TRANSPORT_TRUST_IN_CLIENT = "trust-in-client";
+    public static final String IOR_TRANSPORT_DETECT_REPLAY = "detect-replay";
+    public static final String IOR_TRANSPORT_DETECT_MISORDERING = "detect-misordering";
+    public static final String IOR_AS_CONTEXT = "as-context";
+    public static final String IOR_AS_CONTEXT_AUTH_METHOD = "auth-method";
+    public static final String IOR_AS_CONTEXT_REALM = "realm";
+    public static final String IOR_AS_CONTEXT_REQUIRED = "required";
+    public static final String IOR_SAS_CONTEXT = "sas-context";
+    public static final String IOR_SAS_CONTEXT_CALLER_PROPAGATION = "caller-propagation";
+
     // constants for common org.omg properties.
     public static final String ORB_ADDRESS = "OAIAddr";
     public static final String ORB_PORT = "OAPort";

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemParser.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemParser.java
@@ -81,6 +81,7 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
         final ModelNode subsystem = new ModelNode();
         subsystem.get(OP).set(ADD);
         subsystem.get(OP_ADDR).add(SUBSYSTEM, JacORBExtension.SUBSYSTEM_NAME);
+        nodes.add(subsystem);
 
         Namespace readerNS = Namespace.forUri(reader.getNamespaceURI());
         switch (readerNS) {
@@ -91,15 +92,17 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
             case JacORB_1_1:
             case JacORB_1_2:
             case JacORB_1_3: {
-                this.readElement(readerNS, reader, subsystem);
+                this.readElement_1_1(readerNS, reader, subsystem);
+                break;
+            }
+            case JacORB_1_4: {
+                this.readElement_1_4(readerNS, reader, nodes);
                 break;
             }
             default: {
                 throw unexpectedElement(reader);
             }
         }
-
-        nodes.add(subsystem);
     }
 
     /**
@@ -170,7 +173,7 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
      * @throws javax.xml.stream.XMLStreamException
      *          if an error occurs while parsing the XML.
      */
-    private void readElement(Namespace namespace, XMLExtendedStreamReader reader, ModelNode node) throws XMLStreamException {
+    private void readElement_1_1(Namespace namespace, XMLExtendedStreamReader reader, ModelNode node) throws XMLStreamException {
         final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             // check the element namespace.
@@ -204,6 +207,54 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
                 }
                 case PROPERTIES: {
                     this.parsePropertiesConfig(namespace, reader, node);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
+    }
+
+    private void readElement_1_4(Namespace namespace, XMLExtendedStreamReader reader, List<ModelNode> nodes) throws XMLStreamException {
+        final EnumSet<Element> encountered = EnumSet.noneOf(Element.class);
+        while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+            // check the element namespace.
+            if (namespace != Namespace.forUri(reader.getNamespaceURI()))
+                throw unexpectedElement(reader);
+
+            final Element element = Element.forName(reader.getLocalName());
+            if (!encountered.add(element)) {
+                throw duplicateNamedElement(reader, element.getLocalName());
+            }
+            ModelNode node = nodes.get(0); // main subsystem node.
+            switch (element) {
+                case ORB: {
+                    this.parseORBConfig(namespace, reader, nodes.get(0));
+                    break;
+                }
+                case POA: {
+                    this.parsePOAConfig(namespace, reader, node);
+                    break;
+                }
+                case NAMING: {
+                    this.parseNamingConfig(reader, node);
+                    break;
+                }
+                case INTEROP: {
+                    this.parseInteropConfig(reader, node);
+                    break;
+                }
+                case SECURITY: {
+                    this.parseSecurityConfig(reader, node);
+                    break;
+                }
+                case PROPERTIES: {
+                    this.parsePropertiesConfig(namespace, reader, node);
+                    break;
+                }
+                case IOR_SETTINGS: {
+                    IORSettingsParser.INSTANCE.readElement(reader, nodes);
                     break;
                 }
                 default: {
@@ -731,6 +782,11 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
         if (node.hasDefined(properties)) {
             this.writeGenericProperties(writer, node.get(properties));
         }
+
+        if (node.hasDefined(JacORBSubsystemConstants.IOR_SETTINGS))
+            IORSettingsParser.INSTANCE.writeContent(writer, node.get(JacORBSubsystemConstants.IOR_SETTINGS,
+                    JacORBSubsystemConstants.DEFAULT));
+
         writer.writeEndElement(); // End of subsystem element
     }
 
@@ -931,9 +987,10 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
         JacORB_1_0("urn:jboss:domain:jacorb:1.0"),
         JacORB_1_1("urn:jboss:domain:jacorb:1.1"),
         JacORB_1_2("urn:jboss:domain:jacorb:1.2"),
-        JacORB_1_3("urn:jboss:domain:jacorb:1.3");
+        JacORB_1_3("urn:jboss:domain:jacorb:1.3"),
+        JacORB_1_4("urn:jboss:domain:jacorb:1.4");
 
-        static final Namespace CURRENT = JacORB_1_3;
+        static final Namespace CURRENT = JacORB_1_4;
 
         private final String namespaceURI;
 
@@ -1015,7 +1072,9 @@ public class JacORBSubsystemParser implements XMLStreamConstants, XMLElementRead
 
         // elements used to configure generic properties.
         PROPERTIES(JacORBSubsystemConstants.PROPERTIES),
-        PROPERTY(JacORBSubsystemConstants.PROPERTY);
+        PROPERTY(JacORBSubsystemConstants.PROPERTY),
+
+        IOR_SETTINGS(JacORBSubsystemConstants.IOR_SETTINGS);
 
         private final String name;
 

--- a/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemResource.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemResource.java
@@ -46,7 +46,7 @@ public class JacORBSubsystemResource extends SimpleResourceDefinition {
 
     private JacORBSubsystemResource() {
         super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JacORBExtension.SUBSYSTEM_NAME),
-                JacORBExtension.getResourceDescriptionResolver(JacORBExtension.SUBSYSTEM_NAME),
+                JacORBExtension.getResourceDescriptionResolver(),
                 JacORBSubsystemAdd.INSTANCE,
                 ReloadRequiredRemoveStepHandler.INSTANCE);
     }
@@ -58,6 +58,12 @@ public class JacORBSubsystemResource extends SimpleResourceDefinition {
         for (AttributeDefinition attr : JacORBSubsystemDefinitions.SUBSYSTEM_ATTRIBUTES) {
             registry.registerReadWriteAttribute(attr, null, attributeHander);
         }
+    }
+
+    @Override
+    public void registerChildren(final ManagementResourceRegistration resourceRegistration) {
+        super.registerChildren(resourceRegistration);
+        resourceRegistration.registerSubModel(IORSettingsDefinition.INSTANCE);
     }
 
     private static class JacorbReloadRequiredWriteAttributeHandler extends ReloadRequiredWriteAttributeHandler {

--- a/jacorb/src/main/java/org/jboss/as/jacorb/service/IORSecConfigMetaDataService.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/service/IORSecConfigMetaDataService.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.jacorb.service;
+
+import org.jboss.as.jacorb.JacORBLogger;
+import org.jboss.metadata.ejb.jboss.IORSecurityConfigMetaData;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * <p>
+ * Service that holds the configured {@code IORSecurityConfigMetaData}.
+ * </p>
+ *
+ * @author <a href="mailto:sguilhen@redhat.com">Stefan Guilhen</a>
+ */
+public class IORSecConfigMetaDataService implements Service<IORSecurityConfigMetaData> {
+
+    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("jacorb", "ior-security-config");
+
+    private IORSecurityConfigMetaData iorSecurityConfigMetaData;
+
+    public IORSecConfigMetaDataService(final IORSecurityConfigMetaData metaData) {
+        this.iorSecurityConfigMetaData = metaData;
+    }
+
+    @Override
+    public void start(final StartContext startContext) throws StartException {
+        JacORBLogger.ROOT_LOGGER.debugServiceStartup(startContext.getController().getName().getCanonicalName());
+    }
+
+    @Override
+    public void stop(final StopContext stopContext) {
+        JacORBLogger.ROOT_LOGGER.debugServiceStop(stopContext.getController().getName().getCanonicalName());
+    }
+
+    @Override
+    public IORSecurityConfigMetaData getValue() throws IllegalStateException, IllegalArgumentException {
+        return this.iorSecurityConfigMetaData;
+    }
+}

--- a/jacorb/src/main/resources/org/jboss/as/jacorb/LocalDescriptions.properties
+++ b/jacorb/src/main/resources/org/jboss/as/jacorb/LocalDescriptions.properties
@@ -61,3 +61,28 @@ jacorb.server-requires=Value that indicates the server SSL required parameters (
 
 # generic properties.
 jacorb.properties=A list of generic key/value properties.
+
+# IOR settings properties.
+jacorb.ior-settings=Settings that are to be applied to all generated IORs.
+jacorb.ior-settings.add=Adds the resource that contains the settings that are to be applied to all IORs.
+jacorb.ior-settings.remove=Removes the resource that contains the settings that are to be applied to all IORs.
+jacorb.ior-settings.setting=A set that groups common IOR settings (e.g. transport config settings).
+jacorb.ior-settings.transport-config=The transport config settings.
+jacorb.ior-settings.transport-config.add=Adds the transport config settings.
+jacorb.ior-settings.transport-config.remove=Removes the transport config settings.
+jacorb.ior-settings.transport-config.trust-in-client=Indicates if the transport must require trust in client to be established. Valid values are 'none', 'supported' and 'required'.
+jacorb.ior-settings.transport-config.trust-in-target=Indicates if the transport must require trust in target to be established. Valid values are 'none' and 'supported'.
+jacorb.ior-settings.transport-config.integrity=Indicates whether the transport must require integrity protection or not. Valid values are 'none', 'supported' and 'required'.
+jacorb.ior-settings.transport-config.confidentiality=Indicates whether the transport must require confidentiality protection or not. Valid values are 'none', 'supported' and 'required'.
+jacorb.ior-settings.transport-config.detect-replay=Indicates whether the transport must require replay detection or not. Valid values are 'none', 'supported' and 'required'.
+jacorb.ior-settings.transport-config.detect-misordering=Indicates whether the transport must require misordering detection or not. Valid values are 'none', 'supported' and 'required'.
+jacorb.ior-settings.as-context=The authentication service (AS) context settings.
+jacorb.ior-settings.as-context.add=Adds the authentication service (AS) settings.
+jacorb.ior-settings.as-context.remove=Removes the authentication service (AS) settings.
+jacorb.ior-settings.as-context.auth-method=The authentication method. Valid values are 'none' and 'username_password'.
+jacorb.ior-settings.as-context.realm=The authentication service (AS) realm name.
+jacorb.ior-settings.as-context.required=Indicates if authentication is required (true) or not (false).
+jacorb.ior-settings.sas-context=The secure attribute service (SAS) context settings.
+jacorb.ior-settings.sas-context.add=Adds the secure attribute service (SAS) context settings.
+jacorb.ior-settings.sas-context.remove=Removes the secure attribute service (SAS) context settings.
+jacorb.ior-settings.sas-context.caller-propagation=Indicates whether the caller identity should be propagated in the SAS context or not. Valid values are 'none' and 'supported'.

--- a/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
+++ b/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
@@ -234,4 +234,9 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
         super.standardSubsystemTest("subsystem-1.2-security-client.xml");
     }
 
+    @Test
+    public void testSubsystemWithIORSettings() throws Exception {
+        super.standardSubsystemTest("subsystem-1.4-ior-settings.xml");
+    }
+
 }

--- a/jacorb/src/test/java/org/jboss/as/jacorb/JacORBTransformersTestCase.java
+++ b/jacorb/src/test/java/org/jboss/as/jacorb/JacORBTransformersTestCase.java
@@ -257,4 +257,49 @@ public class JacORBTransformersTestCase extends AbstractSubsystemTest {
 
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version_1_1_0, builder.parseXmlResource("expressions-1.2.xml"), config);
     }
+
+    @Test
+    public void testTransformersIORSettings712() throws Exception {
+        testTransformersIORSettings(ModelTestControllerVersion.V7_1_2_FINAL);
+    }
+
+    @Test
+    public void testTransformersIORSettings713() throws Exception {
+        testTransformersIORSettings(ModelTestControllerVersion.V7_1_3_FINAL);
+    }
+
+    private void testTransformersIORSettings(ModelTestControllerVersion controllerVersion) throws Exception {
+
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+
+        ModelVersion version = ModelVersion.create(1, 1, 0);
+        // Add legacy subsystems
+        builder.createLegacyKernelServicesBuilder(AdditionalInitialization.MANAGEMENT, controllerVersion, version)
+                .addMavenResourceURL("org.jboss.as:jboss-as-jacorb:" + controllerVersion.getMavenGavVersion());
+
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(version);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+
+        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version,
+                builder.parseXmlResource("subsystem-1.4-ior-settings.xml"),
+                new FailedOperationTransformationConfig()
+                        .addFailedAttribute(PathAddress.pathAddress(JacORBSubsystemResource.INSTANCE.getPathElement(),
+                                    IORSettingsDefinition.INSTANCE.getPathElement()),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(PathAddress.pathAddress(JacORBSubsystemResource.INSTANCE.getPathElement(),
+                                    IORSettingsDefinition.INSTANCE.getPathElement(),
+                                    IORTransportConfigDefinition.INSTANCE.getPathElement()),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(PathAddress.pathAddress(JacORBSubsystemResource.INSTANCE.getPathElement(),
+                                    IORSettingsDefinition.INSTANCE.getPathElement(),
+                                    IORASContextDefinition.INSTANCE.getPathElement()),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
+                        .addFailedAttribute(PathAddress.pathAddress(JacORBSubsystemResource.INSTANCE.getPathElement(),
+                                    IORSettingsDefinition.INSTANCE.getPathElement(),
+                                    IORSASContextDefinition.INSTANCE.getPathElement()),
+                                FailedOperationTransformationConfig.REJECTED_RESOURCE));
+    }
 }

--- a/jacorb/src/test/resources/org/jboss/as/jacorb/expressions-1.2.xml
+++ b/jacorb/src/test/resources/org/jboss/as/jacorb/expressions-1.2.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+<subsystem xmlns="urn:jboss:domain:jacorb:1.4">
     <orb name="${test.exp:JBoss}" print-version="${test.exp:off}" use-imr="${test.exp:off}" use-bom="${test.exp:off}"  cache-typecodes="${test.exp:off}"
         cache-poa-names="${test.exp:off}" giop-minor-version ="${test.exp:2}" socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
         <connection retries="${test.exp:5}" retry-interval="${test.exp:500}" client-timeout="${test.exp:0}" server-timeout="${test.exp:0}"

--- a/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.2-security-client.xml
+++ b/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.2-security-client.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+<subsystem xmlns="urn:jboss:domain:jacorb:1.4">
     <orb name="JBoss" print-version="off" use-imr="off" use-bom="off"  cache-typecodes="off"
         cache-poa-names="off" giop-minor-version ="2" socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
         <connection retries="5" retry-interval="500" client-timeout="0" server-timeout="0"

--- a/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.2-security-identity.xml
+++ b/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.2-security-identity.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+<subsystem xmlns="urn:jboss:domain:jacorb:1.4">
     <orb name="JBoss" print-version="off" use-imr="off" use-bom="off"  cache-typecodes="off"
         cache-poa-names="off" giop-minor-version ="2" socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
         <connection retries="5" retry-interval="500" client-timeout="0" server-timeout="0"

--- a/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.2.xml
+++ b/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.2.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+<subsystem xmlns="urn:jboss:domain:jacorb:1.4">
     <orb name="JBoss" print-version="off" use-imr="off" use-bom="off"  cache-typecodes="off"
         cache-poa-names="off" giop-minor-version ="2" socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
         <connection retries="5" retry-interval="500" client-timeout="0" server-timeout="0"

--- a/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.4-ior-settings.xml
+++ b/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-1.4-ior-settings.xml
@@ -1,0 +1,26 @@
+<subsystem xmlns="urn:jboss:domain:jacorb:1.4">
+    <orb name="JBoss" print-version="off" use-imr="off" use-bom="off"  cache-typecodes="off"
+         cache-poa-names="off" giop-minor-version ="2" socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
+        <connection retries="5" retry-interval="500" client-timeout="0" server-timeout="0"
+                    max-server-connections="500" max-managed-buf-size="24" outbuf-size="2048"
+                    outbuf-cache-timeout="-1"/>
+        <initializers security="off" transactions="spec"/>
+    </orb>
+    <poa monitoring="off" queue-wait="on" queue-min="10" queue-max="100">
+        <request-processors pool-size="10" max-threads="32"/>
+    </poa>
+    <naming root-context="JBoss/Naming/root" export-corbaloc="on"/>
+    <interop sun="on" comet="off" iona="off" chunk-custom-rmi-valuetypes="on"
+             lax-boolean-encoding="off" indirection-encoding-disable="off" strict-check-on-tc-creation="off"/>
+    <security support-ssl="off" add-component-via-interceptor="on" client-supports="MutualAuth"
+              client-requires="None" server-supports="MutualAuth" server-requires="None"/>
+    <properties>
+        <property name="some_property" value="some_value"/>
+    </properties>
+    <ior-settings>
+        <transport-config integrity="required" confidentiality="required" detect-replay="supported" detect-misordering="supported"
+                          trust-in-client="none" trust-in-target="none"/>
+        <as-context auth-method="username_password" realm="test_realm" required="true"/>
+        <sas-context caller-propagation="supported"/>
+    </ior-settings>
+</subsystem>


### PR DESCRIPTION
WFLY-2968 Allow configuration of default IOR settings in the jacorb subsystem
- these setting are applied to all EJB IORs generated by WildFly
- they can be overriden by the settings specified in the jboss-ejb3.xml deployment descriptor
