### PR TITLE
[BZ1064405] Missing dependencies in org.picketlink.common module fixed

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
@@ -31,6 +31,8 @@
     <dependencies>
         <module name="javax.api" />
         <module name="javax.xml.stream.api" />
+        <module name="javax.xml.bind.api"/>
+        <module name="javax.xml.ws.api"/>
         <module name="org.jboss.logging" />
     </dependencies>
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3065
