### PR TITLE
[WFLY-3192] :  AroundInvokeAnnotationParsingProcessor should fail when m...

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/EeMessages.java
+++ b/ee/src/main/java/org/jboss/as/ee/EeMessages.java
@@ -920,4 +920,15 @@ public interface EeMessages {
 
     @Message(id = 16714, value = "Instance data can only be set during construction")
     IllegalStateException instanceDataCanOnlyBeSetDuringConstruction();
+
+    /**
+     * Creates an exception indicating that there was a exception while deploying AroundInvokeInterceptor
+     *
+     * @param className the name of the class.
+     * @param numberOfAnnotatedMethods the number of @aroundInvoke annotations in the specified class.
+     *
+     * @return a {@link DeploymentUnitProcessingException} for the error.
+     */
+    @Message(id = 16715, value = "A class must not declare more than one AroundInvoke method. %s has %s methods annotated.")
+    DeploymentUnitProcessingException aroundInvokeAnnotionUsedTooManyTimes(DotName className, int numberOfAnnotatedMethods);
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/AroundInvokeAnnotationParsingProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/AroundInvokeAnnotationParsingProcessor.java
@@ -56,6 +56,7 @@ public class AroundInvokeAnnotationParsingProcessor implements DeploymentUnitPro
 
     private static final DotName AROUND_INVOKE_ANNOTATION_NAME = DotName.createSimple(AroundInvoke.class.getName());
 
+    @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final EEModuleDescription eeModuleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
@@ -67,6 +68,7 @@ public class AroundInvokeAnnotationParsingProcessor implements DeploymentUnitPro
         }
     }
 
+    @Override
     public void undeploy(final DeploymentUnit context) {
     }
 
@@ -77,7 +79,10 @@ public class AroundInvokeAnnotationParsingProcessor implements DeploymentUnitPro
         final MethodInfo methodInfo = MethodInfo.class.cast(target);
         final ClassInfo classInfo = methodInfo.declaringClass();
         final EEModuleClassDescription classDescription = eeModuleDescription.addOrGetLocalClassDescription(classInfo.name().toString());
-
+        final List<AnnotationInstance> classAroundInvokes = classInfo.annotations().get(AROUND_INVOKE_ANNOTATION_NAME);
+        if(classAroundInvokes.size() > 1) {
+           throw MESSAGES.aroundInvokeAnnotionUsedTooManyTimes(classInfo.name(), classAroundInvokes.size());
+        }
         validateArgumentType(classInfo, methodInfo);
         InterceptorClassDescription.Builder builder = InterceptorClassDescription.builder(classDescription.getInterceptorClassDescription());
         builder.setAroundInvoke(MethodIdentifier.getIdentifier(Object.class, methodInfo.name(), InvocationContext.class));


### PR DESCRIPTION
...ore methods with @AroundInvoke annotation are found in the class
Checking the number of @AroundInvoke on class during deployment.

Jira : https://issues.jboss.org/browse/WFLY-3192
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=901324
