### PR TITLE
Introduce AttributeParser and utilize it to fix legacy default shipped configs

### DIFF
--- a/build/src/main/resources/configuration/subsystems/undertow.xml
+++ b/build/src/main/resources/configuration/subsystems/undertow.xml
@@ -26,10 +26,8 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config>
     <extension-module>org.wildfly.extension.undertow</extension-module>
-    <subsystem xmlns="urn:jboss:domain:undertow:1.0">
-        <buffer-caches>
-            <buffer-cache name="default" buffer-size="1024" buffers-per-region="1024" max-regions="10"/>
-        </buffer-caches>
+    <subsystem xmlns="urn:jboss:domain:undertow:1.1">
+        <buffer-cache name="default" />
         <server name="default-server">
             <http-listener name="default" socket-binding="http" />
             <?AJP?>
@@ -39,11 +37,11 @@
                 <filter-ref name="x-powered-by-header"/>
             </host>
         </server>
-        <servlet-container name="default" default-buffer-cache="default" stack-trace-on-error="local-only" >
+        <servlet-container name="default" >
             <jsp-config/>
         </servlet-container>
         <handlers>
-            <file name="welcome-content" path="${jboss.home.dir}/welcome-content" directory-listing="true"/>
+            <file name="welcome-content" path="${jboss.home.dir}/welcome-content" />
         </handlers>
         <filters>
             <response-header name="server-header" header-name="Server" header-value="Wildfly 8"/>

--- a/build/src/main/resources/docs/schema/wildfly-io_1_1.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-io_1_1.xsd
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:io:1.1"
+           targetNamespace="urn:jboss:domain:io:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+    <!-- The io subsystem root element -->
+    <xs:element name="subsystem" type="io-subsystemType"/>
+    <xs:complexType name="io-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the io subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="worker" type="workerType"/>
+            <xs:element name="buffer-pool" type="bufferPoolType"/>
+        </xs:choice>
+    </xs:complexType>
+    <xs:complexType name="workerType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="io-threads" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Default value for io threads is cpu count * 2
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="task-keepalive" type="xs:int" default="60"/>
+        <xs:attribute name="task-max-threads" type="xs:int">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                        Default value for io threads is cpu count * 16
+                    ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stack-size" type="xs:long" default="0"/>
+    </xs:complexType>
+    <xs:complexType name="bufferPoolType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="buffer-size" use="optional" type="xs:int" />
+        <xs:attribute name="buffers-per-slice" use="optional" type="xs:int" />
+        <xs:attribute name="direct-buffers" use="optional" type="xs:boolean" />
+    </xs:complexType>
+</xs:schema>

--- a/build/src/main/resources/docs/schema/wildfly-undertow_1_1.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-undertow_1_1.xsd
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:undertow:1.1"
+           targetNamespace="urn:jboss:domain:undertow:1.1"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.0">
+    <!-- The undertow subsystem root element -->
+    <xs:element name="subsystem" type="undertow-subsystemType"/>
+    <xs:complexType name="undertow-subsystemType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the undertow subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="buffer-cache" type="buffer-cacheType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="server" type="serverType" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="servlet-container" type="servletContainerType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="error-pages" type="errorPagesType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="handlers" type="handlerType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="filters" type="filterType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="default-server" type="xs:string" default="default-server"/>
+        <xs:attribute name="default-virtual-host" type="xs:string" default="default-host"/>
+        <xs:attribute name="default-servlet-container" type="xs:string" default="default"/>
+        <xs:attribute name="instance-id" type="xs:string" use="optional"/>
+    </xs:complexType>
+    <xs:complexType name="serverType">
+        <xs:sequence>
+            <xs:element name="http-listener" type="http-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="https-listener" type="https-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="ajp-listener" type="ajp-listener-type" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="host" type="hostType" minOccurs="1" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="default-host" use="optional" type="xs:string" default="default-host"/>
+        <xs:attribute name="servlet-container" use="optional" type="xs:string" default="default"/>
+    </xs:complexType>
+
+    <xs:complexType name="listener-type">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="socket-binding" use="required" type="xs:string"/>
+        <xs:attribute name="worker" type="xs:string" default="default"/>
+        <xs:attribute name="buffer-pool" type="xs:string" default="default"/>
+        <xs:attribute name="enabled" type="xs:boolean" default="true"/>
+        <xs:attribute name="max-post-size" type="xs:long" default="0"/>
+        <xs:attribute name="buffer-pipelined-data" type="xs:boolean" default="true"/>
+        <xs:attribute name="max-header-size" type="xs:long" default="5120"/>
+        <xs:attribute name="max-parameters" type="xs:long" default="1000"/>
+        <xs:attribute name="max-headers" type="xs:long" default="200"/>
+        <xs:attribute name="max-cookies" type="xs:long" default="200"/>
+        <xs:attribute name="allow-encoded-slash" type="xs:boolean" default="false"/>
+        <xs:attribute name="decode-url" type="xs:boolean" default="true"/>
+        <xs:attribute name="url-charset" type="xs:string" default="UTF-8"/>
+        <xs:attribute name="always-set-keep-alive" type="xs:boolean" default="true"/>
+        <xs:attribute name="max-buffered-request-size" type="xs:long" default="16384"/>
+        <xs:attribute name="record-request-start-time" type="xs:boolean" default="false"/>
+        <xs:attribute name="allow-equals-in-cookie-value" type="xs:boolean" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="http-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="certificate-forwarding" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                If certificate forwarding should be enabled. If this is enabled then the listener will take the certificate from the SSL_CLIENT_CERT
+                                attribute. This should only be enabled if behind a proxy, and the proxy is configured to always set these headers.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="redirect-socket" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                undertow will automatically redirect the request to the socket binding port specified here.
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="proxy-address-forwarding" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                              enables x-forwarded-host and similar headers and set a remote ip address and hostname
+                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="https-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="security-realm" use="required" type="xs:string"/>
+                <xs:attribute name="verify-client" use="optional" type="xs:string"/>
+                <xs:attribute name="enabled-cipher-suites" use="optional" type="xs:string"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="ajp-listener-type">
+        <xs:complexContent>
+            <xs:extension base="listener-type">
+                <xs:attribute name="scheme" type="xs:string"/>
+                <xs:attribute name="redirect-socket" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                                If this listener is supporting non-SSL requests, and a request is received for which a matching <security-constraint> requires SSL transport,
+                                                undertow will automatically redirect the request to the socket binding port specified here.
+                                               ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="servletContainerType">
+        <xs:sequence>
+            <xs:element name="jsp-config" type="jsp-configurationType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="session-cookie" type="session-cookieType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="persistent-sessions" type="persistent-sessionsType" maxOccurs="1" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="allow-non-standard-wrappers" use="optional" type="xs:boolean" default="false"/>
+        <xs:attribute name="default-buffer-cache" use="optional" type="xs:string"/>
+        <xs:attribute name="stack-trace-on-error" use="optional" default="disabled"/>
+        <xs:attribute name="default-encoding" type="xs:string" use="optional"/>
+        <xs:attribute name="use-listener-encoding" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="ignore-flush" type="xs:boolean" use="optional" default="false"/>
+        <xs:attribute name="eager-filter-initialization" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+    <xs:complexType name="hostType">
+        <xs:sequence>
+            <xs:element name="location" type="locationType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="access-log" type="accessLogType" maxOccurs="1" minOccurs="0"/>
+            <xs:element name="filter-ref" type="filter-refType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="single-sign-on" minOccurs="0" maxOccurs="1" type="singleSignOnType" />
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="alias" use="optional" type="xs:string"/>
+        <xs:attribute name="default-web-module" use="optional" type="xs:string" default="ROOT.war"/>
+    </xs:complexType>
+
+    <xs:complexType name="jsp-configurationType">
+        <xs:attribute name="disabled" default="false" type="xs:boolean"/>
+        <xs:attribute name="development" default="false" type="xs:boolean"/>
+        <xs:attribute name="keep-generated" default="true" type="xs:boolean"/>
+        <xs:attribute name="trim-spaces" default="false" type="xs:boolean"/>
+        <xs:attribute name="tag-pooling" default="true" type="xs:boolean"/>
+        <xs:attribute name="mapped-file" default="true" type="xs:boolean"/>
+        <xs:attribute name="check-interval" default="0" type="xs:int"/>
+        <xs:attribute name="modification-test-interval" default="4" type="xs:int"/>
+        <xs:attribute name="recompile-on-fail" default="false" type="xs:boolean"/>
+        <xs:attribute name="smap" default="true" type="xs:boolean"/>
+        <xs:attribute name="dump-smap" default="false" type="xs:boolean"/>
+        <xs:attribute name="generate-strings-as-char-arrays" default="false" type="xs:boolean"/>
+        <xs:attribute name="error-on-use-bean-invalid-class-attribute" default="false" type="xs:boolean"/>
+        <xs:attribute name="scratch-dir" type="xs:string"/>
+        <xs:attribute name="source-vm" default="1.6" type="xs:string"/>
+        <xs:attribute name="target-vm" default="1.6" type="xs:string"/>
+        <xs:attribute name="java-encoding" default="UTF8" type="xs:string"/>
+        <xs:attribute name="x-powered-by" default="true" type="xs:boolean"/>
+        <xs:attribute name="display-source-fragment" default="true" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="session-cookieType">
+        <xs:attribute name="name" type="xs:string"/>
+        <xs:attribute name="domain" type="xs:string"/>
+        <xs:attribute name="comment" type="xs:string"/>
+        <xs:attribute name="http-only" type="xs:boolean"/>
+        <xs:attribute name="secure" type="xs:boolean"/>
+        <xs:attribute name="max-age" type="xs:int"/>
+    </xs:complexType>
+
+    <xs:complexType name="persistent-sessionsType">
+        <xs:attribute name="path" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                  The path to store the session data. If not specified the data will just be stored in memory only.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" use="optional"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlerType">
+        <xs:sequence>
+            <xs:element name="file" type="file-handlerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="reverse-proxy" type="reverse-proxy-handlerType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+
+    <xs:complexType name="filterType">
+        <xs:sequence>
+            <xs:element name="basic-auth" type="basic-authType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="connection-limit" type="connection-limitType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="response-header" type="response-headerType" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="gzip" type="gzipType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="errorPagesType">
+        <xs:sequence>
+            <xs:element name="error-page" type="errorPageType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="locationType">
+        <xs:sequence>
+            <xs:element name="filter-ref" type="filter-refType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="handler" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="accessLogType">
+        <xs:attribute name="pattern" use="optional" type="xs:string" default="common"/>
+        <xs:attribute name="worker" use="optional" type="xs:string" default="default"/>
+        <xs:attribute name="directory" use="optional" type="xs:string" default="${jboss.server.log.dir}"/>
+        <xs:attribute name="prefix" use="optional" type="xs:string" default="access_log"/>
+        <xs:attribute name="rotate" use="optional" type="xs:string" default="true"/>
+    </xs:complexType>
+    <xs:complexType name="errorPageType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="code" use="required" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="file-handlerType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+        <xs:attribute name="cache-buffer-size" use="optional" type="xs:int" default="1024"/>
+        <xs:attribute name="cache-buffers" use="optional" type="xs:int" default="1024"/>
+        <xs:attribute name="directory-listing" use="optional" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="reverse-proxy-handlerType">
+        <xs:sequence>
+            <xs:element name="host" type="reverse-proxy-hostType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="connections-per-thread" use="optional" type="xs:integer"/>
+        <xs:attribute name="session-cookie-names" use="optional" type="xs:string"/>
+        <xs:attribute name="problem-server-retry" use="optional" type="xs:integer"/>
+        <xs:attribute name="max-request-time" use="optional" type="xs:integer"/>
+    </xs:complexType>
+
+    <xs:complexType name="reverse-proxy-hostType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="instance-id" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="filter-refType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="predicate" use="optional" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                          Predicates provide a simple way of making a true/false decision  based on an exchange. Many handlers have a requirement that they be applied conditionally, and predicates provide a general way to specify a condition. Predicates can be created programatically (they are just java classes that implement the Predicate interface), however there is also a simple language for specifying a predicate. Some examples below:
+                          regex['/resources/*.\.css'] - regular expression match of the relative URL
+                          regex[pattern='text/.*', value='%{i,Content-Type}, full-match=true] - Matches requests with a text/.* content type
+                          equals[{'%{i,Content-Type}', 'text/xml'}] - Matches if the content type header is text/xml
+                          contains[search='MSIE', value='%{i,User-Agent}'] and path-suffix['.js'] - User agent contains MSIE and request URL ends with .js
+                          regex['/resources/(*.)\.css'] and equals[{'$1', 'myCssFile'}] - regex match, with a reference to match group 1 later in the expression
+                        ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="singleSignOnType">
+        <xs:attribute name="domain" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie domain to use.
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+
+
+    <xs:complexType name="buffer-cacheType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                  A buffer cache. I cache consists of 1 or more regions, that are split up into smaller buffers.
+                  The total cache size is the buffer size * the buffers per region * the number of regions.
+                ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="buffer-size" use="optional" type="xs:string"/>
+        <xs:attribute name="buffers-per-region" use="optional" type="xs:string"/>
+        <xs:attribute name="max-regions" use="optional" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="basic-authType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="security-domain" use="required" type="xs:string"/>
+
+    </xs:complexType>
+    <xs:complexType name="connection-limitType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="max-concurrent-requests" use="required" type="xs:integer"/>
+        <xs:attribute name="queue-size" use="optional" type="xs:integer"/>
+    </xs:complexType>
+    <xs:complexType name="response-headerType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+        <xs:attribute name="header-name" use="required" type="xs:string"/>
+        <xs:attribute name="header-value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="gzipType">
+        <xs:attribute name="name" use="required" type="xs:string"/>
+    </xs:complexType>
+</xs:schema>

--- a/build/src/main/resources/docs/schema/wildfly-undertow_1_1.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-undertow_1_1.xsd
@@ -315,6 +315,15 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="path" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                              Cookie path to use.
+                              ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
 

--- a/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractAttributeDefinitionBuilder.java
@@ -63,6 +63,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
     protected DeprecationData deprecated = null;
     protected AccessConstraintDefinition[] accessConstraints;
     protected Boolean nullSignficant;
+    protected AttributeParser parser;
 
     /**
      * Creates a builder for an attribute with the give name and type. Equivalent to
@@ -118,6 +119,7 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
         Set<AttributeAccess.Flag> basisFlags = basis.getFlags();
         this.flags = basisFlags.toArray(new AttributeAccess.Flag[basisFlags.size()]);
         this.attributeMarshaller = basis.getAttributeMarshaller();
+        this.parser = basis.getParser();
     }
 
     /**
@@ -399,6 +401,16 @@ public abstract class AbstractAttributeDefinitionBuilder<BUILDER extends Abstrac
      */
     public BUILDER setAttributeMarshaller(AttributeMarshaller marshaller) {
         this.attributeMarshaller = marshaller;
+        return (BUILDER) this;
+    }
+    /**
+     * Sets a custom {@link org.jboss.as.controller.AttributeParser} to use for parsing attribute from xml.
+     * If not set, a {@link org.jboss.as.controller.AttributeParser#SIMPLE} will be used.
+     * @param parser the parser. Can be {@code null}
+     * @return a builder that can be used to continue building the attribute definition
+     */
+    public BUILDER setAttributeParser(AttributeParser parser) {
+        this.parser = parser;
         return (BUILDER) this;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeDefinition.java
@@ -76,6 +76,7 @@ public abstract class AttributeDefinition {
     private final DeprecationData deprecationData;
     private final List<AccessConstraintDefinition> accessConstraints;
     private final Boolean nilSignificant;
+    private final AttributeParser parser;
 
 
     protected AttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
@@ -83,9 +84,10 @@ public abstract class AttributeDefinition {
                                final ParameterValidator validator, final String[] alternatives, final String[] requires,
                                final AttributeAccess.Flag... flags) {
         this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
-                null, validator, true, alternatives, requires, null, false, null, null, null, flags);
+                null, validator, true, alternatives, requires, null, false, null, null, null, AttributeParser.SIMPLE, flags);
     }
 
+    @Deprecated
     protected AttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
             final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
             final ParameterCorrector valueCorrector, final ParameterValidator validator,
@@ -93,7 +95,7 @@ public abstract class AttributeDefinition {
             boolean resourceOnly, DeprecationData deprecationData, final AttributeAccess.Flag... flags) {
         this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit, valueCorrector, validator,
                 validateNull, alternatives, requires, attributeMarshaller, resourceOnly, deprecationData,
-                null, null, flags);
+                null, null, AttributeParser.SIMPLE, flags);
     }
 
     protected AttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
