### PR TITLE
[WFLY-3051] Add a dependency on 'javax.api' to the 'org.wildfly.extension.io' module.

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/wildfly/extension/io/main/module.xml
@@ -30,6 +30,7 @@
     </resources>
 
     <dependencies>
+        <module name="javax.api"/>
         <module name="sun.jdk"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>


### PR DESCRIPTION
This corrects an issue where JMX clients are experiencing connection failures attempting to use http-remoting-jmx over the application servers HTTP server instead of the management HTTP server.
