### PR TITLE
[WFLY-3063] Duplicating the SwitchIdentityTestCase to demonstrate the new API that should be used.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/BridgeBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/BridgeBean.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.container.interceptor.security.api;
+
+import javax.annotation.security.PermitAll;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.naming.NamingException;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Implementation of {@link Manage} interface which calls (remotely) the {@link TargetBean} EJB methods. Methods of this class
+ * are not protected (@PermitAll used on class level).
+ *
+ * @author Josef Cacek
+ */
+@Stateless(name = Manage.BEAN_NAME_BRIDGE)
+@Remote(Manage.class)
+@PermitAll
+public class BridgeBean implements Manage {
+
+    private static Logger LOGGER = Logger.getLogger(BridgeBean.class);
+
+    // Public methods --------------------------------------------------------
+
+    public String role1() {
+        return getTargetBean().role1();
+    }
+
+    public String role2() {
+        return getTargetBean().role2();
+    }
+
+    public String allRoles() {
+        return getTargetBean().allRoles();
+    }
+
+    // Private methods -------------------------------------------------------
+
+    private Manage getTargetBean() {
+        try {
+            return EJBUtil.lookupEJB(TargetBean.class, Manage.class);
+        } catch (NamingException e) {
+            LOGGER.error("Error", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/ClientSecurityInterceptor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/ClientSecurityInterceptor.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.container.interceptor.security.api;
+
+import java.security.Principal;
+import java.util.Map;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+import org.jboss.security.SecurityContextAssociation;
+
+/**
+ * Client side interceptor responsible for propagating the local identity.
+ * 
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author Josef Cacek
+ */
+public class ClientSecurityInterceptor implements EJBClientInterceptor {
+
+    /**
+     * Sets the current principal name to the invocation context. Principal name is stored to the context under the
+     * {@link ServerSecurityInterceptor#DELEGATED_USER_KEY} key.
+     * 
+     * @param context
+     * @throws Exception
+     * @see org.jboss.ejb.client.EJBClientInterceptor#handleInvocation(org.jboss.ejb.client.EJBClientInvocationContext)
+     */
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        Principal currentPrincipal = SecurityContextAssociation.getPrincipal();
+
+        if (currentPrincipal != null) {
+            Map<String, Object> contextData = context.getContextData();
+            contextData.put(ServerSecurityInterceptor.DELEGATED_USER_KEY, currentPrincipal.getName());
+        }
+
+        context.sendRequest();
+    }
+
+    /**
+     * Simply returns the invocation result.
+     */
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        return context.getResult();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/EJBUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/EJBUtil.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.container.interceptor.security.api;
+
+import java.net.UnknownHostException;
+import java.util.Hashtable;
+import java.util.Properties;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+/**
+ * Utility class for looking up EJBs. It contains also some common constants for this test.
+ *
+ * @author Josef Cacek
+ */
+class EJBUtil {
+
+    protected static final String APPLICATION_NAME = "ejb-security-interceptors-with-api-test";
+
+    protected static final String CONNECTION_USERNAME = "guest";
+    protected static final String CONNECTION_PASSWORD = "guest";
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     * Lookup for remote EJBs.
+     *
+     * @param beanImplClass
+     * @param remoteInterface
+     * @return
+     * @throws NamingException
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T lookupEJB(Class<? extends T> beanImplClass, Class<T> remoteInterface) throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        //        jndiProperties.put("jboss.naming.client.ejb.context", "true");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (T) context.lookup("ejb:/" + APPLICATION_NAME + "/" + beanImplClass.getSimpleName() + "!"
+                + remoteInterface.getName());
+    }
+
+    /**
+     * Creates {@link Properties} for the EJB client configuration.
+     *
+     * <pre>
+     * remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+     *
+     * remote.connections=default
+     *
+     * remote.connection.default.host=localhost
+     * remote.connection.default.port = 8080
+     * remote.connection.default.username=guest
+     * remote.connection.default.password=guest
+     *
+     * remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+     * </pre>
+     *
+     * @param hostName
+     * @return
+     * @throws UnknownHostException
+     */
+    public static Properties createEjbClientConfiguration(String hostName) throws UnknownHostException {
+        final Properties pr = new Properties();
+        pr.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        pr.put("remote.connections", "default");
+        pr.put("remote.connection.default.host", hostName);
+        pr.put("remote.connection.default.port", "8080");
+        pr.put("remote.connection.default.username", CONNECTION_USERNAME);
+        pr.put("remote.connection.default.password", CONNECTION_PASSWORD);
+        return pr;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/Manage.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/Manage.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.container.interceptor.security.api;
+
+/**
+ * 
+ * 
+ * @author Josef Cacek
+ */
+public interface Manage {
+
+    String ROLE_ROLE1 = "Role1";
+    String ROLE_ROLE2 = "Role2";
+    String ROLE_USERS = "Users";
+    String ROLE_GUEST = "guest";
+
+    /** All test roles */
+    String[] ROLES_ALL = { ROLE_ROLE1, ROLE_ROLE2, ROLE_GUEST, ROLE_USERS };
+
+    String BEAN_NAME_TARGET = "TargetBean";
+    String BEAN_NAME_BRIDGE = "BridgeBean";
+
+    /** Default result of methods defined in this interface. */
+    String RESULT = "OK";
+
+    String role1();
+
+    String role2();
+
+    String allRoles();
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/ServerSecurityInterceptor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/ServerSecurityInterceptor.java
@@ -1,0 +1,103 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.container.interceptor.security.api;
+
+import java.security.Principal;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.ejb.EJBAccessException;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
+import javax.resource.spi.IllegalStateException;
+
+import org.jboss.as.core.security.api.UserPrincipal;
+import org.jboss.as.security.api.ConnectionSecurityContext;
+import org.jboss.as.security.api.ContextStateCache;
+import org.jboss.as.test.integration.ejb.container.interceptor.security.CurrentUserCredential;
+import org.jboss.logging.Logger;
+import org.jboss.security.SimplePrincipal;
+
+/**
+ * The server side security interceptor responsible for handling any security identity propagated from the client.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ * @author Josef Cacek
+ */
+public class ServerSecurityInterceptor {
+
+    private static final Logger LOGGER = Logger.getLogger(ServerSecurityInterceptor.class);
+
+    static final String DELEGATED_USER_KEY = ServerSecurityInterceptor.class.getName() + ".DelegationUser";
+
+    @AroundInvoke
+    public Object aroundInvoke(final InvocationContext invocationContext) throws Exception {
+        Principal desiredUser = null;
+        UserPrincipal connectionUser = null;
+
+        Map<String, Object> contextData = invocationContext.getContextData();
+        if (contextData.containsKey(DELEGATED_USER_KEY)) {
+            desiredUser = new SimplePrincipal((String) contextData.get(DELEGATED_USER_KEY));
+
+            Collection<Principal> principals = ConnectionSecurityContext.getConnectionPrincipals();
+
+            if (principals != null) {
+                for (Principal current : principals) {
+                    if (current instanceof UserPrincipal) {
+                        connectionUser = (UserPrincipal) current;
+                        break;
+                    }
+                }
+            } else {
+                throw new IllegalStateException("Delegation user requested but no user on connection found.");
+            }
+        }
+
+
+        ContextStateCache stateCache = null;
+
+        try {
+            if (desiredUser != null && connectionUser != null
+                    && (desiredUser.getName().equals(connectionUser.getName()) == false)) {
+                try {
+                    // The final part of this check is to verify that the change does actually indicate a change in user.
+
+                    // We have been requested to switch user and have successfully identified the user from the connection
+                    // so now we attempt the switch.
+                     stateCache = ConnectionSecurityContext.pushIdentity(desiredUser, new CurrentUserCredential(connectionUser.getName()));
+                } catch (Exception e) {
+                    LOGGER.error("Failed to switch security context for user", e);
+                    // Don't propagate the exception stacktrace back to the client for security reasons
+                    throw new EJBAccessException("Unable to attempt switching of user.");
+                }
+            }
+
+            return invocationContext.proceed();
+        } finally {
+            // switch back to original security context
+            if (stateCache != null) {
+                ConnectionSecurityContext.popIdentity(stateCache);
+            }
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/SwitchIdentityTestCase.java
@@ -19,7 +19,7 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.jboss.as.test.integration.ejb.container.interceptor.security;
+package org.jboss.as.test.integration.ejb.container.interceptor.security.api;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
@@ -62,6 +62,8 @@ import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.ejb.container.interceptor.security.CurrentUserCredential;
+import org.jboss.as.test.integration.ejb.container.interceptor.security.GuestDelegationLoginModule;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
 import org.jboss.as.test.integration.security.common.AbstractSecurityRealmsServerSetupTask;
 import org.jboss.as.test.integration.security.common.Utils;
@@ -152,9 +154,8 @@ public class SwitchIdentityTestCase {
         jar.addAsManifestResource(SwitchIdentityTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
         jar.addAsManifestResource(new StringAsset(ClientSecurityInterceptor.class.getName()),
                 "services/org.jboss.ejb.client.EJBClientInterceptor");
-        jar.addAsManifestResource(SwitchIdentityTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
-        jar.addAsManifestResource(Utils.getJBossDeploymentStructure("org.jboss.remoting3", "org.jboss.as.domain-management",
-                "org.jboss.as.controller", "org.jboss.as.core-security"), "jboss-deployment-structure.xml");
+        jar.addAsManifestResource(ClientSecurityInterceptor.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        jar.addAsManifestResource(Utils.getJBossDeploymentStructure("org.jboss.as.security-api", "org.jboss.as.core-security-api"), "jboss-deployment-structure.xml");
         final Properties props = EJBUtil.createEjbClientConfiguration(StringUtils.strip(
                 TestSuiteEnvironment.getServerAddress(), "[]"));
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/TargetBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/TargetBean.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.container.interceptor.security.api;
+
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.PermitAll;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * An implementation of {@link Manage} interface which has protected {@link #role1()} and {@link #role2()} methods.
+ * 
+ * @author Josef Cacek
+ */
+@Stateless(name = Manage.BEAN_NAME_TARGET)
+@DeclareRoles({ Manage.ROLE_ROLE1, Manage.ROLE_ROLE2, Manage.ROLE_GUEST, Manage.ROLE_USERS })
+@Remote(Manage.class)
+public class TargetBean implements Manage {
+
+    // Public methods --------------------------------------------------------
+
+    /**
+     * Method with only {@link Manage#ROLE_ROLE1} access.
+     * 
+     * @return
+     */
+    @RolesAllowed({ ROLE_ROLE1 })
+    public String role1() {
+        return RESULT;
+    }
+
+    /**
+     * Method with only {@link Manage#ROLE_ROLE2} access.
+     * 
+     * @return
+     */
+    @RolesAllowed({ ROLE_ROLE2 })
+    public String role2() {
+        return RESULT;
+    }
+
+    /**
+     * Unprotected method.
+     * 
+     * @return
+     */
+    @PermitAll
+    public String allRoles() {
+        return RESULT;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/jboss-ejb-client.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/jboss-ejb-client.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.0">
+    <client-context>
+        <ejb-receivers exclude-local-receiver="true">
+            <remoting-ejb-receiver outbound-connection-ref="ejb-outbound-connection"/>
+        </ejb-receivers>
+    </client-context>
+</jboss-ejb-client>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/container/interceptor/security/api/jboss-ejb3.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee" xmlns:jee="http://java.sun.com/xml/ns/javaee"
+	xmlns:ci="urn:container-interceptors:1.0" xmlns:s="urn:security">
+	<jee:assembly-descriptor>
+		<ci:container-interceptors>
+			<jee:interceptor-binding>
+				<jee:ejb-name>*</jee:ejb-name>
+				<interceptor-class>org.jboss.as.test.integration.ejb.container.interceptor.security.api.ServerSecurityInterceptor</interceptor-class>
+			</jee:interceptor-binding>
+		</ci:container-interceptors>
+		<s:security>
+			<jee:ejb-name>*</jee:ejb-name>
+			<s:security-domain>switch-identity-test</s:security-domain>
+		</s:security>
+	</jee:assembly-descriptor>
+</jboss:ejb-jar>


### PR DESCRIPTION
At this point I have chosen to duplicate the test so that for the remainder of WildFly 8 we verify that the original approach is not broken - for WildFly 9 I have the task WFLY-3064 to delete the original test.
