### PR TITLE
VaultHander in testsuite doesn't use set iterationCount

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/VaultHandler.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/VaultHandler.java
@@ -152,6 +152,8 @@ public class VaultHandler {
 
         if (iterationCount <= 0) {
             this.iterationCount = new Random().nextInt(90) + 1;
+        } else {
+            this.iterationCount = iterationCount;
         }
 
         if (LOGGER.isDebugEnabled()) {


### PR DESCRIPTION
Only very short repair of org.jboss.as.test.integration.security.common.VaultHander - iterationCount set in constructor is never used.
