### PR TITLE
[WFLY-3099] now escapes the DN properly for group search

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapGroupSearcherFactory.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapGroupSearcherFactory.java
@@ -209,7 +209,7 @@ public class LdapGroupSearcherFactory {
             if (groupRef != null && groupRef.size() > 0) {
                 NamingEnumeration<String> groupRefValues = (NamingEnumeration<String>) groupRef.getAll();
                 while (groupRefValues.hasMore()) {
-                    String distingushedName = groupRefValues.next();
+                    String distingushedName = groupRefValues.next().replace("\\", "\\\\").replace("/", "\\/");
                     SECURITY_LOGGER.tracef("Group found with distinguishedName=%s", distingushedName);
                     String simpleName = null;
                     if (groupNameAttribute != null) {


### PR DESCRIPTION
escape slash and backslash characters in the distingushedName in PrincipalToGroupSearcher(..)

https://issues.jboss.org/browse/WFLY-3099
