### PR TITLE
[JBQA-8853] improved test for [EAP6-63][WFLY-424] Domain Controller Discovery Improvements

### DIFF
--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -1,0 +1,128 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<host xmlns="urn:jboss:domain:2.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:2.0 jboss-as-config_2_0.xsd"
+      name="slave">
+
+    <paths>
+        <path name="domainTestPath" path="/tmp" />
+    </paths>
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                     <secret value="c2xhdmVfdXMzcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                     <local default-user="$local" />
+                     <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <audit-log>
+            <formatters>
+                <json-formatter name="json-formatter"/>
+            </formatters>
+            <handlers>
+                <file-handler name="host-file" formatter="json-formatter" relative-to="jboss.domain.data.dir" path="audit-log.log"/>
+                <file-handler name="server-file" formatter="json-formatter" relative-to="jboss.server.data.dir" path="audit-log.log"/>
+            </handlers>
+            <logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="host-file"/>
+                </handlers>
+            </logger>
+            <server-logger log-boot="true" log-read-only="true" enabled="false">
+                <handlers>
+                    <handler name="server-file"/>
+                </handlers>
+            </server-logger>
+        </audit-log>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="19999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" console-enabled="false"  http-upgrade-enabled="true">
+                <socket interface="management" port="19990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote security-realm="ManagementRealm">
+            <discovery-options>
+                <static-discovery name="start-option" host="${jboss.test.host.master.address}" port="9999" />
+            </discovery-options>
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+ 	<jvms>
+ 	   <jvm name="default">
+          <heap size="64m" max-size="128m"/>
+       </jvm>
+ 	</jvms>
+
+    <servers directory-grouping="by-type">
+        <server name="main-three" group="main-server-group">
+            <socket-bindings socket-binding-group="standard-sockets" port-offset="350"/>
+            <jvm name="default"/>
+        </server>
+        <server name="main-four" group="main-server-group" auto-start="false">
+            <socket-bindings port-offset="450"/>
+            <jvm name="default">
+                <heap size="64m" max-size="256m"/>
+            </jvm>
+        </server>
+        <server name="other-two" group="other-server-group">
+            <!--AS7-4177 override the host level config to smoke test that handling
+                Note we use the same values; this is just to check for obvious fatal errors -->
+            <interfaces>
+                <interface name="public">
+                    <inet-address value="${jboss.test.host.slave.address}"/>
+                </interface>
+            </interfaces>
+            <socket-bindings socket-binding-group="other-sockets" port-offset="550"/>
+        </server>
+        <server name="reload-two" group="reload-test-group"  auto-start="false">
+            <jvm name="default" />
+        </server>
+    </servers>
+</host>


### PR DESCRIPTION
AS test suite already contains tests of managament operations involving discovery options. This commit just changes behaviour during AS start to ensure that AS start without server and port configured in remote element (WFLY-2918) and with static-discovery option.

https://issues.jboss.org/browse/JBQA-8853
