### PR TITLE
[WFLY-3131] isSensitiveValue of class SensitiveVaultExpressionConstraint...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/access/constraint/SensitiveVaultExpressionConstraint.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/constraint/SensitiveVaultExpressionConstraint.java
@@ -125,7 +125,9 @@ public class SensitiveVaultExpressionConstraint extends AllowAllowNotConstraint 
                     || value.getType() == ModelType.STRING) {
                 String valueString = value.asString();
                 if (ExpressionResolver.EXPRESSION_PATTERN.matcher(valueString).matches()) {
-                    valueString = valueString.substring(valueString.indexOf("${") + 2, valueString.indexOf("}"));
+                    int start = valueString.indexOf("${") + 2;
+                    int end = valueString.indexOf("}", start);
+                    valueString = valueString.substring(start, end);
                     return VAULT_PATTERN.matcher(valueString).matches();
                 }
             }
@@ -139,3 +141,4 @@ public class SensitiveVaultExpressionConstraint extends AllowAllowNotConstraint 
         }
     }
 }
+


### PR DESCRIPTION
... uses incorrect index in java.lang.String.substring method

https://issues.jboss.org/browse/WFLY-3131
