### PR TITLE
WFLY-2229 Add support for PKCS12 Keystores in security realms

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
@@ -464,7 +464,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="keystore-type" type="xs:string" use="optional">
+        <xs:attribute name="keystore-type" type="xs:string" use="optional" default="JKS">
             <xs:annotation>
                 <xs:documentation>
                     The type of the keystore file according to Java Cryptography

--- a/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_2_0.xsd
@@ -464,6 +464,15 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="keystore-type" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    The type of the keystore file according to Java Cryptography
+                    Architecture Standard Algorithm Name Documentation. If not
+                    specified, JKS type is used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="extendedKeyStoreType">

--- a/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
+++ b/controller/src/main/java/org/jboss/as/controller/parsing/Attribute.java
@@ -98,6 +98,7 @@ public enum Attribute {
     JAVA_HOME("java-home"),
     KEY_PASSWORD("key-password"),
     KEYSTORE_PASSWORD("keystore-password"),
+    KEYSTORE_TYPE("keystore-type"),
     LOG_BOOT("log-boot"),
     LOG_READ_ONLY("log-read-only"),
     MANAGEMENT_SUBSYSTEM_ENDPOINT("management-subsystem-endpoint"),

--- a/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
+++ b/controller/src/main/resources/org/jboss/as/controller/descriptions/common/LocalDescriptions.properties
@@ -39,6 +39,7 @@ core.management.security-realm.server-identity.ssl.protocol=The protocol to use 
 core.management.security-realm.server-identity.ssl.alias=The alias of the entry to use from the keystore.
 core.management.security-realm.server-identity.ssl.key-password=The password to obtain the key from the keystore.
 core.management.security-realm.server-identity.ssl.keystore-password=The password to open the keystore.
+core.management.security-realm.server-identity.ssl.keystore-type=The type of the keystore file.
 core.management.security-realm.server-identity.ssl.keystore-path=The path of the keystore.
 core.management.security-realm.server-identity.ssl.keystore-relative-to=The name of another previously named path, or of one of the standard paths provided by the system. If 'relative-to' is provided, the value of the 'path' attribute is treated as relative to the path specified by this attribute.
 core.management.security-realm.authentication=Configuration of the server side authentication mechanisms. Optionally one truststore can be defined and one username/password based store can be defined. Authentication will first attempt to use the truststore and if this is not available will fall back to the username/password authentication. If none of these are specified the only available mechanism will be the local mechanism for the Native interface and the HTTP interface will not be accessible.

--- a/domain-management/src/main/java/org/jboss/as/domain/management/ModelDescriptionConstants.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/ModelDescriptionConstants.java
@@ -51,6 +51,7 @@ public class ModelDescriptionConstants {
     public static final String KEYSTORE_PASSWORD = "keystore-password";
     public static final String KEYSTORE_PATH = "keystore-path";
     public static final String KEYSTORE_RELATIVE_TO = "keystore-relative-to";
+    public static final String KEYSTORE_TYPE = "keystore-type";
     public static final String LDAP = "ldap";
     public static final String LOCAL = "local";
     public static final String MAPPED_ROLES = "mapped-roles";

--- a/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/audit/SyslogAuditLogProtocolResourceDefinition.java
@@ -206,6 +206,7 @@ public abstract class SyslogAuditLogProtocolResourceDefinition extends SimpleRes
         public static final PathElement CLIENT_CERT_ELEMENT = PathElement.pathElement(AUTHENTICATION, CLIENT_CERT_STORE);
 
         public static final SimpleAttributeDefinition KEYSTORE_PASSWORD = KeystoreAttributes.KEYSTORE_PASSWORD;
+        public static final SimpleAttributeDefinition KEYSTORE_TYPE = KeystoreAttributes.KEYSTORE_TYPE;
         public static final SimpleAttributeDefinition KEYSTORE_PATH = KeystoreAttributes.KEYSTORE_PATH;
         public static final SimpleAttributeDefinition KEYSTORE_RELATIVE_TO = KeystoreAttributes.KEYSTORE_RELATIVE_TO;
         public static final SimpleAttributeDefinition KEY_PASSWORD = KeystoreAttributes.KEY_PASSWORD;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/parsing/AuditLogXml.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/parsing/AuditLogXml.java
@@ -411,6 +411,10 @@ public class AuditLogXml {
                     SyslogAuditLogProtocolResourceDefinition.Tls.TlsKeyStore.KEYSTORE_PASSWORD.parseAndSetParameter(value, add, reader);
                     break;
                 }
+                case KEYSTORE_TYPE: {
+                    SyslogAuditLogProtocolResourceDefinition.Tls.TlsKeyStore.KEYSTORE_TYPE.parseAndSetParameter(value, add, reader);
+                    break;
+                }
                 case PATH: {
                     SyslogAuditLogProtocolResourceDefinition.Tls.TlsKeyStore.KEYSTORE_PATH.parseAndSetParameter(value, add, reader);
                     break;

--- a/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/parsing/ManagementXml.java
@@ -1020,6 +1020,10 @@ public class ManagementXml {
                         KeystoreAttributes.KEYSTORE_PASSWORD.parseAndSetParameter(value, addOperation, reader);
                         break;
                     }
+                    case KEYSTORE_TYPE: {
+                        KeystoreAttributes.KEYSTORE_TYPE.parseAndSetParameter(value, addOperation, reader);
+                        break;
+                    }
                     case RELATIVE_TO: {
                         KeystoreAttributes.KEYSTORE_RELATIVE_TO.parseAndSetParameter(value, addOperation, reader);
                         break;
@@ -3325,6 +3329,7 @@ public class ManagementXml {
                 KeystoreAttributes.KEYSTORE_PATH.marshallAsAttribute(ssl, writer);
                 KeystoreAttributes.KEYSTORE_RELATIVE_TO.marshallAsAttribute(ssl, writer);
                 KeystoreAttributes.KEYSTORE_PASSWORD.marshallAsAttribute(ssl, writer);
+                KeystoreAttributes.KEYSTORE_TYPE.marshallAsAttribute(ssl, writer);
                 KeystoreAttributes.ALIAS.marshallAsAttribute(ssl, writer);
                 KeystoreAttributes.KEY_PASSWORD.marshallAsAttribute(ssl, writer);
             }
@@ -3376,6 +3381,7 @@ public class ManagementXml {
             KeystoreAttributes.KEYSTORE_PATH.marshallAsAttribute(truststore, writer);
             KeystoreAttributes.KEYSTORE_RELATIVE_TO.marshallAsAttribute(truststore, writer);
             KeystoreAttributes.KEYSTORE_PASSWORD.marshallAsAttribute(truststore, writer);
+            KeystoreAttributes.KEYSTORE_TYPE.marshallAsAttribute(truststore, writer);
         }
 
         if (authentication.hasDefined(LOCAL)) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
@@ -54,6 +54,8 @@ final class FileKeystore {
     private final String path;
     private long lastModificationTime;
     private final char[] keystorePassword;
+    private final String keystoreType;
+
     /** If not a KeyStore it is being used as a trust store. */
     private final boolean isKeyStore;
 
@@ -63,23 +65,25 @@ final class FileKeystore {
     private FileKeystore(final String path, final char[] keystorePassword) {
         this.path = path;
         this.keystorePassword = keystorePassword;
+        this.keystoreType = null;
         this.keyPassword = null;
         this.alias = null;
         this.lastModificationTime = 0;
         this.isKeyStore = false;
     }
 
-    private FileKeystore(final String path, final char[] keystorePassword, final char[] keyPassword, final String alias) {
+    private FileKeystore(final String path, final char[] keystorePassword, final String keystoreType, final char[] keyPassword, final String alias) {
         this.path = path;
         this.keystorePassword = keystorePassword;
+        this.keystoreType = keystoreType != null ? keystoreType : "JKS";
         this.keyPassword = keyPassword;
         this.alias = alias;
         this.lastModificationTime = 0;
         this.isKeyStore = true;
     }
 
-    static FileKeystore newKeyStore(final String path, final char[] keystorePassword, final char[] keyPassword, final String alias) {
-        return new FileKeystore(path, keystorePassword, keyPassword, alias);
+    static FileKeystore newKeyStore(final String path, final char[] keystorePassword, final String keystoreType, final char[] keyPassword, final String alias) {
+        return new FileKeystore(path, keystorePassword, keystoreType, keyPassword, alias);
     }
 
     static FileKeystore newTrustStore(final String path, final char[] keystorePassword) {
@@ -107,7 +111,7 @@ final class FileKeystore {
     void load() throws StartException {
         FileInputStream fis = null;
         try {
-            KeyStore loadedKeystore = KeyStore.getInstance("JKS");
+            KeyStore loadedKeystore = KeyStore.getInstance(keystoreType);
 
             if (new File(path).exists()) {
                 fis = new FileInputStream(path);
@@ -125,7 +129,7 @@ final class FileKeystore {
             if (alias == null) {
                 this.setKeyStore(loadedKeystore);
             } else {
-                KeyStore newKeystore = KeyStore.getInstance("JKS");
+                KeyStore newKeystore = KeyStore.getInstance(keystoreType);
                 newKeystore.load(null);
 
                 KeyStore.ProtectionParameter passParam = new KeyStore.PasswordProtection(keyPassword == null ? keystorePassword

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystore.java
@@ -54,7 +54,9 @@ final class FileKeystore {
     private final String path;
     private long lastModificationTime;
     private final char[] keystorePassword;
-    private final String keystoreType;
+
+    /** JKS is a default value */
+    private String keystoreType = "JKS";
 
     /** If not a KeyStore it is being used as a trust store. */
     private final boolean isKeyStore;
@@ -65,7 +67,6 @@ final class FileKeystore {
     private FileKeystore(final String path, final char[] keystorePassword) {
         this.path = path;
         this.keystorePassword = keystorePassword;
-        this.keystoreType = null;
         this.keyPassword = null;
         this.alias = null;
         this.lastModificationTime = 0;
@@ -75,11 +76,14 @@ final class FileKeystore {
     private FileKeystore(final String path, final char[] keystorePassword, final String keystoreType, final char[] keyPassword, final String alias) {
         this.path = path;
         this.keystorePassword = keystorePassword;
-        this.keystoreType = keystoreType != null ? keystoreType : "JKS";
         this.keyPassword = keyPassword;
         this.alias = alias;
         this.lastModificationTime = 0;
         this.isKeyStore = true;
+
+        if (keystoreType != null) {
+            this.keystoreType = keystoreType;
+        }
     }
 
     static FileKeystore newKeyStore(final String path, final char[] keystorePassword, final String keystoreType, final char[] keyPassword, final String alias) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystoreService.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/FileKeystoreService.java
@@ -44,14 +44,16 @@ public class FileKeystoreService implements Service<FileKeystore> {
      */
     private final String alias;
     private final char[] keyPassword;
+    private final String keystoreType;
 
     private final InjectedValue<String> relativeTo = new InjectedValue<String>();
 
-    private FileKeystoreService(final String path, final char[] keystorePassword, final String alias, final char[] keyPassword) {
+    private FileKeystoreService(final String path, final char[] keystorePassword, final String alias, final char[] keyPassword, final String keystoreType) {
         this.path = path;
         this.keystorePassword = keystorePassword;
         this.alias = alias;
         this.keyPassword = keyPassword;
+        this.keystoreType = keystoreType;
         this.isKeyStore = true;
     }
 
@@ -60,11 +62,12 @@ public class FileKeystoreService implements Service<FileKeystore> {
         this.keystorePassword = keystorePassword;
         this.alias = null;
         this.keyPassword = null;
+        this.keystoreType = null;
         this.isKeyStore = false;
     }
 
-    static FileKeystoreService newKeyStoreService(final String path, final char[] keystorePassword, final String alias, final char[] keyPassword) {
-        return new FileKeystoreService(path, keystorePassword, alias, keyPassword);
+    static FileKeystoreService newKeyStoreService(final String path, final char[] keystorePassword, final String alias, final char[] keyPassword, final String keystoreType) {
+        return new FileKeystoreService(path, keystorePassword, alias, keyPassword, keystoreType);
     }
 
     static FileKeystoreService newTrustStoreService(final String path, final char[] keystorePassword) {
@@ -74,7 +77,7 @@ public class FileKeystoreService implements Service<FileKeystore> {
     public void start(StartContext ctx) throws StartException {
         String relativeTo = this.relativeTo.getOptionalValue();
         String file = relativeTo == null ? path : relativeTo + "/" + path;
-        final FileKeystore fileKeystore = isKeyStore ? FileKeystore.newKeyStore(file, keystorePassword, keyPassword, alias) : FileKeystore.newTrustStore(file, keystorePassword);
+        final FileKeystore fileKeystore = isKeyStore ? FileKeystore.newKeyStore(file, keystorePassword, keystoreType, keyPassword, alias) : FileKeystore.newTrustStore(file, keystorePassword);
         fileKeystore.load();
         theKeyStore = fileKeystore;
     }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
@@ -27,6 +27,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -53,8 +54,8 @@ public class KeystoreAttributes {
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final SimpleAttributeDefinition KEYSTORE_TYPE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.KEYSTORE_TYPE, ModelType.STRING, true)
-            .setXmlName(ModelDescriptionConstants.KEYSTORE_TYPE).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
-            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
+            .setDefaultValue(new ModelNode("JKS")).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
+            .setAllowExpression(true).setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final SimpleAttributeDefinition KEYSTORE_PATH = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.KEYSTORE_PATH, ModelType.STRING, false)
             .setXmlName(ModelDescriptionConstants.PATH)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/KeystoreAttributes.java
@@ -52,6 +52,10 @@ public class KeystoreAttributes {
             .setXmlName(ModelDescriptionConstants.KEYSTORE_PASSWORD).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true)).setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
+    public static final SimpleAttributeDefinition KEYSTORE_TYPE = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.KEYSTORE_TYPE, ModelType.STRING, true)
+            .setXmlName(ModelDescriptionConstants.KEYSTORE_TYPE).setValidator(new StringLengthValidator(1, Integer.MAX_VALUE, false, true))
+            .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
+
     public static final SimpleAttributeDefinition KEYSTORE_PATH = new SimpleAttributeDefinitionBuilder(ModelDescriptionConstants.KEYSTORE_PATH, ModelType.STRING, false)
             .setXmlName(ModelDescriptionConstants.PATH)
             .setAllowExpression(true)

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLServerIdentityResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SSLServerIdentityResourceDefinition.java
@@ -49,7 +49,7 @@ public class SSLServerIdentityResourceDefinition extends SimpleResourceDefinitio
             .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES).build();
 
     public static final AttributeDefinition[] ATTRIBUTE_DEFINITIONS = {
-            PROTOCOL, KeystoreAttributes.KEYSTORE_PASSWORD, KeystoreAttributes.KEYSTORE_PATH, KeystoreAttributes.KEYSTORE_RELATIVE_TO, KeystoreAttributes.ALIAS, KeystoreAttributes.KEY_PASSWORD
+            PROTOCOL, KeystoreAttributes.KEYSTORE_PASSWORD, KeystoreAttributes.KEYSTORE_TYPE, KeystoreAttributes.KEYSTORE_PATH, KeystoreAttributes.KEYSTORE_RELATIVE_TO, KeystoreAttributes.ALIAS, KeystoreAttributes.KEY_PASSWORD
     };
 
     public SSLServerIdentityResourceDefinition() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -607,7 +607,11 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
             }
             ModelNode aliasNode = KeystoreAttributes.ALIAS.resolveModelAttribute(context, ssl);
             String alias = aliasNode.isDefined() ? aliasNode.asString() : null;
-            fileKeystoreService = FileKeystoreService.newKeyStoreService(path, keystorePassword, alias, keyPassword);
+
+            ModelNode keystoreTypeNode = KeystoreAttributes.KEYSTORE_TYPE.resolveModelAttribute(context, ssl);
+            String keystoreType = keystoreTypeNode.isDefined() ? keystoreTypeNode.asString() : null;
+
+            fileKeystoreService = FileKeystoreService.newKeyStoreService(path, keystorePassword, alias, keyPassword, keystoreType);
         } else {
             keyPassword = null;
             fileKeystoreService = FileKeystoreService.newTrustStoreService(path, keystorePassword);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/SecurityRealmAddHandler.java
@@ -608,8 +608,7 @@ public class SecurityRealmAddHandler implements OperationStepHandler {
             ModelNode aliasNode = KeystoreAttributes.ALIAS.resolveModelAttribute(context, ssl);
             String alias = aliasNode.isDefined() ? aliasNode.asString() : null;
 
-            ModelNode keystoreTypeNode = KeystoreAttributes.KEYSTORE_TYPE.resolveModelAttribute(context, ssl);
-            String keystoreType = keystoreTypeNode.isDefined() ? keystoreTypeNode.asString() : null;
+            String keystoreType = KeystoreAttributes.KEYSTORE_TYPE.resolveModelAttribute(context, ssl).asString();
 
             fileKeystoreService = FileKeystoreService.newKeyStoreService(path, keystorePassword, alias, keyPassword, keystoreType);
         } else {


### PR DESCRIPTION
I added support for other keystore types than JKS in Security Realms. The result has been achieved by additional parameter "keystore-type" in keystore configuration node. Any keystore type can be used which is supported by java.security.KeyStore object (is compatible with Java Cryptography Architecture
Standard Algorithm Name Documentation).

As I've found out, configuration model will be completely rebuilt in Wildfly 9 and will consist this functionallity, but I think it will be nice if pkcs12 format will be supported yet by 8. 
