### PR TITLE
[WFLY-2261] Fix standalone.sh --debug [<port>]

### DIFF
--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -16,8 +16,6 @@ do
           shift
           if [ -n "$1" ] && [ "${1#*-}" = "$1" ]; then
               DEBUG_PORT=$1
-          else
-              SERVER_OPTS="$SERVER_OPTS \"$1\""
           fi
           ;;
       --)
@@ -107,6 +105,7 @@ if [ "$DEBUG_MODE" = "true" ]; then
     else
         echo "Debug already enabled in JAVA_OPTS, ignoring --debug argument"
     fi
+    SERVER_OPTS="$SERVER_OPTS --debug ${DEBUG_PORT}"
 fi
 
 # Setup the JVM


### PR DESCRIPTION
Fix standalone.sh script when the debug port is specified on the command
line.

WildFly's server Main class expects to get --debug from its args before
the debug port. Add it to the script's $SERVER_OPTS if debug mode is
set.

```
./standalone.sh 
  => no debug
./standalone.sh --debug
  => debug on default port 8787
./standalone.sh --debug 8888
  => debug on specified port 8888
```

JIRA: https://issues.jboss.org/browse/WFLY-2261
