### PR TITLE
[WFLY-3106] Allow Infinispan cache to set statistics-enabled independently of cache manager.

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationService.java
@@ -88,7 +88,6 @@ public class CacheConfigurationService extends AbstractCacheConfigurationService
                 throw new IllegalArgumentException(e);
             }
         }
-        this.builder.jmxStatistics().enabled(this.dependencies.getCacheContainer().getCacheManagerConfiguration().globalJmxStatistics().enabled());
         TransactionManager tm = this.dependencies.getTransactionManager();
         if (tm != null) {
             this.builder.transaction().transactionManagerLookup(new TransactionManagerProvider(tm));


### PR DESCRIPTION
See https://issues.jboss.org/browse/WFLY-3106
