### PR TITLE
WFLY-3225 Rationalization of server-side management thread pools

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -137,8 +137,8 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.threads.JBossThreadFactory;
-import org.wildfly.security.manager.action.GetAccessControlContextAction;
 import org.wildfly.security.manager.WildFlySecurityManager;
+import org.wildfly.security.manager.action.GetAccessControlContextAction;
 
 /**
  * Creates the service that acts as the {@link org.jboss.as.controller.ModelController} for a Host Controller process.
@@ -190,8 +190,6 @@ public class DomainModelControllerService extends AbstractControllerService impl
     // @GuardedBy(serverInventoryLock), after the HC started reads just use the volatile value
     private volatile ServerInventory serverInventory;
 
-    // TODO look into using the controller executor
-    private volatile ExecutorService proxyExecutor;
     private volatile ScheduledExecutorService pingScheduler;
 
 
@@ -409,8 +407,6 @@ public class DomainModelControllerService extends AbstractControllerService impl
         this.hostControllerConfigurationPersister = new HostControllerConfigurationPersister(environment, hostControllerInfo, executorService, extensionRegistry);
         setConfigurationPersister(hostControllerConfigurationPersister);
         prepareStepHandler.setExecutorService(executorService);
-        ThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("proxy-threads"), Boolean.FALSE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
-        proxyExecutor = Executors.newCachedThreadPool(threadFactory);
         ThreadFactory pingerThreadFactory = new JBossThreadFactory(new ThreadGroup("proxy-pinger-threads"), Boolean.TRUE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
         pingScheduler = Executors.newScheduledThreadPool(PINGER_POOL_SIZE, pingerThreadFactory);
 
@@ -532,7 +528,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
 
             if (ok) {
                 // Install the server > host operation handler
-                ServerToHostOperationHandlerFactoryService.install(serviceTarget, ServerInventoryService.SERVICE_NAME, proxyExecutor, new InternalExecutor(), this, expressionResolver);
+                ServerToHostOperationHandlerFactoryService.install(serviceTarget, ServerInventoryService.SERVICE_NAME,
+                        getExecutorServiceInjector().getValue(), new InternalExecutor(), this, expressionResolver);
 
                 // demand native mgmt services
                 serviceTarget.addService(ServiceName.JBOSS.append("native-mgmt-startup"), Service.NULL)
@@ -674,11 +671,7 @@ public class DomainModelControllerService extends AbstractControllerService impl
     }
 
     protected void stopAsynchronous(StopContext context)  {
-        try {
-            pingScheduler.shutdownNow();
-        } finally {
-            proxyExecutor.shutdown();
-        }
+        pingScheduler.shutdownNow();
     }
 
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -521,7 +521,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
                         InternalExecutor executor = new InternalExecutor();
                         ManagementRemotingServices.installManagementChannelServices(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
                                 new MasterDomainControllerOperationHandlerService(this, executor, executor, runtimeIgnoreTransformationRegistry),
-                                DomainModelControllerService.SERVICE_NAME, ManagementRemotingServices.DOMAIN_CHANNEL, null, null);
+                                DomainModelControllerService.SERVICE_NAME, ManagementRemotingServices.DOMAIN_CHANNEL,
+                                HostControllerService.HC_EXECUTOR_SERVICE_NAME, null, null);
 
                         // Block for the ServerInventory
                         establishServerInventory(inventoryFuture);

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -572,7 +572,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
 
     private void connectToDomainMaster(ServiceTarget serviceTarget, RunningMode currentRunningMode) {
         Future<MasterDomainControllerClient> clientFuture = RemoteDomainConnectionService.install(serviceTarget,
-                getValue(), extensionRegistry,
+                getValue(),
+                extensionRegistry,
                 hostControllerInfo,
                 environment.getProductConfig(),
                 hostControllerInfo.getRemoteDomainControllerSecurityRealm(),
@@ -580,7 +581,9 @@ public class DomainModelControllerService extends AbstractControllerService impl
                 ignoredRegistry,
                 new DomainModelControllerService.InternalExecutor(),
                 this,
-                environment, currentRunningMode);
+                environment,
+                getExecutorServiceInjector().getValue(),
+                currentRunningMode);
         MasterDomainControllerClient masterDomainControllerClient = getFuture(clientFuture);
         //Registers us with the master and gets down the master copy of the domain model to our DC
         //TODO make sure that the RDCS checks env.isUseCachedDC, and if true falls through to that

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerService.java
@@ -69,7 +69,7 @@ import org.jboss.threads.JBossThreadFactory;
 public class HostControllerService implements Service<AsyncFuture<ServiceContainer>> {
 
     public static final ServiceName HC_SERVICE_NAME = ServiceName.JBOSS.append("host", "controller");
-    static final ServiceName HC_EXECUTOR_SERVICE_NAME = HC_SERVICE_NAME.append("executor");
+    public static final ServiceName HC_EXECUTOR_SERVICE_NAME = HC_SERVICE_NAME.append("executor");
     static final int DEFAULT_POOL_SIZE = 20;
 
     private final HostControllerEnvironment environment;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnectionService.java
@@ -170,8 +170,8 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
     private final InjectedValue<Endpoint> endpointInjector = new InjectedValue<Endpoint>();
     private final InjectedValue<SecurityRealm> securityRealmInjector = new InjectedValue<SecurityRealm>();
     private final InjectedValue<ServerInventory> serverInventoryInjector = new InjectedValue<ServerInventory>();
+    private final ExecutorService executor;
 
-    private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutorService;
 
     private ManagementChannelHandler handler;
@@ -184,6 +184,7 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                                           final HostControllerRegistrationHandler.OperationExecutor operationExecutor,
                                           final DomainController domainController,
                                           final HostControllerEnvironment hostControllerEnvironment,
+                                          final ExecutorService executor,
                                           final RunningMode runningMode){
         this.controller = controller;
         this.extensionRegistry = extensionRegistry;
@@ -195,6 +196,7 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
         this.operationExecutor = operationExecutor;
         this.domainController = domainController;
         this.hostControllerEnvironment = hostControllerEnvironment;
+        this.executor = executor;
         this.runningMode = runningMode;
     }
 
@@ -205,10 +207,11 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
                                                                final HostControllerRegistrationHandler.OperationExecutor operationExecutor,
                                                                final DomainController domainController,
                                                                final HostControllerEnvironment hostControllerEnvironment,
+                                                               final ExecutorService executor,
                                                                final RunningMode currentRunningMode) {
         RemoteDomainConnectionService service = new RemoteDomainConnectionService(controller, extensionRegistry, localHostControllerInfo,
                 productConfig, remoteFileRepository, ignoredDomainResourceRegistry, operationExecutor, domainController,
-                hostControllerEnvironment, currentRunningMode);
+                hostControllerEnvironment, executor, currentRunningMode);
         ServiceBuilder<MasterDomainControllerClient> builder = serviceTarget.addService(MasterDomainControllerClient.SERVICE_NAME, service)
                 .addDependency(ManagementRemotingServices.MANAGEMENT_ENDPOINT, Endpoint.class, service.endpointInjector)
                 .addDependency(ServerInventoryService.SERVICE_NAME, ServerInventory.class, service.serverInventoryInjector)
@@ -369,8 +372,6 @@ public class RemoteDomainConnectionService implements MasterDomainControllerClie
         final ManagementChannelHandler handler;
         try {
 
-            ThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("domain-connection-threads"), Boolean.FALSE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
-            this.executor = Executors.newCachedThreadPool(threadFactory);
             ThreadFactory scheduledThreadFactory = new JBossThreadFactory(new ThreadGroup("domain-connection-pinger-threads"), Boolean.TRUE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
             this.scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(scheduledThreadFactory);
 

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
@@ -87,10 +87,6 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
         this.runtimeIgnoreTransformationRegistry = runtimeIgnoreTransformationRegistry;
     }
 
-    protected String getThreadGroupName() {
-        return "domain-mgmt-handler-thread";
-    }
-
     @Override
     public synchronized void start(StartContext context) throws StartException {
         pongRequestHandler.resetConnectionId();

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/MasterDomainControllerOperationHandlerService.java
@@ -21,16 +21,11 @@
 */
 package org.jboss.as.host.controller.mgmt;
 
