### PR TITLE
[WFLY-3069] slaves cannot reconnect to a restarted master if RBAC is enabled

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandler.java
@@ -274,13 +274,13 @@ public class ApplyRemoteMasterDomainModelHandler implements OperationStepHandler
                 PathAddress.pathAddress(CoreManagementResourceDefinition.PATH_ELEMENT, AccessAuthorizationResourceDefinition.PATH_ELEMENT));
         accessControl.writeModel(new ModelNode());
         for(Resource.ResourceEntry entry : accessControl.getChildren(ModelDescriptionConstants.SERVER_GROUP_SCOPED_ROLE)) {
-            rootResource.removeChild(entry.getPathElement());
+            accessControl.removeChild(entry.getPathElement());
         }
         for(Resource.ResourceEntry entry : accessControl.getChildren(ModelDescriptionConstants.HOST_SCOPED_ROLE)) {
-            rootResource.removeChild(entry.getPathElement());
+            accessControl.removeChild(entry.getPathElement());
         }
         for(Resource.ResourceEntry entry : accessControl.getChildren(ModelDescriptionConstants.ROLE_MAPPING)) {
-            rootResource.removeChild(entry.getPathElement());
+            accessControl.removeChild(entry.getPathElement());
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandler.java
@@ -380,6 +380,11 @@ public class ApplyRemoteMasterDomainModelHandler implements OperationStepHandler
         final Set<ServerIdentity> affectedServers;
         //Path that gets called when missing data is piggy-backed as a result of changes to the domain model
         affectedServers = new HashSet<ServerIdentity>();
+
+        if (!hostModel.hasDefined(SERVER_CONFIG)) {
+            return;
+        }
+
         for (String serverName : hostModel.get(SERVER_CONFIG).keys()) {
             ModelNode startOps = createBootOps(context, serverName, startRoot, existingHostModel);
             ModelNode endOps = createBootOps(context, serverName, endRoot, hostModel);

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/AbstractOperationTestCase.java
@@ -22,17 +22,23 @@
 package org.jboss.as.domain.controller.operations;
 
 import static org.jboss.as.controller.ControllerMessages.MESSAGES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_CONTROL;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DEPLOYMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INTERFACE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROVIDER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLE_MAPPING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
@@ -83,6 +89,7 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.controller.LocalHostControllerInfo;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
+import org.jboss.as.domain.management.access.AccessAuthorizationResourceDefinition;
 import org.jboss.as.host.controller.discovery.DiscoveryOption;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
@@ -633,6 +640,15 @@ public abstract class AbstractOperationTestCase {
         final Resource binding2 = Resource.Factory.create();
         binding2.getModel().setEmptyObject();
         rootResource.registerChild(PathElement.pathElement(SOCKET_BINDING_GROUP, "binding-two"), binding2);
+
+        final Resource management = rootResource.getChild(PathElement.pathElement(CORE_SERVICE, MANAGEMENT));
+        final Resource accessControl = management.getChild(AccessAuthorizationResourceDefinition.PATH_ELEMENT);
+
+        final Resource superUser = Resource.Factory.create();
+        accessControl.registerChild(PathElement.pathElement(ROLE_MAPPING, "SuperUser"), superUser);
+        final Resource include = Resource.Factory.create();
+        superUser.registerChild(PathElement.pathElement(INCLUDE, "user-$local"), include);
+        include.getModel().get("name").set("local");
 
         hack(rootResource, EXTENSION);
         hack(rootResource, PATH);

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandlerTestCase.java
@@ -82,6 +82,7 @@ import org.jboss.as.repository.ContentRepository;
 import org.jboss.as.repository.HostFileRepository;
 import org.jboss.as.version.ProductConfig;
 import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
 import org.junit.Test;
 
 /**
@@ -108,7 +109,8 @@ public class ApplyRemoteMasterDomainModelHandlerTestCase extends AbstractOperati
         operation.get(DOMAIN_MODEL).set(getCurrentModelUpdates(root, UpdateListModifier.createForAdditions()));
         final MockOperationContext operationContext = getOperationContext(root, false);
         handler.execute(operationContext, operation);
-        operationContext.verify();
+        final List<OperationAndHandler> operations = operationContext.verify().get(OperationContext.Stage.MODEL);
+        Assert.assertEquals(4, operations.size());
     }
 
     @Test
@@ -167,8 +169,8 @@ public class ApplyRemoteMasterDomainModelHandlerTestCase extends AbstractOperati
 
         assertTrue(addedSteps.containsKey(OperationContext.Stage.MODEL));
         List<OperationAndHandler> modelSteps = addedSteps.get(OperationContext.Stage.MODEL);
-        assertEquals(2, modelSteps.size());
-        OperationAndHandler oah = modelSteps.get(1);
+        assertEquals(4, modelSteps.size());
+        OperationAndHandler oah = modelSteps.get(3);
 
         operationContext = getOperationContext(root, false);
         operationContext.expectStep(PathAddress.pathAddress(PathElement.pathElement(HOST, "localhost"), PathElement.pathElement(SERVER, "server-one")));


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3069
