### PR TITLE
WFLY-2205 Undeployment prints null

### DIFF
--- a/server/src/main/java/org/jboss/as/server/ServerLogger.java
+++ b/server/src/main/java/org/jboss/as/server/ServerLogger.java
@@ -410,4 +410,12 @@ public interface ServerLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 15972, value = "The operating system has limited the number of open files to %d for this process; a value of at least 4096 is recommended")
     void fdTooLow(long fdCount);
+
+    @LogMessage(level = INFO)
+    @Message(id = 15973, value = "Starting subdeployment (runtime-name: \"%s\")")
+    void startingSubDeployment(String deploymentUnitName);
+
+    @LogMessage(level = INFO)
+    @Message(id = 15974, value = "Stopped subdeployment (runtime-name: %s) in %dms")
+    void stoppedSubDeployment(String deploymentUnitName, int elapsedTime);
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUnitService.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/AbstractDeploymentUnitService.java
@@ -65,7 +65,11 @@ public abstract class AbstractDeploymentUnitService implements Service<Deploymen
         deploymentUnit = createAndInitializeDeploymentUnit(context.getController().getServiceContainer());
 
         final String managementName = deploymentUnit.getAttachment(Attachments.MANAGEMENT_NAME);
-        ServerLogger.DEPLOYMENT_LOGGER.startingDeployment(managementName, deploymentName);
+        if (deploymentUnit.getParent()==null) {
+            ServerLogger.DEPLOYMENT_LOGGER.startingDeployment(managementName, deploymentName);
+        } else {
+            ServerLogger.DEPLOYMENT_LOGGER.startingSubDeployment(deploymentName);
+        }
 
         final ServiceName serviceName = deploymentUnit.getServiceName().append(FIRST_PHASE_NAME);
         final Phase firstPhase = Phase.values()[0];
@@ -87,7 +91,11 @@ public abstract class AbstractDeploymentUnitService implements Service<Deploymen
     public synchronized void stop(final StopContext context) {
         final String deploymentName = context.getController().getName().getSimpleName();
         final String managementName = deploymentUnit.getAttachment(Attachments.MANAGEMENT_NAME);
-        ServerLogger.DEPLOYMENT_LOGGER.stoppedDeployment(managementName, deploymentName, (int) (context.getElapsedTime() / 1000000L));
+        if (deploymentUnit.getParent()==null) {
+            ServerLogger.DEPLOYMENT_LOGGER.stoppedDeployment(managementName, deploymentName, (int) (context.getElapsedTime() / 1000000L));
+        } else {
+            ServerLogger.DEPLOYMENT_LOGGER.stoppedSubDeployment(deploymentName, (int) (context.getElapsedTime() / 1000000L));
+        }
         deploymentUnit = null;
         monitor.removeController(context.getController());
         monitor = null;


### PR DESCRIPTION
Fix to WFLY-2205 where null is printed out at subdeployment start/stop..

See http://lists.jboss.org/pipermail/wildfly-dev/2014-February/001883.html for discussion with Brian Stansberry.
