### PR TITLE
[WFLY-2909] When properties change on log4j appenders activate should be invoked

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/logmanager/Log4jAppenderHandler.java
+++ b/logging/src/main/java/org/jboss/as/logging/logmanager/Log4jAppenderHandler.java
@@ -40,6 +40,7 @@ import org.jboss.logmanager.ExtLogRecord;
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public class Log4jAppenderHandler extends ExtHandler {
+    public static final String ACTIVATE_OPTIONS_METHOD_NAME = "activate";
     private volatile Appender appender = null;
     private final boolean applyLayout;
 


### PR DESCRIPTION
The `activate()` method on the `Log4jAppenderHandler` was only getting invoked when a handler was added. This creates a problem when the user changes a property, such as a file, the property value is changed, but the appender might not set the output stream.
