### PR TITLE
VFS issue workaround on windows

### DIFF
--- a/testsuite/integration/secman/src/test/config/security.policy
+++ b/testsuite/integration/secman/src/test/config/security.policy
@@ -16,5 +16,9 @@ grant codeBase "file:${{java.ext.dirs}}/*" {
 grant codeBase "vfs:/content/arquillian-service" {
   permission java.security.AllPermission;
 };
+// Workaround for windows VFS issue - https://issues.jboss.org/browse/WFLY-3195
+grant codeBase "vfs:/${user.dir}/content/arquillian-service" {
+  permission java.security.AllPermission;
+};
 
 // No more grants here.


### PR DESCRIPTION
The secman TS module fails on windows because of the [WFLY-3195](https://issues.jboss.org/browse/WFLY-3195), this is a simple workaround till the issue is fixed.

@kabir reported this issue in EAP PR: https://github.com/jbossas/jboss-eap/pull/1131#issuecomment-39466965
