### PR TITLE
WFLY-3259 Make sure undertow always has a dependency on CDI

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -214,6 +214,8 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
             }
         }
 
+        additionalDependencies.addAll(warMetaData.getAdditionalDependencies());
+
         final ServiceName hostServiceName = UndertowService.virtualHostName(serverInstanceName, hostName);
         TldsMetaData tldsMetaData = deploymentUnit.getAttachment(TldsMetaData.ATTACHMENT_KEY);
         UndertowDeploymentInfoService undertowDeploymentInfoService = UndertowDeploymentInfoService.builder()

--- a/web-common/src/main/java/org/jboss/as/web/common/WarMetaData.java
+++ b/web-common/src/main/java/org/jboss/as/web/common/WarMetaData.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.web.common;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,6 +31,7 @@ import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
 import org.jboss.metadata.web.spec.WebFragmentMetaData;
 import org.jboss.metadata.web.spec.WebMetaData;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.vfs.VirtualFile;
 
 /**
@@ -91,6 +94,9 @@ public class WarMetaData {
      * Final merged metadata.
      */
     private volatile JBossWebMetaData mergedJBossWebMetaData;
+
+
+    private final Set<ServiceName> additionalDependencies = new HashSet<ServiceName>();
 
     public JBossWebMetaData getJBossWebMetaData() {
         return jbossWebMetaData;
@@ -178,5 +184,13 @@ public class WarMetaData {
 
     public void setAdditionalModuleAnnotationsMetadata(List<WebMetaData> additionalModuleAnnotationsMetadata) {
         this.additionalModuleAnnotationsMetadata = additionalModuleAnnotationsMetadata;
+    }
+
+    public void addAdditionalDependency(final ServiceName serviceName) {
+        this.additionalDependencies.add(serviceName);
+    }
+
+    public Set<ServiceName> getAdditionalDependencies() {
+        return Collections.unmodifiableSet(additionalDependencies);
     }
 }

--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
@@ -39,6 +39,7 @@ import org.jboss.as.web.common.ExpressionFactoryWrapper;
 import org.jboss.as.web.common.WarMetaData;
 import org.jboss.as.web.common.WebComponentDescription;
 import org.jboss.as.weld.WeldLogger;
+import org.jboss.as.weld.WeldStartService;
 import org.jboss.as.weld.webtier.jsp.WeldJspExpressionFactoryWrapper;
 import org.jboss.metadata.javaee.spec.ParamValueMetaData;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
@@ -46,6 +47,7 @@ import org.jboss.metadata.web.spec.FilterMappingMetaData;
 import org.jboss.metadata.web.spec.FilterMetaData;
 import org.jboss.metadata.web.spec.FiltersMetaData;
 import org.jboss.metadata.web.spec.ListenerMetaData;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.weld.servlet.ConversationFilter;
 import org.jboss.weld.servlet.WeldInitialListener;
 import org.jboss.weld.servlet.WeldTerminalListener;
@@ -110,6 +112,9 @@ public class WebIntegrationProcessor implements DeploymentUnitProcessor {
             WeldLogger.DEPLOYMENT_LOGGER.debug("Not installing Weld web tier integration as no merged web metadata found");
             return;
         }
+
+        final ServiceName weldStartService = (deploymentUnit.getParent() != null ? deploymentUnit.getParent() : deploymentUnit).getServiceName().append(WeldStartService.SERVICE_NAME);
+        warMetaData.addAdditionalDependency(weldStartService);
 
         List<ListenerMetaData> listeners = webMetaData.getListeners();
         if (listeners == null) {


### PR DESCRIPTION
Up until now it only had an indirect dependency through the components in the deployment, if no components where present then this dependency was missing.
