### PR TITLE
Move channel mbean registration/deregistration to ChannelService.start/stop.

### DIFF
--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/ProtocolStackConfiguration.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/ProtocolStackConfiguration.java
@@ -23,8 +23,6 @@ package org.jboss.as.clustering.jgroups;
 
 import java.util.List;
 
-import javax.management.MBeanServer;
-
 import org.jboss.as.server.ServerEnvironment;
 
 /**
@@ -36,8 +34,6 @@ public interface ProtocolStackConfiguration {
     String getName();
 
     ProtocolDefaults getDefaults();
-
-    MBeanServer getMBeanServer();
 
     TransportConfiguration getTransport();
 

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelFactoryService.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelFactoryService.java
@@ -35,13 +35,13 @@ import org.jboss.msc.service.StopContext;
 public class ChannelFactoryService implements Service<ChannelFactory> {
     private static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append(JGroupsExtension.SUBSYSTEM_NAME).append("stack");
 
-    private final ProtocolStackConfiguration configuration;
-
-    private volatile ChannelFactory factory;
-
     public static ServiceName getServiceName(String name) {
         return (name != null) ? SERVICE_NAME.append(name) : SERVICE_NAME;
     }
+
+    private final ProtocolStackConfiguration configuration;
+
+    private volatile ChannelFactory factory;
 
     public ChannelFactoryService(ProtocolStackConfiguration configuration) {
         this.configuration = configuration;

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
@@ -27,7 +27,6 @@ import javax.management.MBeanServer;
 
 import org.jboss.as.clustering.jgroups.ChannelFactory;
 import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
-import org.jboss.as.clustering.msc.AsynchronousService;
 import org.jboss.as.jmx.MBeanServerService;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -58,7 +57,7 @@ public class ChannelService implements Service<Channel>, ChannelListener {
 
     public static ServiceBuilder<Channel> build(ServiceTarget target, String id, String stack) {
         ChannelService service = new ChannelService(id);
-        return AsynchronousService.addService(target, getServiceName(id), service)
+        return target.addService(getServiceName(id), service)
                 .addDependency(ChannelFactoryService.getServiceName(stack), ChannelFactory.class, service.factory)
                 .addDependency(MBeanServerService.SERVICE_NAME, MBeanServer.class, service.server)
         ;

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelService.java
@@ -23,17 +23,25 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import static org.jboss.as.clustering.jgroups.logging.JGroupsLogger.ROOT_LOGGER;
 
+import javax.management.MBeanServer;
+
 import org.jboss.as.clustering.jgroups.ChannelFactory;
 import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
+import org.jboss.as.clustering.msc.AsynchronousService;
+import org.jboss.as.jmx.MBeanServerService;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
-import org.jboss.msc.value.Value;
+import org.jboss.msc.value.InjectedValue;
 import org.jgroups.Address;
 import org.jgroups.Channel;
 import org.jgroups.ChannelListener;
+import org.jgroups.JChannel;
+import org.jgroups.jmx.JmxConfigurator;
 
 /**
  * Provides a channel for use by dependent services.
@@ -48,13 +56,22 @@ public class ChannelService implements Service<Channel>, ChannelListener {
         return SERVICE_NAME.append(id);
     }
 
-    private final Value<ChannelFactory> factory;
+    public static ServiceBuilder<Channel> build(ServiceTarget target, String id, String stack) {
+        ChannelService service = new ChannelService(id);
+        return AsynchronousService.addService(target, getServiceName(id), service)
+                .addDependency(ChannelFactoryService.getServiceName(stack), ChannelFactory.class, service.factory)
+                .addDependency(MBeanServerService.SERVICE_NAME, MBeanServer.class, service.server)
+        ;
+    }
+
+    private final InjectedValue<MBeanServer> server = new InjectedValue<>();
+    private final InjectedValue<ChannelFactory> factory = new InjectedValue<>();
     private final String id;
+
     private volatile Channel channel;
 
-    public ChannelService(String id, Value<ChannelFactory> factory) {
+    private ChannelService(String id) {
         this.id = id;
-        this.factory = factory;
     }
 
     @Override
@@ -70,13 +87,14 @@ public class ChannelService implements Service<Channel>, ChannelListener {
             this.channel.addChannelListener(this);
             // Don't connect the channel here
             // This will be done by Infinispan (see AS7-5904)
+            JmxConfigurator.registerChannel((JChannel) this.channel, this.server.getValue(), this.id);
         } catch (Exception e) {
             throw new StartException(e);
         }
 
-        if  (ROOT_LOGGER.isTraceEnabled())  {
+        if (ROOT_LOGGER.isTraceEnabled())  {
             String output = this.channel.getProtocolStack().printProtocolSpec(true);
-            ROOT_LOGGER.tracef("JGroups channel named %s created with configuration:\n %s", this.id, output);
+            ROOT_LOGGER.tracef("JGroups channel %s created with configuration:\n %s", this.id, output);
         }
     }
 
@@ -85,6 +103,11 @@ public class ChannelService implements Service<Channel>, ChannelListener {
         if (this.channel != null) {
             this.channel.removeChannelListener(this);
             this.channel.close();
+            try {
+                JmxConfigurator.unregisterChannel((JChannel) this.channel, this.server.getValue(), this.id);
+            } catch (Exception e) {
+                ROOT_LOGGER.debug(e.getMessage(), e);
+            }
         }
         this.channel = null;
     }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolStackAdd.java
@@ -38,8 +38,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 
-import javax.management.MBeanServer;
-
 import org.jboss.as.clustering.jgroups.ChannelFactory;
 import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
 import org.jboss.as.clustering.jgroups.ProtocolConfiguration;
@@ -56,7 +54,6 @@ import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.Resource;
-import org.jboss.as.jmx.MBeanServerService;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
@@ -245,7 +242,6 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
         ServiceBuilder<ChannelFactory> builder = target
                 .addService(ChannelFactoryService.getServiceName(name), new ChannelFactoryService(stackConfig))
                 .addDependency(ProtocolDefaultsService.SERVICE_NAME, ProtocolDefaults.class, stackConfig.getDefaultsInjector())
-                .addDependency(MBeanServerService.SERVICE_NAME, MBeanServer.class, stackConfig.getMBeanServerInjector())
                 .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, stackConfig.getEnvironmentInjector())
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
         ;
@@ -346,7 +342,6 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
 
     static class ProtocolStack implements ProtocolStackConfiguration {
         private final InjectedValue<ProtocolDefaults> defaults = new InjectedValue<ProtocolDefaults>();
-        private final InjectedValue<MBeanServer> mbeanServer = new InjectedValue<MBeanServer>();
         private final InjectedValue<ServerEnvironment> environment = new InjectedValue<ServerEnvironment>();
 
         private final String name;
@@ -362,10 +357,6 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
 
         Injector<ProtocolDefaults> getDefaultsInjector() {
             return this.defaults;
-        }
-
-        Injector<MBeanServer> getMBeanServerInjector() {
-            return this.mbeanServer;
         }
 
         Injector<ServerEnvironment> getEnvironmentInjector() {
@@ -390,11 +381,6 @@ public class ProtocolStackAdd extends AbstractAddStepHandler {
         @Override
         public ProtocolDefaults getDefaults() {
             return this.defaults.getValue();
-        }
-
-        @Override
-        public MBeanServer getMBeanServer() {
-            return this.mbeanServer.getOptionalValue();
         }
 
         @Override


### PR DESCRIPTION
This lets us get remove that hacky map of channels in JChannelFactory.
