### PR TITLE
[WFLY-2966] OutboundSocketBinding#getUnresolvedDestinationAddress()

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAdd.java
@@ -631,7 +631,7 @@ public abstract class CacheAdd extends AbstractAddStepHandler {
                     @Override
                     public void inject(OutboundSocketBinding value) {
                         try {
-                            builder.addServer().host(value.getDestinationAddress().getHostAddress()).port(value.getDestinationPort());
+                            builder.addServer().host(value.getResolvedDestinationAddress().getHostAddress()).port(value.getDestinationPort());
                         } catch (UnknownHostException e) {
                             throw InfinispanMessages.MESSAGES.failedToInjectSocketBinding(e, value);
                         }

--- a/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
@@ -161,7 +161,7 @@ class SessionProviderFactory {
             }
             final InetAddress destinationAddress;
             try {
-                destinationAddress = binding.getDestinationAddress();
+                destinationAddress = binding.getResolvedDestinationAddress();
             } catch (UnknownHostException uhe) {
                 throw MailMessages.MESSAGES.unknownOutboundSocketBindingDestination(uhe, ref);
             }

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -188,11 +188,7 @@ class HornetQService implements Service<HornetQServer> {
                             }
                         } else {
                             port = binding.getDestinationPort();
-                            if (binding.getDestinationAddress().isLoopbackAddress()) {
-                                host = binding.getDestinationAddress().getHostName();
-                            } else {
-                                host = binding.getDestinationAddress().getHostAddress();
-                            }
+                            host = binding.getUnresolvedDestinationAddress();
                         }
                         tc.getParams().put(HOST, host);
                         tc.getParams().put(PORT, String.valueOf(port));

--- a/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
+++ b/network/src/main/java/org/jboss/as/network/OutboundSocketBinding.java
@@ -52,7 +52,7 @@ public class OutboundSocketBinding {
     private final int destinationPort;
 
     /**
-     * The destination address is lazily resolved whenever a request is made {@link #getDestinationAddress()}
+     * The destination address is lazily resolved whenever a request is made {@link #getUnresolvedDestinationAddress()} ()}
      * or for {@link #connect()}
      */
     private InetAddress resolvedDestinationAddress;
@@ -123,7 +123,7 @@ public class OutboundSocketBinding {
      */
     public Socket connect() throws IOException {
         final Socket socket = this.createSocket();
-        final InetAddress destinationAddress = this.getDestinationAddress();
+        final InetAddress destinationAddress = this.getResolvedDestinationAddress();
         final int destinationPort = this.getDestinationPort();
         final SocketAddress destination = new InetSocketAddress(destinationAddress, destinationPort);
         socket.connect(destination);
@@ -132,20 +132,36 @@ public class OutboundSocketBinding {
     }
 
     /**
-     * Returns the destination address of this outbound socket binding. If the destination address
+     * Returns the <em>unresolved</em> destination address of this outbound socket binding.
+     */
+    public String getUnresolvedDestinationAddress() {
+        return this.unresolvedDestinationAddress;
+    }
+
+    /**
+     * Returns the <em>resolved</em> destination address of this outbound socket binding. If the destination address
      * is already resolved then this method return that address or else it tries to resolve the
      * address before return.
      *
-     * @return
      * @throws UnknownHostException If the destination address cannot be resolved
      */
-    public synchronized InetAddress getDestinationAddress() throws UnknownHostException {
+    public synchronized InetAddress getResolvedDestinationAddress() throws UnknownHostException {
         if (this.resolvedDestinationAddress != null) {
             return this.resolvedDestinationAddress;
         }
         this.resolvedDestinationAddress = InetAddress.getByName(this.unresolvedDestinationAddress);
         return this.resolvedDestinationAddress;
     }
+
+    /**
+    * @deprecated use {@link #getResolvedDestinationAddress()} instead to get the resolved destination address
+    * or {@link #getUnresolvedDestinationAddress()} to get the unresolved destination address.
+    */
+    @Deprecated
+    public synchronized InetAddress getDestinationAddress() throws UnknownHostException {
+        return getResolvedDestinationAddress();
+    }
+
 
     public int getDestinationPort() {
         return this.destinationPort;

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/LocalOutboundConnectionService.java
@@ -96,7 +96,7 @@ public class LocalOutboundConnectionService extends AbstractOutboundConnectionSe
             return this.connectionURI;
         }
         final OutboundSocketBinding destinationOutboundSocket = this.destinationOutboundSocketBindingInjectedValue.getValue();
-        final InetAddress destinationAddress = destinationOutboundSocket.getDestinationAddress();
+        final InetAddress destinationAddress = destinationOutboundSocket.getResolvedDestinationAddress();
         final int port = destinationOutboundSocket.getDestinationPort();
 
         this.connectionURI = new URI(LOCAL_URI_SCHEME + destinationAddress.getHostAddress() + ":" + port);

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionService.java
@@ -149,7 +149,7 @@ public class RemoteOutboundConnectionService extends AbstractOutboundConnectionS
             return this.connectionURI;
         }
         final OutboundSocketBinding destinationOutboundSocket = this.destinationOutboundSocketBindingInjectedValue.getValue();
-        final InetAddress destinationAddress = destinationOutboundSocket.getDestinationAddress();
+        final InetAddress destinationAddress = destinationOutboundSocket.getResolvedDestinationAddress();
         final int port = destinationOutboundSocket.getDestinationPort();
 
         this.connectionURI = new URI(protocol + "://" + NetworkUtils.formatPossibleIpv6Address(destinationAddress.getHostAddress()) + ":" + port);


### PR DESCRIPTION
- add getUnresolvedDestinationAddress() to the OutboundSocketBinding
  class which returns the unresolved destination address (as a String)
- add getResolvedDestinationAddress() to return the (resolved)
  InetAddress and deprecates the getDestinationAddress().
- replaces all calls to getDestinationAddress() by one of the two new
  methods.
  - in the messaging subsystem, the unresolved string is used (as this
    address will be resolved on the client side).
  - in all the other subsystem, getResolvedDestinationAddress is called
    so that there is no functional changes to them.

JIRA: https://issues.jboss.org/browse/WFLY-2966
