### PR TITLE
WFLY-2881: Reworks CalendarTimeout wrt proper usage of Calendar#add. Inc...

### DIFF
--- a/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
@@ -424,8 +424,8 @@ public class CalendarBasedTimeoutTestCase {
         long diff = nextTimeout.getTimeInMillis() - firstTimeout.getTimeInMillis();
         Assert.assertEquals(timeZoneDisplayName, 15 * 1000, diff);
 
-        Calendar currentSystemDate = new GregorianCalendar();
-        Calendar nextTimeoutFromNow = calendarTimeout.getNextTimeout(currentSystemDate);
+        Calendar date = new GregorianCalendar(2014,3,18);
+        Calendar nextTimeoutFromNow = calendarTimeout.getNextTimeout(date);
 //        logger.debug("Next timeout from now is " + nextTimeoutFromNow.getTime());
         int nextMinute = nextTimeoutFromNow.get(Calendar.MINUTE);
         int nextSecond = nextTimeoutFromNow.get(Calendar.SECOND);
@@ -476,64 +476,88 @@ public class CalendarBasedTimeoutTestCase {
     /**
      * Create a Timeout with a Schedule start date in the past (day before) to ensure the time is set correctly.
      * The schedule is on the first day of month to ensure that the calculated time must be moved to the next month.
+     *
+     * The test is run for each day of a whole year.
      */
     //@Test
     public void testWithStartInThePast() {
-        ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
-        schedule.month("*");
-        schedule.dayOfMonth("1");
-        schedule.hour("0-1");
-        schedule.minute("0");
-        schedule.second("0/5");
-        Calendar start = Calendar.getInstance(this.timezone);
-        // subtract one day
-        start.add(Calendar.DAY_OF_MONTH, -1);
-        if(start.get(Calendar.DAY_OF_MONTH) == 1) {
-            // if the previous day is 1, subtract one more day
-            start.add(Calendar.DAY_OF_MONTH, -1);
-        }
-        schedule.start(start.getTime());
-
-        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
-        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
-
-        if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
-                firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
-                firstTimeout.get(Calendar.MINUTE) != 0 ||
-                firstTimeout.get(Calendar.SECOND) != 0) {
-            Assert.fail(timeZoneDisplayName);
-        }
+        Calendar start = new GregorianCalendar(this.timezone);
+        start.clear();
+        start.set(2014,3,18);
+        Calendar end = (Calendar) start.clone();
+        end.add(Calendar.YEAR,1);
+        do {
+            // setup schedule
+            ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
+            schedule.month("*");
+            schedule.dayOfMonth("1");
+            schedule.hour("0-1");
+            schedule.minute("0");
+            schedule.second("0/5");
+            Calendar scheduleStart = (Calendar) start.clone();
+            // subtract one day
+            scheduleStart.add(Calendar.DAY_OF_MONTH, -1);
+            if(scheduleStart.get(Calendar.DAY_OF_MONTH) == 1) {
+                // if the previous day is 1, subtract one more day
+                scheduleStart.add(Calendar.DAY_OF_MONTH, -1);
+            }
+            schedule.start(scheduleStart.getTime());
+            // create calendar timeout and retrieve first timeout
+            CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+            Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+            // assert first timeout result
+            if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
+                    firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
+                    firstTimeout.get(Calendar.MINUTE) != 0 ||
+                    firstTimeout.get(Calendar.SECOND) != 0) {
+                Assert.fail(timeZoneDisplayName);
+            }
+            // move to next day
+            start.add(Calendar.DAY_OF_MONTH,1);
+        } while (start.before(end));
     }
 
     /**
      * Check a Timeout if the Schedule start date in the future (day after)
      * The schedule is on the first day of month to ensure that the calculated time must be moved to the next month.
+     *
+     * The test is run for each day of a whole year.
      */
     //@Test
     public void testWithStartInTheFutureAndLaterSchedule() {
-        ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
-        schedule.month("*");
-        schedule.dayOfMonth("1");
-        schedule.hour("0-12");
-        schedule.minute("0/5");
-        schedule.second("0");
-        Calendar start = Calendar.getInstance(this.timezone);
-        // add one day
-        start.add(Calendar.DAY_OF_MONTH, 1);
-        if(start.get(Calendar.DAY_OF_MONTH) == 1) {
-            // if the next day is 1, add one more day, to avoid first timeout by advancing minutes only
-            start.add(Calendar.DAY_OF_MONTH, 1);
-        }
-        schedule.start(start.getTime());
-
-        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
-        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
-
-        if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
-                firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
-                firstTimeout.get(Calendar.MINUTE) != 0) {
-            Assert.fail(timeZoneDisplayName);
-        }
+        Calendar start = new GregorianCalendar(this.timezone);
+        start.clear();
+        start.set(2014,3,18);
+        Calendar end = (Calendar) start.clone();
+        end.add(Calendar.YEAR, 1);
+        do {
+            // setup schedule
+            ScheduleExpression schedule = this.getTimezoneSpecificScheduleExpression();
+            schedule.month("*");
+            schedule.dayOfMonth("1");
+            schedule.hour("0-12");
+            schedule.minute("0/5");
+            schedule.second("0");
+            Calendar scheduleStart = (Calendar) start.clone();
+            // add one day
+            scheduleStart.add(Calendar.DAY_OF_MONTH, 1);
+            if(scheduleStart.get(Calendar.DAY_OF_MONTH) == 1) {
+                // if the next day is 1, add one more day, to avoid first timeout by advancing minutes only
+                scheduleStart.add(Calendar.DAY_OF_MONTH, 1);
+            }
+            schedule.start(scheduleStart.getTime());
+            // create calendar timeout and retrieve first timeout
+            CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(schedule);
+            Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+            // assert first timeout result
+            if(firstTimeout.get(Calendar.DAY_OF_MONTH) != 1 ||
+                    firstTimeout.get(Calendar.HOUR_OF_DAY) != 0 ||
+                    firstTimeout.get(Calendar.MINUTE) != 0) {
+                Assert.fail(timeZoneDisplayName);
+            }
+            // move to next day
+            start.add(Calendar.DAY_OF_MONTH,1);
+        } while (start.before(end));
     }
 
     private ScheduleExpression getTimezoneSpecificScheduleExpression() {


### PR DESCRIPTION
...ludes fix shown by the CalendarBasedTimeoutTestCase in specific dates, where the CalendarTimeout first timeout has day 1 instead of 0

Besides fixing the concrete issue, this PR reworks the CalendarTimeout, truncating the calendar before setting or adding values to calendar fields, which I think is a better approach, specially since Calendar#add() is a bit unpredictable, for instance adding one year does not always just changes the year, sand the javadoc alerts for that, it may change other fields of the calendar due to years and months with different number of days. The PR also optimizes performance. 

This PR is an alternative to https://github.com/wildfly/wildfly/pull/6044
