### PR TITLE
Clean up modules.xml

### DIFF
--- a/build/lib.xml
+++ b/build/lib.xml
@@ -56,13 +56,8 @@
             <resources/>
 
             <!-- Some final cleanup -->
-            <replace file="${module.repo.output.dir}/${current.module.path}/${module.xml}">
-                <replacetoken>
-                    <![CDATA[
-        <!-- Insert resources here -->]]></replacetoken>
-                <replacevalue>
-                </replacevalue>
-            </replace>
+            <replaceregexp file="${module.repo.output.dir}/${current.module.path}/${module.xml}" match="\s+&lt;!-- Insert resources here --&gt;" replace=""
+                          flags="gis" byline="false"/>
 
         </sequential>
     </macrodef>

--- a/build/src/main/resources/modules/system/layers/base/asm/asm/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/asm/asm/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="asm.asm">
+<module xmlns="urn:jboss:module:1.3" name="asm.asm">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/ch/qos/cal10n/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/ch/qos/cal10n/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="ch.qos.cal10n">
+<module xmlns="urn:jboss:module:1.3" name="ch.qos.cal10n">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/classmate/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/classmate/main/module.xml
@@ -22,7 +22,7 @@
 ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.classmate">
+<module xmlns="urn:jboss:module:1.3" name="com.fasterxml.classmate">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-annotations/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-annotations/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.core.jackson-annotations">
+<module xmlns="urn:jboss:module:1.3" name="com.fasterxml.jackson.core.jackson-annotations">
      <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-core/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.core.jackson-core">
+<module xmlns="urn:jboss:module:1.3" name="com.fasterxml.jackson.core.jackson-core">
      <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-databind/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/core/jackson-databind/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.core.jackson-databind">
+<module xmlns="urn:jboss:module:1.3" name="com.fasterxml.jackson.core.jackson-databind">
      <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/fasterxml/jackson/jaxrs/jackson-jaxrs-json-provider/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
+<module xmlns="urn:jboss:module:1.3" name="com.fasterxml.jackson.jaxrs.jackson-jaxrs-json-provider">
      <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/com/github/relaxng/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/github/relaxng/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 
-<module xmlns="urn:jboss:module:1.1" name="com.github.relaxng">
+<module xmlns="urn:jboss:module:1.3" name="com.github.relaxng">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/google/guava/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/google/guava/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.google.guava">
+<module xmlns="urn:jboss:module:1.3" name="com.google.guava">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/h2database/h2/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/h2database/h2/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.h2database.h2">
+<module xmlns="urn:jboss:module:1.3" name="com.h2database.h2">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/com/sun/codemodel/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/codemodel/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.codemodel">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.codemodel">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/sun/istack/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/istack/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.istack">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.istack">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.jsf-impl">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.jsf-impl">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/sun/xml/bind/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/xml/bind/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.xml.bind">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.xml.bind">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/sun/xml/fastinfoset/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/xml/fastinfoset/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.xml.fastinfoset">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.xml.fastinfoset">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/sun/xml/messaging/saaj/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/xml/messaging/saaj/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.xml.messaging.saaj">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.xml.messaging.saaj">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/sun/xml/txw2/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/xml/txw2/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.xml.txw2">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.xml.txw2">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/com/sun/xsom/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/xsom/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="com.sun.xsom">
+<module xmlns="urn:jboss:module:1.3" name="com.sun.xsom">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/gnu/getopt/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/gnu/getopt/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="gnu.getopt">
+<module xmlns="urn:jboss:module:1.3" name="gnu.getopt">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/ibm/jdk/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="ibm.jdk">
+<module xmlns="urn:jboss:module:1.3" name="ibm.jdk">
     <resources>
 
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="io.netty">
+<module xmlns="urn:jboss:module:1.3" name="io.netty">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/io/undertow/core/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="io.undertow.core">
+<module xmlns="urn:jboss:module:1.3" name="io.undertow.core">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/io/undertow/jasper-jdt/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/io/undertow/jasper-jdt/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="io.undertow.jasper-jdt">
+<module xmlns="urn:jboss:module:1.3" name="io.undertow.jasper-jdt">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/io/undertow/jsp/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/io/undertow/jsp/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="io.undertow.jsp">
+<module xmlns="urn:jboss:module:1.3" name="io.undertow.jsp">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/io/undertow/servlet/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="io.undertow.servlet">
+<module xmlns="urn:jboss:module:1.3" name="io.undertow.servlet">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/io/undertow/websocket/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/io/undertow/websocket/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="io.undertow.websocket">
+<module xmlns="urn:jboss:module:1.3" name="io.undertow.websocket">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javaee.api">
+<module xmlns="urn:jboss:module:1.3" name="javaee.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/activation/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/activation/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.activation.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.activation.api">
     <dependencies>
         <module name="javax.api" />
         <module name="javax.mail.api" optional="true">