+import static java.security.AccessController.doPrivileged;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 
-import static java.security.AccessController.doPrivileged;
-
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jboss.as.controller.CurrentOperationIdHolder;
@@ -54,14 +49,13 @@ import org.jboss.as.protocol.mgmt.ManagementChannelHandler;
 import org.jboss.as.protocol.mgmt.ManagementClientChannelStrategy;
 import org.jboss.as.protocol.mgmt.ManagementPongRequestHandler;
 import org.jboss.as.protocol.mgmt.ManagementRequestContext;
-import org.wildfly.security.manager.action.GetAccessControlContextAction;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
-import org.jboss.msc.service.StopContext;
 import org.jboss.remoting3.Channel;
 import org.jboss.threads.JBossThreadFactory;
+import org.wildfly.security.manager.action.GetAccessControlContextAction;
 
 /**
  * Installs {@link MasterDomainControllerOperationHandlerImpl} which handles requests from slave DC to master DC.
@@ -77,7 +71,6 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
     private final TransactionalOperationExecutor txOperationExecutor;
     private final ManagementPongRequestHandler pongRequestHandler = new ManagementPongRequestHandler();
     private final ThreadFactory threadFactory = new JBossThreadFactory(new ThreadGroup("slave-request-threads"), Boolean.FALSE, null, "%G - %t", null, null, doPrivileged(GetAccessControlContextAction.getInstance()));
-    private volatile ExecutorService slaveRequestExecutor;
     private final DomainControllerRuntimeIgnoreTransformationRegistry runtimeIgnoreTransformationRegistry;
 
     public MasterDomainControllerOperationHandlerService(final DomainController domainController, final HostControllerRegistrationHandler.OperationExecutor operationExecutor, TransactionalOperationExecutor txOperationExecutor, DomainControllerRuntimeIgnoreTransformationRegistry runtimeIgnoreTransformationRegistry) {
@@ -90,26 +83,17 @@ public class MasterDomainControllerOperationHandlerService extends AbstractModel
     @Override
     public synchronized void start(StartContext context) throws StartException {
         pongRequestHandler.resetConnectionId();
-        slaveRequestExecutor = new ThreadPoolExecutor(1, Integer.MAX_VALUE,
-                5L, TimeUnit.SECONDS,
-                new SynchronousQueue<Runnable>(),
-                threadFactory);
         super.start(context);
-    }
-
-    @Override
-    public synchronized void stop(StopContext context) {
-        slaveRequestExecutor.shutdown();
-        super.stop(context);
     }
 
     @Override
     public ManagementChannelHandler startReceiving(final Channel channel) {
         final ManagementChannelHandler handler = new ManagementChannelHandler(ManagementClientChannelStrategy.create(channel), getExecutor());
         // Assemble the request handlers for the domain channel
-        handler.addHandlerFactory(new HostControllerRegistrationHandler(handler, domainController, operationExecutor, slaveRequestExecutor, runtimeIgnoreTransformationRegistry));
+        handler.addHandlerFactory(new HostControllerRegistrationHandler(handler, domainController, operationExecutor,
+                getExecutor(), runtimeIgnoreTransformationRegistry));
         handler.addHandlerFactory(new ModelControllerClientOperationHandler(getController(), handler));
-        handler.addHandlerFactory(new MasterDomainControllerOperationHandlerImpl(domainController, slaveRequestExecutor));
+        handler.addHandlerFactory(new MasterDomainControllerOperationHandlerImpl(domainController, getExecutor()));
         handler.addHandlerFactory(pongRequestHandler);
         handler.addHandlerFactory(new DomainTransactionalProtocolOperationHandler(txOperationExecutor, handler));
         channel.receiveMessage(handler.getReceiver());

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/NativeManagementServices.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/NativeManagementServices.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.remote.ModelControllerClientOperationHandlerFactoryService;
 import org.jboss.as.host.controller.DomainModelControllerService;
+import org.jboss.as.host.controller.HostControllerService;
 import org.jboss.as.host.controller.jmx.RemotingConnectorService;
 import org.jboss.as.host.controller.mgmt.ServerToHostOperationHandlerFactoryService;
 import org.jboss.as.protocol.ProtocolChannelClient;
@@ -53,7 +54,8 @@ public class NativeManagementServices {
 
             ManagementRemotingServices.installManagementChannelServices(serviceTarget, ManagementRemotingServices.MANAGEMENT_ENDPOINT,
                     new ModelControllerClientOperationHandlerFactoryService(),
-                    DomainModelControllerService.SERVICE_NAME, ManagementRemotingServices.MANAGEMENT_CHANNEL, verificationHandler, newControllers);
+                    DomainModelControllerService.SERVICE_NAME, ManagementRemotingServices.MANAGEMENT_CHANNEL,
+                    HostControllerService.HC_EXECUTOR_SERVICE_NAME, verificationHandler, newControllers);
 
             RemotingConnectorService.addService(serviceTarget, verificationHandler);
 

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingServices.java
@@ -91,6 +91,13 @@ public class RemotingServices {
         return endpointName.append("channel").append(channelName);
     }
 
+    /**
+     * Add a service controller, registering a verification listener if present and adding the controller
+     * to the given list, if present
+     * @param newControllers the list of new controllers to add the controller to. May be {@code null}
+     * @param verificationHandler the verification listener to register. May be {@code null}
+     * @param builder the builder for the service controller. Will not be {@code null}
+     */
     public static void addController(final List<ServiceController<?>> newControllers,
             final ServiceVerificationHandler verificationHandler, final ServiceBuilder<?> builder) {
         if (verificationHandler != null) {

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/management/ManagementRemotingServices.java
@@ -79,10 +79,10 @@ public final class ManagementRemotingServices extends RemotingServices {
      * @param endpointName the name of the endpoint to install the stream server into
      * @param networkInterfaceBinding the network interface binding
      * @param port the port
-     * @param securityRealmName the security real name
+     * @param securityRealm the security real name
      * @param options the remoting options
-     * @param verificationHandler
-     * @param newControllers
+     * @param verificationHandler the verification listener to register. May be {@code null}
+     * @param newControllers the list of new controllers to add the controller to. May be {@code null}
      */
     public static void installDomainConnectorServices(final ServiceTarget serviceTarget,
                                                       final ServiceName endpointName,
@@ -106,8 +106,8 @@ public final class ManagementRemotingServices extends RemotingServices {
      * @param channelName the name of the channel
      * @param operationHandlerName the name of the operation handler to handle request for this channel
      * @param options the remoting options
-     * @param verificationHandler
-     * @param newControllers list to add the new services to
+     * @param verificationHandler the verification listener to register. May be {@code null}
+     * @param newControllers the list of new controllers to add the controller to. May be {@code null}
      * @param onDemand whether to install the services on demand
      */
     public static void installManagementChannelOpenListenerService(
@@ -137,12 +137,12 @@ public final class ManagementRemotingServices extends RemotingServices {
 
     /**
      * Set up the services to create a channel listener and operation handler service.
-     *
-     * @param serviceTarget the service target to install the services into
+     *  @param serviceTarget the service target to install the services into
      * @param endpointName the endpoint name to install the services into
      * @param channelName the name of the channel
-     * @param verificationHandler
-     * @param newControllers list to add the new services to
+     * @param executorServiceName service name of the executor service to use in the operation handler service
+     * @param verificationHandler the verification listener to register. May be {@code null}
+     * @param newControllers the list of new controllers to add the controller to. May be {@code null}
      */
     public static void installManagementChannelServices(
             final ServiceTarget serviceTarget,
@@ -150,7 +150,7 @@ public final class ManagementRemotingServices extends RemotingServices {
             final AbstractModelControllerOperationHandlerFactoryService operationHandlerService,
             final ServiceName modelControllerName,
             final String channelName,
-            final ServiceVerificationHandler verificationHandler,
+            ServiceName executorServiceName, final ServiceVerificationHandler verificationHandler,
             final List<ServiceController<?>> newControllers) {
 
         final OptionMap options = OptionMap.create(RemotingOptions.RECEIVE_WINDOW_SIZE, ProtocolChannelClient.Configuration.WINDOW_SIZE,
@@ -159,6 +159,7 @@ public final class ManagementRemotingServices extends RemotingServices {
 
         final ServiceBuilder<?> builder = serviceTarget.addService(operationHandlerName, operationHandlerService)
             .addDependency(modelControllerName, ModelController.class, operationHandlerService.getModelControllerInjector())
+            .addDependency(executorServiceName, ExecutorService.class, operationHandlerService.getExecutorInjector())
             .setInitialMode(ACTIVE);
 
         addController(newControllers, verificationHandler, builder);

--- a/server/src/main/java/org/jboss/as/server/DomainServerCommunicationServices.java
+++ b/server/src/main/java/org/jboss/as/server/DomainServerCommunicationServices.java
@@ -22,9 +22,13 @@
 
 package org.jboss.as.server;
 
+import java.io.Serializable;
+import java.net.InetSocketAddress;
+
 import org.jboss.as.controller.ControlledProcessStateService;
 import org.jboss.as.controller.ExpressionResolver;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.protocol.ProtocolChannelClient;
 import org.jboss.as.remoting.EndpointConfigFactory;
 import org.jboss.as.remoting.EndpointService;
@@ -42,10 +46,6 @@ import org.jboss.remoting3.Endpoint;
 import org.jboss.remoting3.RemotingOptions;
 import org.wildfly.security.manager.WildFlySecurityManager;
 import org.xnio.OptionMap;
-
-import java.io.Serializable;
-import java.net.InetSocketAddress;
-import org.jboss.as.network.NetworkUtils;
 
 /**
  * Service activator for the communication services of a managed server in a domain.
@@ -97,11 +97,10 @@ public class DomainServerCommunicationServices  implements ServiceActivator, Ser
             final int port = managementSocket.getPort();
             final String host = NetworkUtils.canonize(managementSocket.getAddress().getHostAddress());
             HostControllerConnectionService service = new HostControllerConnectionService(host, port, serverName, serverProcessName, authKey, initialOperationID, managementSubsystemEndpoint);
-            serviceTarget.addService(HostControllerConnectionService.SERVICE_NAME, service)
+            Services.addServerExecutorDependency(serviceTarget.addService(HostControllerConnectionService.SERVICE_NAME, service), service.getExecutorInjector(), false)
                     .addDependency(endpointName, Endpoint.class, service.getEndpointInjector())
                     .addDependency(ControlledProcessStateService.SERVICE_NAME, ControlledProcessStateService.class, service.getProcessStateServiceInjectedValue())
-                    .setInitialMode(ServiceController.Mode.ACTIVE)
-                    .install();
+                    .setInitialMode(ServiceController.Mode.ACTIVE).install();
 
         } catch (OperationFailedException e) {
             throw new ServiceRegistryException(e);

--- a/server/src/main/java/org/jboss/as/server/Services.java
+++ b/server/src/main/java/org/jboss/as/server/Services.java
@@ -51,7 +51,7 @@ public final class Services {
     /**
      * The service corresponding to the {@link java.util.concurrent.ExecutorService} for this instance.
      */
-    static final ServiceName JBOSS_SERVER_EXECUTOR = JBOSS_AS.append("server-executor");
+    public static final ServiceName JBOSS_SERVER_EXECUTOR = JBOSS_AS.append("server-executor");
 
     /**
      * The service corresponding to the {@link org.jboss.as.server.moduleservice.ServiceModuleLoader} for this instance.

--- a/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeManagementServices.java
@@ -42,6 +42,7 @@ class NativeManagementServices {
                     new ModelControllerClientOperationHandlerFactoryService(),
                     Services.JBOSS_SERVER_CONTROLLER,
                     ManagementRemotingServices.MANAGEMENT_CHANNEL,
+                    Services.JBOSS_SERVER_EXECUTOR,
                     verificationHandler,
                     newControllers);
 

--- a/server/src/main/java/org/jboss/as/server/operations/NativeRemotingManagementAddHandler.java
+++ b/server/src/main/java/org/jboss/as/server/operations/NativeRemotingManagementAddHandler.java
@@ -72,6 +72,7 @@ public class NativeRemotingManagementAddHandler extends AbstractAddStepHandler {
                 new ModelControllerClientOperationHandlerFactoryService(),
                 Services.JBOSS_SERVER_CONTROLLER,
                 ManagementRemotingServices.MANAGEMENT_CHANNEL,
+                Services.JBOSS_SERVER_EXECUTOR,
                 verificationHandler,
                 newControllers);
     }


### PR DESCRIPTION
Replace several specialized pools and just use the general pool for the HC or server.

I'd like to take this further and get rid of the remaining specialized pool for end user mgmt requests and use some other mechanism for throttling those, but that will require bigger changes to task handling than I can take on at present.
