### PR TITLE
[WFLY-3125] Update the test for the --password argument in the add-user utility.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/DomainManagementMessages.java
@@ -1068,7 +1068,7 @@ public interface DomainManagementMessages {
      * Instructions for the {@link org.jboss.as.domain.management.security.adduser.AddUser.CommandLineArgument#PASSWORD} command line argument.
      * @return the message.
      */
-    @Message(id = Message.NONE, value = "Password of the user. Should not be same as the username")
+    @Message(id = Message.NONE, value = "Password of the user, this will be checked against the password requirements defined within the add-user.properties configuration")
     String argPassword();
 
     /**


### PR DESCRIPTION
The requirements are now configurable so not feasible to have the requirements in the help text, instead identify where the requirements are defined.
