### PR TITLE
WFLY-3007 :  Canonizing all IP addresses as String

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/audit/SyslogAuditLogHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/audit/SyslogAuditLogHandler.java
@@ -31,6 +31,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
+import org.jboss.as.controller.interfaces.InetAddressUtil;
 
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.logmanager.ExtLogRecord;
@@ -178,7 +179,7 @@ public class SyslogAuditLogHandler extends AuditLogHandler {
                 //i18n not needed, user code will not end up here
                 throw new IllegalStateException("Unknown protocol");
             }
-            handler = new SyslogHandler(syslogServerAddress, port, facility.convert(), syslogType, protocol, hostName == null ? InetAddress.getLocalHost().getHostName() : hostName);
+            handler = new SyslogHandler(syslogServerAddress, port, facility.convert(), syslogType, protocol, hostName == null ? InetAddressUtil.getLocalHostName() : hostName);
             handler.setEscapeEnabled(false); //Escaping is handled by the formatter
             handler.setAppName(appName);
             handler.setTruncate(truncate);

--- a/controller/src/main/java/org/jboss/as/controller/interfaces/InetAddressUtil.java
+++ b/controller/src/main/java/org/jboss/as/controller/interfaces/InetAddressUtil.java
@@ -32,6 +32,10 @@ import static org.jboss.as.controller.ControllerMessages.MESSAGES;
  * @created 26.1.12 22:47
  */
 public class InetAddressUtil {
+
+    private static final int MAX_GROUP_LENGTH = 4;
+    private static final int IPV6_LEN = 8;
+
     /**
      * Methods returns InetAddress for localhost
      *
@@ -51,9 +55,234 @@ public class InetAddressUtil {
     public static String getLocalHostName() {
         try {
             InetAddress address = getLocalHost();
-            return address != null ? address.getHostName() : null;
+            return address != null ? canonize(address.getHostName()) : null;
         } catch (UnknownHostException e) {
             throw MESSAGES.cannotDetermineDefaultName(e);
         }
+    }
+
+    /**
+     * <p>Convert IPv6 adress into RFC 5952 form.
+     * E.g. 2001:db8:0:1:0:0:0:1 -> 2001:db8:0:1::1</p>
+     *
+     * <p>Method is null safe, and if IPv4 address or host name is passed to the
+     * method it is returned wihout any processing.</p>
+     *
+     * <p>Method also supports IPv4 in IPv6 (e.g. 0:0:0:0:0:ffff:192.0.2.1 ->
+     * ::ffff:192.0.2.1), and zone ID (e.g. fe80:0:0:0:f0f0:c0c0:1919:1234%4
+     * -> fe80::f0f0:c0c0:1919:1234%4).</p>
+     *
+     * @param ipv6Address String representing valid IPv6 address.
+     * @return String representing IPv6 in canonical form.
+     * @throws IllegalArgumentException if IPv6 format is unacceptable.
+     */
+    public static String canonize(String ipv6Address) throws IllegalArgumentException {
+
+        if (ipv6Address == null) {
+            return null;
+        }
+
+        // Definitely not an IPv6, return untouched input.
+        if (!mayBeIPv6Address(ipv6Address)) {
+            return ipv6Address;
+        }
+
+        // Length without zone ID (%zone) or IPv4 address
+        int ipv6AddressLength = ipv6Address.length();
+        if (isIPv4AddressInIPv6(ipv6Address)) {
+            // IPv4 in IPv6
+            // e.g. 0:0:0:0:0:FFFF:127.0.0.1
+            int lastColonPos = ipv6Address.lastIndexOf(":");
+            int lastColonsPos = ipv6Address.lastIndexOf("::");
+            if (lastColonsPos >= 0 && lastColonPos == lastColonsPos + 1) {
+                // IPv6 part ends with two consecutive colons, last colon is part of IPv6 format.
+                // e.g. ::127.0.0.1
+                ipv6AddressLength = lastColonPos + 1;
+            } else {
+                // IPv6 part ends with only one colon, last colon is not part of IPv6 format.
+                // e.g. ::FFFF:127.0.0.1
+                ipv6AddressLength = lastColonPos;
+            }
+        } else if (ipv6Address.contains(":") && ipv6Address.contains("%")) {
+            // Zone ID
+            // e.g. fe80:0:0:0:f0f0:c0c0:1919:1234%4
+            ipv6AddressLength = ipv6Address.lastIndexOf("%");
+        }
+
+        StringBuilder result = new StringBuilder();
+        char [][] groups = new char[IPV6_LEN][MAX_GROUP_LENGTH];
+        int groupCounter = 0;
+        int charInGroupCounter = 0;
+
+        // Index of the current zeroGroup, -1 means not found.
+        int zeroGroupIndex = -1;
+        int zeroGroupLength = 0;
+
+        // maximum length zero group, if there is more then one, then first one
+        int maxZeroGroupIndex = -1;
+        int maxZeroGroupLength = 0;
+
+        boolean isZero = true;
+        boolean groupStart = true;
+
+        /*
+         *  Two consecutive colons, initial expansion.
+         *  e.g. 2001:db8:0:0:1::1 -> 2001:db8:0:0:1:0:0:1
+         */
+        StringBuilder expanded = new StringBuilder(ipv6Address);
+        int colonsPos = ipv6Address.indexOf("::");
+        int length = ipv6AddressLength;
+        int change = 0;
+
+        if (colonsPos >= 0 && colonsPos < ipv6AddressLength - 2) {
+            int colonCounter = 0;
+            for (int i = 0; i < ipv6AddressLength; i++) {
+                if (ipv6Address.charAt(i) == ':') {
+                    colonCounter++;
+                }
+            }
+
+            if (colonsPos == 0) {
+                expanded.insert(0, "0");
+                change = change + 1;
+            }
+
+            for (int i = 0; i < IPV6_LEN - colonCounter; i++) {
+                expanded.insert(colonsPos + 1, "0:");
+                change = change + 2;
+            }
+
+
+            if (colonsPos == ipv6AddressLength - 2) {
+                expanded.setCharAt(colonsPos + change + 1, '0');
+            } else {
+                expanded.deleteCharAt(colonsPos + change + 1);
+                change = change - 1;
+            }
+            length = length + change;
+        }
+
+
+        // Processing one char at the time
+        for (int charCounter = 0; charCounter < length; charCounter++) {
+            char c = expanded.charAt(charCounter);
+            if (c >= 'A' && c <= 'F') {
+                c = (char) (c + 32);
+            }
+            if (c != ':') {
+                groups[groupCounter][charInGroupCounter] = c;
+                if (!(groupStart && c == '0')) {
+                    ++charInGroupCounter;
+                    groupStart = false;
+                }
+                if (c != '0') {
+                    isZero = false;
+                }
+            }
+            if (c == ':' || charCounter == (length - 1)) {
+                // We reached end of current group
+                if (isZero) {
+                    ++zeroGroupLength;
+                    if (zeroGroupIndex == -1) {
+                        zeroGroupIndex = groupCounter;
+                    }
+                }
+
+                if (!isZero || charCounter == (length - 1)) {
+                    // We reached end of zero group
+                    if (zeroGroupLength > maxZeroGroupLength) {
+                        maxZeroGroupLength = zeroGroupLength;
+                        maxZeroGroupIndex = zeroGroupIndex;
+                    }
+                    zeroGroupLength = 0;
+                    zeroGroupIndex = -1;
+                }
+                ++groupCounter;
+                charInGroupCounter = 0;
+                isZero = true;
+                groupStart = true;
+            }
+        }
+
+        int numberOfGroups = groupCounter;
+
+        // Output results
+        for (groupCounter = 0; groupCounter < numberOfGroups; groupCounter++) {
+            if (maxZeroGroupLength <= 1 || groupCounter < maxZeroGroupIndex
+                    || groupCounter >= maxZeroGroupIndex + maxZeroGroupLength) {
+                for (int j = 0; j < MAX_GROUP_LENGTH; j++) {
+                    if (groups[groupCounter][j] != 0) {
+                        result.append(groups[groupCounter][j]);
+                    }
+                }
+                if (groupCounter < (numberOfGroups - 1)
+                        && (groupCounter != maxZeroGroupIndex - 1
+                                || maxZeroGroupLength <= 1)) {
+                    result.append(':');
+                }
+            } else if (groupCounter == maxZeroGroupIndex) {
+                result.append("::");
+            }
+        }
+
+        // Solve problem with three colons in IPv4 in IPv6 format
+        // e.g. 0:0:0:0:0:0:127.0.0.1 -> :::127.0.0.1 -> ::127.0.0.1
+        int resultLength = result.length();
+        if (result.charAt(resultLength - 1) == ':' && ipv6AddressLength < ipv6Address.length()
+                && ipv6Address.charAt(ipv6AddressLength) == ':') {
+            result.delete(resultLength - 1, resultLength);
+        }
+
+        /*
+         * Append IPv4 from IPv4-in-IPv6 format or Zone ID
+         */
+        for (int i = ipv6AddressLength; i < ipv6Address.length(); i++) {
+            result.append(ipv6Address.charAt(i));
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Heuristic check if string might be an IPv6 address.
+     *
+     * @param input Any string or null
+     * @return true, if input string contains only hex digits and at least two colons, before '.' or '%' character.
+     */
+    private static boolean mayBeIPv6Address(String input) {
+        if (input == null) {
+            return false;
+        }
+
+        boolean result = false;
+        int colonsCounter = 0;
+        int length = input.length();
+        for (int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if (c == '.' || c == '%') {
+                // IPv4 in IPv6 or Zone ID detected, end of checking.
+                break;
+            }
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+                    || (c >= 'A' && c <= 'F') || c == ':')) {
+                return false;
+            } else if (c == ':') {
+                colonsCounter++;
+            }
+        }
+        if (colonsCounter >= 2) {
+            result = true;
+        }
+        return result;
+    }
+    /**
+     * Check if it is an IPv4 in IPv6 format.
+     * e.g. 0:0:0:0:0:FFFF:127.0.0.1
+     *
+     * @param ipv6Address the address
+     * @return true, if input string is an IPv4 address in IPv6 format.
+     */
+    private static boolean isIPv4AddressInIPv6(String ipv6Address) {
+        return (ipv6Address.contains(":") && ipv6Address.contains("."));
     }
 }