--- a/build/src/main/resources/modules/system/layers/base/javax/annotation/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/annotation/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.annotation.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.annotation.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/api/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="javax.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.api">
     <dependencies>
         <system export="true">
             <paths>

--- a/build/src/main/resources/modules/system/layers/base/javax/batch/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/batch/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.batch.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.batch.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/ejb/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.ejb.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.ejb.api">
     <dependencies>
         <!-- This dep is for javax.naming -->
         <module name="javax.api" export="true"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/el/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/el/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.el.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.el.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/enterprise/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.enterprise.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.enterprise.api">
     <dependencies>
         <module name="org.glassfish.javax.el" export="true"/>
         <module name="javax.inject.api" export="true"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/enterprise/concurrent/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/enterprise/concurrent/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.enterprise.concurrent.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.enterprise.concurrent.api">
     
     <dependencies>
     </dependencies>

--- a/build/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/faces/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.faces.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.faces.api">
     <dependencies>
         <module name="com.sun.jsf-impl"/>
         <module name="javax.enterprise.api" export="true"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/inject/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.inject.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.inject.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/interceptor/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.interceptor.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.interceptor.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/jms/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/jms/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.jms.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.jms.api">
     <dependencies>
         <module name="javax.transaction.api" export="true"/>
     </dependencies>

--- a/build/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -22,4 +22,4 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.1" name="javax.json.api" target-name="org.glassfish.javax.json"/>
+<module-alias xmlns="urn:jboss:module:1.3" name="javax.json.api" target-name="org.glassfish.javax.json"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/jws/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/jws/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.jws.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.jws.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/mail/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/mail/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.mail.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.mail.api">
     <dependencies>
         <module name="javax.activation.api" />
         <module name="javax.api"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.management.j2ee.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.management.j2ee.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/persistence/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.persistence.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.persistence.api">
     <dependencies>
         <!-- PersistenceUnitInfo needs javax.sql.DataSource -->
         <module name="javax.api" export="true"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/resource/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/resource/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.resource.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.resource.api">
     <dependencies>
         <module name="javax.transaction.api" export="true"/>
         <module name="javax.api" export="false">

--- a/build/src/main/resources/modules/system/layers/base/javax/rmi/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/rmi/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.rmi.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.rmi.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/security/auth/message/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/security/auth/message/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.security.auth.message.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.security.auth.message.api">
 
     <dependencies>
         <!-- Needed for javax.security.auth -->

--- a/build/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/security/jacc/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.security.jacc.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.security.jacc.api">
     <dependencies>
         <module name="javax.servlet.api"/>
         <module name="org.jboss.common-core"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/servlet/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/servlet/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.servlet.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.servlet.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/servlet/jsp/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.servlet.jsp.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.servlet.jsp.api">
     <dependencies>
         <module name="javax.servlet.api" export="true"/>
         <module name="org.glassfish.javax.el" export="true"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/servlet/jstl/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/servlet/jstl/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.servlet.jstl.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.servlet.jstl.api">
     <dependencies>
         <!-- org.xml.sax -->
         <module name="javax.api" export="false"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/transaction/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/transaction/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.transaction.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.transaction.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/validation/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.validation.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.validation.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/websocket/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/websocket/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.websocket.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.websocket.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.ws.rs.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.ws.rs.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/wsdl4j/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/wsdl4j/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.wsdl4j.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.wsdl4j.api">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/xml/bind/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.xml.bind.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.xml.bind.api">
 
 
     <dependencies>

