### PR TITLE
WFLY-3260 Fix WSTestCase

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/EndpointService.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/EndpointService.java
@@ -37,7 +37,7 @@ import javax.xml.ws.WebServiceFeature;
  * @author <a href="mailto:flavia.rainone@jboss.com">Flavia Rainone</a>
  */
 @WebServiceClient(name = "EndpointService",
-                  wsdlLocation = "META-INF/wsdl/EndpointService.wsdl",//"http://localhost:8080/ws-example?wsdl",
+                  wsdlLocation = "http://localhost:8080/ws-example?wsdl",
                   targetNamespace = "http://webservices.smoke.test.as.jboss.org/")
 public class EndpointService extends Service {
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/SimpleServlet.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/SimpleServlet.java
@@ -54,10 +54,8 @@ public class SimpleServlet extends HttpServlet {
         log.info("Received request");
 
         Writer writer = resp.getWriter();
-        writer.write("Servlet Response\n");
-        SimpleStatelessSessionLocal bean = session;
-        String msg = bean.echo("Hello from Servlet");
-        writer.write(msg);
+        boolean ok = session.isInjectionOK();
+        writer.write("" + ok);
         writer.close();
     }
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/SimpleStatelessSessionBean.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/SimpleStatelessSessionBean.java
@@ -48,7 +48,8 @@ public class SimpleStatelessSessionBean implements SimpleStatelessSessionLocal {
         endpoint4 = endpoint;
     }
 
-    public String echo(String msg) {
-        return "Echo " + msg + " -- Endpoint:" + endpoint1 + " " + endpoint2 + " " + endpoint3 + " " + endpoint4 + ")";
+    @Override
+    public boolean isInjectionOK() {
+        return (endpoint1 != null && endpoint2 != null && endpoint3 != null && endpoint4 != null);
     }
 }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/SimpleStatelessSessionLocal.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/SimpleStatelessSessionLocal.java
@@ -27,5 +27,5 @@ package org.jboss.as.test.smoke.webservices;
  *
  */
 public interface SimpleStatelessSessionLocal {
-   String echo(String msg);
+    boolean isInjectionOK();
 }

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/WSTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/webservices/WSTestCase.java
@@ -70,7 +70,7 @@ public class WSTestCase {
 
     @Test
     public void testWSDL() throws Exception {
-        String s = performCall("?wsdl");
+        String s = performCall("ws-example/?wsdl");
         Assert.assertNotNull(s);
         Assert.assertTrue(s.contains("wsdl:definitions"));
     }
@@ -125,7 +125,7 @@ public class WSTestCase {
             checkCountMetric(endpointResult, managementClient.getControllerClient(), "response-count");
         }
     }
-    
+
     private void checkCountMetric(final ModelNode endpointResult, final ModelControllerClient client, final String metricName) throws IOException {
     	final ModelNode readAttribute = new ModelNode();
         readAttribute.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION);
@@ -147,9 +147,13 @@ public class WSTestCase {
         Assert.assertEquals("Foo", port.echo("Foo"));
     }
 
+    @Test
+    public void testWSInjection() throws Exception {
+        Assert.assertEquals("true", performCall("servlet"));
+    }
 
-    private String performCall(String params) throws Exception {
-        URL url = new URL(this.url.toExternalForm() + "ws-example/" + params);
+    private String performCall(String urlPattern) throws Exception {
+        URL url = new URL(this.url.toExternalForm() + urlPattern);
         return HttpRequest.get(url.toExternalForm(), 30, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
- send request to servlet to initialize it

SimpleServlet wasn't even initialized. Therefore, WS injection into SimpleStatelessSessionBean was not tested.
Now, a request is made in 'testWSInjection()' to initialize the servlet and check that the WS injection into SimpleStatelessSessionBean was performed.
