### PR TITLE
bugfix for wrong context path of deployed wars when context name contains dots

### DIFF
--- a/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
+++ b/arquillian/common/src/main/java/org/jboss/as/arquillian/container/ManagementClient.java
@@ -305,10 +305,6 @@ public class ManagementClient implements AutoCloseable, Closeable {
         if (correctedName.startsWith("/")) {
             correctedName = correctedName.substring(1);
         }
-        if (correctedName.indexOf(".") != -1) {
-            correctedName = correctedName.substring(0,
-                    correctedName.lastIndexOf("."));
-        }
         return correctedName;
     }
 

--- a/arquillian/container-managed/pom.xml
+++ b/arquillian/container-managed/pom.xml
@@ -92,6 +92,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.arquillian.protocol</groupId>
+            <artifactId>arquillian-protocol-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jboss</groupId>
             <artifactId>jboss-ejb-client</artifactId>
             <scope>test</scope>

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.net.URL;
 
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -40,9 +41,12 @@ import org.junit.runner.RunWith;
 @RunAsClient
 public class ManagedAsClientWebArchiveServletTestCase {
 
+    private static final String CONTEXT_NAME = "foo-v1.2";
+
     @Deployment(testable = false)
+    @OverProtocol("Servlet 3.0")
     public static WebArchive createDeployment() throws Exception {
-        return ShrinkWrap.create(WebArchive.class).addClass(HelloWorldServlet.class);
+        return ShrinkWrap.create(WebArchive.class, CONTEXT_NAME + ".war").addClass(HelloWorldServlet.class);
     }
 
     @ArquillianResource
@@ -51,6 +55,9 @@ public class ManagedAsClientWebArchiveServletTestCase {
     @Test
     public void shouldBeAbleToInvokeServlet() throws Exception {
         Assert.assertNotNull(deploymentUrl);
+        Assert.assertTrue("deploymentUrl should end with " + CONTEXT_NAME + "/, but is " + deploymentUrl + 
+                ", the context URL seems to be wrong",
+                deploymentUrl.toString().endsWith(CONTEXT_NAME + "/"));
         String result = getContent(new URL(deploymentUrl.toString() + HelloWorldServlet.URL_PATTERN.substring(1)));
         Assert.assertEquals(HelloWorldServlet.GREETING, result);
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/PolicyContextTestCase.java
@@ -68,7 +68,7 @@ public class PolicyContextTestCase {
     @Test
     public void testHttpServletRequestFromPolicyContext(@ArquillianResource URL webAppURL) throws Exception {
         String externalFormURL = webAppURL.toExternalForm();
-        String servletURL = externalFormURL.substring(0, externalFormURL.length() - 1) + ".war" + PolicyContextTestServlet.SERVLET_PATH;
+        String servletURL = externalFormURL.substring(0, externalFormURL.length() - 1) + PolicyContextTestServlet.SERVLET_PATH;
         LOGGER.info("Testing JACC permissions: " + servletURL);
 
         String response = HttpRequest.get(servletURL, 1000, SECONDS);


### PR DESCRIPTION
I detected a problem where Servlets of WARs which contain a dot in their context-name will get searched under a wrong name.
This causes headaches at our side, especially when using the `arquillian-protocol-servlet` so that I debugged the problem to understand it and implement a fix.
We have the problem with `org.jboss.as:jboss-as-arquillian-common:jar:7.2.0.Final`, which we are using, but I verified the problem exists with wildfly master, too.

Here what happens for a war named `foo-v0.3.war`:
- In `ManagementClient.getProtocolMetaData` the value of `deploymentName` is still correct, deploymentNode also contains the right information including `context-root` with value `foo-v0.3`
-  In `ManagementClient.extractWebArchiveContexts` the variable `context-name` is filled by `context-root` and still is `foo-v0.3`
- When iterating over `servletNode.keys()` the servlets get added at the wrong contextName since `contextName` already has lost its `.war` extension, but `ManagementClient.toContextName` is called which removes everything from the last do to the end.
- All Servlets get added to the wrong context name `foo-v0`
- **Bug**
