### PR TITLE
builder methods without parameters causes exception due missing cache name

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonService.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonService.java
@@ -22,6 +22,15 @@
 
 package org.wildfly.clustering.server.singleton;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 import org.jboss.as.clustering.msc.AsynchronousService;
 import org.jboss.as.clustering.msc.DelegatingServiceBuilder;
 import org.jboss.as.clustering.msc.ServiceContainerHelper;
@@ -51,15 +60,6 @@ import org.wildfly.clustering.server.provider.ServiceProviderRegistrationFactory
 import org.wildfly.clustering.singleton.Singleton;
 import org.wildfly.clustering.singleton.SingletonElectionPolicy;
 import org.wildfly.clustering.singleton.election.SimpleSingletonElectionPolicy;
-
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Decorates an MSC service ensuring that it is only started on one node in the cluster at any given time.

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonService.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonService.java
@@ -22,15 +22,6 @@
 
 package org.wildfly.clustering.server.singleton;
 
-import java.io.Serializable;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
-
 import org.jboss.as.clustering.msc.AsynchronousService;
 import org.jboss.as.clustering.msc.DelegatingServiceBuilder;
 import org.jboss.as.clustering.msc.ServiceContainerHelper;
@@ -61,6 +52,15 @@ import org.wildfly.clustering.singleton.Singleton;
 import org.wildfly.clustering.singleton.SingletonElectionPolicy;
 import org.wildfly.clustering.singleton.election.SimpleSingletonElectionPolicy;
 
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * Decorates an MSC service ensuring that it is only started on one node in the cluster at any given time.
  * @author Paul Ferraro
@@ -68,6 +68,7 @@ import org.wildfly.clustering.singleton.election.SimpleSingletonElectionPolicy;
 public class SingletonService<T extends Serializable> implements Service<T>, ServiceProviderRegistration.Listener, SingletonContext<T>, Singleton {
 
     public static final String DEFAULT_CONTAINER = "server";
+    public static final String DEFAULT_CACHE = "default";
 
     private final InjectedValue<Group> group = new InjectedValue<>();
     private final InjectedValue<ServiceProviderRegistrationFactory> registrationFactory = new InjectedValue<>();
@@ -96,7 +97,7 @@ public class SingletonService<T extends Serializable> implements Service<T>, Ser
     }
 
     public ServiceBuilder<T> build(ServiceTarget target, String containerName) {
-        return this.build(target, containerName, null);
+        return this.build(target, containerName, DEFAULT_CACHE);
     }
 
     public ServiceBuilder<T> build(ServiceTarget target, String containerName, String cacheName) {


### PR DESCRIPTION
Create a singleton service with parameterless builder methods like this:

SingletonService<String> singletonService = new SingletonService<String>(HA_SINGLETON_SERVICE_NAME, new HASingletonSampleService());

 singletonService.build(CurrentServiceContainer.getServiceContainer()) 
                .install()
                .setMode(ServiceController.Mode.ACTIVE);

causes
 java.lang.IllegalArgumentException: Name segment is null for server
    at org.jboss.msc.service.ServiceName.of(ServiceName.java:87) [jboss-msc-1.2.1.Final.jar:1.2.1.Final]
    at org.jboss.msc.service.ServiceName.append(ServiceName.java:117) [jboss-msc-1.2.1.Final.jar:1.2.1.Final]
    at org.wildfly.clustering.server.group.CacheGroupProvider.getServiceName(CacheGroupProvider.java:56)
    at org.wildfly.clustering.server.singleton.SingletonService.build(SingletonService.java:114)
