### PR TITLE
[8.1.0] Add sun.jdk dependancy to xnio nio module so provider detection works properly

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/xnio/nio/main/module.xml
@@ -35,5 +35,6 @@
         <module name="javax.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.xnio"/>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>


### PR DESCRIPTION
see https://community.jboss.org/message/870675 for details
