### PR TITLE
https://issues.jboss.org/browse/WFLY-2710 way (new command, extension of...

### DIFF
--- a/patching/src/main/resources/help/patch.txt
+++ b/patching/src/main/resources/help/patch.txt
@@ -14,6 +14,8 @@ SYNOPSIS
     history         - display the patching history
     info            - information about the active patches
     rollback        - rollback a patch that has been applied
+    inspect         - fetch and print key information from the patch.xml
+                      of the specified patch file
 
 	and <action_arguments> depends on the <action>
 
@@ -72,6 +74,17 @@ ACTION: history
 
     patch history
       [--host=<host>]
+
+ACTION: inspect
+
+    Fetches key information (patch id, patch type, target identity name
+    and version, description) from the patch.xml of the specified patch file.
+
+    patch inspect <file_path>
+
+    <file_path>          - the path to the patch to inspect.
+                           The path can be either absolute or relative to the
+                           current directory.
 
 DESCRIPTION
 


### PR DESCRIPTION
... existing command) to display information about patch file

Implemented in the form of new patch command action - inspect, e.g. 'patch inspect path_to_patch_archive'

Thanks,
Alexey
