### PR TITLE
Upgrade jboss-vfs to 3.2.4.Beta2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.org.jboss.jandex>1.1.0.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.2.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-transaction-spi>7.1.0.Final</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.jboss-vfs>3.2.4.Beta1</version.org.jboss.jboss-vfs>
+        <version.org.jboss.jboss-vfs>3.2.4.Beta2</version.org.jboss.jboss-vfs>
         <version.org.jboss.narayana>5.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>1.2.0.Final</version.org.jboss.logging.jboss-logging-tools>


### PR DESCRIPTION
addresses WFLY-3195 VFS root creation is wrong on Windows

testrun on windows http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=13505&tab=buildResultsDiv&buildTypeId=MasterWindows
