### PR TITLE
[WFLY-2303] worker-timeout was also supported in 1.0 and 1.1 schemas

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-mod-cluster_1_0.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-mod-cluster_1_0.xsd
@@ -115,6 +115,16 @@
         <xs:documentation>Load balancing group</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="worker-timeout" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Number of seconds to wait for a worker to become available to handle a request. When no workers of a
+          balancer are usable, mod_cluster will retry after a while (workerTimeout/100). That is timeout in the
+          balancer mod_proxy documentation. A value of -1 indicates that the HTTPd will not wait
+          for a worker to be available and will return an error if none is available.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <!-- general SSL definitions -->

--- a/build/src/main/resources/docs/schema/jboss-as-mod-cluster_1_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-mod-cluster_1_1.xsd
@@ -120,6 +120,16 @@
         <xs:documentation>The web connector on which mod_cluster will operate.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="worker-timeout" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Number of seconds to wait for a worker to become available to handle a request. When no workers of a
+          balancer are usable, mod_cluster will retry after a while (workerTimeout/100). That is timeout in the
+          balancer mod_proxy documentation. A value of -1 indicates that the HTTPd will not wait
+          for a worker to be available and will return an error if none is available.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <!-- general SSL definitions -->

--- a/build/src/main/resources/docs/schema/jboss-as-mod-cluster_1_2.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-mod-cluster_1_2.xsd
@@ -125,16 +125,16 @@
         <xs:documentation>Session draining strategy used during undeployment of a web application.</xs:documentation>
       </xs:annotation>
     </xs:attribute>
-      <xs:attribute name="worker-timeout" type="xs:int" use="optional">
-          <xs:annotation>
-              <xs:documentation>
-                  Number of seconds to wait for a worker to become available to handle a request. When no workers of a
-                  balancer are usable, mod_cluster will retry after a while (workerTimeout/100). That is timeout in the
-                  balancer mod_proxy documentation. A value of -1 indicates that the HTTPd will not wait
-                  for a worker to be available and will return an error if none is available.
-              </xs:documentation>
-          </xs:annotation>
-      </xs:attribute>
+    <xs:attribute name="worker-timeout" type="xs:int" use="optional">
+      <xs:annotation>
+        <xs:documentation>
+          Number of seconds to wait for a worker to become available to handle a request. When no workers of a
+          balancer are usable, mod_cluster will retry after a while (workerTimeout/100). That is timeout in the
+          balancer mod_proxy documentation. A value of -1 indicates that the HTTPd will not wait
+          for a worker to be available and will return an error if none is available.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
   </xs:complexType>
 
   <!-- general SSL definitions -->


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2303

Minor XSD update.
