### PR TITLE
WFLY-3136 SRV 7.7.2 non-compliance

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
@@ -86,7 +86,7 @@ public class InfinispanBeanFactory<G, I, T> implements BeanFactory<G, I, T> {
 
     @Override
     public BeanEntry<G> findValue(I id) {
-        return this.invoker.invoke(this.cache, new FindOperation<BeanKey<I>, BeanEntry<G>>(this.createKey(id)));
+        return this.invoker.invoke(this.cache, new LockingFindOperation<BeanKey<I>, BeanEntry<G>>(this.createKey(id)));
     }
 
     @Override

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
@@ -106,7 +106,7 @@ public class CoarseSessionFactory<L> implements SessionFactory<CoarseSessionEntr
 
     @Override
     public CoarseSessionEntry<L> findValue(String id) {
-        CoarseSessionCacheEntry<L> entry = this.invoker.invoke(this.sessionCache, new FindOperation<String, CoarseSessionCacheEntry<L>>(id));
+        CoarseSessionCacheEntry<L> entry = this.invoker.invoke(this.sessionCache, new LockingFindOperation<String, CoarseSessionCacheEntry<L>>(id));
         if (entry == null) return null;
         MarshalledValue<Map<String, Object>, MarshallingContext> value = this.invoker.invoke(this.attributesCache, new FindOperation<SessionAttributesCacheKey, MarshalledValue<Map<String, Object>, MarshallingContext>>(new SessionAttributesCacheKey(id)), Flag.SKIP_LOCKING);
         return new CoarseSessionEntry<>(entry, value);

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionFactory.java
@@ -84,7 +84,7 @@ public class FineSessionFactory<L> implements SessionFactory<FineSessionCacheEnt
 
     @Override
     public FineSessionCacheEntry<L> findValue(String id) {
-        return this.invoker.invoke(this.sessionCache, new FindOperation<String, FineSessionCacheEntry<L>>(id));
+        return this.invoker.invoke(this.sessionCache, new LockingFindOperation<String, FineSessionCacheEntry<L>>(id));
     }
 
     @Override


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3136
Protected from access by other nodes via eager lock, but only when pessimistic locking is enabled.  Otherwise, Infinispan doesn't acquire pessimistic locks until cache entry is written.