--- a/build/src/main/resources/modules/system/layers/base/javax/xml/rpc/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/xml/rpc/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.xml.rpc.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.xml.rpc.api">
     <dependencies>
         <module name="javax.api" />
         <module name="javax.xml.soap.api" export="true"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/xml/soap/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/xml/soap/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.xml.soap.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.xml.soap.api">
     <dependencies>
         <module name="javax.activation.api" export="true"/>
         <module name="javax.api"/>

--- a/build/src/main/resources/modules/system/layers/base/javax/xml/stream/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/xml/stream/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.xml.stream.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.xml.stream.api">
 
     <dependencies>
         <system export="true">

--- a/build/src/main/resources/modules/system/layers/base/javax/xml/ws/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/javax/xml/ws/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="javax.xml.ws.api">
+<module xmlns="urn:jboss:module:1.3" name="javax.xml.ws.api">
     <dependencies>
         <module name="javax.xml.bind.api" export="true"/>
         <module name="javax.xml.soap.api" export="true"/>

--- a/build/src/main/resources/modules/system/layers/base/net/jcip/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/net/jcip/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="net.jcip">
+<module xmlns="urn:jboss:module:1.3" name="net.jcip">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/nu/xom/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/nu/xom/main/module.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="nu.xom">
+<module xmlns="urn:jboss:module:1.3" name="nu.xom">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/antlr/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/antlr/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.antlr">
+<module xmlns="urn:jboss:module:1.3" name="org.antlr">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/avro/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/avro/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.avro">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.avro">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/beanutils/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/beanutils/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.beanutils">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.beanutils">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/cli/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/cli/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.cli">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.cli">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/codec/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/codec/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.codec">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.codec">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/collections/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/collections/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.collections">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.collections">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/configuration/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/configuration/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.configuration">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.configuration">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/io/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/io/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.io">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.io">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/lang/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/lang/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.lang">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.lang">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/logging/main/module.xml
@@ -22,4 +22,4 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.1" name="org.apache.commons.logging" target-name="org.slf4j.jcl-over-slf4j"/>
+<module-alias xmlns="urn:jboss:module:1.3" name="org.apache.commons.logging" target-name="org.slf4j.jcl-over-slf4j"/>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/commons/pool/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/commons/pool/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.commons.pool">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.commons.pool">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.cxf.impl">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.cxf.impl">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.cxf">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.cxf">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/httpcomponents/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.httpcomponents">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.httpcomponents">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/james/mime4j/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/james/mime4j/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.james.mime4j">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.james.mime4j">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/log4j/main/module.xml
@@ -22,4 +22,4 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.1" name="org.apache.log4j" target-name="org.jboss.log4j.logmanager"/>
+<module-alias xmlns="urn:jboss:module:1.3" name="org.apache.log4j" target-name="org.jboss.log4j.logmanager"/>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/lucene/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.lucene">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.lucene">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/neethi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/neethi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.neethi">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.neethi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the OpenJPA module  -->
-<module xmlns="urn:jboss:module:1.1" name="org.apache.openjpa">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.openjpa">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/qpid/proton/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.qpid.proton">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.qpid.proton">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/santuario/xmlsec/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.santuario.xmlsec">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.santuario.xmlsec">
 
     <exports>
         <exclude path="javax/**"/>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/velocity/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/velocity/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.velocity">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.velocity">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/ws/security/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/ws/security/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.ws.security">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.ws.security">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/ws/xmlschema/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/ws/xmlschema/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.ws.xmlschema">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.ws.xmlschema">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/apache/xalan/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/xalan/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.xalan">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.xalan">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/apache/xerces/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/xerces/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.xerces">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.xerces">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/apache/xml-resolver/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.apache.xml-resolver">
+<module xmlns="urn:jboss:module:1.3" name="org.apache.xml-resolver">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/bouncycastle/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.bouncycastle">
+<module xmlns="urn:jboss:module:1.3" name="org.bouncycastle">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.codehaus.jackson.jackson-core-asl">
+<module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-core-asl">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.codehaus.jackson.jackson-jaxrs">
+<module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-jaxrs">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.codehaus.jackson.jackson-mapper-asl">
+<module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-mapper-asl">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.codehaus.jackson.jackson-xc">
+<module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-xc">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/codehaus/jettison/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/codehaus/jettison/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.codehaus.jettison">
+<module xmlns="urn:jboss:module:1.3" name="org.codehaus.jettison">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/codehaus/woodstox/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.codehaus.woodstox">
+<module xmlns="urn:jboss:module:1.3" name="org.codehaus.woodstox">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/dom4j/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/dom4j/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.dom4j">
+<module xmlns="urn:jboss:module:1.3" name="org.dom4j">
   <resources>
     <!-- Insert resources here -->
   </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/eclipse/persistence/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/eclipse/persistence/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the EclipseLink module  -->
