### PR TITLE
WFLY-2881: Fix for issue shown by the CalendarBasedTimeoutTestCase in sp...

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
@@ -616,6 +616,10 @@ public class CalendarBasedTimeout {
                 nextCal = this.advanceTillMonthHasDate(nextCal, nextDayOfMonth);
             }
         } else if (nextDayOfMonth < currentDayOfMonth) {
+            nextCal.clear();
+            nextCal.set(Calendar.YEAR, currentCal.get(Calendar.YEAR));
+            nextCal.set(Calendar.MONTH, currentCal.get(Calendar.MONTH));
+
             // since the next day is before the current day we need to shift to the next month
             nextCal.add(Calendar.MONTH, 1);
             // also we need to reset the time
@@ -684,13 +688,20 @@ public class CalendarBasedTimeout {
 
     private Calendar advanceTillMonthHasDate(Calendar cal, Integer date) {
         Calendar copy = this.copy(cal);
+        int year;
+        int month;
         // make sure the month can handle the date
         while (monthHasDate(copy, date) == false) {
-            if (copy.get(Calendar.YEAR) > Year.MAX_YEAR) {
+            year = copy.get(Calendar.YEAR);
+            if (year > Year.MAX_YEAR) {
                 return null;
             }
             // this month can't handle the date, so advance month to next month
             // and get the next suitable matching month
+            month = copy.get(Calendar.MONTH);
+            copy.clear();
+            copy.set(Calendar.YEAR, year);
+            copy.set(Calendar.MONTH, month);
             copy.add(Calendar.MONTH, 1);
             copy = this.computeNextMonth(copy);
             if (copy == null) {
@@ -712,7 +723,7 @@ public class CalendarBasedTimeout {
 
     private Calendar copy(Calendar cal) {
         Calendar copy = new GregorianCalendar(cal.getTimeZone());
-        copy.setTime(cal.getTime());
+        copy.setTimeInMillis(cal.getTimeInMillis());
 
         return copy;
     }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
@@ -424,8 +424,8 @@ public class CalendarBasedTimeoutTestCase {
         long diff = nextTimeout.getTimeInMillis() - firstTimeout.getTimeInMillis();
         Assert.assertEquals(timeZoneDisplayName, 15 * 1000, diff);
 
-        Calendar currentSystemDate = new GregorianCalendar();
-        Calendar nextTimeoutFromNow = calendarTimeout.getNextTimeout(currentSystemDate);
+        Calendar date = new GregorianCalendar(2014,3,18);
+        Calendar nextTimeoutFromNow = calendarTimeout.getNextTimeout(date);
 //        logger.debug("Next timeout from now is " + nextTimeoutFromNow.getTime());
         int nextMinute = nextTimeoutFromNow.get(Calendar.MINUTE);
         int nextSecond = nextTimeoutFromNow.get(Calendar.SECOND);
@@ -476,64 +476,88 @@ public class CalendarBasedTimeoutTestCase {
     /**
      * Create a Timeout with a Schedule start date in the past (day before) to ensure the time is set correctly.
      * The schedule is on the first day of month to ensure that the calculated time must be moved to the next month.
+     *
+     * The test is run for each day of a whole year.
      */
     //@Test
     public void testWithStartInThePast() {
-        ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
-        schedule.month("*");
-        schedule.dayOfMonth("1");
-        schedule.hour("0-1");
-        schedule.minute("0");
-        schedule.second("0/5");
-        Calendar start = Calendar.getInstance(this.timezone);
-        // subtract one day
-        start.add(Calendar.DAY_OF_MONTH, -1);
-        if(start.get(Calendar.DAY_OF_MONTH) == 1) {
-            // if the previous day is 1, subtract one more day
-            start.add(Calendar.DAY_OF_MONTH, -1);
-        }
-        schedule.start(start.getTime());
-
-        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
-        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
-
-        if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
-                firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
-                firstTimeout.get(Calendar.MINUTE) != 0 ||
-                firstTimeout.get(Calendar.SECOND) != 0) {
-            Assert.fail(timeZoneDisplayName);
-        }
+        Calendar start = new GregorianCalendar(this.timezone);
+        start.clear();
+        start.set(2014,3,18);
+        Calendar end = (Calendar) start.clone();
+        end.add(Calendar.YEAR,1);
+        do {
+            // setup schedule
+            ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
+            schedule.month("*");
+            schedule.dayOfMonth("1");
+            schedule.hour("0-1");
+            schedule.minute("0");
+            schedule.second("0/5");
+            Calendar scheduleStart = (Calendar) start.clone();
+            // subtract one day
+            scheduleStart.add(Calendar.DAY_OF_MONTH, -1);
+            if(scheduleStart.get(Calendar.DAY_OF_MONTH) == 1) {
+                // if the previous day is 1, subtract one more day
+                scheduleStart.add(Calendar.DAY_OF_MONTH, -1);
+            }
+            schedule.start(scheduleStart.getTime());
+            // create calendar timeout and retrieve first timeout
+            CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+            Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+            // assert first timeout result
+            if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
+                    firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
+                    firstTimeout.get(Calendar.MINUTE) != 0 ||
+                    firstTimeout.get(Calendar.SECOND) != 0) {
+                Assert.fail(timeZoneDisplayName);
+            }
+            // move to next day
+            start.add(Calendar.DAY_OF_MONTH,1);
+        } while (start.before(end));
     }
 
     /**
      * Check a Timeout if the Schedule start date in the future (day after)
      * The schedule is on the first day of month to ensure that the calculated time must be moved to the next month.
+     *
+     * The test is run for each day of a whole year.
      */
     //@Test
     public void testWithStartInTheFutureAndLaterSchedule() {
-        ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
-        schedule.month("*");
-        schedule.dayOfMonth("1");
-        schedule.hour("0-12");
-        schedule.minute("0/5");
-        schedule.second("0");
-        Calendar start = Calendar.getInstance(this.timezone);
-        // add one day
-        start.add(Calendar.DAY_OF_MONTH, 1);
-        if(start.get(Calendar.DAY_OF_MONTH) == 1) {
-            // if the next day is 1, add one more day, to avoid first timeout by advancing minutes only
-            start.add(Calendar.DAY_OF_MONTH, 1);
-        }
-        schedule.start(start.getTime());
-
-        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
-        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
-
-        if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
-                firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
-                firstTimeout.get(Calendar.MINUTE) != 0) {
-            Assert.fail(timeZoneDisplayName);
-        }
+        Calendar start = new GregorianCalendar(this.timezone);
+        start.clear();
+        start.set(2014,3,18);
+        Calendar end = (Calendar) start.clone();
+        end.add(Calendar.YEAR, 1);
+        do {
+            // setup schedule
+            ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
+            schedule.month("*");
+            schedule.dayOfMonth("1");
+            schedule.hour("0-12");
+            schedule.minute("0/5");
+            schedule.second("0");
+            Calendar scheduleStart = (Calendar) start.clone();
+            // add one day
+            scheduleStart.add(Calendar.DAY_OF_MONTH, 1);
+            if(scheduleStart.get(Calendar.DAY_OF_MONTH) == 1) {
+                // if the next day is 1, add one more day, to avoid first timeout by advancing minutes only
+                scheduleStart.add(Calendar.DAY_OF_MONTH, 1);
+            }
+            schedule.start(scheduleStart.getTime());
+            // create calendar timeout and retrieve first timeout
+            CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+            Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+            // assert first timeout result
+            if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
+                    firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
+                    firstTimeout.get(Calendar.MINUTE) != 0) {
+                Assert.fail(timeZoneDisplayName);
+            }
+            // move to next day
+            start.add(Calendar.DAY_OF_MONTH,1);
+        } while (start.before(end));
     }
 
     private ScheduleExpression getTimezoneSpecificScheduleExpression() {


### PR DESCRIPTION
...ecific dates, where the CalendarTimeout first timeout has day 1 instead of 0

This PR just extends the test coverage and fixes the concrete issue I noticed in the end of February, which led to the test deactivation. I'm not sure if the issue is just a matter of timezone offsets or a JDK bug, since what happens is that sometimes Calendar.set(Calendar.HOUR_OF_DAY, 0) fails to update the calendar hour, which stay set to 1. Cleaning the calendar fields before setting them works fine.

This PR is an alternative to https://github.com/wildfly/wildfly/pull/6045 , which goes beyond fixing the issue and provides a rework of the entire CalendarTimeout logic.