--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/standalone/root/StandaloneRootResourceTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/standalone/root/StandaloneRootResourceTestCase.java
@@ -43,6 +43,7 @@ import org.jboss.as.core.model.test.KernelServices;
 import org.jboss.as.core.model.test.KernelServicesBuilder;
 import org.jboss.as.core.model.test.TestModelType;
 import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.server.controller.descriptions.ServerDescriptionConstants;
 import org.jboss.as.version.Version;
 import org.jboss.dmr.ModelNode;
@@ -266,7 +267,7 @@ public class StandaloneRootResourceTestCase extends AbstractCoreModelTest {
     }
 
     private String getDefaultServerName() throws Exception {
-        String hostName = InetAddress.getLocalHost().getHostName().toLowerCase();
+        String hostName = NetworkUtils.canonize(InetAddress.getLocalHost().getHostName().toLowerCase());
         int index = hostName.indexOf('.');
         return index == -1 ? hostName : hostName.substring(0, index);
     }

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AbstractAuditLogHandlerTestCase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/auditlog/AbstractAuditLogHandlerTestCase.java
@@ -51,6 +51,7 @@ import org.jboss.as.controller.audit.ManagedAuditLoggerImpl;
 import org.jboss.as.controller.audit.SyslogAuditLogHandler;
 import org.jboss.as.controller.audit.SyslogAuditLogHandler.Transport;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.interfaces.InetAddressUtil;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