-<module xmlns="urn:jboss:module:1.1" name="org.eclipse.persistence">
+<module xmlns="urn:jboss:module:1.3" name="org.eclipse.persistence">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/fusesource/jansi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/fusesource/jansi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.fusesource.jansi">
+<module xmlns="urn:jboss:module:1.3" name="org.fusesource.jansi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/el/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.glassfish.javax.el">
+<module xmlns="urn:jboss:module:1.3" name="org.glassfish.javax.el">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/enterprise/concurrent/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/enterprise/concurrent/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.glassfish.javax.enterprise.concurrent">
+<module xmlns="urn:jboss:module:1.3" name="org.glassfish.javax.enterprise.concurrent">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/glassfish/javax/json/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.glassfish.javax.json">
+<module xmlns="urn:jboss:module:1.3" name="org.glassfish.javax.json">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/3/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/3/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 3.x module  -->
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate" slot="3">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate" slot="3">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 4.1.x (works with Hibernate 4.2.x jars also) module  -->
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate" slot="4.1">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate" slot="4.1">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/commons-annotations/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/commons-annotations/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 4.0.x module-->
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate.commons-annotations">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.commons-annotations">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/envers/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/envers/main/module.xml
@@ -22,4 +22,4 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.1" name="org.hibernate.envers" target-name="org.hibernate"/>
+<module-alias xmlns="urn:jboss:module:1.3" name="org.hibernate.envers" target-name="org.hibernate"/>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/hql/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/hql/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate.hql">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.hql">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- Represents the Hibernate 4.3.x module-->
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -25,7 +25,7 @@
 <!-- Hibernate Search Engine: the fulltext indexing and query capabilities
      without the ORM integration bits. This is reused by several other project
      outside of the Hibernate group. -->
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate.search.engine">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.search.engine">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/search/orm/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/search/orm/main/module.xml
@@ -24,7 +24,7 @@
 <!-- Hibernate Search ORM: integrates org.hibernate.search.engine with
      Hibernate ORM to provide Hibernate Search functionality to
      JPA Applications -->
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate.search.orm">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.search.orm">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/cdi/main/module.xml
@@ -22,7 +22,7 @@
 ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate.validator.cdi">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.validator.cdi">
 
   <resources>
     <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hibernate.validator">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.validator">
 
   <resources>
     <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/hornetq/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hornetq/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hornetq">
+<module xmlns="urn:jboss:module:1.3" name="org.hornetq">
     <resources>
         <resource-root path="lib"/>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/amqp/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/amqp/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hornetq.protocol.amqp">
