### PR TITLE
WFLY-2976 use http-remoting as default for the remote-outbound-connection

### DIFF
--- a/build/src/main/resources/docs/schema/wildfly-remoting_2_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-remoting_2_0.xsd
@@ -122,7 +122,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
-        <xs:attribute name="sasl-protocol" type="xs:string" default="remoting">
+        <xs:attribute name="sasl-protocol" type="xs:string" default="http-remoting">
             <xs:annotation>
                 <xs:documentation>
                     <![CDATA[Where a SaslServer or SaslClient are created by default the protocol specified it 'remoting', this can be used to override this.

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemoteOutboundConnectionResourceDefinition.java
@@ -66,7 +66,7 @@ class RemoteOutboundConnectionResourceDefinition extends AbstractOutboundConnect
     public static final SimpleAttributeDefinition PROTOCOL = new SimpleAttributeDefinitionBuilder(
             CommonAttributes.PROTOCOL, ModelType.STRING, true).setValidator(
                     new EnumValidator<Protocol>(Protocol.class, true, false))
-            .setDefaultValue(new ModelNode(Protocol.REMOTE.toString()))
+            .setDefaultValue(new ModelNode(Protocol.HTTP_REMOTING.toString()))
             .setAllowExpression(true)
             .build();
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingExtension.java
@@ -70,7 +70,7 @@ public class RemotingExtension implements Extension {
 
 
     private static final int MANAGEMENT_API_MAJOR_VERSION = 2;
-    private static final int MANAGEMENT_API_MINOR_VERSION = 0;
+    private static final int MANAGEMENT_API_MINOR_VERSION = 1;
     private static final int MANAGEMENT_API_MICRO_VERSION = 0;
 
     private static final ModelVersion VERSION_1_1 = ModelVersion.create(1, 1);


### PR DESCRIPTION
supersedes #5935

Discussed with Brian that we don't really want transformers at this point. 