@@ -235,7 +236,7 @@ public class AbstractAuditLogHandlerTestCase extends ManagementControllerTestBas
         composite.get(STEPS).add(handler);
 
         ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.UDP));
-        protocol.get(HOST).set(addr.getHostName());
+        protocol.get(HOST).set(InetAddressUtil.canonize(addr.getHostName()));
         protocol.get(PORT).set(port);
         composite.get(STEPS).add(protocol);
 
@@ -256,7 +257,7 @@ public class AbstractAuditLogHandlerTestCase extends ManagementControllerTestBas
         composite.get(STEPS).add(handler);
 
         ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.TCP));
-        protocol.get(HOST).set(addr.getHostName());
+        protocol.get(HOST).set(InetAddressUtil.canonize(addr.getHostName()));
         protocol.get(PORT).set(port);
         if (transfer != null) {
             protocol.get(MESSAGE_TRANSFER).set(transfer.name());
@@ -281,7 +282,7 @@ public class AbstractAuditLogHandlerTestCase extends ManagementControllerTestBas
         composite.get(STEPS).add(handler);
 
         ModelNode protocol = Util.createAddOperation(createSyslogHandlerProtocolAddress(handlerName, SyslogAuditLogHandler.Transport.TLS));
-        protocol.get(HOST).set(addr.getHostName());
+        protocol.get(HOST).set(InetAddressUtil.canonize(addr.getHostName()));
         protocol.get(PORT).set(port);
         if (transfer != null) {
             protocol.get(MESSAGE_TRANSFER).set(transfer.name());

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerEnvironment.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.operations.common.ProcessEnvironment;
 import org.jboss.as.controller.persistence.ConfigurationFile;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.process.DefaultJvmUtils;
 import org.jboss.as.version.ProductConfig;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -286,7 +287,7 @@ public class HostControllerEnvironment extends ProcessEnvironment {
             }
             if (qualifiedHostName == null) {
                 try {
-                    qualifiedHostName = InetAddress.getLocalHost().getHostName();
+                    qualifiedHostName = NetworkUtils.canonize(InetAddress.getLocalHost().getHostName());
                 } catch (UnknownHostException e) {
                     qualifiedHostName = null;
                 }

--- a/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/SessionProviderFactory.java
@@ -32,6 +32,7 @@ import java.util.Properties;
 import javax.mail.Authenticator;
 import javax.mail.PasswordAuthentication;
 import javax.mail.Session;
+import org.jboss.as.network.NetworkUtils;
 
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.metadata.javaee.spec.MailSessionMetaData;
@@ -128,7 +129,7 @@ class SessionProviderFactory {
             Map<String, String> customProps = server.getProperties();
             if (server.getOutgoingSocketBinding() != null) {
                 InetSocketAddress socketAddress = getServerSocketAddress(server);
-                props.setProperty(getHostKey(protocol), socketAddress.getAddress().getHostName());
+                props.setProperty(getHostKey(protocol), NetworkUtils.canonize(socketAddress.getAddress().getHostName()));
                 props.setProperty(getPortKey(protocol), String.valueOf(socketAddress.getPort()));
             } else {
                 String host = customProps.get("host");

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -49,6 +49,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.services.path.AbsolutePathService;
 import org.jboss.as.controller.services.path.PathManager;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.security.plugins.SecurityDomainContext;
@@ -182,13 +183,13 @@ class HornetQService implements Service<HornetQServer> {
                             port = sa.getPort();
                             // resolve the host name of the address only if a loopback address has been set
                             if (sa.getAddress().isLoopbackAddress()) {
-                                host = sa.getAddress().getHostName();
+                                host = NetworkUtils.canonize(sa.getAddress().getHostName());
                             } else {
-                                host = sa.getAddress().getHostAddress();
+                                host = NetworkUtils.canonize(sa.getAddress().getHostAddress());
                             }
                         } else {
                             port = binding.getDestinationPort();
-                            host = binding.getUnresolvedDestinationAddress();
+                            host = NetworkUtils.canonize(binding.getUnresolvedDestinationAddress());
                         }
                         tc.getParams().put(HOST, host);
                         tc.getParams().put(PORT, String.valueOf(port));

--- a/network/src/main/java/org/jboss/as/network/NetworkUtils.java
+++ b/network/src/main/java/org/jboss/as/network/NetworkUtils.java
@@ -37,6 +37,7 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 public class NetworkUtils {
 
+    private static final int MAX_GROUP_LENGTH = 4;
     private static final int IPV6_LEN = 8;
     private static final boolean can_bind_to_mcast_addr; // are we running on Linux ?
 
@@ -45,16 +46,245 @@ public class NetworkUtils {
     }
 
     public static String formatPossibleIpv6Address(String address) {
-        if (address == null) {
-            return address;
+        if(address == null) {
+            return null;
         }
-        if (!address.contains(":")) {
-            return address;
-        }
+        String ipv6Address;
         if (address.startsWith("[") && address.endsWith("]")) {
-            return address;
+            ipv6Address = address.substring(0, address.lastIndexOf(']')).substring(1);
+        } else {
+            ipv6Address = address;
         }
-        return "[" + address + "]";
+        // Definitely not an IPv6, return untouched input.
+        if (!mayBeIPv6Address(ipv6Address)) {
+            return ipv6Address;
+        }
+        return '[' + canonize(ipv6Address) + ']';
+    }
+
+    /**
+     * <p>Convert IPv6 adress into RFC 5952 form.
+     * E.g. 2001:db8:0:1:0:0:0:1 -> 2001:db8:0:1::1</p>
+     *
+     * <p>Method is null safe, and if IPv4 address or host name is passed to the
+     * method it is returned wihout any processing.</p>
+     *
+     * <p>Method also supports IPv4 in IPv6 (e.g. 0:0:0:0:0:ffff:192.0.2.1 ->
+     * ::ffff:192.0.2.1), and zone ID (e.g. fe80:0:0:0:f0f0:c0c0:1919:1234%4
+     * -> fe80::f0f0:c0c0:1919:1234%4).</p>
+     *
+     * @param ipv6Address String representing valid IPv6 address.
+     * @return String representing IPv6 in canonical form.
+     * @throws IllegalArgumentException if IPv6 format is unacceptable.
+     */
+    public static String canonize(String ipv6Address) throws IllegalArgumentException {
+
+        if (ipv6Address == null) {
+            return null;
+        }
+
+        // Definitely not an IPv6, return untouched input.
+        if (!mayBeIPv6Address(ipv6Address)) {
+            return ipv6Address;
+        }
+
+        // Length without zone ID (%zone) or IPv4 address
+        int ipv6AddressLength = ipv6Address.length();
+        if (isIPv4AddressInIPv6(ipv6Address)) {
+            // IPv4 in IPv6
+            // e.g. 0:0:0:0:0:FFFF:127.0.0.1
+            int lastColonPos = ipv6Address.lastIndexOf(":");
+            int lastColonsPos = ipv6Address.lastIndexOf("::");
+            if (lastColonsPos >= 0 && lastColonPos == lastColonsPos + 1) {
+                // IPv6 part ends with two consecutive colons, last colon is part of IPv6 format.
+                // e.g. ::127.0.0.1
+                ipv6AddressLength = lastColonPos + 1;
+            } else {
+                // IPv6 part ends with only one colon, last colon is not part of IPv6 format.
+                // e.g. ::FFFF:127.0.0.1
+                ipv6AddressLength = lastColonPos;
+            }
+        } else if (ipv6Address.contains(":") && ipv6Address.contains("%")) {
+            // Zone ID
+            // e.g. fe80:0:0:0:f0f0:c0c0:1919:1234%4
+            ipv6AddressLength = ipv6Address.lastIndexOf("%");
+        }
+
+        StringBuilder result = new StringBuilder();
+        char [][] groups = new char[IPV6_LEN][MAX_GROUP_LENGTH];
+        int groupCounter = 0;
+        int charInGroupCounter = 0;
+
+        // Index of the current zeroGroup, -1 means not found.
+        int zeroGroupIndex = -1;
+        int zeroGroupLength = 0;
+
+        // maximum length zero group, if there is more then one, then first one
+        int maxZeroGroupIndex = -1;
+        int maxZeroGroupLength = 0;
+
+        boolean isZero = true;
+        boolean groupStart = true;
+
+        /*
+         *  Two consecutive colons, initial expansion.
+         *  e.g. 2001:db8:0:0:1::1 -> 2001:db8:0:0:1:0:0:1
+         */
+        StringBuilder expanded = new StringBuilder(ipv6Address);
+        int colonsPos = ipv6Address.indexOf("::");
+        int length = ipv6AddressLength;
+        int change = 0;
+
+        if (colonsPos >= 0 && colonsPos < ipv6AddressLength - 2) {
+            int colonCounter = 0;
+            for (int i = 0; i < ipv6AddressLength; i++) {
+                if (ipv6Address.charAt(i) == ':') {
+                    colonCounter++;
+                }
+            }
+
+            if (colonsPos == 0) {
+                expanded.insert(0, "0");
+                change = change + 1;
+            }
+
+            for (int i = 0; i < IPV6_LEN - colonCounter; i++) {
+                expanded.insert(colonsPos + 1, "0:");
+                change = change + 2;
+            }
+
+
+            if (colonsPos == ipv6AddressLength - 2) {
+                expanded.setCharAt(colonsPos + change + 1, '0');
+            } else {
+                expanded.deleteCharAt(colonsPos + change + 1);
+                change = change - 1;
+            }
+            length = length + change;
+        }
+
+
+        // Processing one char at the time
+        for (int charCounter = 0; charCounter < length; charCounter++) {
+            char c = expanded.charAt(charCounter);
+            if (c >= 'A' && c <= 'F') {
+                c = (char) (c + 32);
+            }
+            if (c != ':') {
+                groups[groupCounter][charInGroupCounter] = c;
+                if (!(groupStart && c == '0')) {
+                    ++charInGroupCounter;
+                    groupStart = false;
+                }
+                if (c != '0') {
+                    isZero = false;
+                }
+            }
+            if (c == ':' || charCounter == (length - 1)) {
+                // We reached end of current group
+                if (isZero) {
+                    ++zeroGroupLength;
+                    if (zeroGroupIndex == -1) {
+                        zeroGroupIndex = groupCounter;
+                    }
+                }
+
+                if (!isZero || charCounter == (length - 1)) {
+                    // We reached end of zero group
+                    if (zeroGroupLength > maxZeroGroupLength) {
+                        maxZeroGroupLength = zeroGroupLength;
+                        maxZeroGroupIndex = zeroGroupIndex;
+                    }
+                    zeroGroupLength = 0;
+                    zeroGroupIndex = -1;
+                }
+                ++groupCounter;
+                charInGroupCounter = 0;
+                isZero = true;
+                groupStart = true;
+            }
+        }
+
+        int numberOfGroups = groupCounter;
+
+        // Output results
+        for (groupCounter = 0; groupCounter < numberOfGroups; groupCounter++) {
+            if (maxZeroGroupLength <= 1 || groupCounter < maxZeroGroupIndex
+                    || groupCounter >= maxZeroGroupIndex + maxZeroGroupLength) {
+                for (int j = 0; j < MAX_GROUP_LENGTH; j++) {
+                    if (groups[groupCounter][j] != 0) {
+                        result.append(groups[groupCounter][j]);
+                    }
+                }
+                if (groupCounter < (numberOfGroups - 1)
+                        && (groupCounter != maxZeroGroupIndex - 1
+                                || maxZeroGroupLength <= 1)) {
+                    result.append(':');
+                }
+            } else if (groupCounter == maxZeroGroupIndex) {
+                result.append("::");
+            }
+        }
+
+        // Solve problem with three colons in IPv4 in IPv6 format
+        // e.g. 0:0:0:0:0:0:127.0.0.1 -> :::127.0.0.1 -> ::127.0.0.1
+        int resultLength = result.length();
+        if (result.charAt(resultLength - 1) == ':' && ipv6AddressLength < ipv6Address.length()
+                && ipv6Address.charAt(ipv6AddressLength) == ':') {
+            result.delete(resultLength - 1, resultLength);
+        }
+
+        /*
+         * Append IPv4 from IPv4-in-IPv6 format or Zone ID
+         */
+        for (int i = ipv6AddressLength; i < ipv6Address.length(); i++) {
+            result.append(ipv6Address.charAt(i));
+        }
+
+        return result.toString();
+    }
+
+    /**
+     * Heuristic check if string might be an IPv6 address.
+     *
+     * @param input Any string or null
+     * @return true, if input string contains only hex digits and at least two colons, before '.' or '%' character.
+     */
+    private static boolean mayBeIPv6Address(String input) {
+        if (input == null) {
+            return false;
+        }
+
+        boolean result = false;
+        int colonsCounter = 0;
+        int length = input.length();
+        for (int i = 0; i < length; i++) {
+            char c = input.charAt(i);
+            if (c == '.' || c == '%') {
+                // IPv4 in IPv6 or Zone ID detected, end of checking.
+                break;
+            }
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+                    || (c >= 'A' && c <= 'F') || c == ':')) {
+                return false;
+            } else if (c == ':') {
+                colonsCounter++;
+            }
+        }
+        if (colonsCounter >= 2) {
+            result = true;
+        }
+        return result;
+    }
+    /**
+     * Check if it is an IPv4 in IPv6 format.
+     * e.g. 0:0:0:0:0:FFFF:127.0.0.1
+     *
+     * @param ipv6Address the address
+     * @return true, if input string is an IPv4 address in IPv6 format.
+     */
+    private static boolean isIPv4AddressInIPv6(String ipv6Address) {
+        return (ipv6Address.contains(":") && ipv6Address.contains("."));
     }
 
     /**
@@ -130,7 +360,7 @@ public class NetworkUtils {
                    if(i == 0){
                        stringBuilder.append("::");
                    } else {
-                       stringBuilder.append(":");
+                       stringBuilder.append(':');
                    }
                }
            } else {

--- a/server/src/main/java/org/jboss/as/server/DomainServerCommunicationServices.java
+++ b/server/src/main/java/org/jboss/as/server/DomainServerCommunicationServices.java
@@ -45,6 +45,7 @@ import org.xnio.OptionMap;
 
 import java.io.Serializable;
 import java.net.InetSocketAddress;
+import org.jboss.as.network.NetworkUtils;
 
 /**
  * Service activator for the communication services of a managed server in a domain.
@@ -94,7 +95,7 @@ public class DomainServerCommunicationServices  implements ServiceActivator, Ser
 
             // Install the communication services
             final int port = managementSocket.getPort();
-            final String host = managementSocket.getAddress().getHostAddress();
+            final String host = NetworkUtils.canonize(managementSocket.getAddress().getHostAddress());
             HostControllerConnectionService service = new HostControllerConnectionService(host, port, serverName, serverProcessName, authKey, initialOperationID, managementSubsystemEndpoint);
             serviceTarget.addService(HostControllerConnectionService.SERVICE_NAME, service)
                     .addDependency(endpointName, Endpoint.class, service.getEndpointInjector())

--- a/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
+++ b/server/src/main/java/org/jboss/as/server/ServerEnvironment.java
@@ -43,6 +43,7 @@ import org.jboss.as.controller.audit.ManagedAuditLoggerImpl;
 import org.jboss.as.controller.interfaces.InetAddressUtil;
 import org.jboss.as.controller.operations.common.ProcessEnvironment;
 import org.jboss.as.controller.persistence.ConfigurationFile;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.as.version.Version;
 import org.jboss.modules.Module;
@@ -621,7 +622,7 @@ public class ServerEnvironment extends ProcessEnvironment implements Serializabl
             }
             if (qualifiedHostName == null) {
                 try {
-                    qualifiedHostName = InetAddressUtil.getLocalHost().getHostName();
+                    qualifiedHostName = NetworkUtils.canonize(InetAddressUtil.getLocalHost().getHostName());
                 } catch (UnknownHostException e) {
                     qualifiedHostName = null;
                 }

--- a/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/BindingMetricHandlers.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.network.ManagedBinding;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -120,7 +121,7 @@ public final class BindingMetricHandlers {
             ManagedBinding managedBinding = binding.getManagedBinding();
             if (managedBinding != null) {
                 InetAddress addr = managedBinding.getBindAddress().getAddress();
-                result.set(addr.getHostAddress());
+                result.set(NetworkUtils.canonize(addr.getHostAddress()));
             }
         }
 

--- a/server/src/main/java/org/jboss/as/server/services/net/NetworkInterfaceRuntimeHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/NetworkInterfaceRuntimeHandler.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.network.NetworkInterfaceBinding;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
@@ -67,7 +68,7 @@ public class NetworkInterfaceRuntimeHandler implements OperationStepHandler {
                     final InetAddress address = binding.getAddress();
                     final ModelNode result = new ModelNode();
                     if(RESOLVED_ADDRESS.getName().equals(attributeName)) {
-                        result.set(address.getHostAddress());
+                        result.set(NetworkUtils.canonize(address.getHostAddress()));
                     }
                     context.getResult().set(result);
                 }

--- a/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceResolveHandler.java
+++ b/server/src/main/java/org/jboss/as/server/services/net/SpecifiedInterfaceResolveHandler.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.interfaces.ParsedInterfaceCriteria;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.resource.InterfaceDefinition;
 import org.jboss.as.network.NetworkInterfaceBinding;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.server.ServerMessages;
 import org.jboss.as.server.controller.descriptions.ServerDescriptions;
 import org.jboss.dmr.ModelNode;
@@ -83,7 +84,7 @@ public class SpecifiedInterfaceResolveHandler implements OperationStepHandler {
 
         try {
             NetworkInterfaceBinding nib = NetworkInterfaceService.createBinding(parsed);
-            context.getResult().set(nib.getAddress().getHostAddress());
+            context.getResult().set(NetworkUtils.canonize(nib.getAddress().getHostAddress()));
         } catch (SocketException e) {
             throw ServerMessages.MESSAGES.cannotResolveInterface(e, e);
         } catch (UnknownHostException e) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.ejb3.subsystem.EJB3Extension;
 import org.jboss.as.ejb3.subsystem.EJB3SubsystemModel;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.remoting.RemotingExtension;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
@@ -70,7 +71,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.UND
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
-
 
 /**
  * @author Jaikiran Pai
@@ -482,7 +482,7 @@ public class EJBManagementUtil {
             }
             if (qualifiedHostName == null) {
                 try {
-                    qualifiedHostName = InetAddress.getLocalHost().getHostName();
+                    qualifiedHostName = NetworkUtils.canonize(InetAddress.getLocalHost().getHostName());
                 } catch (UnknownHostException e) {
                     qualifiedHostName = null;
                 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/api/SocketsAndInterfacesTestCase.java
@@ -59,6 +59,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RES
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import org.jboss.as.network.NetworkUtils;
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
 
 /**
@@ -115,7 +116,7 @@ public class SocketsAndInterfacesTestCase extends ContainerResourceMgmtTestBase 
         result = executeOperation(op);
 
         // test the connector
-        String testHost = testNic.getInetAddresses().nextElement().getHostName();
+        String testHost = NetworkUtils.canonize(testNic.getInetAddresses().nextElement().getHostName());
         Assert.assertTrue("Could not connect to created connector.",WebUtil.testHttpURL(new URL(
                 "http", testHost, TEST_PORT, "/").toString()));
 


### PR DESCRIPTION
All calls to InetAddress.getHostName() are wrapped in NetworkUtils to canonize IPv6 addresses.
Jira Issue : https://issues.jboss.org/browse/WFLY-3007
