### PR TITLE
[WFLY-3199] Remove external BOM from jboss-as-parent

### DIFF
--- a/domain-management/pom.xml
+++ b/domain-management/pom.xml
@@ -59,6 +59,18 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-parent</artifactId>
+                <version>${version.org.apache.ds}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.directory.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6471,15 +6471,6 @@
                 </exclusions>
             </dependency>
 
-            <!-- lastly define extra BOMs -->
-
-            <dependency>
-                <groupId>org.apache.directory.server</groupId>
-                <artifactId>apacheds-parent</artifactId>
-                <version>${version.org.apache.ds}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -25,6 +25,18 @@
         <enforcer.skip>true</enforcer.skip>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.directory.server</groupId>
+                <artifactId>apacheds-parent</artifactId>
+                <version>${version.org.apache.ds}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.wildfly</groupId>


### PR DESCRIPTION
All runtime dependency versions must be explicity defined in jboss-as-parent
https://issues.jboss.org/browse/WFLY-3199
