### PR TITLE
Remove explicit CompressedOps as they are on by default in JDK7.

### DIFF
--- a/build/src/main/resources/bin/standalone.bat
+++ b/build/src/main/resources/bin/standalone.bat
@@ -180,17 +180,6 @@ if not "%PRESERVE_JAVA_OPTS%" == "true" (
   )
 )
 
-if not "%PRESERVE_JAVA_OPTS%" == "true" (
-  rem Add compressed oops, if supported (64 bit VM), and not overriden
-  echo "%JAVA_OPTS%" | findstr /I "\-XX:\-UseCompressedOops \-client" > nul
-  if errorlevel == 1 (
-    "%JAVA%" -XX:+UseCompressedOops -version > nul 2>&1
-    if not errorlevel == 1 (
-      set "JAVA_OPTS=-XX:+UseCompressedOops %JAVA_OPTS%"
-    )
-  )
-)
-
 rem EAP6-121 feature disabled
 rem if not "%PRESERVE_JAVA_OPTS%" == "true" (
   rem Add rotating GC logs, if supported, and not already defined

--- a/build/src/main/resources/bin/standalone.sh
+++ b/build/src/main/resources/bin/standalone.sh
@@ -216,13 +216,6 @@ if [ "$PRESERVE_JAVA_OPTS" != "true" ]; then
         fi
     fi
 
-    if [ $CLIENT_VM = false ]; then
-        NO_COMPRESSED_OOPS=`echo $JAVA_OPTS | $GREP "\-XX:\-UseCompressedOops"`
-        if [ "x$NO_COMPRESSED_OOPS" = "x" ]; then
-            "$JAVA" $JVM_OPTVERSION -server -XX:+UseCompressedOops -version >/dev/null 2>&1 && PREPEND_JAVA_OPTS="$PREPEND_JAVA_OPTS -XX:+UseCompressedOops"
-        fi
-    fi
-
     # EAP6-121 feature disabled
     # Enable rotating GC logs if the JVM supports it and GC logs are not already enabled
     #NO_GC_LOG_ROTATE=`echo $JAVA_OPTS | $GREP "\-verbose:gc"`


### PR DESCRIPTION
from java7 docs "In Java SE 7, use of compressed oops is the default for 64-bit JVM processes when -Xmx isn't specified and for values of -Xmx less than 32 gigabytes."