+<module xmlns="urn:jboss:module:1.3" name="org.hornetq.protocol.amqp">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/stomp/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hornetq/protocol/stomp/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hornetq.protocol.stomp">
+<module xmlns="urn:jboss:module:1.3" name="org.hornetq.protocol.stomp">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hornetq/ra/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hornetq/ra/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.hornetq.ra">
+<module xmlns="urn:jboss:module:1.3" name="org.hornetq.ra">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/jdbc/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/jdbc/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.cachestore.jdbc">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.cachestore.jdbc">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/remote/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/cachestore/remote/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.cachestore.remote">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.cachestore.remote">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/client/hotrod/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.client.hotrod">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.client.hotrod">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/commons/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/commons/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.commons">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.commons">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/lucene/directory/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/lucene/directory/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.lucene.directory">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.lucene.directory">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/lucene/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/lucene/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.lucene">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.lucene">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/query/dsl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/query/dsl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.query.dsl">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.query.dsl">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.infinispan.query">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.query">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jacorb/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jacorb/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jacorb">
+<module xmlns="urn:jboss:module:1.3" name="org.jacorb">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/javassist/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/javassist/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.javassist">
+<module xmlns="urn:jboss:module:1.3" name="org.javassist">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jaxen/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jaxen/main/module.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jaxen">
+<module xmlns="urn:jboss:module:1.3" name="org.jaxen">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jberet.jberet-core">
+<module xmlns="urn:jboss:module:1.3" name="org.jberet.jberet-core">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/aesh/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/aesh/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.aesh">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.aesh">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/aggregate/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/aggregate/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.aggregate">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.aggregate">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.appclient">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.appclient">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/cli/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.cli">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.cli">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.clustering.common">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.clustering.common">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/ejb3/infinispan/main/module.xml
@@ -21,4 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.1" name="org.jboss.as.clustering.ejb3.infinispan" target-name="org.wildfly.clustering.ejb.infinispan"/>
+<module-alias xmlns="urn:jboss:module:1.3" name="org.jboss.as.clustering.ejb3.infinispan" target-name="org.wildfly.clustering.ejb.infinispan"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.clustering.infinispan">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.clustering.infinispan">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/jgroups/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/jgroups/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.clustering.jgroups">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.clustering.jgroups">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/web/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/web/infinispan/main/module.xml
@@ -21,4 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.1" name="org.jboss.as.clustering.web.infinispan" target-name="org.wildfly.clustering.web.infinispan"/>
+<module-alias xmlns="urn:jboss:module:1.3" name="org.jboss.as.clustering.web.infinispan" target-name="org.wildfly.clustering.web.infinispan"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/cmp/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/cmp/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.cmp">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.cmp">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.connector">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.connector">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/console/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/console/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.console">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.console">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller-client/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.controller-client">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.controller-client">
 
     <exports>
         <exclude path="**/impl/*"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.controller">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.controller">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/core-security-api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/core-security-api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.core-security-api">    
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.core-security-api">    
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/core-security/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.core-security">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.core-security">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-repository/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-repository/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.deployment-repository">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.deployment-repository">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/deployment-scanner/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.deployment-scanner">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.deployment-scanner">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-add-user/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-add-user/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.domain-add-user">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.domain-add-user">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-error-context/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-error-context/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.domain-http-error-context">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.domain-http-error-context">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-http-interface/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.domain-http-interface">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.domain-http-interface">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/domain-management/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.domain-management">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.domain-management">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
@@ -21,7 +21,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.ee">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.ee">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.ejb3">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.ejb3">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.embedded">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.embedded">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/host-controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.host-controller">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.host-controller">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jacorb/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jacorb/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jacorb">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jacorb">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxr/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxr/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jaxr">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jaxr">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jaxrs">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jaxrs">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jdr">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jdr">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jmx">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jmx">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/3/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/3/module.xml
@@ -25,7 +25,7 @@
 <!-- deprecated module that applications including Hibernate 3 jars might have a dependency on.
 -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jpa.hibernate" slot="3">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jpa.hibernate" slot="3">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/4/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/4/module.xml
@@ -29,7 +29,7 @@
      or use module org.hibernate which contains the JPA integration classes for Hibernate 4.3.x
 -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jpa.hibernate" slot="4">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jpa.hibernate" slot="4">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jpa">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jpa">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/openjpa/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/openjpa/main/module.xml
@@ -23,7 +23,7 @@
   -->
 
 <!-- contains the JPA integration classes for OpenJPA 2.x --> 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jpa.openjpa">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jpa.openjpa">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jpa.spi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jpa.spi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jsf-injection">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jsf-injection">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jsf">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jsf">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.jsr77">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.jsr77">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/logging/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.logging">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.logging">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/mail/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/mail/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.mail">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.mail">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/management-client-content/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/management-client-content/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.management-client-content">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.management-client-content">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.messaging">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.messaging">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/modcluster/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/modcluster/main/module.xml
