### PR TITLE
[WFLY-2187] Make the class and module attributes on a custom handler writable

### DIFF
--- a/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/AbstractHandlerDefinition.java
@@ -155,15 +155,6 @@ abstract class AbstractHandlerDefinition extends TransformerResourceDefinition {
 
     protected AbstractHandlerDefinition(final PathElement path,
                                         final Class<? extends Handler> type,
-                                        final AttributeDefinition[] addAttributes,
-                                        final AttributeDefinition[] readOnlyAttributes,
-                                        final AttributeDefinition[] writableAttributes,
-                                        final ConfigurationProperty<?>... constructionProperties) {
-        this(path, type, PropertySorter.NO_OP, addAttributes, readOnlyAttributes, writableAttributes, constructionProperties);
-    }
-
-    protected AbstractHandlerDefinition(final PathElement path,
-                                        final Class<? extends Handler> type,
                                         final PropertySorter propertySorter,
                                         final AttributeDefinition[] addAttributes,
                                         final AttributeDefinition[] readOnlyAttributes,

--- a/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
+++ b/logging/src/main/java/org/jboss/as/logging/CustomHandlerResourceDefinition.java
@@ -39,16 +39,11 @@ class CustomHandlerResourceDefinition extends AbstractHandlerDefinition {
     public static final String CUSTOM_HANDLER = "custom-handler";
     static final PathElement CUSTOM_HANDLE_PATH = PathElement.pathElement(CUSTOM_HANDLER);
 
-    static final AttributeDefinition[] READ_ONLY_ATTRIBUTES = {CLASS, MODULE};
-    static final AttributeDefinition[] WRITABLE_ATTRIBUTES = Logging.join(DEFAULT_ATTRIBUTES, NAMED_FORMATTER, PROPERTIES);
-    // Add attributes are a combination of writable and read-only attributes
-    static final AttributeDefinition[] ADD_ATTRIBUTES = Logging.join(WRITABLE_ATTRIBUTES, READ_ONLY_ATTRIBUTES);
+    static final AttributeDefinition[] ATTRIBUTES = Logging.join(DEFAULT_ATTRIBUTES, CLASS, MODULE, NAMED_FORMATTER, PROPERTIES);
 
     public CustomHandlerResourceDefinition(final boolean includeLegacyAttributes) {
         super(CUSTOM_HANDLE_PATH, null,
-                (includeLegacyAttributes ? Logging.join(ADD_ATTRIBUTES, LEGACY_ATTRIBUTES) : ADD_ATTRIBUTES),
-                READ_ONLY_ATTRIBUTES,
-                (includeLegacyAttributes ? Logging.join(WRITABLE_ATTRIBUTES, LEGACY_ATTRIBUTES) : WRITABLE_ATTRIBUTES));
+                (includeLegacyAttributes ? Logging.join(ATTRIBUTES, LEGACY_ATTRIBUTES) : ATTRIBUTES));
     }
 
     @Override

--- a/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
+++ b/logging/src/test/java/org/jboss/as/logging/LoggingSubsystemTestCase.java
@@ -190,7 +190,7 @@ public class LoggingSubsystemTestCase extends AbstractLoggingSubsystemTest {
                                         .addConfig(new RejectExpressionsConfig(SizeRotatingHandlerResourceDefinition.ATTRIBUTES))
                                         .build())
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(CustomHandlerResourceDefinition.CUSTOM_HANDLE_PATH),
-                                new RejectExpressionsConfig(CustomHandlerResourceDefinition.WRITABLE_ATTRIBUTES))
+                                new RejectExpressionsConfig(CustomHandlerResourceDefinition.ATTRIBUTES))
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(SyslogHandlerResourceDefinition.SYSLOG_HANDLER_PATH),
                                 FailedOperationTransformationConfig.REJECTED_RESOURCE)
                         .addFailedAttribute(SUBSYSTEM_ADDRESS.append(PatternFormatterResourceDefinition.PATTERN_FORMATTER_PATH),

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/logging/operations/CustomHandlerOperationsTestCase.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.helpers.Operations;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logmanager.handlers.ConsoleHandler;
+import org.jboss.logmanager.handlers.QueueHandler;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
@@ -108,6 +109,8 @@ public class CustomHandlerOperationsTestCase extends AbstractLoggingOperationsTe
         testWrite(address, "encoding", "utf-8");
         testWrite(address, "formatter", "[test] %d{HH:mm:ss,SSS} %-5p [%c] %s%E%n");
         testWrite(address, "filter-spec", "deny");
+        testWrite(address, "class", QueueHandler.class.getName());
+        testWrite(address, "module", "org.jboss.logmanager");
         // Create a properties value
         final ModelNode properties = new ModelNode().setEmptyObject();
         properties.get("autoFlush").set(true);


### PR DESCRIPTION
Previously the `class` and `module` attributes on the `custom-handler` were not writable. Make the attributes writable.
