### PR TITLE
https://issues.jboss.org/browse/WFLY-3004 CLI system property replacement fo...

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/BaseOperationCommand.java
@@ -255,8 +255,7 @@ public abstract class BaseOperationCommand extends CommandHandlerWithHelp implem
         if(!headers.isPresent(ctx.getParsedCommandLine())) {
             return;
         }
-        final String headersValue = headers.getValue(ctx.getParsedCommandLine());
-        final ModelNode headersNode = headers.getValueConverter().fromString(ctx, headersValue);
+        final ModelNode headersNode = headers.toModelNode(ctx);
         final ModelNode opHeaders = request.get(Util.OPERATION_HEADERS);
         opHeaders.set(headersNode);
     }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ConnectHandler.java
@@ -27,6 +27,7 @@ import java.util.List;
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineException;
+import org.jboss.as.cli.impl.ArgumentWithValue;
 import org.jboss.as.cli.operation.ParsedCommandLine;
 
 /**
@@ -35,6 +36,8 @@ import org.jboss.as.cli.operation.ParsedCommandLine;
  * @author Alexey Loubyansky
  */
 public class ConnectHandler extends CommandHandlerWithHelp {
+
+    private final ArgumentWithValue arg = new ArgumentWithValue(this, 0, "--controller");
 
     public ConnectHandler() {
         this("connect");
@@ -60,16 +63,14 @@ public class ConnectHandler extends CommandHandlerWithHelp {
     @Override
     protected void doHandle(CommandContext ctx) throws CommandLineException {
 
-        String controller = null;
-
         final ParsedCommandLine parsedCmd = ctx.getParsedCommandLine();
+        final String controller = arg.getValue(parsedCmd);
         final List<String> args = parsedCmd.getOtherProperties();
 
         if (!args.isEmpty()) {
             if (args.size() != 1) {
                 throw new CommandFormatException("The command expects only one argument but got " + args);
             }
-            controller = args.get(0);
         }
 
         ctx.connectController(controller);

--- a/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/GenericTypeOperationHandler.java
@@ -1205,8 +1205,9 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                 }
                 builder.addProperty(Util.NAME, propName);
 
-                final String valueString = args.getPropertyValue(argName);
-                ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
+//                final String valueString = args.getPropertyValue(argName);
+//                ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
+                final ModelNode nodeValue = arg.toModelNode(ctx);
                 builder.getModelNode().get(Util.VALUE).set(nodeValue);
 
                 steps.add(builder.buildRequest());
@@ -1277,8 +1278,9 @@ public class GenericTypeOperationHandler extends BatchModeCommandHandler {
                     propName = argName.substring(1);
                 }
 
-                final String valueString = parsedArgs.getPropertyValue(argName);
-                ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
+//                final String valueString = parsedArgs.getPropertyValue(argName);
+//                ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
+                final ModelNode nodeValue = arg.toModelNode(ctx);
                 request.get(propName).set(nodeValue);
             }
             return request;

--- a/cli/src/main/java/org/jboss/as/cli/handlers/ResourceCompositeOperationHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/ResourceCompositeOperationHandler.java
@@ -184,8 +184,6 @@ public class ResourceCompositeOperationHandler extends BaseOperationCommand {
         composite.get(Util.ADDRESS).setEmptyList();
         final ModelNode steps = composite.get(Util.STEPS);
 
-        final ParsedCommandLine parsedArgs = ctx.getParsedCommandLine();
-
         for(String opName : this.ops) {
             final ModelNode req = new ModelNode();
             req.get(Util.OPERATION).set(opName);
@@ -209,9 +207,11 @@ public class ResourceCompositeOperationHandler extends BaseOperationCommand {
                     propName = argName.substring(1);
                 }
 
-                final String valueString = arg.getValue(parsedArgs);
-                if(valueString != null) {
-                    ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
+//                final String valueString = arg.getOriginalValue(parsedArgs, false);
+//                if(valueString != null) {
+//                    ModelNode nodeValue = arg.getValueConverter().fromString(ctx, valueString);
+                final ModelNode nodeValue = arg.toModelNode(ctx);
+                if(nodeValue != null) {
                     req.get(propName).set(nodeValue);
                 }
             }

--- a/cli/src/main/java/org/jboss/as/cli/handlers/SetVariableHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/SetVariableHandler.java
@@ -70,6 +70,7 @@ public class SetVariableHandler extends CommandHandlerWithHelp {
             return;
         }
         for(String arg : vars) {
+            arg = ArgumentWithValue.resolveValue(arg);
             if(arg.charAt(0) == '$') {
                 arg = arg.substring(1);
                 if(arg.isEmpty()) {

--- a/cli/src/main/java/org/jboss/as/cli/handlers/jca/XADataSourceAddCompositeHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/handlers/jca/XADataSourceAddCompositeHandler.java
@@ -66,9 +66,12 @@ public class XADataSourceAddCompositeHandler extends ResourceCompositeOperationH
         final ModelNode req = super.buildRequestWithoutHeaders(ctx);
         final ModelNode steps = req.get(Util.STEPS);
 
-        final String xaPropsStr = xaProps.getValue(ctx.getParsedCommandLine());
-        if(xaPropsStr != null) {
-            final List<Property> propsList = xaProps.getValueConverter().fromString(ctx, xaPropsStr).asPropertyList();
+//        final String xaPropsStr = xaProps.getOriginalValue(ctx.getParsedCommandLine(), false);
+//        if(xaPropsStr != null) {
+//            final List<Property> propsList = xaProps.getValueConverter().fromString(ctx, xaPropsStr).asPropertyList();
+        final ModelNode xaPropsNode = xaProps.toModelNode(ctx);
+        if(xaPropsNode != null) {
+            final List<Property> propsList = xaPropsNode.asPropertyList();
             for(Property prop : propsList) {
                 final ModelNode address = this.buildOperationAddress(ctx);
                 address.add(XA_DATASOURCE_PROPERTIES, prop.getName());

--- a/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithValue.java
+++ b/cli/src/main/java/org/jboss/as/cli/impl/ArgumentWithValue.java
@@ -24,10 +24,17 @@ package org.jboss.as.cli.impl;
 import java.util.List;
 
 import org.jboss.as.cli.ArgumentValueConverter;
+import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.CommandLineCompleter;
 import org.jboss.as.cli.handlers.CommandHandlerWithArguments;
 import org.jboss.as.cli.operation.ParsedCommandLine;
+import org.jboss.as.cli.parsing.ExpressionBaseState;
+import org.jboss.as.cli.parsing.ParsingContext;
+import org.jboss.as.cli.parsing.ParsingStateCallbackHandler;
+import org.jboss.as.cli.parsing.StateParser;
+import org.jboss.as.cli.parsing.WordCharacterHandler;
+import org.jboss.dmr.ModelNode;
 
 /**
  *
@@ -77,23 +84,74 @@ public class ArgumentWithValue extends ArgumentWithoutValue {
      */
     @Override
     public String getValue(ParsedCommandLine args, boolean required) throws CommandFormatException {
+        return getResolvedValue(args, required);
+    }
 
+    /**
+     * Calls getOriginalValue(ParsedCommandLine parsedLine, boolean required) and correctly
+     * handles escape sequences and resolves system properties.
+     *
+     * @param parsedLine  parsed command line
+     * @param required  whether the argument is required
+     * @return  resolved argument value
+     * @throws CommandFormatException  in case the required argument is missing
+     */
+    public String getResolvedValue(ParsedCommandLine parsedLine, boolean required) throws CommandFormatException {
+        final String value = getOriginalValue(parsedLine, required);
+        return resolveValue(value);
+    }
+
+    public static String resolveValue(final String value) throws CommandFormatException {
+        if(value == null) {
+            return null;
+        }
+
+        final StringBuilder buf = new StringBuilder();
+        final ExpressionBaseState state = new ExpressionBaseState("EXPR", true, false);
+        state.setDefaultHandler(WordCharacterHandler.IGNORE_LB_ESCAPE_ON);
+        StateParser.parse(value, new ParsingStateCallbackHandler(){
+            @Override
+            public void enteredState(ParsingContext ctx) throws CommandFormatException {
+            }
+
+            @Override
+            public void leavingState(ParsingContext ctx) throws CommandFormatException {
+            }
+
+            @Override
+            public void character(ParsingContext ctx) throws CommandFormatException {
+                buf.append(ctx.getCharacter());
+            }}, state);
+        return buf.toString();
+    }
+
+    /**
+     * Returns value as it appeared on the command line with escape sequences
+     * and system properties not resolved. The variables, though, are resolved
+     * during the initial parsing of the command line.
+     *
+     * @param parsedLine  parsed command line
+     * @param required  whether the argument is required
+     * @return  argument value as it appears on the command line
+     * @throws CommandFormatException  in case the required argument is missing
+     */
+    public String getOriginalValue(ParsedCommandLine parsedLine, boolean required) throws CommandFormatException {
         String value = null;
-        if(args.hasProperties()) {
+        if(parsedLine.hasProperties()) {
             if(index >= 0) {
-                List<String> others = args.getOtherProperties();
+                List<String> others = parsedLine.getOtherProperties();
                 if(others.size() > index) {
                     return others.get(index);
                 }
             }
 
-            value = args.getPropertyValue(fullName);
+            value = parsedLine.getPropertyValue(fullName);
             if(value == null && shortName != null) {
-                value = args.getPropertyValue(shortName);
+                value = parsedLine.getPropertyValue(shortName);
             }
         }
 
-        if(required && value == null && !isPresent(args)) {
+        if(required && value == null && !isPresent(parsedLine)) {
             StringBuilder buf = new StringBuilder();
             buf.append("Required argument ");
             buf.append('\'').append(fullName).append('\'');
@@ -101,6 +159,15 @@ public class ArgumentWithValue extends ArgumentWithoutValue {
             throw new CommandFormatException(buf.toString());
         }
         return value;
+    }
+
+    public ModelNode toModelNode(CommandContext ctx) throws CommandFormatException {
+        final ParsedCommandLine parsedLine = ctx.getParsedCommandLine();
+        final String value = getOriginalValue(parsedLine, false);
+        if(value == null) {
+            return null;
+        }
+        return valueConverter.fromString(ctx, value);
     }
 
     @Override

--- a/cli/src/main/java/org/jboss/as/cli/parsing/LineBreakHandler.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/LineBreakHandler.java
@@ -50,7 +50,7 @@ public class LineBreakHandler implements CharacterHandler {
             } else if(fallbackToEscape){
                 ctx.enterState(EscapeCharacterState.INSTANCE);
             } else {
-                doHandle(ctx);
+                ctx.enterState(EscapeCharacterState.KEEP_ESCAPE);
             }
         } else {
             doHandle(ctx);

--- a/cli/src/main/java/org/jboss/as/cli/parsing/StateParser.java
+++ b/cli/src/main/java/org/jboss/as/cli/parsing/StateParser.java
@@ -163,12 +163,14 @@ public class StateParser {
 
             // TODO resolve variables
             int endIndex = location + 1;
-            if(endIndex >= input.length() || !Character.isJavaIdentifierStart(input.charAt(endIndex))) {
+            char c = input.charAt(endIndex);
+            if(endIndex >= input.length() || !(Character.isJavaIdentifierStart(c) && c != '$')) {
                 // simply '$'
                 return;
             }
             while(++endIndex < input.length()) {
-                if(!Character.isJavaIdentifierPart(input.charAt(endIndex))) {
+                c = input.charAt(endIndex);
+                if(!(Character.isJavaIdentifierPart(c) && c != '$')) {
                     break;
                 }
             }

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/PropertyReplacementTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/PropertyReplacementTestCase.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+
 import org.jboss.as.cli.CommandFormatException;
 import org.jboss.as.cli.operation.OperationRequestAddress;
 import org.jboss.as.cli.operation.ParsedCommandLine;
@@ -155,10 +156,10 @@ public class PropertyReplacementTestCase {
 
     @Test
     public void testCommandArgumentNameAndValue() throws Exception {
-        final ParsedCommandLine parsed = parse("command-name --${" + OP_PROP_PROP_NAME + "}=${OP_PROP_PROP_NAME}");
+        final ParsedCommandLine parsed = parse("command-name --${" + OP_PROP_PROP_NAME + "}=${" + OP_PROP_PROP_NAME + "}");
         assertEquals("command-name", parsed.getOperationName());
         // there is a different config option whether to resolve argument values
-        assertEquals(parsed.getPropertyValue("--" + OP_PROP_PROP_VALUE), "${OP_PROP_PROP_NAME}");
+        assertEquals(parsed.getPropertyValue("--" + OP_PROP_PROP_VALUE), "${" + OP_PROP_PROP_NAME + "}");
     }
 
     @Test
@@ -194,6 +195,15 @@ public class PropertyReplacementTestCase {
         headers = new ModelNode();
         parsed.getLastHeader().addTo(null, headers);
         assertEquals(OP_PROP_VALUE, headers.get(OP_PROP_PROP_VALUE).asString());
+    }
+
+    @Test
+    public void testSystemPropertiesInTheMix() throws Exception {
+        final ParsedCommandLine parsed = parse("co${" + OP_PROP_NAME + "}${" + OP_PROP_NAME + "} "
+                + "--${" + OP_PROP_PROP_NAME + "}_${" + OP_PROP_PROP_NAME + "}=${" + OP_PROP_PROP_NAME + "}");
+        assertEquals("co" + OP_PROP_VALUE + OP_PROP_VALUE, parsed.getOperationName());
+        assertTrue(parsed.getOtherProperties().isEmpty());
+        assertEquals("${" + OP_PROP_PROP_NAME + "}", parsed.getPropertyValue("--" + OP_PROP_PROP_VALUE + "_" + OP_PROP_PROP_VALUE));
     }
 
     private void assertFailedToParse(String line) {

--- a/cli/src/test/java/org/jboss/as/cli/parsing/test/VariablesTestCase.java
+++ b/cli/src/test/java/org/jboss/as/cli/parsing/test/VariablesTestCase.java
@@ -28,6 +28,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.util.List;
+
 import org.jboss.as.cli.CommandContext;
 import org.jboss.as.cli.CommandContextFactory;
 import org.jboss.as.cli.CommandFormatException;
@@ -198,6 +200,24 @@ public class VariablesTestCase {
         headers = new ModelNode();
         parsed.getLastHeader().addTo(null, headers);
         assertEquals(OP_VAR_VALUE, headers.get(OP_PROP_VAR_VALUE).asString());
+    }
+
+    @Test
+    public void testVariablesInTheMix() throws Exception {
+        final ParsedCommandLine parsed = parse("co$" + OP_VAR_NAME + "$" + OP_VAR_NAME + " $" + OP_PROP_VAR_NAME + ":$" + OP_PROP_VAR_NAME);
+        assertEquals("co" + OP_VAR_VALUE + OP_VAR_VALUE, parsed.getOperationName());
+        final List<String> props = parsed.getOtherProperties();
+        assertEquals(1, props.size());
+        assertEquals(OP_PROP_VAR_VALUE + ':' + OP_PROP_VAR_VALUE, props.get(0));
+    }
+
+    @Test
+    public void testEscapingVariableName() throws Exception {
+        final ParsedCommandLine parsed = parse("set v=\\$" + OP_VAR_NAME);
+        assertEquals("set", parsed.getOperationName());
+        final List<String> props = parsed.getOtherProperties();
+        assertEquals(1, props.size());
+        assertEquals("v=\\$" + OP_VAR_NAME, props.get(0));
     }
 
     private void assertFailedToParse(String line) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileWithPropertiesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/FileWithPropertiesTestCase.java
@@ -58,6 +58,11 @@ public class FileWithPropertiesTestCase {
     private static final String SERVER_PROP_NAME = "cli-arg-test";
     private static final String CLI_PROP_NAME = "cli.prop.name";
     private static final String CLI_PROP_VALUE = "cli.prop.value";
+    private static final String HOST_PROP_NAME = "cli.host.name";
+    private static final String HOST_PROP_VALUE = TestSuiteEnvironment.getServerAddress();
+    private static final String PORT_PROP_NAME = "cli.port.name";
+    private static final String PORT_PROP_VALUE = String.valueOf(TestSuiteEnvironment.getServerPort());
+    private static final String CONNECT_COMMAND = "connect ${" + HOST_PROP_NAME + "}:${" + PORT_PROP_NAME + "}";
     private static final String SET_PROP_COMMAND = "/system-property=" + SERVER_PROP_NAME + ":add(value=${cli.prop.name})";
     private static final String GET_PROP_COMMAND = "/system-property=" + SERVER_PROP_NAME + ":read-resource";
     private static final String REMOVE_PROP_COMMAND = "/system-property=" + SERVER_PROP_NAME + ":remove";
@@ -126,6 +131,8 @@ public class FileWithPropertiesTestCase {
         ensureRemoved(PROPS_FILE);
         try {
             writer = new BufferedWriter(new FileWriter(SCRIPT_FILE));
+            writer.write(CONNECT_COMMAND);
+            writer.newLine();
             writer.write(SET_PROP_COMMAND);
             writer.newLine();
             writer.write(GET_PROP_COMMAND);
@@ -146,10 +153,9 @@ public class FileWithPropertiesTestCase {
         writer = null;
         try {
             writer = new BufferedWriter(new FileWriter(PROPS_FILE));
-            writer.write(CLI_PROP_NAME);
-            writer.write('=');
-            writer.write(CLI_PROP_VALUE);
-            writer.write('\n');
+            writer.write(CLI_PROP_NAME); writer.write('='); writer.write(CLI_PROP_VALUE); writer.newLine();
+            writer.write(HOST_PROP_NAME); writer.write('='); writer.write(HOST_PROP_VALUE); writer.newLine();
+            writer.write(PORT_PROP_NAME); writer.write('='); writer.write(PORT_PROP_VALUE); writer.newLine();
         } catch (IOException e) {
             fail("Failed to write to " + PROPS_FILE.getAbsolutePath() + ": " + e.getLocalizedMessage());
         } finally {
@@ -241,8 +247,8 @@ public class FileWithPropertiesTestCase {
         command.add("-mp");
         command.add(modulePath);
         command.add("org.jboss.as.cli");
-        command.add("-c");
-        command.add("--controller=" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getServerPort());
+        //command.add("-c");
+        //command.add("--controller=" + TestSuiteEnvironment.getServerAddress() + ":" + TestSuiteEnvironment.getServerPort());
         command.add("--file=" + SCRIPT_FILE.getAbsolutePath());
         command.add("--properties=" + PROPS_FILE.getAbsolutePath());
         builder.command(command);


### PR DESCRIPTION
...r arguments of commands handled on the client-side

The issue is that argument values that are as operation request parameters are resolved during their conversion from string representation to DMR ModelNode. The resolution step is missing for argument values used for client-side commands like connect, cd, etc.

Thanks,
Alexey
