### PR TITLE
[WFLY-3268] Increase memory due to clustering testuite OOM failures

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -143,7 +143,7 @@
         <ds.jdbc.driver.target.path>${basedir}/target/jbossas/standalone/deployments</ds.jdbc.driver.target.path>
 
         <!-- Common surefire properties. -->
-        <surefire.memory.args>-Xmx512m -XX:MaxPermSize=256m</surefire.memory.args>
+        <surefire.memory.args>-Xmx768m -XX:MaxPermSize=256m</surefire.memory.args>
         <surefire.jpda.args></surefire.jpda.args>
         <as.debug.port>8787</as.debug.port>
         <surefire.system.args>${surefire.memory.args} ${surefire.jpda.args} -Djboss.dist=${jboss.dist}</surefire.system.args>


### PR DESCRIPTION
Some of the clustering tests

```
org.jboss.as.test.clustering.cluster.ejb.stateful.StatefulTimeoutTestCase(SYNC-tcp).timeout
org.jboss.as.test.clustering.cluster.ejb.stateful.StatefulFailoverTestCase(SYNC-tcp).nestedBeanFailover
org.jboss.as.test.clustering.cluster.singleton.SingletonTestCase(SYNC-tcp).testSingletonService
```

are failing due to OOM

```
ERROR [org.infinispan.topology.ClusterTopologyManagerImpl] (transport-thread-4) ISPN000230: Failed to start rebalance for cache default-host/stateful-failover: java.lang.OutOfMemoryError: unable to create new native thread
```

Let's see if this helps. As Tom says, the systems have 3-4 GB RAM, so this should be alright there.

https://issues.jboss.org/browse/WFLY-3268
