### PR TITLE
WFLY-2976 use http-remoting as default for the remote-outbound-connection

### DIFF
--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -66,7 +66,7 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
     public static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(
             CommonAttributes.PROTOCOL, ModelType.STRING, true).setValidator(
                     new EnumValidator<Protocol>(Protocol.class, true, false))
-            .setDefaultValue(new ModelNode(Protocol.REMOTE.toString()))
+            .setDefaultValue(new ModelNode(Protocol.HTTP_REMOTING.toString()))
             .setAllowExpression(true)
             .build();
 


### PR DESCRIPTION
Change the protocol default to http-remoting
https://issues.jboss.org/browse/WFLY-2976
