### PR TITLE
WFLY-2993 + Few build related fixes, jboss parent upgrade

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -47,7 +47,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.threads"/>
         <module name="org.jboss.vfs"/>
-        <module name="org.picketbox"/>
+        <module name="org.picketbox" optional="true"/>
         <module name="javax.api"/>
     </dependencies>
 

--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -137,6 +137,7 @@
         <dependency>
            <groupId>org.picketbox</groupId>
            <artifactId>picketbox</artifactId>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test Dependencies -->
@@ -145,38 +146,14 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>sun.jdk</groupId>
+            <artifactId>jconsole</artifactId>
+            <version>jdk</version>
+            <scope>system</scope>
+            <systemPath>${java.home}/../lib/jconsole.jar</systemPath>
+        </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>linux-windows</id>
-            <activation>
-                <file><exists>${java.home}/../lib/tools.jar</exists></file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>sun.jdk</groupId>
-                    <artifactId>jconsole</artifactId>
-                    <version>jdk</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/../lib/jconsole.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>os-x</id>
-            <activation>
-                <file><exists>${java.home}/bundle/Classes/classes.jar</exists></file>
-            </activation>
-            <dependencies>
-                <dependency>
-                    <groupId>sun.jdk</groupId>
-                    <artifactId>jconsole</artifactId>
-                    <version>jdk</version>
-                    <scope>system</scope>
-                    <systemPath>${java.home}/bundle/Classes/jconsole.jar</systemPath>
-                </dependency>
-            </dependencies>
-        </profile>
-    </profiles>
 </project>

--- a/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/CliConfigImpl.java
@@ -26,6 +26,7 @@ import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +44,6 @@ import org.jboss.as.cli.ControllerAddress;
 import org.jboss.as.cli.SSLConfig;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.logging.Logger;