@@ -21,4 +21,4 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module-alias xmlns="urn:jboss:module:1.1" name="org.jboss.as.modcluster" target-name="org.wildfly.extension.mod_cluster"/>
+<module-alias xmlns="urn:jboss:module:1.3" name="org.jboss.as.modcluster" target-name="org.wildfly.extension.mod_cluster"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.naming">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.naming">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/network/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.network">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.network">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/patching/cli/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/patching/cli/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.patching.cli">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.patching.cli">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/patching/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.patching">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.patching">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/platform-mbean/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.platform-mbean">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.platform-mbean">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/pojo/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/pojo/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.pojo">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.pojo">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/process-controller/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.process-controller">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.process-controller">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/protocol/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.protocol">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.protocol">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/remoting/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.remoting">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.remoting">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/sar/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/sar/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.sar">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.sar">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/security-api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/security-api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.security-api">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.security-api">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.security">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.security">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.server">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.server">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/standalone/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.standalone">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.standalone">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/system-jmx/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/system-jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.system-jmx">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.system-jmx">
     
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/threads/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.threads">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.threads">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.transactions">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.transactions">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/vault-tool/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/vault-tool/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.vault-tool">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.vault-tool">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/version/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/version/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.version">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.version">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/web-common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/web-common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.web-common">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.web-common">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/web/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/web/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.web">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.web">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.webservices">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.webservices">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.webservices.server.integration">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.webservices.server.integration">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.weld">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.weld">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.as.xts">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.as.xts">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/classfilewriter/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/classfilewriter/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.classfilewriter">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.classfilewriter">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/com/sun/httpserver/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/com/sun/httpserver/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.com.sun.httpserver">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.com.sun.httpserver">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/common-beans/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/common-beans/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.common-beans">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.common-beans">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/common-core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/common-core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.common-core">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.common-core">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/deployers/jboss-service-deployer/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/deployers/jboss-service-deployer/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.deployers.jboss-service-deployer">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.deployers.jboss-service-deployer">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/dmr/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/dmr/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.dmr">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.dmr">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ejb-client">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ejb-client">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ejb/remote/protocol/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ejb/remote/protocol/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ejb.remote.protocol">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ejb.remote.protocol">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ejb3">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ejb3">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.genericjms">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.genericjms">
     <resources>
        <resource-root path="."/>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.iiop-client">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.iiop-client">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/integration/ext-content/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/integration/ext-content/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.integration.ext-content">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.integration.ext-content">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/invocation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.invocation">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.invocation">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.api">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ironjacamar.api">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/impl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.impl">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ironjacamar.impl">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ironjacamar/jdbcadapters/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ironjacamar.jdbcadapters">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ironjacamar.jdbcadapters">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/jandex/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/jandex/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.jandex">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.jandex">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/jaxbintros/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/jaxbintros/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.jaxbintros">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.jaxbintros">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/jboss-transaction-spi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/jboss-transaction-spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.jboss-transaction-spi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.jboss-transaction-spi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/jts/integration/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/jts/integration/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.jts.integration">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.jts.integration">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/jts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.jts">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.jts">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/log4j/logmanager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.log4j.logmanager">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.log4j.logmanager">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/logging/jul-to-slf4j-stub/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/logging/jul-to-slf4j-stub/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.logging.jul-to-slf4j-stub">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.logging.jul-to-slf4j-stub">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/logging/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/logging/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.logging">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.logging">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/logmanager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.logmanager">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.logmanager">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/marshalling/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.marshalling">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.marshalling">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/marshalling/river/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.marshalling.river">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.marshalling.river">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/metadata/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/metadata/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.metadata">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.metadata">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/container/spi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/container/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.mod_cluster.container.spi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.mod_cluster.container.spi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/mod_cluster/core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.mod_cluster.core">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.mod_cluster.core">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/modules/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/modules/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.modules">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.modules">
     <dependencies>
         <system export="true">
             <paths>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/msc/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.msc">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.msc">
 
     <main-class name="org.jboss.msc.Version"/>
 

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.narayana.rts">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.narayana.rts">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.narayana.txframework">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.narayana.txframework">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remote-naming/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remote-naming/main/module.xml
@@ -20,7 +20,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.remote-naming">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.remote-naming">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting-jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.remoting-jmx">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.remoting-jmx">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.remoting">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.remoting">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting3/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting3/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.remoting3">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.remoting3">
     <!-- This module is deprecated and subject to being removed in a subsequent release.      -->
 
     <!-- Any use of the Remoting library should now reference the org.jboss.remoting          -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/remoting3/remoting-jmx/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/remoting3/remoting-jmx/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.remoting3.remoting-jmx">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.remoting3.remoting-jmx">
     <!-- This module is deprecated and subject to being removed in a subsequent release.      -->
     
     <!-- Any use of the Remoting JMX library should now reference the org.jboss.remoting-jmx  -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/jose-jwt/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/jose-jwt/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.jose-jwt">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.jose-jwt">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-atom-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-atom-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-atom-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-atom-provider">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-cdi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-cdi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-crypto/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-crypto/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-crypto">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-crypto">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jackson-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-jackson-provider">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jackson2-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jackson2-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-jackson2-provider">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxb-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxb-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-jaxb-provider">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jaxrs">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-jaxrs">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jettison-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jettison-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jettison-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-jettison-provider">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jsapi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jsapi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-jsapi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-jsapi">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-p-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-json-p-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-json-p-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-json-p-provider">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-multipart-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-multipart-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-multipart-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-multipart-provider">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-spring/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-spring">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-spring">
 
     <resources>
         <!-- This module just contains the jar as a resource root. It cannot be depended on to get

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider-11/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-validator-provider-11/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-validator-provider-11">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-validator-provider-11">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-yaml-provider/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-yaml-provider/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.resteasy.resteasy-yaml-provider">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-yaml-provider">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/sasl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/sasl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.sasl">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.sasl">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/security/negotiation/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/security/negotiation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.security.negotiation">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.security.negotiation">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/security/xacml/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/security/xacml/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.security.xacml">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.security.xacml">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/shrinkwrap/core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/shrinkwrap/core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.shrinkwrap.core">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.shrinkwrap.core">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/staxmapper/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/staxmapper/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.staxmapper">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.staxmapper">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/stdio/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/stdio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.stdio">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.stdio">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/threads/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/threads/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.threads">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.threads">
 
    <properties>
        <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/vfs/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.vfs">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.vfs">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/weld/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.weld.api">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.weld.api">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.weld.core">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.weld.core">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/weld/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.weld.spi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.weld.spi">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.api">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.api">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.common">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.common">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-client/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.cxf.jbossws-cxf-client">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.cxf.jbossws-cxf-client">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-factories/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-factories/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.cxf.jbossws-cxf-factories">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.cxf.jbossws-cxf-factories">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.cxf.jbossws-cxf-server">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.cxf.jbossws-cxf-server">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-httpserver/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-httpserver/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.cxf.jbossws-cxf-transports-httpserver">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.cxf.jbossws-cxf-transports-httpserver">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-udp/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-transports-udp/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.cxf.jbossws-cxf-transports-udp">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.cxf.jbossws-cxf-transports-udp">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.jaxws-client">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.jaxws-client">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-jboss-httpserver-httpspi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-jboss-httpserver-httpspi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.jaxws-jboss-httpserver-httpspi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.jaxws-jboss-httpserver-httpspi">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/saaj-impl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/saaj-impl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.saaj-impl">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.saaj-impl">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/spi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.spi">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.spi">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.tools.common">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.tools.common">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsconsume/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsconsume/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.tools.wsconsume">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.tools.wsconsume">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsprovide/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/ws/tools/wsprovide/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.ws.tools.wsprovide">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.ws.tools.wsprovide">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/xb/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/xb/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.xb">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.xb">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.xnio">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.xnio">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/netty/netty-xnio-transport/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/netty/netty-xnio-transport/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.xnio.netty.netty-xnio-transport">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.xnio.netty.netty-xnio-transport">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.xnio.nio">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.xnio.nio">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jboss.xts">
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.xts">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jdom/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jdom/main/module.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jdom">
+<module xmlns="urn:jboss:module:1.3" name="org.jdom">
 
     <dependencies>
         <module name="org.jaxen"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jgroups/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jgroups/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jgroups">
