### PR TITLE
[WFLY-3275] Make log4j a test only dependency.

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -50,11 +50,6 @@
 
     <dependencies>
 
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-
         <!-- TODO: why do we need jandex in minimal? -->
         <dependency>
             <groupId>org.jboss</groupId>
@@ -1010,7 +1005,7 @@
 
                 <dependency>
                     <groupId>org.jboss.hal</groupId>
-                    <artifactId>release-stream</artifactId>                    
+                    <artifactId>release-stream</artifactId>
                     <classifier>resources</classifier>
                 </dependency>
 
@@ -1924,37 +1919,37 @@
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-api</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-impl</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-federation</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-common</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-config</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-idm-api</artifactId>
                 </dependency>
-            
+
                 <dependency>
                     <groupId>org.picketlink</groupId>
                     <artifactId>picketlink-idm-impl</artifactId>
                 </dependency>
-    
+
                 <dependency>
                     <groupId>org.picketlink.distribution</groupId>
                     <artifactId>picketlink-jbas7</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1926,6 +1926,7 @@
                 <groupId>log4j</groupId>
                 <artifactId>log4j</artifactId>
                 <version>${version.log4j}</version>
+                <scope>test</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>ant</groupId>
@@ -4783,6 +4784,10 @@
                 <version>${version.org.jboss.narayana}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.jboss.narayana.rts</groupId>
                         <artifactId>restat-util</artifactId>
                     </exclusion>
@@ -4807,6 +4812,10 @@
                 <version>${version.org.jboss.narayana}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.jboss.narayana.rts</groupId>
                         <artifactId>restat-util</artifactId>
                     </exclusion>
@@ -4817,6 +4826,12 @@
                 <groupId>org.jboss.narayana.rts</groupId>
                 <artifactId>restat-util</artifactId>
                 <version>${version.org.jboss.narayana}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
              </dependency>
 
             <dependency>
@@ -5864,6 +5879,10 @@
                     <exclusion>
                         <groupId>javax.xml.stream</groupId>
                         <artifactId>stax-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.apache.cxf</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,6 @@
         <version.org.powermock>1.5</version.org.powermock>
         <version.org.scannotation>1.0.3</version.org.scannotation>
         <version.org.slf4j>1.7.2.jbossorg-1</version.org.slf4j>
-        <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.org.eclipse.aether>0.9.0.M3</version.org.eclipse.aether>
         <version.org.eclipse.sisu.plexus>0.0.0.M5</version.org.eclipse.sisu.plexus>
         <version.org.testng>6.1.1</version.org.testng>
@@ -6340,12 +6339,6 @@
                         <artifactId>javassist</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-
-            <dependency>
-                <groupId>org.syslog4j</groupId>
-                <artifactId>syslog4j</artifactId>
-                <version>${version.org.syslog4j}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/AuditLogFieldsOfLogTestCase.java
@@ -43,7 +43,6 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.as.domain.management.audit.AuditLogLoggerResourceDefinition;
-import org.jboss.as.test.integration.security.common.BlockedFileSyslogServerEventHandler;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/BlockedFileSyslogServerEventHandler.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/auditlog/BlockedFileSyslogServerEventHandler.java
@@ -1,4 +1,4 @@
-package org.jboss.as.test.integration.security.common;
+package org.jboss.as.test.manualmode.auditlog;
 
 import java.io.IOException;
 import java.util.concurrent.BlockingQueue;

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -280,6 +280,11 @@
     <dependencies>
         <!-- Dependencies specific to the integration tests. -->
         <dependency>
+            <groupId>org.syslog4j</groupId>
+            <artifactId>syslog4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-webservices-tests-integration</artifactId>
             <version>${project.version}</version>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -154,6 +154,7 @@
 
         <!-- Arquillian dependency versions -->
         <version.arquillian_wildfly>${project.parent.version}</version.arquillian_wildfly>
+        <version.org.syslog4j>0.9.30</version.org.syslog4j>
         <version.saxon>8.7</version.saxon>
 
         <!-- Don't try to deploy the testsuite modules because they don't build jars -->
@@ -180,6 +181,11 @@
                 <version>1.7</version>
                 <scope>system</scope>
                 <systemPath>${java.home}/../lib/tools.jar</systemPath> <!-- since jdk7 also on MAC this is proper path -->
+            </dependency>
+            <dependency>
+                <groupId>org.syslog4j</groupId>
+                <artifactId>syslog4j</artifactId>
+                <version>${version.org.syslog4j}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -86,11 +86,6 @@
             <artifactId>apacheds-server-annotations</artifactId>
             <scope>compile</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.syslog4j</groupId>
-            <artifactId>syslog4j</artifactId>
-        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Made syslog4j a test only dependency. Moved one test class from shared to the manualmode module. I see no real reason to have this in the shared module.
