### PR TITLE
[WFLY-3233] disable .jar invalidation for patching

### DIFF
--- a/patching/pom.xml
+++ b/patching/pom.xml
@@ -37,6 +37,23 @@
 
     <name>WildFly: Patching Core</name>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <systemProperties>
+                        <property>
+                            <name>org.wildfly.patching.jar.invalidation</name>
+                            <value>true</value>
+                        </property>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
 
         <dependency>

--- a/patching/src/main/java/org/jboss/as/patching/runner/PatchModuleInvalidationUtils.java
+++ b/patching/src/main/java/org/jboss/as/patching/runner/PatchModuleInvalidationUtils.java
@@ -32,6 +32,7 @@ import java.nio.ByteOrder;
 import java.nio.channels.FileChannel;
 
 import org.jboss.as.patching.PatchLogger;
+import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
  * Cripple a JAR or other zip file by flipping a bit in the end of central directory record
@@ -43,6 +44,8 @@ import org.jboss.as.patching.PatchLogger;
  * @author Emanuel Muckenhuber
  */
 class PatchModuleInvalidationUtils {
+
+    private static final boolean ENABLE_INVALIDATION = Boolean.parseBoolean(WildFlySecurityManager.getPropertyPrivileged("org.wildfly.patching.jar.invalidation", "false"));
 
     /**
      * Local file header marker
@@ -142,6 +145,9 @@ class PatchModuleInvalidationUtils {
      * @throws IOException
      */
     static void processFile(final File file, final PatchingTaskContext.Mode mode) throws IOException {
+        if (!ENABLE_INVALIDATION) {
+            return;
+        }
         if (mode == PatchingTaskContext.Mode.APPLY) {
             updateJar(file, GOOD_ENDSIG_PATTERN, GOOD_END_BAD_BYTE_SKIP, CRIPPLED_ENDSIG, GOOD_ENDSIG);
         } else if (mode == PatchingTaskContext.Mode.ROLLBACK) {

--- a/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationTestCase.java
+++ b/patching/src/test/java/org/jboss/as/patching/tests/PatchModuleInvalidationTestCase.java
@@ -43,6 +43,9 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -50,6 +53,7 @@ import org.junit.Test;
  */
 public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
 
+    private static final Boolean INVALIDATION_ENABLED = Boolean.getBoolean("org.wildfly.patching.jar.invalidation");
     private static final String MODULE_NAME = "org.jboss.test.module";
     private static final String RESOURCE = "resource0.jar";
 
@@ -60,6 +64,11 @@ public class PatchModuleInvalidationTestCase extends AbstractPatchingTest {
             return new String[] { RESOURCE };
         }
     };
+
+    @BeforeClass
+    public static void checkValidationEnabled() {
+        Assume.assumeTrue(INVALIDATION_ENABLED);
+    }
 
     @Test
     public void test() throws Exception {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3233 simple system property to disable .jar invaldation by default
