### PR TITLE
WFLY-3287 Upgrade vfs to 3.2.5.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
         <version.org.jboss.jandex>1.1.0.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.2.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-transaction-spi>7.1.0.Final</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.jboss-vfs>3.2.4.Final</version.org.jboss.jboss-vfs>
+        <version.org.jboss.jboss-vfs>3.2.5.Final</version.org.jboss.jboss-vfs>
         <version.org.jboss.narayana>5.0.0.Final</version.org.jboss.narayana>
         <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-tools>1.2.0.Final</version.org.jboss.logging.jboss-logging-tools>


### PR DESCRIPTION
- fixes     JBVFS-195 Reading MANIFEST with NULL char will fail
