### PR TITLE
[WFLY-3275] Make log4j and syslog4j a test only dependency.

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -50,11 +50,6 @@
 
     <dependencies>
 
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-
         <!-- TODO: why do we need jandex in minimal? -->
         <dependency>
             <groupId>org.jboss</groupId>
@@ -1010,7 +1005,7 @@
 
                 <dependency>
                     <groupId>org.jboss.hal</groupId>
-                    <artifactId>release-stream</artifactId>                    
+                    <artifactId>release-stream</artifactId>
                     <classifier>resources</classifier>
                 </dependency>
 
@@ -1924,37 +1919,37 @@
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-api</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-impl</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-federation</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-common</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-config</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-idm-api</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-idm-impl</artifactId>
                 </dependency>
-    
+
                 <dependency>
                     <groupId>org.picketlink.distribution</groupId>
                     <artifactId>picketlink-jbas7</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1927,6 +1927,7 @@
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>${version.log4j}</version>
+                <scope>test</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>ant</groupId>
@@ -4808,6 +4809,10 @@
                 <version>${version.org.jboss.narayana}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.jboss.narayana.rts</groupId>
                         <artifactId>restat-util</artifactId>
                     </exclusion>
@@ -4818,6 +4823,12 @@
                 <groupId>org.jboss.narayana.rts</groupId>
                 <artifactId>restat-util</artifactId>
                 <version>${version.org.jboss.narayana}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
              </dependency>
 
             <dependency>
@@ -5867,6 +5878,10 @@
                         <artifactId>stax-api</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.apache.cxf</groupId>
                         <artifactId>cxf-rt-bindings-soap</artifactId>
                     </exclusion>
@@ -6346,6 +6361,7 @@
                 <groupId>org.syslog4j</groupId>
                 <artifactId>syslog4j</artifactId>
                 <version>${version.org.syslog4j}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/BlockedFileSyslogServerEventHandler.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/BlockedFileSyslogServerEventHandler.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.security.common;
+package org.jboss.as.test.manualmode.auditlog;
 
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;


### PR DESCRIPTION
Moved one test class from shared to the manualmode module. I see no real reason to have this in the shared module.