@@ -104,7 +106,7 @@ public abstract class AttributeDefinition {
                                   final AttributeAccess.Flag... flags) {
         this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit, valueCorrector, validator,
                 validateNull, alternatives, requires, attributeMarshaller, resourceOnly, deprecationData,
-                accessConstraints, null, flags);
+                accessConstraints, null, AttributeParser.SIMPLE, flags);
     }
 
     protected AttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
@@ -112,13 +114,14 @@ public abstract class AttributeDefinition {
                                   final ParameterCorrector valueCorrector, final ParameterValidator validator,
                                   boolean validateNull, final String[] alternatives, final String[] requires, AttributeMarshaller attributeMarshaller,
                                   boolean resourceOnly, DeprecationData deprecationData, final AccessConstraintDefinition[] accessConstraints,
-                                  Boolean nilSignificant, final AttributeAccess.Flag... flags) {
+                                  Boolean nilSignificant, AttributeParser parser, final AttributeAccess.Flag... flags) {
 
         this.name = name;
         this.xmlName = xmlName;
         this.type = type;
         this.allowNull = allowNull;
         this.allowExpression = allowExpression;
+        this.parser = parser != null ? parser : AttributeParser.SIMPLE;
         this.defaultValue = new ModelNode();
         if (defaultValue != null) {
             this.defaultValue.set(defaultValue);
@@ -841,5 +844,9 @@ public abstract class AttributeDefinition {
 
     protected void addAccessConstraints(ModelNode result, Locale locale) {
         AccessConstraintDescriptionProviderUtil.addAccessConstraints(result, accessConstraints, locale);
+    }
+
+    public AttributeParser getParser() {
+        return parser;
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
+++ b/controller/src/main/java/org/jboss/as/controller/AttributeParser.java
@@ -1,0 +1,173 @@
+/*
+ *
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2014, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
+ */
+
+package org.jboss.as.controller;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * @author Tomaz Cerar (c) 2014 Red Hat Inc.
+ */
+public abstract class AttributeParser {
+
+    /**
+     * Creates a {@link org.jboss.dmr.ModelNode} using the given {@code value} after first validating the node
+     * against {@link org.jboss.as.controller.AttributeDefinition#getValidator() this object's validator}., and then stores it in the given {@code operation}
+     * model node as a key/value pair whose key is this attribute's getName() name}.
+     * <p>
+     * If {@code value} is {@code null} an {@link org.jboss.dmr.ModelType#UNDEFINED undefined} node will be stored if such a value
+     * is acceptable to the validator.
+     * </p>
+     * <p>
+     * The expected usage of this method is in parsers seeking to build up an operation to store their parsed data
+     * into the configuration.
+     * </p>
+     *
+     * @param value     the value. Will be {@link String#trim() trimmed} before use if not {@code null}.
+     * @param operation model node of type {@link org.jboss.dmr.ModelType#OBJECT} into which the parsed value should be stored
+     * @param reader    {@link javax.xml.stream.XMLStreamReader} from which the {@link javax.xml.stream.XMLStreamReader#getLocation() location} from which
+     *                  the attribute value was read can be obtained and used in any {@code XMLStreamException}, in case
+     *                  the given value is invalid.
+     * @throws javax.xml.stream.XMLStreamException if {@code value} is not valid
+     */
+    public void parseAndSetParameter(final AttributeDefinition attribute, final String value, final ModelNode operation, final XMLStreamReader reader) throws XMLStreamException {
+        ModelNode paramVal = parse(attribute, value, reader);
+        operation.get(attribute.getName()).set(paramVal);
+    }
+
+    /**
+     * Creates and returns a {@link org.jboss.dmr.ModelNode} using the given {@code value} after first validating the node
+     * against {@link org.jboss.as.controller.AttributeDefinition#getValidator() this object's validator}.
+     * <p>
+     * If {@code value} is {@code null} an {@link org.jboss.dmr.ModelType#UNDEFINED undefined} node will be returned.
+     * </p>
+     *
+     * @param value  the value. Will be {@link String#trim() trimmed} before use if not {@code null}.
+     * @param reader {@link XMLStreamReader} from which the {@link XMLStreamReader#getLocation() location} from which
+     *               the attribute value was read can be obtained and used in any {@code XMLStreamException}, in case
+     *               the given value is invalid.
+     * @return {@code ModelNode} representing the parsed value
+     * @throws javax.xml.stream.XMLStreamException if {@code value} is not valid
+     * @see #parseAndSetParameter(org.jboss.as.controller.AttributeDefinition, String, ModelNode, XMLStreamReader)
+     */
+    public ModelNode parse(final AttributeDefinition attribute, final String value, final XMLStreamReader reader) throws XMLStreamException {
+        try {
+            return parse(attribute, value);
+        } catch (OperationFailedException e) {
+            throw new XMLStreamException(e.getFailureDescription().toString(), reader.getLocation());
+        }
+    }
+
+    private ModelNode parse(final AttributeDefinition attribute, final String value) throws OperationFailedException {
+        final String trimmed = value == null ? null : value.trim();
+        ModelNode node;
+        if (trimmed != null) {
+            if (attribute.isAllowExpression()) {
+                node = ParseUtils.parsePossibleExpression(trimmed);
+            } else {
+                node = new ModelNode().set(trimmed);
+            }
+            if (node.getType() != ModelType.EXPRESSION) {
+                // Convert the string to the expected type
+                switch (attribute.getType()) {
+                    case BIG_DECIMAL:
+                        node.set(node.asBigDecimal());
+                        break;
+                    case BIG_INTEGER:
+                        node.set(node.asBigInteger());
+                        break;
+                    case BOOLEAN:
+                        node.set(node.asBoolean());
+                        break;
+                    case BYTES:
+                        node.set(node.asBytes());
+                        break;
+                    case DOUBLE:
+                        node.set(node.asDouble());
+                        break;
+                    case INT:
+                        node.set(node.asInt());
+                        break;
+                    case LONG:
+                        node.set(node.asLong());
+                        break;
+                }
+            }
+        } else {
+            node = new ModelNode();
+        }
+
+        attribute.getValidator().validateParameter(attribute.getXmlName(), node);
+
+        return node;
+    }
+
+    public static final AttributeParser SIMPLE = new AttributeParser() {
+    };
+
+    public static final AttributeParser LIST = new AttributeParser() {
+        @Override
+        public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
+            ModelNode paramVal = parse(attribute, value, reader);
+            operation.get(attribute.getName()).add(paramVal);
+            super.parseAndSetParameter(attribute, value, operation, reader);
+        }
+    };
+
+    public static final AttributeParser STRING_LIST = new AttributeParser() {
+        @Override
+        public void parseAndSetParameter(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
+            if (value == null) { return; }
+            for (String element : value.split(",")) {
+                parseAndAddParameterElement(attribute, element, operation, reader);
+            }
+        }
+
+        private void parseAndAddParameterElement(AttributeDefinition attribute, String value, ModelNode operation, XMLStreamReader reader) throws XMLStreamException {
+            ModelNode paramVal = parse(attribute, value, reader);
+            operation.get(attribute.getName()).add(paramVal);
+        }
+    };
+
+    public static final class DiscardOldDefaultValueParser extends AttributeParser{
+        private final String value;
+
+        public DiscardOldDefaultValueParser(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public ModelNode parse(AttributeDefinition attribute, String value, XMLStreamReader reader) throws XMLStreamException {
+            if (!this.value.equals(value)) { //if default value set, ignore it!
+                return super.parse(attribute, value, reader);
+            }
+            return new ModelNode();
+        }
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/ExpressionResolverImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ExpressionResolverImpl.java
@@ -24,6 +24,7 @@ package org.jboss.as.controller;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.dmr.Property;
+import org.jboss.dmr.ValueExpression;
 
 /**
  * Basic {@link ExpressionResolver} implementation.
@@ -135,7 +136,7 @@ public class ExpressionResolverImpl implements ExpressionResolver {
         if (EXPRESSION_PATTERN.matcher(possibleExpression).matches()) {
             // Keep resolving, but don't fail on unresolvable strings
             ModelNode expression = new ModelNode();
-            expression.setExpression(possibleExpression);
+            expression.set(new ValueExpression(possibleExpression));
             return resolveExpressionType(expression, true);
         }
         return new ModelNode(possibleExpression);

--- a/controller/src/main/java/org/jboss/as/controller/ListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ListAttributeDefinition.java
@@ -50,7 +50,7 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
 
     public ListAttributeDefinition(final String name, final boolean allowNull, final ParameterValidator elementValidator,
                                       final AttributeAccess.Flag... flags) {
-        this(name, name, allowNull, false, 0, Integer.MAX_VALUE, elementValidator, null, null, null,false, null, null, null, flags);
+        this(name, name, allowNull, false, 0, Integer.MAX_VALUE, elementValidator, null, null, null,false, null, null, null, null, flags);
     }
 
     @Deprecated
@@ -66,7 +66,7 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
             final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller,
             boolean resourceOnly, final DeprecationData deprecated, final AttributeAccess.Flag... flags) {
         this(name, xmlName, allowNull, allowExpressions, minSize, maxSize, elementValidator, alternatives, requires, attributeMarshaller, resourceOnly,
-                deprecated, null, null, flags);
+                deprecated, null, null, null, flags);
     }
 
     @Deprecated
@@ -76,7 +76,7 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
                                    final boolean resourceOnly, final DeprecationData deprecated,
                                    final AccessConstraintDefinition[] accessConstraints, final AttributeAccess.Flag... flags) {
         this(name, xmlName, allowNull, allowExpressions, minSize, maxSize, elementValidator, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, null, flags);
     }
 
     @Deprecated
@@ -84,7 +84,7 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
                                    final int minSize, final int maxSize, final ParameterValidator elementValidator,
                                    final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
         this(name, xmlName, allowNull, allowExpressions, minSize, maxSize, elementValidator, alternatives, requires,
-                null, false, null, null, null, flags);
+                null, false, null, null, null, null, flags);
     }
 
     @Deprecated
@@ -93,7 +93,7 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
                                    final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller,
                                    final AccessConstraintDefinition[] accessConstraints, final AttributeAccess.Flag... flags) {
         this(name, xmlName, allowNull, allowExpressions, minSize, maxSize, elementValidator, alternatives, requires,
-                attributeMarshaller, false, null, accessConstraints, null, flags);
+                attributeMarshaller, false, null, accessConstraints, null, null, flags);
     }
 
     protected ListAttributeDefinition(final String name, final String xmlName, final boolean allowNull, final boolean allowExpressions,
@@ -102,11 +102,23 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
                                       final boolean resourceOnly,  final DeprecationData deprecated,
                                       final AccessConstraintDefinition[] accessConstraints, final Boolean niSignificant,
                                       final AttributeAccess.Flag... flags) {
-        super(name, xmlName, null, ModelType.LIST, allowNull, allowExpressions, null, null,
-                new ListValidator(elementValidator, allowNull, minSize, maxSize), allowNull, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, niSignificant, flags);
-        this.elementValidator = elementValidator;
+        this(name, xmlName, allowNull, allowExpressions, minSize, maxSize, elementValidator, alternatives, requires,
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, niSignificant, null, flags);
     }
+
+    protected ListAttributeDefinition(final String name, final String xmlName, final boolean allowNull, final boolean allowExpressions,
+                                          final int minSize, final int maxSize, final ParameterValidator elementValidator,
+                                          final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller,
+                                          final boolean resourceOnly,  final DeprecationData deprecated,
+                                          final AccessConstraintDefinition[] accessConstraints,
+                                          final Boolean niSignificant,
+                                          final AttributeParser parser,
+                                          final AttributeAccess.Flag... flags) {
+            super(name, xmlName, null, ModelType.LIST, allowNull, allowExpressions, null, null,
+                    new ListValidator(elementValidator, allowNull, minSize, maxSize), allowNull, alternatives, requires,
+                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, niSignificant, parser, flags);
+            this.elementValidator = elementValidator;
+        }
 
     /**
      * The validator used to validate elements in the list.
@@ -199,6 +211,10 @@ public abstract class ListAttributeDefinition extends AttributeDefinition {
         return result;
     }
 
+    @Override
+    public ParameterValidator getValidator() {
+        return elementValidator;
+    }
 
     protected abstract void addValueTypeDescription(final ModelNode node, final ResourceBundle bundle);
 

--- a/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/MapAttributeDefinition.java
@@ -54,14 +54,14 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
 
     public MapAttributeDefinition(final String name, final boolean allowNull, final ParameterValidator elementValidator) {
         this(name, name, allowNull, false, 0, Integer.MAX_VALUE, null, elementValidator,
-                null, null, null, false, null, null, (Boolean) null);
+                null, null, null, false, null, null, (Boolean) null, null);
     }
 
     @Deprecated
     public MapAttributeDefinition(final String name, final String xmlName, final boolean allowNull,
                                   final int minSize, final int maxSize, final ParameterValidator elementValidator) {
         this(name, xmlName, allowNull, false, minSize, maxSize, null, elementValidator, null, null, null,
-                false, null, null, (Boolean) null);
+                false, null, null, (Boolean) null, null);
     }
 
     @Deprecated
@@ -69,7 +69,7 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
                                   final int minSize, final int maxSize, final ParameterValidator elementValidator,
                                   final String[] alternatives, final String[] requires, final AttributeAccess.Flag... flags) {
         this(name, xmlName, allowNull, false, minSize, maxSize, null, elementValidator, alternatives, requires, null,
-                false, null, null, null, flags);
+                false, null, null, null, null, flags);
     }
 
     @Deprecated
@@ -78,7 +78,7 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
             final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecated,
             final AccessConstraintDefinition[] accessConstraints, final AttributeAccess.Flag... flags) {
         this(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, elementValidator,
-                alternatives, requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, flags);
+                alternatives, requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, null, flags);
     }
 
     protected MapAttributeDefinition(final String name, final String xmlName, final boolean allowNull, boolean allowExpression,
@@ -86,9 +86,11 @@ public abstract class MapAttributeDefinition extends AttributeDefinition {
                                      final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller,
                                      final boolean resourceOnly, final DeprecationData deprecated,
                                      final AccessConstraintDefinition[] accessConstraints,
-                                     final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+                                     final Boolean nullSignificant,
+                                     final AttributeParser parser,
+                                     final AttributeAccess.Flag... flags) {
         super(name, xmlName, null, ModelType.OBJECT, allowNull, allowExpression, null, corrector, new MapValidator(elementValidator, allowNull, minSize, maxSize), false,
-                alternatives, requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                alternatives, requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, parser, flags);
         this.elementValidator = elementValidator;
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectListAttributeDefinition.java
@@ -53,9 +53,9 @@ public class ObjectListAttributeDefinition extends ListAttributeDefinition {
 
     private ObjectListAttributeDefinition(final String name, final String xmlName, final ObjectTypeAttributeDefinition valueType, final boolean allowNull, final int minSize, final int maxSize, final String[] alternatives, final String[] requires,
                                           final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecated,
-                                          final AccessConstraintDefinition[] accessConstraints, Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+                                          final AccessConstraintDefinition[] accessConstraints, Boolean nullSignificant, final AttributeParser parser, final AttributeAccess.Flag... flags) {
         super(name, xmlName, allowNull, false, minSize, maxSize, valueType.getValidator(), alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                resourceOnly, deprecated, accessConstraints, nullSignificant, parser, flags);
         this.valueType = valueType;
     }
 
@@ -196,7 +196,7 @@ public class ObjectListAttributeDefinition extends ListAttributeDefinition {
             if (maxSize < 1) { maxSize = Integer.MAX_VALUE; }
             return new ObjectListAttributeDefinition(name, xmlName, valueType, allowNull, minSize, maxSize,
                     alternatives, requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints,
-                    nullSignficant, flags);
+                    nullSignficant, parser, flags);
         }
 
         /*

--- a/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/ObjectTypeAttributeDefinition.java
@@ -58,7 +58,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
     protected ObjectTypeAttributeDefinition(final String name, final AttributeDefinition[] valueTypes, final boolean allowNull,
                                             final ParameterCorrector corrector) {
         this(name, name, null, valueTypes, allowNull, new ObjectTypeValidator(allowNull, valueTypes), corrector,
-                null, null, null, false, null, null, (Boolean) null);
+                null, null, null, false, null, null, (Boolean) null, null);
     }
 
     @Deprecated
@@ -67,7 +67,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
             final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecated,
             final AttributeAccess.Flag... flags) {
         this(name, xmlName, suffix, valueTypes, allowNull, validator, corrector, alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecated, null, null, flags);
+                resourceOnly, deprecated, null, null, null, flags);
     }
 
     @Deprecated
@@ -76,17 +76,17 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
                                             final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecated,
                                             final AccessConstraintDefinition[] accessConstraints, final AttributeAccess.Flag... flags) {
         this(name, xmlName, suffix, valueTypes, allowNull, validator, corrector, alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecated, accessConstraints, null, flags);
+                resourceOnly, deprecated, accessConstraints, null, null, flags);
     }
 
     protected ObjectTypeAttributeDefinition(final String name, final String xmlName, final String suffix, final AttributeDefinition[] valueTypes, final boolean allowNull,
                                             final ParameterValidator validator, final ParameterCorrector corrector, final String[] alternatives, final String[] requires,
                                             final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecated,
                                             final AccessConstraintDefinition[] accessConstraints,
-                                            final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+                                            final Boolean nullSignificant, final AttributeParser parser, final AttributeAccess.Flag... flags) {
         super(name, xmlName, null, ModelType.OBJECT, allowNull, false, null, corrector, validator, false, alternatives,
                 requires, getAttributeMarshaller(attributeMarshaller, valueTypes), resourceOnly, deprecated,
-                accessConstraints, nullSignificant, flags);
+                accessConstraints, nullSignificant, parser, flags);
         this.valueTypes = valueTypes;
         if (suffix == null) {
             this.suffix = "";
@@ -309,7 +309,7 @@ public class ObjectTypeAttributeDefinition extends SimpleAttributeDefinition {
             if (xmlName == null) { xmlName = name; }
             if (validator == null) { validator = new ObjectTypeValidator(allowNull, valueTypes); }
             return new ObjectTypeAttributeDefinition(name, xmlName, suffix, valueTypes, allowNull, validator, corrector, alternatives, requires,
-                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
 
         public Builder setSuffix(final String suffix) {

--- a/controller/src/main/java/org/jboss/as/controller/PrimitiveListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PrimitiveListAttributeDefinition.java
@@ -49,7 +49,7 @@ public class PrimitiveListAttributeDefinition extends ListAttributeDefinition {
             final String[] alternatives, final String[] requires, ParameterValidator elementValidator, final AttributeMarshaller attributeMarshaller,
             final boolean resourceOnly, final DeprecationData deprecated, final AccessConstraintDefinition[] accessConstraints, final AttributeAccess.Flag... flags) {
         this(name, xmlName, allowNull, allowExpressions, valueType, minSize, maxSize, elementValidator, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, null, flags);
     }
 
     protected PrimitiveListAttributeDefinition(final String name, final String xmlName, final boolean allowNull,
@@ -58,10 +58,12 @@ public class PrimitiveListAttributeDefinition extends ListAttributeDefinition {
                                                final String[] alternatives, final String[] requires,
                                                final AttributeMarshaller attributeMarshaller,
                                                final boolean resourceOnly, final DeprecationData deprecated,
-                                               final AccessConstraintDefinition[] accessConstraints, final Boolean nullSignificant,
+                                               final AccessConstraintDefinition[] accessConstraints,
+                                               final Boolean nullSignificant,
+                                               final AttributeParser parser,
                                                final AttributeAccess.Flag... flags) {
         super(name, xmlName, allowNull, allowExpressions, minSize, maxSize, elementValidator, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, parser,flags);
         this.valueType = valueType;
     }
 
@@ -135,7 +137,7 @@ public class PrimitiveListAttributeDefinition extends ListAttributeDefinition {
             }
             return new PrimitiveListAttributeDefinition(name, xmlName, allowNull, allowExpression, valueType, minSize,
                     maxSize, validator, alternatives, requires,
-                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PropertiesAttributeDefinition.java
@@ -58,9 +58,9 @@ public final class PropertiesAttributeDefinition extends MapAttributeDefinition 
                                           final int minSize, final int maxSize, final ParameterCorrector corrector, final ParameterValidator elementValidator,
                                           final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller, final boolean resourceOnly,
                                           final DeprecationData deprecated, final AccessConstraintDefinition[] accessConstraints,
-                                          final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+                                          final Boolean nullSignificant, final AttributeParser parser,  final AttributeAccess.Flag... flags) {
         super(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, elementValidator, alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                resourceOnly, deprecated, accessConstraints, nullSignificant, parser, flags);
     }
 
     @Override
@@ -185,7 +185,7 @@ public final class PropertiesAttributeDefinition extends MapAttributeDefinition 
                 attributeMarshaller = new PropertiesAttributeMarshaller(wrapXmlElement, wrapperElement);
             }
             return new PropertiesAttributeDefinition(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, validator, alternatives,
-                    requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                    requires, attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinition.java
@@ -113,7 +113,7 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
         super(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
                 corrector, createParameterValidator(validator, type, allowNull, allowExpression), validateNull, alternatives, requires, null, false, null, null, flags);
     }
-
+    @Deprecated
     public SimpleAttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
                                      final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
                                      final ParameterCorrector corrector, final ParameterValidator validator,
@@ -121,7 +121,7 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
         super(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
                 corrector, createParameterValidator(validator, type, allowNull, allowExpression), validateNull, alternatives, requires, attributeMarshaller, resourceOnly, deprecated, null, flags);
     }
-
+    @Deprecated
     public SimpleAttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
             final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
             final ParameterCorrector corrector, final ParameterValidator validator,
@@ -130,7 +130,7 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
             final AccessConstraintDefinition[] accessConstraints, final AttributeAccess.Flag... flags) {
         this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
                 corrector, createParameterValidator(validator, type, allowNull, allowExpression), validateNull, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints,null,AttributeParser.SIMPLE, flags);
     }
 
     @Deprecated
@@ -151,9 +151,23 @@ public class SimpleAttributeDefinition extends AttributeDefinition {
                                      final boolean resourceOnly, final DeprecationData deprecated,
                                      final AccessConstraintDefinition[] accessConstraints, final Boolean nullSignificant,
                                      final AttributeAccess.Flag... flags) {
+        this(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
+                corrector, createParameterValidator(validator, type, allowNull, allowExpression), validateNull, alternatives, requires,
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, null, flags);
+    }
+
+    protected SimpleAttributeDefinition(String name, String xmlName, final ModelNode defaultValue, final ModelType type,
+                                     final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit,
+                                     final ParameterCorrector corrector, final ParameterValidator validator,
+                                     boolean validateNull, String[] alternatives, String[] requires, AttributeMarshaller attributeMarshaller,
+                                     final boolean resourceOnly, final DeprecationData deprecated,
+                                     final AccessConstraintDefinition[] accessConstraints,
+                                     final Boolean nullSignificant,
+                                     final AttributeParser parser,
+                                     final AttributeAccess.Flag... flags) {
         super(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
                 corrector, createParameterValidator(validator, type, allowNull, allowExpression), validateNull, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, parser, flags);
     }
 
     private static ParameterValidator createParameterValidator(final ParameterValidator existing, final ModelType type,final boolean allowNull, final boolean allowExpression) {

--- a/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleAttributeDefinitionBuilder.java
@@ -81,6 +81,7 @@ public class SimpleAttributeDefinitionBuilder extends AbstractAttributeDefinitio
 
     public SimpleAttributeDefinitionBuilder(final String attributeName, final ModelType type, final boolean allowNull) {
         super(attributeName, type, allowNull);
+        parser = AttributeParser.SIMPLE;
     }
 
     public SimpleAttributeDefinitionBuilder(final SimpleAttributeDefinition basis) {
@@ -94,7 +95,7 @@ public class SimpleAttributeDefinitionBuilder extends AbstractAttributeDefinitio
     public SimpleAttributeDefinition build() {
         return new SimpleAttributeDefinition(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
                 corrector, validator, validateNull, alternatives, requires, attributeMarshaller, resourceOnly,deprecated,
-                accessConstraints, nullSignficant, flags);
+                accessConstraints, nullSignficant, parser, flags);
     }
 
     /*

--- a/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleListAttributeDefinition.java
@@ -55,7 +55,7 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
                                             final boolean resourceOnly, final DeprecationData deprecated,
                                             final AccessConstraintDefinition[] accessConstraints, final AttributeAccess.Flag... flags) {
         this(name, xmlName, valueType, allowNull, minSize, maxSize, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, null, null, flags);
     }
 
     protected SimpleListAttributeDefinition(final String name, final String xmlName, final AttributeDefinition valueType,
@@ -63,9 +63,10 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
                                             final String[] alternatives, final String[] requires, AttributeMarshaller attributeMarshaller,
                                             final boolean resourceOnly, final DeprecationData deprecated,
                                             final AccessConstraintDefinition[] accessConstraints, final Boolean nullSignificant,
+                                            final AttributeParser parser,
                                             final AttributeAccess.Flag... flags) {
         super(name, xmlName, allowNull, false, minSize, maxSize, valueType.getValidator(), alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, parser, flags);
         this.valueType = valueType;
     }
 
@@ -243,7 +244,7 @@ public class SimpleListAttributeDefinition extends ListAttributeDefinition {
                 };
             }
             return new SimpleListAttributeDefinition(name, xmlName, valueType, allowNull, minSize, maxSize, alternatives, requires,
-                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
 
         /*

--- a/controller/src/main/java/org/jboss/as/controller/SimpleMapAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/SimpleMapAttributeDefinition.java
@@ -55,9 +55,9 @@ public class SimpleMapAttributeDefinition extends MapAttributeDefinition {
                                          final int minSize, final int maxSize, final ParameterCorrector corrector, final ParameterValidator elementValidator,
                                          final String[] alternatives, final String[] requires, final AttributeMarshaller attributeMarshaller,final boolean resourceOnly,
                                          final DeprecationData deprecated, final AccessConstraintDefinition[] accessConstraints,
-                                         final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+                                         final Boolean nullSignificant, final AttributeParser parser, final AttributeAccess.Flag... flags) {
         super(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, elementValidator, alternatives,
-                requires, attributeMarshaller, resourceOnly,deprecated, accessConstraints, nullSignificant, flags);
+                requires, attributeMarshaller, resourceOnly,deprecated, accessConstraints, nullSignificant, parser, flags);
     }
 
     @Override
@@ -125,7 +125,7 @@ public class SimpleMapAttributeDefinition extends MapAttributeDefinition {
                 attributeMarshaller = new MapAttributeMarshaller();
             }
             return new SimpleMapAttributeDefinition(name, xmlName, allowNull, allowExpression, minSize, maxSize, corrector, validator, alternatives, requires,
-                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
     }
 }

--- a/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/StringListAttributeDefinition.java
@@ -44,9 +44,9 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
                                           final int minSize, final int maxSize, ParameterValidator elementValidator, final String[] alternatives,
                                           final String[] requires, final AttributeMarshaller attributeMarshaller, final boolean resourceOnly,
                                           final DeprecationData deprecated, final AccessConstraintDefinition[] accessConstraints,
-                                          final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+                                          final Boolean nullSignificant, final AttributeParser parser, final AttributeAccess.Flag... flags) {
         super(name, xmlName, allowNull, allowExpressions, ModelType.STRING, minSize, maxSize, elementValidator, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, parser, flags);
     }
 
     public List<String> unwrap(final OperationContext context, final ModelNode model) throws OperationFailedException {
@@ -72,6 +72,7 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
     public static class Builder extends AbstractAttributeDefinitionBuilder<Builder, StringListAttributeDefinition> {
         public Builder(final String name) {
             super(name, ModelType.STRING);
+            parser = AttributeParser.STRING_LIST;
             validator = new ModelTypeValidator(ModelType.STRING);
         }
 
@@ -86,7 +87,7 @@ public final class StringListAttributeDefinition extends PrimitiveListAttributeD
         public StringListAttributeDefinition build() {
             return new StringListAttributeDefinition(name, xmlName, allowNull, allowExpression, minSize, maxSize,
                     validator, alternatives, requires,
-                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
     }
 }

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOExtension.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOExtension.java
@@ -58,14 +58,15 @@ public class IOExtension implements Extension {
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.IO_1_0.getUriString(), IOSubsystemParser_1_0.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.IO_1_1.getUriString(), IOSubsystemParser_1_1.INSTANCE);
     }
 
     @Override
     public void initialize(ExtensionContext context) {
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0, 0);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 1, 0);
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(IORootDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE, false);
-        subsystem.registerXMLElementWriter(IOSubsystemParser_1_0.INSTANCE);
+        subsystem.registerXMLElementWriter(IOSubsystemParser_1_1.INSTANCE);
     }
 
 

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemParser_1_0.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemParser_1_0.java
@@ -22,58 +22,45 @@
 
 package org.wildfly.extension.io;
 
-import java.util.List;
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
 
+import java.util.List;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PersistentResourceXMLDescription;
-import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.dmr.ModelNode;
 import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
-
-import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
  */
-class IOSubsystemParser_1_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+class IOSubsystemParser_1_0 implements XMLStreamConstants, XMLElementReader<List<ModelNode>> {
+
     static final IOSubsystemParser_1_0 INSTANCE = new IOSubsystemParser_1_0();
 
+    private final PersistentResourceXMLDescription xmlDescription;
 
-    private static final PersistentResourceXMLDescription xmlDescription;
-
-    static {
+    private IOSubsystemParser_1_0() {
         xmlDescription = builder(IORootDefinition.INSTANCE)
                 .addChild(
                         builder(WorkerResourceDefinition.INSTANCE)
+                                .addAttribute(WorkerResourceDefinition.WORKER_IO_THREADS, new AttributeParser.DiscardOldDefaultValueParser("3"))
                                 .addAttributes(
-                                        WorkerResourceDefinition.WORKER_IO_THREADS,
                                         WorkerResourceDefinition.WORKER_TASK_KEEPALIVE,
                                         WorkerResourceDefinition.WORKER_TASK_MAX_THREADS,
                                         WorkerResourceDefinition.STACK_SIZE)
                 )
                 .addChild(
                         builder(BufferPoolResourceDefinition.INSTANCE)
-                                .addAttributes(BufferPoolResourceDefinition.BUFFER_SIZE,
-                                        BufferPoolResourceDefinition.BUFFER_PER_SLICE,
-                                        BufferPoolResourceDefinition.DIRECT_BUFFERS)
+                                .addAttribute(BufferPoolResourceDefinition.BUFFER_SIZE, new AttributeParser.DiscardOldDefaultValueParser("16384"))
+                                .addAttribute(BufferPoolResourceDefinition.BUFFER_PER_SLICE, new AttributeParser.DiscardOldDefaultValueParser("128"))
+                                .addAttribute(BufferPoolResourceDefinition.DIRECT_BUFFERS)
                 )
                 .build();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void writeContent(XMLExtendedStreamWriter writer, SubsystemMarshallingContext context) throws XMLStreamException {
-        ModelNode model = new ModelNode();
-        model.get(IORootDefinition.INSTANCE.getPathElement().getKeyValuePair()).set(context.getModelNode());//this is bit of workaround for SPRD to work properly
-        xmlDescription.persist(writer, model, Namespace.CURRENT.getUriString());
     }
 
     /**

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemParser_1_1.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/IOSubsystemParser_1_1.java
@@ -1,0 +1,88 @@
+/*
+ *
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2014, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
+ */
+
+package org.wildfly.extension.io;
+
+import static org.jboss.as.controller.PersistentResourceXMLDescription.builder;
+
+import java.util.List;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PersistentResourceXMLDescription;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
+ */
+class IOSubsystemParser_1_1 implements XMLStreamConstants, XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+    static final IOSubsystemParser_1_1 INSTANCE = new IOSubsystemParser_1_1();
+
+
+    private static final PersistentResourceXMLDescription xmlDescription;
+
+    static {
+        xmlDescription = builder(IORootDefinition.INSTANCE)
+                .addChild(
+                        builder(WorkerResourceDefinition.INSTANCE)
+                                .addAttributes(
+                                        WorkerResourceDefinition.WORKER_IO_THREADS,
+                                        WorkerResourceDefinition.WORKER_TASK_KEEPALIVE,
+                                        WorkerResourceDefinition.WORKER_TASK_MAX_THREADS,
+                                        WorkerResourceDefinition.STACK_SIZE)
+                )
+                .addChild(
+                        builder(BufferPoolResourceDefinition.INSTANCE)
+                                .addAttributes(BufferPoolResourceDefinition.BUFFER_SIZE,
+                                        BufferPoolResourceDefinition.BUFFER_PER_SLICE,
+                                        BufferPoolResourceDefinition.DIRECT_BUFFERS)
+                )
+                .build();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void writeContent(XMLExtendedStreamWriter writer, SubsystemMarshallingContext context) throws XMLStreamException {
+        ModelNode model = new ModelNode();
+        model.get(IORootDefinition.INSTANCE.getPathElement().getKeyValuePair()).set(context.getModelNode());//this is bit of workaround for SPRD to work properly
+        xmlDescription.persist(writer, model, Namespace.CURRENT.getUriString());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void readElement(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
+        xmlDescription.parse(reader, PathAddress.EMPTY_ADDRESS, list);
+    }
+}
+

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/Namespace.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/Namespace.java
@@ -34,12 +34,13 @@ enum Namespace {
     // must be first
     UNKNOWN(null),
 
-    IO_1_0("urn:jboss:domain:io:1.0");
+    IO_1_0("urn:jboss:domain:io:1.0"),
+    IO_1_1("urn:jboss:domain:io:1.1");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = IO_1_0;
+    public static final Namespace CURRENT = IO_1_1;
 
     private final String name;
 

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/OptionAttributeDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/OptionAttributeDefinition.java
@@ -30,6 +30,7 @@ import java.math.BigInteger;
 
 import org.jboss.as.controller.AbstractAttributeDefinitionBuilder;
 import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.DeprecationData;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.OperationFailedException;
@@ -55,9 +56,9 @@ public class OptionAttributeDefinition extends SimpleAttributeDefinition {
                                       MeasurementUnit measurementUnit, ParameterCorrector corrector, ParameterValidator validator, boolean validateNull,
                                       String[] alternatives, String[] requires, AttributeMarshaller attributeMarshaller, boolean resourceOnly,
                                       DeprecationData deprecated, Option<?> option, Class<?> optionType, AccessConstraintDefinition[] accessConstraints,
-                                      Boolean nullSignificant, AttributeAccess.Flag... flags) {
+                                      Boolean nullSignificant, final AttributeParser parser, AttributeAccess.Flag... flags) {
         super(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit, corrector, validator, validateNull, alternatives, requires,
-                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, flags);
+                attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignificant, parser, flags);
         this.option = option;
         this.optionType = optionType;
 
@@ -112,7 +113,7 @@ public class OptionAttributeDefinition extends SimpleAttributeDefinition {
         public OptionAttributeDefinition build() {
             return new OptionAttributeDefinition(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit,
                     corrector, validator, validateNull, alternatives, requires, attributeMarshaller, resourceOnly,
-                    deprecated, option, optionType, accessConstraints, nullSignficant, flags);
+                    deprecated, option, optionType, accessConstraints, nullSignficant, parser, flags);
         }
 
         private void setType() {

--- a/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
+++ b/io/subsystem/src/main/java/org/wildfly/extension/io/WorkerResourceDefinition.java
@@ -39,16 +39,11 @@ import org.xnio.Options;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 class WorkerResourceDefinition extends PersistentResourceDefinition {
-    //The defaults for these come from XnioWorker
 
-    /*static final OptionAttributeDefinition THREAD_DAEMON = new OptionAttributeDefinition.Builder(Constants.THREAD_DAEMON, Options.THREAD_DAEMON)
-            .setDefaultValue(new ModelNode(false))
-            .build();*/
     static final OptionAttributeDefinition WORKER_TASK_CORE_THREADS = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_CORE_THREADS, Options.WORKER_TASK_CORE_THREADS)
-            .setDefaultValue(new ModelNode(4))
+            .setDefaultValue(new ModelNode(2))
             .build();
     static final OptionAttributeDefinition WORKER_TASK_MAX_THREADS = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_MAX_THREADS, Options.WORKER_TASK_MAX_THREADS)
-            .setDefaultValue(new ModelNode(15))
             .build();
     static final OptionAttributeDefinition WORKER_TASK_KEEPALIVE = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_KEEPALIVE, Options.WORKER_TASK_KEEPALIVE)
             .setDefaultValue(new ModelNode(60))
@@ -57,24 +52,10 @@ class WorkerResourceDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode(0L))
             .build();
     static final OptionAttributeDefinition WORKER_IO_THREADS = new OptionAttributeDefinition.Builder(Constants.WORKER_IO_THREADS, Options.WORKER_IO_THREADS)
-            .setDefaultValue(new ModelNode(4))
             .build();
     /*static final OptionAttributeDefinition WORKER_TASK_LIMIT = new OptionAttributeDefinition.Builder(Constants.WORKER_TASK_LIMIT, Options.WORKER_TASK_LIMIT)
             .setDefaultValue(new ModelNode(0x4000))
             .build();*/
-
-    /*
-    workers support...
-    WORKER_NAME THREAD_DAEMON WORKER_TASK_CORE_THREADS WORKER_TASK_MAX_THREADS WORKER_TASK_KEEPALIVE STACK_SIZE WORKER_READ_THREADS WORKER_WRITE_THREADS
-    WORKER_NAME should be derived from the resource name for ease of debugging and whatnot
-    maybe something like "%s I/O" where %s is the name of the resource
-    in current upstream, WORKER_TASK_CORE_THREADS and WORKER_TASK_KEEPALIVE have no effect
-    or WORKER_TASK_LIMIT which should also be supported
-    actually, forget that last one
-    WORKER_TASK_LIMIT should diaf
-    limiting the work queue will just lead to 500 errors and other problems
-     */
-
 
     static OptionAttributeDefinition[] ATTRIBUTES = new OptionAttributeDefinition[]{
             WORKER_IO_THREADS,

--- a/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystem10TestCase.java
+++ b/io/tests/src/test/java/org/wildfly/extension/io/IOSubsystem10TestCase.java
@@ -1,7 +1,7 @@
 /*
  *
  *  JBoss, Home of Professional Open Source.
- *  Copyright 2013, Red Hat, Inc., and individual contributors
+ *  Copyright 2014, Red Hat, Inc., and individual contributors
  *  as indicated by the @author tags. See the copyright.txt file in the
  *  distribution for a full listing of individual contributors.
  *
@@ -40,16 +40,20 @@ import org.xnio.XnioWorker;
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
-public class IOSubsystemTestCase extends AbstractSubsystemBaseTest {
+public class IOSubsystem10TestCase extends AbstractSubsystemBaseTest {
 
-    public IOSubsystemTestCase() {
+    public IOSubsystem10TestCase() {
         super(IOExtension.SUBSYSTEM_NAME, new IOExtension());
     }
 
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        super.compareXml(configId, marshalled, readResource("shipped-default.xml"));
+    }
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("io-1.1.xml");
+        return readResource("io-1.0.xml");
     }
 
     @Test

--- a/io/tests/src/test/resources/org/wildfly/extension/io/io-1.0.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/io-1.0.xml
@@ -23,6 +23,6 @@
   -->
 
 <subsystem xmlns="urn:jboss:domain:io:1.0">
-    <worker name="default" io-threads="3" task-keepalive="100" stack-size="5000" task-max-threads="100"/>
-    <buffer-pool name="default" buffer-size="2048" buffers-per-slice="2048"/>
+    <worker name="default" io-threads="3"/>
+    <buffer-pool name="default" buffer-size="16384" buffers-per-slice="128"/>
 </subsystem>

--- a/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/io-1.1.xml
@@ -1,8 +1,7 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <!--
   ~ /*
   ~ * JBoss, Home of Professional Open Source.
-  ~ * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
   ~ * as indicated by the @author tags. See the copyright.txt file in the
   ~ * distribution for a full listing of individual contributors.
   ~ *
@@ -23,12 +22,7 @@
   ~ */
   -->
 
-<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
-    <extension-module>org.wildfly.extension.io</extension-module>
-    <subsystem xmlns="urn:jboss:domain:io:1.1">
-        <worker name="default" />
-        <buffer-pool name="default" />
-    </subsystem>
-</config>
-
+<subsystem xmlns="urn:jboss:domain:io:1.1">
+    <worker name="default" task-keepalive="100" stack-size="5000" />
+    <buffer-pool name="default" buffer-size="2048" buffers-per-slice="2048"/>
+</subsystem>

--- a/io/tests/src/test/resources/org/wildfly/extension/io/shipped-default.xml
+++ b/io/tests/src/test/resources/org/wildfly/extension/io/shipped-default.xml
@@ -1,8 +1,7 @@
-<?xml version='1.0' encoding='UTF-8'?>
 <!--
   ~ /*
   ~ * JBoss, Home of Professional Open Source.
-  ~ * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
   ~ * as indicated by the @author tags. See the copyright.txt file in the
   ~ * distribution for a full listing of individual contributors.
   ~ *
@@ -23,12 +22,7 @@
   ~ */
   -->
 
-<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
-<config>
-    <extension-module>org.wildfly.extension.io</extension-module>
-    <subsystem xmlns="urn:jboss:domain:io:1.1">
-        <worker name="default" />
-        <buffer-pool name="default" />
-    </subsystem>
-</config>
-
+<subsystem xmlns="urn:jboss:domain:io:1.1">
+    <worker name="default" />
+    <buffer-pool name="default" />
+</subsystem>

--- a/logging/src/main/java/org/jboss/as/logging/LogHandlerListAttributeDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/LogHandlerListAttributeDefinition.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import org.jboss.as.controller.AbstractAttributeDefinitionBuilder;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.DeprecationData;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -52,9 +53,12 @@ public class LogHandlerListAttributeDefinition extends SimpleListAttributeDefini
     LogHandlerListAttributeDefinition(final String name, final String xmlName, final String propertyName, final AttributeDefinition valueType,
                                       final boolean allowNull, final int minSize, final int maxSize, final String[] alternatives, final String[] requires,
                                       final AttributeMarshaller attributeMarshaller, final boolean resourceOnly,final DeprecationData deprecationData,
-                                      final AccessConstraintDefinition[] accessConstraints, final Boolean nilSignificant, final AttributeAccess.Flag... flags) {
+                                      final AccessConstraintDefinition[] accessConstraints,
+                                      final Boolean nilSignificant,
+                                      final AttributeParser parser,
+                                      final AttributeAccess.Flag... flags) {
         super(name, xmlName, valueType,allowNull, minSize, maxSize,  alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecationData, accessConstraints, nilSignificant, flags);
+                resourceOnly, deprecationData, accessConstraints, nilSignificant, parser, flags);
         this.propertyName = propertyName;
     }
 
@@ -109,7 +113,7 @@ public class LogHandlerListAttributeDefinition extends SimpleListAttributeDefini
             if (propertyName == null) propertyName = name;
             if (attributeMarshaller == null) attributeMarshaller = HandlersAttributeMarshaller.INSTANCE;
             return new LogHandlerListAttributeDefinition(name, xmlName, propertyName, CommonAttributes.HANDLER, allowNull, minSize, maxSize, alternatives, requires,
-                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                    attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
 
         public Builder setPropertyName(final String propertyName) {

--- a/logging/src/main/java/org/jboss/as/logging/PropertyAttributeDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PropertyAttributeDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.logging;
 
 import org.jboss.as.controller.AbstractAttributeDefinitionBuilder;
 import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.DeprecationData;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -52,16 +53,16 @@ public class PropertyAttributeDefinition extends SimpleAttributeDefinition imple
                                        final ParameterValidator validator, final boolean validateNull, final String[] alternatives, final String[] requires,
                                        final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecationData, final Flag... flags) {
         this(name, xmlName, propertyName, resolver, defaultValue, type, allowNull, allowExpression, measurementUnit, corrector, validator, validateNull, alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecationData, null, null, flags);
+                resourceOnly, deprecationData, null, null, null, flags);
     }
 
     private PropertyAttributeDefinition(final String name, final String xmlName, final String propertyName, final ModelNodeResolver<String> resolver, final ModelNode defaultValue, final ModelType type,
             final boolean allowNull, final boolean allowExpression, final MeasurementUnit measurementUnit, final ParameterCorrector corrector,
             final ParameterValidator validator, final boolean validateNull, final String[] alternatives, final String[] requires,
             final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecationData,
-            final AccessConstraintDefinition[] accessConstraints, Boolean nullSignificant, final Flag... flags) {
+            final AccessConstraintDefinition[] accessConstraints, Boolean nullSignificant, final AttributeParser parser, final Flag... flags) {
         super(name, xmlName, defaultValue, type, allowNull, allowExpression, measurementUnit, corrector, validator, validateNull, alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecationData, accessConstraints, nullSignificant, flags);
+                resourceOnly, deprecationData, accessConstraints, nullSignificant, parser, flags);
         this.propertyName = propertyName;
         this.resolver = resolver;
     }
@@ -164,7 +165,7 @@ public class PropertyAttributeDefinition extends SimpleAttributeDefinition imple
             if (propertyName == null) propertyName = name;
             return new PropertyAttributeDefinition(name, xmlName, propertyName, resolver, defaultValue, type, allowNull, allowExpression, measurementUnit,
                     corrector, validator, validateNull, alternatives, requires, attributeMarshaller, resourceOnly,
-                    deprecated, accessConstraints, nullSignficant, flags);
+                    deprecated, accessConstraints, nullSignficant, parser, flags);
         }
 
         public Builder setPropertyName(final String propertyName) {

--- a/logging/src/main/java/org/jboss/as/logging/PropertyObjectTypeAttributeDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/PropertyObjectTypeAttributeDefinition.java
@@ -25,6 +25,7 @@ package org.jboss.as.logging;
 import org.jboss.as.controller.AbstractAttributeDefinitionBuilder;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
+import org.jboss.as.controller.AttributeParser;
 import org.jboss.as.controller.DeprecationData;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -53,9 +54,9 @@ public class PropertyObjectTypeAttributeDefinition extends ObjectTypeAttributeDe
                                                   final ParameterValidator validator, final ParameterCorrector corrector, final String[] alternatives, final String[] requires,
                                                   final AttributeMarshaller attributeMarshaller, final boolean resourceOnly, final DeprecationData deprecationData,
                                                   final AccessConstraintDefinition[] accessConstraints,
-                                                  final Boolean nullSignificant, final AttributeAccess.Flag... flags) {
+                                                  final Boolean nullSignificant, final AttributeParser parser, final AttributeAccess.Flag... flags) {
         super(name, xmlName, suffix, valueTypes, allowNull, validator, corrector, alternatives, requires, attributeMarshaller,
-                resourceOnly, deprecationData, accessConstraints, nullSignificant, flags);
+                resourceOnly, deprecationData, accessConstraints, nullSignificant, parser, flags);
         this.propertyName = propertyName;
         this.resolver = resolver;
     }
@@ -116,7 +117,7 @@ public class PropertyObjectTypeAttributeDefinition extends ObjectTypeAttributeDe
                 validator = new ObjectTypeValidator(allowNull, valueTypes);
             }
             return new PropertyObjectTypeAttributeDefinition(name, xmlName, propertyName, suffix, valueTypes, allowNull, resolver, validator, corrector, alternatives, requires,
-                        attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, flags);
+                        attributeMarshaller, resourceOnly, deprecated, accessConstraints, nullSignficant, parser, flags);
         }
 
         public Builder setSuffix(final String suffix) {

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,6 @@
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>
         <version.org.hibernate>4.3.4.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.4.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>1.0.1.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.0-api>
         <version.org.hibernate.validator>5.1.0.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.0.0.Alpha6</version.org.hibernate.hql>

--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/PermissionResourceDefinition.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/PermissionResourceDefinition.java
@@ -109,7 +109,7 @@ class PermissionResourceDefinition extends PersistentResourceDefinition {
                                                    final String xmlWrapperElement, final LinkedHashMap<String, AttributeDefinition> attributes,
                                                    final List<PersistentResourceXMLDescription> children, final boolean useValueAsElementName,
                                                    final boolean noAddOperation, final AdditionalOperationsGenerator additionalOperationsGenerator) {
-            super(resourceDefinition, xmlElementName, xmlWrapperElement, attributes, children, useValueAsElementName, noAddOperation, additionalOperationsGenerator);
+            super(resourceDefinition, xmlElementName, xmlWrapperElement, attributes, children, useValueAsElementName, noAddOperation, additionalOperationsGenerator, null);
         }
 
         /**

--- a/undertow/src/main/java/org/wildfly/extension/undertow/BufferCacheDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/BufferCacheDefinition.java
@@ -34,6 +34,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -41,19 +42,22 @@ import org.jboss.dmr.ModelType;
  */
 public class BufferCacheDefinition extends PersistentResourceDefinition {
     protected static final SimpleAttributeDefinition BUFFER_SIZE = new SimpleAttributeDefinitionBuilder(Constants.BUFFER_SIZE, ModelType.INT)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setValidator(new IntRangeValidator(0, false, true))
+            .setDefaultValue(new ModelNode(1024))
             .build();
     protected static final SimpleAttributeDefinition BUFFERS_PER_REGION = new SimpleAttributeDefinitionBuilder(Constants.BUFFERS_PER_REGION, ModelType.INT)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setValidator(new IntRangeValidator(0, false, true))
+            .setDefaultValue(new ModelNode(1024))
             .build();
     protected static final SimpleAttributeDefinition MAX_REGIONS = new SimpleAttributeDefinitionBuilder(Constants.MAX_REGIONS, ModelType.INT)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
             .setValidator(new IntRangeValidator(0, false, true))
+            .setDefaultValue(new ModelNode(10))
             .build();
     static final BufferCacheDefinition INSTANCE = new BufferCacheDefinition();
     private static final List<SimpleAttributeDefinition> ATTRIBUTES = Collections.unmodifiableList(Arrays.asList(BUFFER_SIZE, BUFFERS_PER_REGION, MAX_REGIONS));

--- a/undertow/src/main/java/org/wildfly/extension/undertow/JSPConfig.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/JSPConfig.java
@@ -46,7 +46,7 @@ public class JSPConfig {
             servletInfo = null;
         } else {
 
-            final io.undertow.servlet.api.ServletInfo jspServlet = new ServletInfo("Default JSP Servlet", JspServlet.class)
+            final io.undertow.servlet.api.ServletInfo jspServlet = new ServletInfo("jsp", JspServlet.class)
                     .addMapping("*.jsp")
                     .addMapping("*.jspx");
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -95,6 +95,7 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
             .addOption(UndertowOptions.ALWAYS_SET_KEEP_ALIVE, "always-set-keep-alive", new ModelNode(true))
             .addOption(UndertowOptions.MAX_BUFFERED_REQUEST_SIZE, "max-buffered-request-size", new ModelNode(16384))
             .addOption(UndertowOptions.RECORD_REQUEST_START_TIME, "record-request-start-time", new ModelNode(false))
+            .addOption(UndertowOptions.ALLOW_EQUALS_IN_COOKIE_VALUE, "allow-equals-in-cookie-value", new ModelNode(false))
             .build();
 
     protected static final Collection ATTRIBUTES;

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Namespace.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Namespace.java
@@ -33,12 +33,13 @@ enum Namespace {
     // must be first
     UNKNOWN(null),
 
-    UNDERTOW_1_0("urn:jboss:domain:undertow:1.0");
+    UNDERTOW_1_0("urn:jboss:domain:undertow:1.0"),
+    UNDERTOW_1_1("urn:jboss:domain:undertow:1.1");
 
     /**
      * The current namespace version.
      */
-    public static final Namespace CURRENT = UNDERTOW_1_0;
+    public static final Namespace CURRENT = UNDERTOW_1_1;
 
     private final String name;
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerAdd.java
@@ -69,11 +69,10 @@ final class ServletContainerAdd extends AbstractBoottimeAddStepHandler {
     public void installRuntimeServices(OperationContext context, ModelNode model, List<ServiceController<?>> newControllers, String name) throws OperationFailedException {
         final ModelNode fullModel = Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS));
 
-        SessionCookieConfig config = SessionCookieDefinition.INSTANCE.getConfig(context, fullModel.get(SessionCookieDefinition.INSTANCE.getPathElement().getKeyValuePair()));
-        boolean persistentSessions = PersistentSessionsDefinition.isEnabled(context, fullModel.get(PersistentSessionsDefinition.INSTANCE.getPathElement().getKeyValuePair()));
+        final SessionCookieConfig config = SessionCookieDefinition.INSTANCE.getConfig(context, fullModel.get(SessionCookieDefinition.INSTANCE.getPathElement().getKeyValuePair()));
+        final boolean persistentSessions = PersistentSessionsDefinition.isEnabled(context, fullModel.get(PersistentSessionsDefinition.INSTANCE.getPathElement().getKeyValuePair()));
         final boolean allowNonStandardWrappers = ServletContainerDefinition.ALLOW_NON_STANDARD_WRAPPERS.resolveModelAttribute(context, model).asBoolean();
-        final ModelNode bufferCacheValue = ServletContainerDefinition.DEFAULT_BUFFER_CACHE.resolveModelAttribute(context, model);
-        final String bufferCache = bufferCacheValue.isDefined() ? bufferCacheValue.asString() : null;
+        final String bufferCache = ServletContainerDefinition.DEFAULT_BUFFER_CACHE.resolveModelAttribute(context, model).asString();
 
         JSPConfig jspConfig = JspDefinition.INSTANCE.getConfig(context, fullModel.get(JspDefinition.INSTANCE.getPathElement().getKeyValuePair()));
 
@@ -82,8 +81,16 @@ final class ServletContainerAdd extends AbstractBoottimeAddStepHandler {
         final String defaultEncoding = defaultEncodingValue.isDefined()? defaultEncodingValue.asString() : null;
         final boolean useListenerEncoding = ServletContainerDefinition.USE_LISTENER_ENCODING.resolveModelAttribute(context, model).asBoolean();
         final boolean ignoreFlush = ServletContainerDefinition.IGNORE_FLUSH.resolveModelAttribute(context, model).asBoolean();
+        final boolean eagerFilterInit = ServletContainerDefinition.EAGER_FILTER_INIT.resolveModelAttribute(context, model).asBoolean();
 
-        final ServletContainerService container = new ServletContainerService(allowNonStandardWrappers, ServletStackTraces.valueOf(stackTracesString.toUpperCase().replace('-', '_')), config, jspConfig, defaultEncoding, useListenerEncoding, ignoreFlush);
+        final ServletContainerService container = new ServletContainerService(allowNonStandardWrappers,
+                ServletStackTraces.valueOf(stackTracesString.toUpperCase().replace('-', '_')),
+                config,
+                jspConfig,
+                defaultEncoding,
+                useListenerEncoding,
+                ignoreFlush,
+                eagerFilterInit);
         final ServiceTarget target = context.getServiceTarget();
         final ServiceBuilder<ServletContainerService> builder = target.addService(UndertowService.SERVLET_CONTAINER.append(name), container);
         if(bufferCache != null) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerDefinition.java
@@ -56,12 +56,13 @@ public class ServletContainerDefinition extends PersistentResourceDefinition {
             new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_BUFFER_CACHE, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setAllowExpression(true)
+                    .setDefaultValue(new ModelNode("default"))
                     .build();
 
     protected static final SimpleAttributeDefinition STACK_TRACE_ON_ERROR =
             new SimpleAttributeDefinitionBuilder(Constants.STACK_TRACE_ON_ERROR, ModelType.STRING, true)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-                    .setDefaultValue(new ModelNode(Constants.NONE))
+                    .setDefaultValue(new ModelNode(ServletStackTraces.LOCAL_ONLY.toString()))
                     .setValidator(new EnumValidator<>(ServletStackTraces.class, true, true))
                     .setAllowExpression(true)
                     .build();
@@ -87,6 +88,14 @@ public class ServletContainerDefinition extends PersistentResourceDefinition {
                     .setDefaultValue(new ModelNode(false))
                     .build();
 
+
+    protected static final AttributeDefinition EAGER_FILTER_INIT =
+            new SimpleAttributeDefinitionBuilder("eager-filter-initialization", ModelType.BOOLEAN, true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setAllowExpression(true)
+                    .setDefaultValue(new ModelNode(false))
+                    .build();
+
     private static final List<? extends PersistentResourceDefinition> CHILDREN;
     private static final Collection<AttributeDefinition> ATTRIBUTES = Arrays.asList(
             ALLOW_NON_STANDARD_WRAPPERS,
@@ -94,7 +103,8 @@ public class ServletContainerDefinition extends PersistentResourceDefinition {
             STACK_TRACE_ON_ERROR,
             DEFAULT_ENCODING,
             USE_LISTENER_ENCODING,
-            IGNORE_FLUSH);
+            IGNORE_FLUSH,
+            EAGER_FILTER_INIT);
 
     static {
         List<PersistentResourceDefinition>  children = new ArrayList<>();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServletContainerService.java
@@ -49,8 +49,10 @@ public class ServletContainerService implements Service<ServletContainerService>
     private final String defaultEncoding;
     private final boolean useListenerEncoding;
     private final boolean ignoreFlush;
+    private final boolean eagerFilterInit;
 
-    public ServletContainerService(boolean allowNonStandardWrappers, ServletStackTraces stackTraces, SessionCookieConfig sessionCookieConfig, JSPConfig jspConfig, String defaultEncoding, boolean useListenerEncoding, boolean ignoreFlush) {
+    public ServletContainerService(boolean allowNonStandardWrappers, ServletStackTraces stackTraces, SessionCookieConfig sessionCookieConfig, JSPConfig jspConfig,
+                                   String defaultEncoding, boolean useListenerEncoding, boolean ignoreFlush, boolean eagerFilterInit) {
         this.allowNonStandardWrappers = allowNonStandardWrappers;
         this.stackTraces = stackTraces;
         this.sessionCookieConfig = sessionCookieConfig;
@@ -58,6 +60,7 @@ public class ServletContainerService implements Service<ServletContainerService>
         this.defaultEncoding = defaultEncoding;
         this.useListenerEncoding = useListenerEncoding;
         this.ignoreFlush = ignoreFlush;
+        this.eagerFilterInit = eagerFilterInit;
     }
 
     public void start(StartContext context) throws StartException {
@@ -118,5 +121,9 @@ public class ServletContainerService implements Service<ServletContainerService>
 
     public boolean isIgnoreFlush() {
         return ignoreFlush;
+    }
+
+    public boolean isEagerFilterInit() {
+        return eagerFilterInit;
     }
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnAdd.java
@@ -59,7 +59,9 @@ class SingleSignOnAdd extends AbstractAddStepHandler {
                 final PathAddress serverAddress = hostAddress.subAddress(0, hostAddress.size() - 1);
 
         final ModelNode domainModelNode = SingleSignOnDefinition.DOMAIN.resolveModelAttribute(context, model);
+        final ModelNode pathNode = SingleSignOnDefinition.PATH.resolveModelAttribute(context, model);
         final String domain = domainModelNode.isDefined() ? domainModelNode.asString() : null;
+        final String path = pathNode.isDefined() ? pathNode.asString() : null;
         final String serverName = serverAddress.getLastElement().getValue();
         final String hostName = hostAddress.getLastElement().getValue();
         final ServiceName serviceName = UndertowService.ssoServiceName(serverName, hostName);
@@ -68,12 +70,14 @@ class SingleSignOnAdd extends AbstractAddStepHandler {
         final ServiceTarget target = context.getServiceTarget();
 
         ServiceName managerServiceName = serviceName.append("manager");
-        ServiceController<?> factoryController = SingleSignOnManagerService.build(target, managerServiceName, virtualHostServiceName).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
+        ServiceController<?> factoryController = SingleSignOnManagerService.build(target, managerServiceName, virtualHostServiceName)
+                .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                .install();
         if (newControllers != null) {
             newControllers.add(factoryController);
         }
 
-        final SingleSignOnService service = new SingleSignOnService(domain);
+        final SingleSignOnService service = new SingleSignOnService(domain, path);
         final ServiceController<?> sc = target.addService(serviceName, service)
                 .addDependency(virtualHostServiceName, Host.class, service.getHost())
                 .addDependency(managerServiceName, SingleSignOnManager.class, service.getSingleSignOnSessionManager())

--- a/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnDefinition.java
@@ -41,12 +41,16 @@ import org.jboss.dmr.ModelType;
  */
 class SingleSignOnDefinition extends PersistentResourceDefinition {
 
-    static final SimpleAttributeDefinition DOMAIN = new SimpleAttributeDefinitionBuilder(Constants.DOMAIN, ModelType.STRING)
+    static final SimpleAttributeDefinition DOMAIN = new SimpleAttributeDefinitionBuilder(Constants.DOMAIN, ModelType.STRING, true)
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .build();
+    static final SimpleAttributeDefinition PATH = new SimpleAttributeDefinitionBuilder("path", ModelType.STRING, true)
             .setAllowNull(true)
             .setAllowExpression(true)
             .build();
 
-    static final List<AttributeDefinition> ATTRIBUTES = Arrays.<AttributeDefinition>asList(DOMAIN);
+    static final List<AttributeDefinition> ATTRIBUTES = Arrays.<AttributeDefinition>asList(DOMAIN, PATH);
 
     static final SingleSignOnDefinition INSTANCE = new SingleSignOnDefinition();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/SingleSignOnService.java
@@ -36,24 +36,27 @@ import org.jboss.msc.value.InjectedValue;
  * @author Tomaz Cerar (c) 2014 Red Hat Inc.
  * @author Paul Ferraro
  */
-public class SingleSignOnService implements Service<SingleSignOnService> {
+class SingleSignOnService implements Service<SingleSignOnService> {
 
     private static final String AUTHENTICATION_MECHANISM_NAME = "SSO";
 
     private final String domain;
+    private final String path;
     private final InjectedValue<Host> host = new InjectedValue<>();
     private final InjectedValue<SingleSignOnManager> manager = new InjectedValue<>();
 
-    public SingleSignOnService(String domain) {
+    SingleSignOnService(String domain,String path) {
         this.domain = domain;
+        this.path = path;
     }
 
     @Override
     public void start(StartContext startContext) {
         Host host = this.host.getValue();
         ServletSingleSignOnAuthenticationMechainism mechanism = new ServletSingleSignOnAuthenticationMechainism(this.manager.getValue());
-        mechanism.setDomain((this.domain != null) ? this.domain : host.getName());
-
+        mechanism.setDomain(this.domain);
+        //todo uncomment when we get new release of undertow
+        //mechanism.setPath(this.path);
         host.registerAdditionalAuthenticationMechanism(AUTHENTICATION_MECHANISM_NAME, mechanism);
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowExtension.java
@@ -76,18 +76,19 @@ public class UndertowExtension implements Extension {
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_1_0.getUriString(), UndertowSubsystemParser_1_0.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, Namespace.UNDERTOW_1_1.getUriString(), UndertowSubsystemParser_1_1.INSTANCE);
     }
 
     @Override
     public void initialize(ExtensionContext context) {
-        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0, 0);
+        final SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 1, 0);
         final ManagementResourceRegistration registration = subsystem.registerSubsystemModel(UndertowRootDefinition.INSTANCE);
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE, false);
 
         final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(DeploymentDefinition.INSTANCE);
         deployments.registerSubModel(DeploymentServletDefinition.INSTANCE);
 
-        subsystem.registerXMLElementWriter(UndertowSubsystemParser_1_0.INSTANCE);
+        subsystem.registerXMLElementWriter(UndertowSubsystemParser_1_1.INSTANCE);
     }
 
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -521,6 +521,9 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
             //in most cases flush just hurts performance for no good reason
             d.setIgnoreFlush(servletContainer.isIgnoreFlush());
 
+            //controlls initizalization of filters on start of application
+            d.setEagerFilterInit(servletContainer.isEagerFilterInit());
+
             d.setAllowNonStandardWrappers(servletContainer.isAllowNonStandardWrappers());
             d.setServletStackTraces(servletContainer.getStackTraces());
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/handlers/ReverseProxyHandler.java
@@ -45,7 +45,7 @@ import java.util.List;
  */
 public class ReverseProxyHandler extends Handler {
 
-    public static final ReverseProxyHandler INSTANCE = new ReverseProxyHandler();
+
 
     public static final AttributeDefinition PROBLEM_SERVER_RETRY = new SimpleAttributeDefinitionBuilder(Constants.PROBLEM_SERVER_RETRY, ModelType.INT)
             .setAllowNull(true)
@@ -68,7 +68,10 @@ public class ReverseProxyHandler extends Handler {
     public static final AttributeDefinition MAX_REQUEST_TIME = new SimpleAttributeDefinitionBuilder(Constants.MAX_REQUEST_TIME, ModelType.INT)
             .setAllowNull(true)
             .setAllowExpression(true)
+            .setDefaultValue(new ModelNode(-1))
             .build();
+
+    public static final ReverseProxyHandler INSTANCE = new ReverseProxyHandler();
 
     private ReverseProxyHandler() {
         super(Constants.REVERSE_PROXY);
@@ -90,11 +93,8 @@ public class ReverseProxyHandler extends Handler {
         String sessionCookieNames = SESSION_COOKIE_NAMES.resolveModelAttribute(context, model).asString();
         int connectionsPerThread = CONNECTIONS_PER_THREAD.resolveModelAttribute(context, model).asInt();
         int problemServerRetry = PROBLEM_SERVER_RETRY.resolveModelAttribute(context, model).asInt();
-        ModelNode maxTimeNode = MAX_REQUEST_TIME.resolveModelAttribute(context, model);
-        int maxTime = -1;
-        if (maxTimeNode.isDefined()) {
-            maxTime = maxTimeNode.asInt();
-        }
+        int maxTime = MAX_REQUEST_TIME.resolveModelAttribute(context, model).asInt();
+
         final LoadBalancingProxyClient lb = new LoadBalancingProxyClient()
                 .setConnectionsPerThread(connectionsPerThread)
                 .setProblemServerRetry(problemServerRetry);

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -58,6 +58,7 @@ undertow.servlet-container.allow-non-standard-wrappers=If true then request and 
 undertow.servlet-container.use-listener-encoding=Use encoding defined on listener
 undertow.servlet-container.ignore-flush=Ignore flushes on the servlet output stream. In most cases these just hurt performance for no good reason.
 undertow.servlet-container.default-encoding=Default encoding to use for all deployed applications
+undertow.servlet-container.eager-filter-initialization=If true undertow calls filter init() on deployment start rather than when first requested.
 undertow.error-page=Server error pages
 undertow.handler=Undertow handlers
 undertow.handler.add=Add the handler element
@@ -116,6 +117,8 @@ undertow.listener.max-buffered-request-size=Maximum size of a buffered request, 
   Requests are not usually buffered, the most common case is when performing SSL renegotiation for a POST request, and the post data must be fully\
   buffered in order to perform the renegotiation.
 undertow.listener.record-request-start-time=If this is true then Undertow will record the request start time, to allow for request time to be logged. This has a small but measurable performance impact
+undertow.listener.allow-equals-in-cookie-value=If this is true then Undertow will allow non-escaped equals characters in unquoted cookie values. \
+  Unquoted cookie values may not contain equals characters. If present the value ends before the equals sign. The remainder of the cookie value will be dropped.
 undertow.host=An Undertow host
 undertow.host.add=Adds a new host
 undertow.host.remove=Removes a host

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -86,6 +86,7 @@ undertow.single-sign-on.cache-container=Enables clustered SSO using the specifie
 undertow.single-sign-on.cache-name=Name of the cache to use in the cache container.
 undertow.single-sign-on.domain=The cookie domain that will be used.
 undertow.single-sign-on.re-authenticate=Enables reauthentication with the realm when using SSO.
+undertow.single-sign-on.path=Cookie path.
 undertow.listener=http listener
 undertow.listener.add=Add listener
 undertow.listener.remove=Listener name

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowDefaultConfigUpgradeTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowDefaultConfigUpgradeTestCase.java
@@ -1,0 +1,88 @@
+/*
+ *
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2014, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
+ *
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
+ *
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
+ */
+
+package org.wildfly.extension.undertow;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+
+import java.io.IOException;
+import java.util.List;
+
+import io.undertow.predicate.Predicates;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.handlers.PathHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.as.domain.management.security.SecurityRealmService;
+import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.naming.service.NamingStoreService;
+import org.jboss.as.remoting.HttpListenerRegistryService;
+import org.jboss.as.server.Services;
+import org.jboss.as.server.moduleservice.ServiceModuleLoader;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.jboss.as.subsystem.test.AdditionalInitialization;
+import org.jboss.as.subsystem.test.ControllerInitializer;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.as.subsystem.test.KernelServicesBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.junit.Assert;
+import org.junit.Test;
+import org.wildfly.extension.io.BufferPoolService;
+import org.wildfly.extension.io.IOServices;
+import org.wildfly.extension.io.WorkerService;
+import org.wildfly.extension.undertow.filters.FilterRef;
+import org.wildfly.extension.undertow.filters.FilterService;
+import org.xnio.OptionMap;
+import org.xnio.Options;
+
+/**
+ * This is the barebone test example that tests subsystem
+ *
+ * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
+ */
+public class UndertowDefaultConfigUpgradeTestCase extends AbstractSubsystemBaseTest {
+
+    public UndertowDefaultConfigUpgradeTestCase() {
+        super(UndertowExtension.SUBSYSTEM_NAME, new UndertowExtension());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("undertow-default-8.0.0.xml");
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        super.compareXml(configId, marshalled, readResource("undertow-default.xml"));
+    }
+}

--- a/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem10TestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/UndertowSubsystem10TestCase.java
@@ -1,23 +1,25 @@
 /*
- * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
- * as indicated by the @author tags. See the copyright.txt file in the
- * distribution for a full listing of individual contributors.
  *
- * This is free software; you can redistribute it and/or modify it
- * under the terms of the GNU Lesser General Public License as
- * published by the Free Software Foundation; either version 2.1 of
- * the License, or (at your option) any later version.
+ *  JBoss, Home of Professional Open Source.
+ *  Copyright 2014, Red Hat, Inc., and individual contributors
+ *  as indicated by the @author tags. See the copyright.txt file in the
+ *  distribution for a full listing of individual contributors.
  *
- * This software is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
- * Lesser General Public License for more details.
+ *  This is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation; either version 2.1 of
+ *  the License, or (at your option) any later version.
  *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this software; if not, write to the Free
- * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
- * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *  This software is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this software; if not, write to the Free
+ *  Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ *  02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ * /
  */
 
 package org.wildfly.extension.undertow;
@@ -68,15 +70,20 @@ import org.xnio.Options;
  *
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a>
  */
-public class UndertowSubsystemTestCase extends AbstractSubsystemBaseTest {
+public class UndertowSubsystem10TestCase extends AbstractSubsystemBaseTest {
 
-    public UndertowSubsystemTestCase() {
+    public UndertowSubsystem10TestCase() {
         super(UndertowExtension.SUBSYSTEM_NAME, new UndertowExtension());
     }
 
     @Override
     protected String getSubsystemXml() throws IOException {
-        return readResource("undertow-1.1.xml");
+        return readResource("undertow-1.0.xml");
+    }
+
+    @Override
+    protected KernelServices standardSubsystemTest(String configId, boolean compareXml) throws Exception {
+        return super.standardSubsystemTest(configId, false);
     }
 
     @Test
@@ -201,6 +208,8 @@ public class UndertowSubsystemTestCase extends AbstractSubsystemBaseTest {
             target.addService(SecurityRealm.ServiceUtil.createServiceName("other"), new SecurityRealmService("other", false))
                     .setInitialMode(ServiceController.Mode.ACTIVE)
                     .install();
+
+
         }
     }
 }

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.1.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-1.1.xml
@@ -1,31 +1,32 @@
 <!--
-  ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
-  ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
-  ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ /*
+  ~ * JBoss, Home of Professional Open Source.
+  ~ * Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ * as indicated by the @author tags. See the copyright.txt file in the
+  ~ * distribution for a full listing of individual contributors.
+  ~ *
+  ~ * This is free software; you can redistribute it and/or modify it
+  ~ * under the terms of the GNU Lesser General Public License as
+  ~ * published by the Free Software Foundation; either version 2.1 of
+  ~ * the License, or (at your option) any later version.
+  ~ *
+  ~ * This software is distributed in the hope that it will be useful,
+  ~ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ * Lesser General Public License for more details.
+  ~ *
+  ~ * You should have received a copy of the GNU Lesser General Public
+  ~ * License along with this software; if not, write to the Free
+  ~ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~ */
   -->
 
-<subsystem xmlns="urn:jboss:domain:undertow:1.0" default-virtual-host="default-virtual-host" default-servlet-container="myContainer"
+<subsystem xmlns="urn:jboss:domain:undertow:1.1" default-virtual-host="default-virtual-host" default-servlet-container="myContainer"
            default-server="some-server" instance-id="some-id">
 
-    <buffer-caches>
-        <buffer-cache name="default" buffer-size="1025" buffers-per-region="1054" max-regions="15"/>
-    </buffer-caches>
+    <buffer-cache name="default" buffer-size="1025" buffers-per-region="1054" max-regions="15"/>
+    <buffer-cache name="extra" buffer-size="1025" buffers-per-region="1054" max-regions="15"/>
 
     <server name="default-server" default-host="localhost" servlet-container="myContainer">
         <ajp-listener name="ajp-connector" socket-binding="ajp" redirect-socket="ajps" max-parameters="5000"/>
@@ -53,7 +54,7 @@
     </server>
 
 
-    <servlet-container name="myContainer" default-buffer-cache="extra" use-listener-encoding="${prop.foo:false}" default-encoding="utf-8" ignore-flush="true">
+    <servlet-container name="myContainer" default-buffer-cache="extra" use-listener-encoding="${prop.foo:false}" default-encoding="utf-8" ignore-flush="true" eager-filter-initialization="true">
         <jsp-config
                 disabled="${prop.disabled:false}"
                 keep-generated="${prop.keep-generated:true}"

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-default-8.0.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-default-8.0.0.xml
@@ -1,0 +1,24 @@
+<subsystem xmlns="urn:jboss:domain:undertow:1.0">
+      <buffer-caches>
+          <buffer-cache name="default" buffer-size="1024" buffers-per-region="1024" max-regions="10"/>
+      </buffer-caches>
+      <server name="default-server">
+          <http-listener name="default" socket-binding="http" />
+          <?AJP?>
+          <host name="default-host" alias="localhost">
+              <location name="/" handler="welcome-content" />
+              <filter-ref name="server-header"/>
+              <filter-ref name="x-powered-by-header"/>
+          </host>
+      </server>
+      <servlet-container name="default" default-buffer-cache="default" stack-trace-on-error="local-only" >
+          <jsp-config/>
+      </servlet-container>
+      <handlers>
+          <file name="welcome-content" path="${jboss.home.dir}/welcome-content" directory-listing="true"/>
+      </handlers>
+      <filters>
+          <response-header name="server-header" header-name="Server" header-value="Wildfly 8"/>
+          <response-header name="x-powered-by-header" header-name="X-Powered-By" header-value="Undertow 1"/>
+      </filters>
+  </subsystem>

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-default.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-default.xml
@@ -1,73 +1,21 @@
-<!--
-  ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
-  ~ as indicated by the @author tags. See the copyright.txt file in the
-  ~ distribution for a full listing of individual contributors.
-  ~
-  ~ This is free software; you can redistribute it and/or modify it
-  ~ under the terms of the GNU Lesser General Public License as
-  ~ published by the Free Software Foundation; either version 2.1 of
-  ~ the License, or (at your option) any later version.
-  ~
-  ~ This software is distributed in the hope that it will be useful,
-  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~ Lesser General Public License for more details.
-  ~
-  ~ You should have received a copy of the GNU Lesser General Public
-  ~ License along with this software; if not, write to the Free
-  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  -->
-
-<subsystem xmlns="urn:jboss:domain:undertow:1.0" default-virtual-host="default-virtual-host" default-servlet-container="default-servlet-container"
-           default-server="some-server" instance-id="some-id">
-
-
-    <buffer-caches>
-        <buffer-cache name="default" buffer-size="1024" buffers-per-region="1024" max-regions="10"/>
-    </buffer-caches>
-
-    <server name="default-server" default-host="localhost" servlet-container="blah">
-        <http-listener name="default" socket-binding="http"/>
-        <ajp-listener name="ajp-connector" socket-binding="ajp"/>
-
-        <host name="default-host" alias="localhost">
-            <location name="/" handler="welcome-content">
-            </location>
-
-        </host>
-
-    </server>
-     <server name="test" default-host="test-context" servlet-container="blah">
-           <host name="default-host"/>
+<subsystem xmlns="urn:jboss:domain:undertow:1.1">
+       <buffer-cache name="default" />
+       <server name="default-server">
+           <http-listener name="default" socket-binding="http" />
+           <host name="default-host" alias="localhost">
+               <location name="/" handler="welcome-content" />
+               <filter-ref name="server-header"/>
+               <filter-ref name="x-powered-by-header"/>
+           </host>
        </server>
-
-    <servlet-container name="default" >
-        <jsp-config
-                    disabled="${prop.disabled:false}"
-                    development="${prop.development:false}"
-                    keep-generated="${prop.keep-generated:true}"
-                    trim-spaces="${prop.trim-spaces:true}"
-                    tag-pooling="${prop.tag-pooling:true}"
-                    mapped-file="${prop.mapped-file:true}"
-                    check-interval="${prop.check-interval:20}"
-                    modification-test-interval="${prop.modification-test-interval:1000}"
-                    recompile-on-fail="${prop.recompile-on-fail:true}"
-                    smap="${prop.smap:true}"
-                    dump-smap="${prop.dump-smap:true}"
-                    generate-strings-as-char-arrays="${prop.generate-strings-as-char-arrays:true}"
-                    error-on-use-bean-invalid-class-attribute="${prop.error-on-use-bean-invalid-class-attribute:true}"
-                    scratch-dir="${prop.scratch-dir:/some/dir}"
-                    source-vm="${prop.source-vm:1.7}"
-                    target-vm="${prop.target-vm:1.7}"
-                    java-encoding="${prop.java-encoding:utf-8}"
-                    x-powered-by="${prop.x-powered-by:true}"
-                    display-source-fragment="${prop.display-source-fragment:true}"/>
-    </servlet-container>
-
-    <handlers>
-        <file name="welcome-content" path="${jboss.home.dir}/welcome-content" directory-listing="true"/>
-    </handlers>
-
-</subsystem>
+       <servlet-container name="default" >
+           <jsp-config/>
+       </servlet-container>
+       <handlers>
+           <file name="welcome-content" path="${jboss.home.dir}/welcome-content" />
+       </handlers>
+       <filters>
+           <response-header name="server-header" header-name="Server" header-value="Wildfly 8"/>
+           <response-header name="x-powered-by-header" header-name="X-Powered-By" header-value="Undertow 1"/>
+       </filters>
+   </subsystem>


### PR DESCRIPTION
- introduce smart defaults for IO subsystem
- introduce IO & Undertow 1.1 schema
- fix shipped configs
- WFLY-3028 It should be possible to initialize Filters on deployment rather than on first use
- introduce allow-equals-in-cookie-value listener option
- add tests to test legacy shipped configs with current shipped for IO & undertow