+<module xmlns="urn:jboss:module:1.3" name="org.jgroups">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/joda/time/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/joda/time/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.joda.time">
+<module xmlns="urn:jboss:module:1.3" name="org.joda.time">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/jsoup/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jsoup/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.jsoup">
+<module xmlns="urn:jboss:module:1.3" name="org.jsoup">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/kohsuke/rngom/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/kohsuke/rngom/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.kohsuke.rngom">
+<module xmlns="urn:jboss:module:1.3" name="org.kohsuke.rngom">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/omg/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/omg/api/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="org.omg.api">
+<module xmlns="urn:jboss:module:1.3" name="org.omg.api">
     <dependencies>
         <module name="org.jacorb" export="false">
             <exports>

--- a/build/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.opensaml">
+<module xmlns="urn:jboss:module:1.3" name="org.opensaml">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/osgi/core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/osgi/core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.osgi.core">
+<module xmlns="urn:jboss:module:1.3" name="org.osgi.core">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/picketbox/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketbox/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketbox">
+<module xmlns="urn:jboss:module:1.3" name="org.picketbox">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.common">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.common">
 
     <resources>
             <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/config/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/config/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.config">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.config">
 
     <resources>
             <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/core/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/core/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.core.api">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.core.api">
     <resources>
             <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/core/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/core/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.core">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.core">
 
     <resources>
             <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/bindings/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/bindings/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.federation.bindings">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.federation.bindings">
     <resources>
             <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.federation">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.federation">
     <resources>
             <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/idm/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/idm/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.idm.api">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.idm.api">
 
     <resources>
             <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/idm/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/idm/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink.idm">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink.idm">
 
     <resources>
             <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.picketlink">