-import org.jboss.security.vault.SecurityVaultException;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.jboss.staxmapper.XMLMapper;
@@ -752,7 +752,7 @@ class CliConfigImpl implements CliConfig {
                     final VaultConfig vaultConfig = VaultConfig.load(vaultFile);
                     try {
                         vaultReader.init(vaultConfig.getOptions());
-                    } catch (SecurityVaultException e) {
+                    } catch (GeneralSecurityException e) {
                         throw new XMLStreamException("Failed to initialize vault", e);
                     }
                 } else if ("alias".equals(localName)) {
@@ -778,7 +778,7 @@ class CliConfigImpl implements CliConfig {
         private String getPassword(CLIVaultReader vaultReader, String str) throws XMLStreamException {
             try {
                 return vaultReader.retrieve(str);
-            } catch (SecurityVaultException e) {
+            } catch (GeneralSecurityException e) {
                 throw new XMLStreamException("Failed to retrieve from vault '" + str + "'", e);
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,6 @@
         <version.org.apache.cxf>2.7.10</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>2.6.1</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
-        <version.org.apache.ds.all>2.0.0-M7</version.org.apache.ds.all>
         <version.org.apache.httpcomponents.httpclient>4.2.1</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.2.1</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
@@ -3101,13 +3100,6 @@
                          <artifactId>spring-jms</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-all</artifactId>
-                <scope>test</scope>
-                <version>${version.org.apache.ds.all}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <parent>
       <groupId>org.jboss</groupId>
       <artifactId>jboss-parent</artifactId>
-      <version>12</version>
+      <version>13</version>
     </parent>
 
     <groupId>org.wildfly</groupId>
@@ -64,7 +64,6 @@
             For example: <version.surefire.plugin>2.11</version.surefire.plugin>
           -->
         <maven.min.version>3.1.0</maven.min.version>
-        <version.checkstyle.plugin>2.11</version.checkstyle.plugin>
         <!--
             Dependency versions. Please keep alphabetical.
 

--- a/testsuite/integration/rbac/pom.xml
+++ b/testsuite/integration/rbac/pom.xml
@@ -342,43 +342,4 @@
         </profile>
 
     </profiles>
-
-    <dependencies>
-
-        <dependency>
-            <groupId>org.apache.directory.server</groupId>
-            <artifactId>apacheds-all</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- Exclude the Apache DS M15 stuff -->
-        <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-testsuite-shared</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.directory.api</groupId>
-                    <artifactId>api-ldap-codec-standalone</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.directory.jdbm</groupId>
-                    <artifactId>apacheds-jdbm1</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.directory.server</groupId>
-                    <artifactId>apacheds-core-annotations</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.directory.server</groupId>
-                    <artifactId>apacheds-interceptor-kerberos</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.directory.server</groupId>
-                    <artifactId>apacheds-server-annotations</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-    </dependencies>
-
 </project>

--- a/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/LdapRoleMappingG2UTestCase.java
+++ b/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/LdapRoleMappingG2UTestCase.java
@@ -25,6 +25,10 @@ package org.jboss.as.test.integration.mgmt.access;
 import java.io.InputStream;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
 import org.apache.directory.server.core.annotations.CreateDS;
@@ -33,10 +37,6 @@ import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.factory.DSAnnotationProcessor;
 import org.apache.directory.server.factory.ServerAnnotationProcessor;
 import org.apache.directory.server.ldap.LdapServer;
-import org.apache.directory.shared.ldap.model.entry.DefaultEntry;
-import org.apache.directory.shared.ldap.model.ldif.LdifEntry;
-import org.apache.directory.shared.ldap.model.ldif.LdifReader;
-import org.apache.directory.shared.ldap.model.schema.SchemaManager;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -58,7 +58,8 @@ public class LdapRoleMappingG2UTestCase {
             allowAnonAccess = true
     )
     @CreateLdapServer(
-            transports = @CreateTransport(protocol = "LDAP", address = "localhost", port = 10389)
+            transports = @CreateTransport(protocol = "LDAP", address = "localhost", port = 10389),
+            allowAnonymousAccess = true
     )
     public static void setUp() throws Exception {
         directoryService = DSAnnotationProcessor.getDirectoryService();

--- a/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/LdapRoleMappingU2GTestCase.java
+++ b/testsuite/integration/rbac/src/test/java/org/jboss/as/test/integration/mgmt/access/LdapRoleMappingU2GTestCase.java
@@ -25,6 +25,10 @@ package org.jboss.as.test.integration.mgmt.access;
 import java.io.InputStream;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.directory.api.ldap.model.entry.DefaultEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifEntry;
+import org.apache.directory.api.ldap.model.ldif.LdifReader;
+import org.apache.directory.api.ldap.model.schema.SchemaManager;
 import org.apache.directory.server.annotations.CreateLdapServer;
 import org.apache.directory.server.annotations.CreateTransport;
 import org.apache.directory.server.core.annotations.CreateDS;
@@ -33,10 +37,6 @@ import org.apache.directory.server.core.api.DirectoryService;
 import org.apache.directory.server.core.factory.DSAnnotationProcessor;
 import org.apache.directory.server.factory.ServerAnnotationProcessor;
 import org.apache.directory.server.ldap.LdapServer;
-import org.apache.directory.shared.ldap.model.entry.DefaultEntry;
-import org.apache.directory.shared.ldap.model.ldif.LdifEntry;
-import org.apache.directory.shared.ldap.model.ldif.LdifReader;
-import org.apache.directory.shared.ldap.model.schema.SchemaManager;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
@@ -58,7 +58,8 @@ public class LdapRoleMappingU2GTestCase {
             allowAnonAccess = true
     )
     @CreateLdapServer(
-            transports = @CreateTransport(protocol = "LDAP", address = "localhost", port = 10389)
+            transports = @CreateTransport(protocol = "LDAP", address = "localhost", port = 10389),
+            allowAnonymousAccess = true
     )
     public static void setUp() throws Exception {
         directoryService = DSAnnotationProcessor.getDirectoryService();


### PR DESCRIPTION
- WFLY-2993 Core: jboss.sh fails to start with org.picketbox module missing
- Update to jboss parent 13 
- Use one common version of apache directory server across the board.
