### PR TITLE
Synchronize Arquillian javaVmArguments with the AS memory defaults

### DIFF
--- a/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
+++ b/arquillian/container-managed-domain/src/main/java/org/jboss/as/arquillian/container/domain/managed/ManagedDomainContainerConfiguration.java
@@ -35,7 +35,7 @@ public class ManagedDomainContainerConfiguration extends CommonDomainContainerCo
 
     private String modulePath = System.getProperty("module.path");
 
-    private String javaVmArguments = System.getProperty("jboss.options", "-Xmx512m -XX:MaxPermSize=128m");
+    private String javaVmArguments = System.getProperty("jboss.options", "-Xmx512m -XX:MaxPermSize=256m");
 
     private int startupTimeoutInSeconds = 60;
 

--- a/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
+++ b/arquillian/container-managed/src/main/java/org/jboss/as/arquillian/container/managed/ManagedContainerConfiguration.java
@@ -37,7 +37,7 @@ public class ManagedContainerConfiguration extends DistributionContainerConfigur
      */
     private static final Integer DEFAULT_VALUE_WAIT_FOR_PORTS_TIMEOUT_SECONDS = 10;
 
-    private String javaVmArguments = System.getProperty("jboss.options", "-Xmx512m -XX:MaxPermSize=128m");
+    private String javaVmArguments = System.getProperty("jboss.options", "-Xmx512m -XX:MaxPermSize=256m");
 
     private String jbossArguments;
 


### PR DESCRIPTION
Unless this was intentional to keep these desynchronized... 