+<module xmlns="urn:jboss:module:1.3" name="org.picketlink">
     <resources>
     </resources>
 

--- a/build/src/main/resources/modules/system/layers/base/org/scannotation/scannotation/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/scannotation/scannotation/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.scannotation.scannotation">
+<module xmlns="urn:jboss:module:1.3" name="org.scannotation.scannotation">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/slf4j/ext/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/slf4j/ext/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.slf4j.ext">
+<module xmlns="urn:jboss:module:1.3" name="org.slf4j.ext">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/slf4j/impl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/slf4j/impl/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.slf4j.impl">
+<module xmlns="urn:jboss:module:1.3" name="org.slf4j.impl">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/slf4j/jcl-over-slf4j/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/slf4j/jcl-over-slf4j/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.slf4j.jcl-over-slf4j">
+<module xmlns="urn:jboss:module:1.3" name="org.slf4j.jcl-over-slf4j">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/slf4j/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.slf4j">
+<module xmlns="urn:jboss:module:1.3" name="org.slf4j">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.api">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.api">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.ejb.infinispan">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.ejb.infinispan">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/spi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.ejb.spi">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.ejb.spi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.server">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.server">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/singleton/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.singleton">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.singleton">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/api/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/api/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.web.api">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.web.api">
 
     <resources>
         <!-- Insert resources here -->

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.web.infinispan">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.web.infinispan">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/spi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/spi/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.web.spi">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.web.spi">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/undertow/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.clustering.web.undertow">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.clustering.web.undertow">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.batch">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.batch">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -24,7 +24,7 @@
   ~ */
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.io">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.io">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.mod_cluster">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.mod_cluster">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.rts">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.rts">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/security/manager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.security.manager">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.security.manager">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.undertow">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.undertow">
     <resources>
         <!-- Insert resources here -->
     </resources>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/jberet/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/jberet/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.jberet">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.jberet">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/mod_cluster/undertow/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/mod_cluster/undertow/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.mod_cluster.undertow">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.mod_cluster.undertow">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/security/manager/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.wildfly.security.manager">
+<module xmlns="urn:jboss:module:1.3" name="org.wildfly.security.manager">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>

--- a/build/src/main/resources/modules/system/layers/base/org/yaml/snakeyaml/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/yaml/snakeyaml/main/module.xml
@@ -22,7 +22,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.1" name="org.yaml.snakeyaml">
+<module xmlns="urn:jboss:module:1.3" name="org.yaml.snakeyaml">
 
     <properties>
         <property name="jboss.api" value="private"/>

--- a/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -21,7 +21,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.1" name="sun.jdk">
+<module xmlns="urn:jboss:module:1.3" name="sun.jdk">
     <resources>
         <!-- currently jboss modules has not way of importing services from
         classes.jar so we duplicate them here -->


### PR DESCRIPTION
Update to latest schema and remove 'Insert resources here' comment. 

The 1.3 schema is required to use the new build plugin I am working on, so I think it makes sense to merge this now so there is as little difference as possible between the build that is produced by the plugin and our existing build.
