### PR TITLE
[WFLY-1156] support source address and port for messaging connectors

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -40,6 +40,7 @@ import org.hornetq.api.core.DiscoveryGroupConfiguration;
 import org.hornetq.api.core.TransportConfiguration;
 import org.hornetq.core.config.Configuration;
 import org.hornetq.core.journal.impl.AIOSequentialFileFactory;
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
 import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.server.JournalType;
 import org.hornetq.core.server.impl.HornetQServerImpl;
@@ -189,6 +190,12 @@ class HornetQService implements Service<HornetQServer> {
                         } else {
                             port = binding.getDestinationPort();
                             host = binding.getUnresolvedDestinationAddress();
+                            if (binding.getSourceAddress() != null) {
+                                tc.getParams().put(TransportConstants.LOCAL_ADDRESS_PROP_NAME, binding.getSourceAddress().getHostAddress());
+                            }
+                            if (binding.getSourcePort() != null) {
+                                tc.getParams().put(TransportConstants.LOCAL_PORT_PROP_NAME, binding.getSourcePort());
+                            }
                         }
                         tc.getParams().put(HOST, host);
                         tc.getParams().put(PORT, String.valueOf(port));


### PR DESCRIPTION
If an outbound-socket-binding is used to configure messaging connectors,
fill the connector's local-address and local-port properties using the
binding's sourceAddress & sourcePort (provided they are defined).

JIRA: https://issues.jboss.org/browse/WFLY-1156
