### PR TITLE
[WFLY-3016] prevent NullPointerException in JDR CommandLineMain

### DIFF
--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
@@ -95,13 +95,13 @@ public class CommandLineMain {
         JdrReport response = null;
         try {
             response = reportService.standaloneCollect(protocol, host, port);
+            System.out.println("JDR started: " + response.getStartTime().toString());
+            System.out.println("JDR ended: " + response.getEndTime().toString());
+            System.out.println("JDR location: " + response.getLocation());
         } catch (OperationFailedException e) {
             System.out.println("Failed to complete the JDR report: " + e.getMessage());
         }
 
-        System.out.println("JDR started: " + response.getStartTime().toString());
-        System.out.println("JDR ended: " + response.getEndTime().toString());
-        System.out.println("JDR location: " + response.getLocation());
-        System.exit(0);
+       System.exit(0);
     }
 }


### PR DESCRIPTION
Move the prints into the try { } since if standaloneCollect throws an exception, the response object will be null
