### PR TITLE
[WFLY-3159] Upgrade Generic JMS RA to 1.0.3.Final

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/META-INF/ra.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/META-INF/ra.xml
@@ -98,6 +98,12 @@
                     <config-property-type>java.lang.Boolean</config-property-type>
                     <config-property-value>true</config-property-value>
                 </config-property>
+                <config-property>
+                   <description>The JNDI name to lookup the TransactionSynchronizationRegistry.</description>
+                   <config-property-name>TransactionSynchronizationRegistryLookup</config-property-name>
+                   <config-property-type>java.lang.String</config-property-type>
+                   <config-property-value>java:jboss/TransactionSynchronizationRegistry</config-property-value>
+                </config-property>
                 <connectionfactory-interface>org.jboss.resource.adapter.jms.JmsConnectionFactory
                 </connectionfactory-interface>
                 <connectionfactory-impl-class>org.jboss.resource.adapter.jms.JmsConnectionFactoryImpl

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
         <version.org.jboss.com.sun.httpserver>1.0.1.Final</version.org.jboss.com.sun.httpserver>
         <version.org.jboss.ejb-client>2.0.0.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.1.0</version.org.jboss.ejb3.ext-api>
-        <version.org.jboss.genericjms>1.0.2.Final</version.org.jboss.genericjms>
+        <version.org.jboss.genericjms>1.0.3.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.1.Final</version.org.jboss.invocation>
         <version.org.jboss.ironjacamar>1.1.4.Final</version.org.jboss.ironjacamar>


### PR DESCRIPTION
- upgrade generic JMS RA to 1.0.3.Final
- add config property TransactionSynchronizationRegistryLookup in the
  ra.xml file of the org.jboss.generic.jms module to lookup WildFly
  transaction synchronization registry. The registry will be used by the
  RA to determine whether there is an active transaction when JMS
  session are created. If that's the case, session creation parameters are
  ignore and the JMS session will always be transacted.

JIRA: https://issues.jboss.org/browse/WFLY-3159
