### PR TITLE
[WFLY-3094] Validate address-settings configuration

### DIFF
--- a/build/src/main/resources/configuration/subsystems/messaging.xml
+++ b/build/src/main/resources/configuration/subsystems/messaging.xml
@@ -88,6 +88,14 @@
                    </entries>
                </pooled-connection-factory>
            </jms-connection-factories>
+           <jms-destinations>
+               <jms-queue name="ExpiryQueue">
+                   <entry name="java:/jms/queue/ExpiryQueue"/>
+               </jms-queue>
+               <jms-queue name="DLQ">
+                   <entry name="java:/jms/queue/DLQ"/>
+               </jms-queue>
+           </jms-destinations>
        </hornetq-server>
    </subsystem>
    <supplement name="ha">

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingAdd.java
@@ -33,13 +33,14 @@ import org.hornetq.core.server.HornetQServer;
 import org.hornetq.core.settings.impl.AddressFullMessagePolicy;
 import org.hornetq.core.settings.impl.AddressSettings;
 import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
@@ -51,13 +52,17 @@ import org.jboss.msc.service.ServiceController;
  */
 class AddressSettingAdd extends AbstractAddStepHandler {
 
-    static final OperationStepHandler INSTANCE = new AddressSettingAdd();
+    static final OperationStepHandler INSTANCE = new AddressSettingAdd(AddressSettingDefinition.ATTRIBUTES);
+
+    private AddressSettingAdd(AttributeDefinition... attributes) {
+        super(attributes);
+    }
 
     @Override
-    protected void populateModel(final ModelNode operation, final ModelNode model) throws OperationFailedException {
-        for(final SimpleAttributeDefinition attribute : AddressSettingDefinition.ATTRIBUTES) {
-            attribute.validateAndSet(operation, model);
-        }
+    protected void populateModel(OperationContext context, ModelNode operation, final Resource resource) throws OperationFailedException {
+        super.populateModel(context, operation, resource);
+
+        context.addStep(AddressSettingsValidator.ADD_VALIDATOR, OperationContext.Stage.MODEL);
     }
 
     @Override

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsValidator.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsValidator.java
@@ -1,0 +1,128 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging;
+
+import static org.hornetq.jms.client.HornetQDestination.JMS_QUEUE_ADDRESS_PREFIX;
+import static org.hornetq.jms.client.HornetQDestination.JMS_TOPIC_ADDRESS_PREFIX;
+import static org.jboss.as.controller.PathAddress.pathAddress;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.messaging.CommonAttributes.DEAD_LETTER_ADDRESS;
+import static org.jboss.as.messaging.CommonAttributes.EXPIRY_ADDRESS;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Validate that address-settings' attributes are properly configured.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+class AddressSettingsValidator {
+
+    /**
+     * Validates that an address-setting:add operation does not define expiry-address or dead-letter address
+     * without corresponding resources for them.
+     */
+    static OperationStepHandler ADD_VALIDATOR = new OperationStepHandler() {
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            String addressSetting = PathAddress.pathAddress(operation.require(OP_ADDR)).getLastElement().getValue();
+
+            PathAddress address = pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
+            Resource hornetqServer = context.readResourceFromRoot(MessagingServices.getHornetQServerPathAddress(address), true);
+
+            checkExpiryAddress(context, operation, hornetqServer, addressSetting);
+            checkDeadLetterAddress(context, operation, hornetqServer, addressSetting);
+
+            context.stepCompleted();
+        }
+    };
+
+    /**
+     * Validate that an updated address-settings still has resources bound corresponding
+     * to expiry-address and dead-letter-address (if they are defined).
+     */
+    static void validateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        String addressSetting = PathAddress.pathAddress(operation.require(OP_ADDR)).getLastElement().getValue();
+        PathAddress address = pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
+
+        Resource hornetqServer = context.readResourceFromRoot(MessagingServices.getHornetQServerPathAddress(address), true);
+
+        checkExpiryAddress(context, resource.getModel(), hornetqServer, addressSetting);
+        checkDeadLetterAddress(context, resource.getModel(), hornetqServer, addressSetting);
+
+        context.stepCompleted();
+    }
+
+    private static void checkExpiryAddress(OperationContext context, ModelNode model, Resource hornetqServer, String addressSetting) throws OperationFailedException {
+        ModelNode expiryAddress = EXPIRY_ADDRESS.resolveModelAttribute(context, model);
+        if (!findMatchingResource(expiryAddress, hornetqServer)) {
+            MessagingLogger.MESSAGING_LOGGER.noMatchingExpiryAddress(expiryAddress.asString(), addressSetting);
+        }
+    }
+
+    private static void checkDeadLetterAddress(OperationContext context, ModelNode model, Resource hornetqServer, String addressSetting) throws OperationFailedException {
+        ModelNode deadLetterAddress = DEAD_LETTER_ADDRESS.resolveModelAttribute(context, model);
+        if (!findMatchingResource(deadLetterAddress, hornetqServer)) {
+            MessagingLogger.MESSAGING_LOGGER.noMatchingDeadLetterAddress(deadLetterAddress.asString(), addressSetting);
+        }
+    }
+
+    private static boolean findMatchingResource(ModelNode addressNode, Resource hornetqServer) {
+        if (!addressNode.isDefined()) {
+            // do not search for a match if the address is not defined
+            return true;
+        }
+
+        final String address = addressNode.asString();
+        final String addressPrefix;
+        final String childType;
+
+        if (address.startsWith(JMS_QUEUE_ADDRESS_PREFIX)) {
+            // JMS Queue
+            childType = CommonAttributes.JMS_QUEUE;
+            addressPrefix = JMS_QUEUE_ADDRESS_PREFIX;
+        } else if (address.startsWith(JMS_TOPIC_ADDRESS_PREFIX)) {
+            // JMS Topic
+            childType = CommonAttributes.JMS_TOPIC;
+            addressPrefix = JMS_TOPIC_ADDRESS_PREFIX;
+        } else {
+            // Core Queue
+            childType = CommonAttributes.CORE_QUEUE;
+            // no special address prefix for core queues
+            addressPrefix = "";
+        }
+
+        for (String childName : hornetqServer.getChildrenNames(childType)) {
+            if (address.equals(addressPrefix + childName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsWriteHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsWriteHandler.java
@@ -46,6 +46,14 @@ class AddressSettingsWriteHandler extends AbstractWriteAttributeHandler<AddressS
         super(AddressSettingDefinition.ATTRIBUTES);
     }
 
+
+    @Override
+    protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue, ModelNode oldValue, Resource model) throws OperationFailedException {
+        super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
+
+        AddressSettingsValidator.validateModel(context, operation, model);
+    }
+
     @Override
     protected boolean applyUpdateToRuntime(final OperationContext context, final ModelNode operation, final String attributeName, final ModelNode resolvedValue,
                                            final ModelNode currentValue, final HandbackHolder<RevertHandback> handbackHolder) throws OperationFailedException {

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingLogger.java
@@ -232,4 +232,24 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 11617, value = "No connectors were explicitly defined for the pooled connection factory %s. Using %s as the connector.")
     void connectorForPooledConnectionFactory(String name, String connectorName);
+
+    /**
+     * Logs a warn message when there is no resource matching the address-settings' expiry-address.
+     *
+     * @param address the name of the address-settings' missing expiry-address
+     * @param addressSettings the name of the address-settings
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11618, value = "There is no resource matching the expiry-address %s for the address-settings %s, expired messages from destinations matching this address-setting will be lost!")
+    void noMatchingExpiryAddress(String address, String addressSettings);
+
+    /**
+     * Logs a warn message when there is no resource matching the address-settings' dead-letter-address.
+     *
+     * @param address the name of the address-settings' missing dead-letter-address
+     * @param addressSettings the name of the address-settings
+     */
+    @LogMessage(level = WARN)
+    @Message(id = 11619, value = "There is no resource matching the dead-letter-address %s for the address-settings %s, undelivered messages from destinations matching this address-setting will be lost!")
+    void noMatchingDeadLetterAddress(String address, String addressSettings);
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/JmsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/JmsTestCase.java
@@ -22,6 +22,8 @@
 package org.jboss.as.test.integration.management.cli;
 
 import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.jboss.arquillian.junit.Arquillian;
@@ -61,33 +63,34 @@ public class JmsTestCase extends AbstractCliTestBase {
     }
 
     private void testAddJmsQueue() throws Exception {
-
+        String queueName = "testJmsQueue";
         // check the queue is not registered
         cli.sendLine("cd /subsystem=messaging/hornetq-server=default/jms-queue");
         cli.sendLine("ls");
         String ls = cli.readOutput();
-        Assert.assertNull(ls);
+        assertFalse(ls.contains(queueName));
 
         // create queue
-        cli.sendLine("jms-queue add --queue-address=testJmsQueue --entries=testJmsQueue");
+        cli.sendLine(String.format("jms-queue add --queue-address=%s --entries=%s", queueName, queueName));
 
         // check it is listed
         cli.sendLine("cd /subsystem=messaging/hornetq-server=default/jms-queue");
         cli.sendLine("ls");
         ls = cli.readOutput();
-        assertTrue(ls.contains("testJmsQueue"));
+        assertTrue(ls.contains(queueName));
     }
 
     private void testRemoveJmsQueue() throws Exception {
+        String queueName = "testJmsQueue";
 
-        // create queue
-        cli.sendLine("jms-queue remove --queue-address=testJmsQueue");
+        // remove the queue
+        cli.sendLine("jms-queue remove --queue-address=" + queueName);
 
         // check it is listed
         cli.sendLine("cd /subsystem=messaging/hornetq-server=default/jms-queue");
         cli.sendLine("ls");
         String ls = cli.readOutput();
-        Assert.assertNull(ls);
+        assertFalse(ls.contains(queueName));
     }
 
     private void testAddJmsTopic() throws Exception {


### PR DESCRIPTION
- check that if address-settings' expiry-address and dead-letter-address
  are defined, then there must be corresponding resources (either
  jms-queue, jms-topic, or core-queue) bound to them.
  If that's not the case, logs a warning that there me be unintended
  message loss.
- add 2 JMS Queue (ExpiryQueue and DLQ) to the full configuration to
  satistfy these constraints.

JIRA: https://issues.jboss.org/browse/WFLY-3094
