### PR TITLE
[WFLY-3151] Allow the CLI script to work with directories that include spaces

### DIFF
--- a/build/src/main/resources/bin/jboss-cli.sh
+++ b/build/src/main/resources/bin/jboss-cli.sh
@@ -1,5 +1,17 @@
 #!/bin/sh
 
+CLI_OPTS=""
+while [ "$#" -gt 0 ]
+do
+    case "$1" in
+      *)
+          CLI_OPTS="$CLI_OPTS \"$1\""
+          ;;
+    esac
+    shift
+done
+
+
 DIRNAME=`dirname "$0"`
 
 # OS specific support (must be 'true' or 'false').
@@ -74,7 +86,7 @@ fi
 
 LOG_CONF=`echo $JAVA_OPTS | grep "logging.configuration"`
 if [ "x$LOG_CONF" = "x" ]; then
-    JAVA_OPTS="$JAVA_OPTS -Dlogging.configuration=file:$JBOSS_HOME/bin/jboss-cli-logging.properties"
+    JAVA_OPTS="$JAVA_OPTS \"-Dlogging.configuration=file:$JBOSS_HOME/bin/jboss-cli-logging.properties\""
 else
     echo "logging.configuration already set in JAVA_OPTS"
 fi
@@ -82,4 +94,4 @@ fi
 # Sample JPDA settings for remote socket debugging
 #JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=n"
 
-eval \"$JAVA\" $JAVA_OPTS -jar \"$JBOSS_HOME/jboss-modules.jar\" -mp \"${JBOSS_MODULEPATH}\" org.jboss.as.cli '"$@"'
+eval \"$JAVA\" $JAVA_OPTS -jar \"$JBOSS_HOME/jboss-modules.jar\" -mp \"${JBOSS_MODULEPATH}\" org.jboss.as.cli "$CLI_OPTS"


### PR DESCRIPTION
If the `$JBOSS_HOME` included a space the `logging.properties` would cause issues as it wasn't quoted. Also quote the incoming arguments as the could also include spaces.
