### PR TITLE
[WFLY-3103] fix PrimitiveListAttributeDefinition.Builder

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PrimitiveListAttributeDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/PrimitiveListAttributeDefinition.java
@@ -112,7 +112,6 @@ public class PrimitiveListAttributeDefinition extends ListAttributeDefinition {
     public static class Builder extends AbstractAttributeDefinitionBuilder<Builder, PrimitiveListAttributeDefinition> {
         private final ModelType valueType;
 
-
         public Builder(final String name, final ModelType valueType) {
             super(name, ModelType.LIST);
             this.valueType = valueType;
@@ -121,6 +120,7 @@ public class PrimitiveListAttributeDefinition extends ListAttributeDefinition {
         public Builder(final PrimitiveListAttributeDefinition basic) {
             super(basic);
             this.valueType = basic.getValueType();
+            this.validator = basic.getElementValidator();
         }
 
         public static Builder of(final String name, final ModelType valueType) {


### PR DESCRIPTION
take the copied AttributeDefinition's elementValidator to set the
builder's validator.

JIRA: https://issues.jboss.org/browse/WFLY-3103
