### PR TITLE
[WFLY-2741] Single process management operation timeouts

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -59,6 +59,7 @@ public class Util {
     public static final String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
     public static final String ARCHIVE = "archive";
     public static final String ATTRIBUTES = "attributes";
+    public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BYTES = "bytes";
     public static final String CHILDREN = "children";
     public static final String CHILD_TYPE = "child-type";

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
@@ -79,6 +79,28 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
             return parsedOp.getLastChunkIndex() + result;
         }};
 
+    private static final CommandLineCompleter INT_HEADER_COMPLETER = new CommandLineCompleter(){
+
+        private final DefaultCallbackHandler parsedOp = new DefaultCallbackHandler();
+
+        @Override
+        public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
+            try {
+                ParserUtil.parseHeaders(buffer, parsedOp);
+            } catch (CommandFormatException e) {
+                //e.printStackTrace();
+                return -1;
+            }
+            if(parsedOp.endsOnSeparator()) {
+                return buffer.length();
+            }
+            if(parsedOp.getLastHeader() == null) {
+                candidates.add("=");
+                return buffer.length();
+            }
+            return buffer.length();
+        }};
+
     private static final Map<String, OperationRequestHeader> HEADERS;
     static {
         HEADERS = new HashMap<String, OperationRequestHeader>();
@@ -86,6 +108,7 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
 
         addBooleanHeader(Util.ALLOW_RESOURCE_SERVICE_RESTART);
         addBooleanHeader(Util.ROLLBACK_ON_RUNTIME_FAILURE);
+        addIntHeader(Util.BLOCKING_TIMEOUT);
     }
 
     private static void addBooleanHeader(final String name) {
@@ -98,6 +121,20 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
             @Override
             public CommandLineCompleter getCompleter() {
                 return BOOLEAN_HEADER_COMPLETER;
+            }};
+        HEADERS.put(header.getName(), header);
+    }
+
+    private static void addIntHeader(final String name) {
+        OperationRequestHeader header = new OperationRequestHeader(){
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public CommandLineCompleter getCompleter() {
+                return INT_HEADER_COMPLETER;
             }};
         HEADERS.put(header.getName(), header);
     }

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -55,6 +55,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.security.auth.Subject;
@@ -89,7 +90,7 @@ abstract class AbstractOperationContext implements OperationContext {
     final Thread initiatingThread;
     private final EnumMap<Stage, Deque<Step>> steps;
     private final ModelController.OperationTransactionControl transactionControl;
-    private final ControlledProcessState processState;
+    final ControlledProcessState processState;
     private final boolean booting;
     private final ProcessType processType;
     private final RunningMode runningMode;
@@ -319,12 +320,13 @@ abstract class AbstractOperationContext implements OperationContext {
 
     /**
      * If appropriate for this implementation, block waiting for the
-     * {@link ModelControllerImpl#acquireContainerMonitor()} method to return, ensuring that the controller's
-     * MSC ServiceContainer is settled and it is safe to proceed to service status verification.
+     * {@link ModelControllerImpl#awaitContainerStability(long, java.util.concurrent.TimeUnit, boolean)} method to return,
+     * ensuring that the controller's MSC ServiceContainer is settled and it is safe to proceed to service status verification.
      *
      * @throws InterruptedException if the thread is interrupted while blocking
+     * @throws java.util.concurrent.TimeoutException if attaining container stability takes an unacceptable amount of time
      */
-    abstract void awaitModelControllerContainerMonitor() throws InterruptedException;
+    abstract void awaitServiceContainerStability() throws InterruptedException, TimeoutException;
 
     /**
      * Create a persistence resource (if appropriate for this implementation) for use in persisting the configuration
@@ -350,7 +352,7 @@ abstract class AbstractOperationContext implements OperationContext {
      *
      * @throws InterruptedException if the thread is interrupted while waiting
      */
-    abstract void waitForRemovals() throws InterruptedException;
+    abstract void waitForRemovals() throws InterruptedException, TimeoutException;
 
     /**
      * Gets whether any steps have taken actions that indicate a wish to write to the model or the service container.
@@ -455,22 +457,17 @@ abstract class AbstractOperationContext implements OperationContext {
                         // a change was made to the runtime. Thus, we must wait
                         // for stability before resuming in to verify.
                         try {
-                            awaitModelControllerContainerMonitor();
+                            awaitServiceContainerStability();
                         } catch (InterruptedException e) {
                             cancelled = true;
-                            if (response != null) {
-                                response.get(OUTCOME).set(CANCELLED);
-                                response.get(FAILURE_DESCRIPTION).set(MESSAGES.operationCancelled());
-                                response.get(ROLLED_BACK).set(true);
-                            }
-                            resultAction = ResultAction.ROLLBACK;
-                            respectInterruption = false;
-                            logAuditRecord();
-                            Thread.currentThread().interrupt();
-                            if (activeStep != null && activeStep.resultHandler != null) {
-                                // Finalize
-                                activeStep.finalizeStep(null);
-                            }
+                            handleContainerStabilityFailure(response, e);
+                            return;
+                        }  catch (TimeoutException te) {
+                            // The service container is in an unknown state; but we don't require restart
+                            // because rollback may allow the container to stabilize. We force require-restart
+                            // in the rollback handling if the container cannot stabilize (see OperationContextImpl.releaseStepLocks)
+                            //processState.setRestartRequired();  // don't use our restartRequired() method as this is not reversible in rollback
+                            handleContainerStabilityFailure(response, te);
                             return;
                         }
                     }
@@ -646,7 +643,7 @@ abstract class AbstractOperationContext implements OperationContext {
                 // This can happen with an operation with many, many steps that use the recursive no-arg completeStep()
                 // variant. This should be rare now as handlers are largely migrated from this variant.
                 // But, log a special message for this case
-                MGMT_OP_LOGGER.operationFailed(t, step.operation.get(OP), step.operation.get(OP_ADDR),
+                MGMT_OP_LOGGER.operationFailedInsufficientStackSpace(t, step.operation.get(OP), step.operation.get(OP_ADDR),
                         AbstractControllerService.BOOT_STACK_SIZE_PROPERTY, AbstractControllerService.DEFAULT_BOOT_STACK_SIZE);
             } else {
                 MGMT_OP_LOGGER.operationFailed(t, step.operation.get(OP), step.operation.get(OP_ADDR));
@@ -722,6 +719,28 @@ abstract class AbstractOperationContext implements OperationContext {
                 throwThrowable(toThrow);
             }
         }
+    }
+
+    private void handleContainerStabilityFailure(ModelNode response, Exception cause) {
+        boolean interrupted = cause instanceof InterruptedException;
+        assert interrupted || cause instanceof TimeoutException;
+
+        if (response != null) {
+            response.get(OUTCOME).set(CANCELLED);
+            response.get(FAILURE_DESCRIPTION).set(interrupted? MESSAGES.operationCancelled(): MESSAGES.timeoutExecutingOperation());
+            response.get(ROLLED_BACK).set(true);
+        }
+        resultAction = ResultAction.ROLLBACK;
+        respectInterruption = false;
+        logAuditRecord();
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        if (activeStep != null && activeStep.resultHandler != null) {
+            // Finalize
+            activeStep.finalizeStep(null);
+        }
+
     }
 
     private static void throwThrowable(Throwable toThrow) {
@@ -875,6 +894,7 @@ abstract class AbstractOperationContext implements OperationContext {
         private Object restartStamp;
         private ResultHandler resultHandler;
         Step predecessor;
+        boolean hasRemovals;
 
         private Step(final OperationStepHandler handler, final ModelNode response, final ModelNode operation,
                 final PathAddress address) {
@@ -939,7 +959,7 @@ abstract class AbstractOperationContext implements OperationContext {
             AbstractOperationContext.this.activeStep = this;
 
             try {
-                handleRollback();
+                handleResult();
 
                 if (currentStage != null && currentStage != Stage.DONE) {
                     // This is a failure because the next step failed to call
@@ -976,15 +996,18 @@ abstract class AbstractOperationContext implements OperationContext {
             }
         }
 
-        private void handleRollback() {
+        private void handleResult() {
             if (resultHandler != null) {
+                hasRemovals = false;
                 try {
                     ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(handler.getClass());
                     try {
                         resultHandler.handleResult(resultAction, AbstractOperationContext.this, operation);
                     } finally {
                         WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
-                        waitForRemovals();
+                        if (hasRemovals) {
+                            waitForRemovals();
+                        }
                     }
                 } catch (Exception e) {
                     report(MessageSeverity.ERROR,

--- a/controller/src/main/java/org/jboss/as/controller/BlockingTimeout.java
+++ b/controller/src/main/java/org/jboss/as/controller/BlockingTimeout.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING_TIMEOUT;
+
+import org.jboss.dmr.ModelNode;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * Encapsulates information about how long management operation execution should block
+ * before timing out.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+class BlockingTimeout {
+
+    public static final String SYSTEM_PROPERTY = "jboss.as.management.blocking.timeout";
+    private static final int DEFAULT_TIMEOUT = 300;  // seconds
+    private static final String DEFAULT_TIMEOUT_STRING = Long.toString(DEFAULT_TIMEOUT);
+    private static final int SHORT_TIMEOUT = 5000;
+    private static String sysPropValue;
+    private static int defaultValue;
+
+    private final int blockingTimeout;
+    private final int shortTimeout;
+    private volatile boolean timeoutDetected;
+
+    BlockingTimeout(final ModelNode headerValue) {
+        Integer opHeaderValue;
+        if (headerValue != null && headerValue.isDefined()) {
+            opHeaderValue = headerValue.asInt();
+            if (opHeaderValue < 1) {
+                throw ControllerMessages.MESSAGES.invalidBlockingTimeout(opHeaderValue.longValue(), BLOCKING_TIMEOUT);
+            }
+            blockingTimeout = opHeaderValue * 1000;
+        } else {
+            blockingTimeout = resolveDefaultTimeout();
+        }
+        shortTimeout = Math.min(blockingTimeout, SHORT_TIMEOUT);
+    }
+
+    private static int resolveDefaultTimeout() {
+        String propValue = WildFlySecurityManager.getPropertyPrivileged(SYSTEM_PROPERTY, DEFAULT_TIMEOUT_STRING);
+        if (sysPropValue == null || !sysPropValue.equals(propValue)) {
+            // First call or the system property changed
+            sysPropValue = propValue;
+            int number = -1;
+            try {
+                number = Integer.valueOf(sysPropValue);
+            } catch (NumberFormatException nfe) {
+                // ignored
+            }
+
+            if (number > 0) {
+                defaultValue = number * 1000; // seconds to ms
+            } else {
+                ControllerLogger.MGMT_OP_LOGGER.invalidDefaultBlockingTimeout(sysPropValue, SYSTEM_PROPERTY, DEFAULT_TIMEOUT);
+                defaultValue = DEFAULT_TIMEOUT * 1000; // seconds to ms
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Gets the maximum period, in ms, a blocking call should block.
+     * @return the maximum period. Will be a value greater than zero.
+     */
+    int getBlockingTimeout() {
+        return timeoutDetected ? shortTimeout : blockingTimeout;
+    }
+
+    /**
+     * Notifies this object that a timeout has occurred, allowing shorter timeouts values
+     * to be returned from {@link #getBlockingTimeout()}
+     */
+    void timeoutDetected() {
+        timeoutDetected = true;
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
+++ b/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
@@ -29,6 +29,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.jboss.msc.service.AbstractServiceListener;
 import org.jboss.msc.service.ServiceController;
@@ -57,11 +59,12 @@ public final class ContainerStateMonitor extends AbstractServiceListener<Object>
         serviceRegistry = registry;
     }
 
-    void acquire() {
-        // does nothing
-    }
-
-    void release() {
+    /**
+     * Log a report of any problematic container state changes and reset container state change history
+     * so another run of this method or of {@link #awaitContainerStateChangeReport(long, java.util.concurrent.TimeUnit)}
+     * will produce a report not including any changes included in a report returned by this run.
+     */
+    void logContainerStateChangesAndReset() {
         ContainerStateChangeReport changeReport = createContainerStateChangeReport(true);
 
         if (changeReport != null) {
@@ -76,31 +79,72 @@ public final class ContainerStateMonitor extends AbstractServiceListener<Object>
         controller.removeListener(this);
     }
 
-    void awaitUninterruptibly() {
-        boolean interruped = false;
+    /**
+     * Await service container stability ignoring thread interruption.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     *
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    void awaitStabilityUninterruptibly(long timeout, TimeUnit timeUnit) throws TimeoutException {
+        boolean interrupted = false;
         try {
+            long toWait = timeUnit.toMillis(timeout);
+            long msTimeout = System.currentTimeMillis() + toWait;
             while (true) {
+                if (interrupted) {
+                    toWait = msTimeout - System.currentTimeMillis();
+                }
                 try {
-                    monitor.awaitStability(failed, problems);
+                    if (toWait <= 0 || !monitor.awaitStability(toWait, TimeUnit.MILLISECONDS, failed, problems)) {
+                        throw new TimeoutException();
+                    }
                     break;
                 } catch (InterruptedException e) {
-                    interruped = true;
+                    interrupted = true;
                 }
             }
         } finally {
-            if (interruped) {
+            if (interrupted) {
                 Thread.currentThread().interrupt();
             }
         }
     }
 
-    void await() throws InterruptedException {
-        monitor.awaitStability(failed, problems);
+    /**
+     * Await service container stability.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     *
+     * @throws java.lang.InterruptedException if the thread is interrupted while awaiting service container stability
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    void awaitStability(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+        if (!monitor.awaitStability(timeout, timeUnit, failed, problems)) {
+            throw new TimeoutException();
+        }
     }
 
-    ContainerStateChangeReport awaitContainerStateChangeReport() throws InterruptedException {
-        monitor.awaitStability(failed, problems);
-        return createContainerStateChangeReport(false);
+    /**
+     * Await service container stability and then report on container state changes. Does not reset change history,
+     * so another run of this method with no intervening call to {@link #logContainerStateChangesAndReset()}
+     * will produce a report including any changes included in a report returned by the first run.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     *
+     * @return a change report, or {@code null} if there is nothing to report
+     *
+     * @throws java.lang.InterruptedException if the thread is interrupted while awaiting service container stability
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    ContainerStateChangeReport awaitContainerStateChangeReport(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+        if (monitor.awaitStability(timeout, timeUnit, failed, problems)) {
+            return createContainerStateChangeReport(false);
+        }
+        throw new TimeoutException();
     }
 
     /**
@@ -190,6 +234,7 @@ public final class ContainerStateMonitor extends AbstractServiceListener<Object>
             msg.append(MESSAGES.serviceStatusReportFailed());
             for (ServiceController<?> controller : changeReport.getFailedControllers()) {
                 msg.append("      ").append(controller.getName());
+                //noinspection ThrowableResultOfMethodCallIgnored
                 final StartException startException = controller.getStartException();
                 if (startException != null) {
                     msg.append(": ").append(startException.toString());

--- a/controller/src/main/java/org/jboss/as/controller/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerLogger.java
@@ -274,7 +274,7 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 14613, value = "Operation (%s) failed - address: (%s) -- due to insufficient stack space for the thread used to " +
             "execute operations. If this error is occurring during server boot, setting " +
             "system property %s to a value higher than [%d] may resolve this problem.")
-    void operationFailed(@Cause Throwable cause, ModelNode op, ModelNode opAddress, String propertyName, int defaultSize);
+    void operationFailedInsufficientStackSpace(@Cause Throwable cause, ModelNode op, ModelNode opAddress, String propertyName, int defaultSize);
 
     /**
      * Logs a warning message indicating a wildcard address was detected and will ignore other interface criteria.
@@ -485,6 +485,23 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = Level.ERROR)
     @Message(id = 13409, value = "[%d] consecutive management operation audit logging failures have occurred in handler '%s'; disabling this handler for audit logging")
     void disablingLogHandlerDueToFailures(int failureCount, String name);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 13410, value = "Invalid value %s for property %s; must be a numeric value greater than zero. Default value of %d will be used.")
+    void invalidDefaultBlockingTimeout(String sysPropValue, String sysPropName, long defaultUsed);
+
+    @LogMessage(level = Level.DEBUG)
+    @Message(id = 13411, value = "Timeout after [%d] seconds waiting for initial service container stability before allowing runtime changes for operation '%s' at address '%s'. Operation will roll back; process restart is required.")
+    void timeoutAwaitingInitialStability(long blockingTimeout, String name, PathAddress address);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 13412, value = "Timeout after [%d] seconds waiting for service container stability. Operation will roll back. Step that first updated the service container was '%s' at address '%s'")
+    void timeoutExecutingOperation(long blockingTimeout, String name, PathAddress address);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 13413, value = "Timeout after [%d] seconds waiting for service container stability while finalizing an operation. Process must be restarted. Step that first updated the service container was '%s' at address '%s'")
+    void timeoutCompletingOperation(long blockingTimeout, String name, PathAddress address);
+
 
     // 13449 IS END OF 134xx SERIES USABLE FOR LOGGER MESSAGES
 

--- a/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
+++ b/controller/src/main/java/org/jboss/as/controller/ControllerMessages.java
@@ -2746,9 +2746,20 @@ public interface ControllerMessages {
     @Message(id = 13483, value = "The following attributes must NOT be defined as %s in the current model: %s")
     String attributesMustNotBeDefinedAs(ModelNode value, Set<String> names);
 
-
     @Message(id = 13484, value="A uri with bad syntax '%s' was passed for validation.")
     OperationFailedException badUriSyntax(String uri);
+
+    @Message(id = 13485, value = "Illegal value %d for operation header %s; value must be greater than zero")
+    IllegalStateException invalidBlockingTimeout(long timeout, String headerName);
+
+    @Message(id = 13486, value = "The service container has been destabilized by a previous operation and further runtime updates cannot be processed. Restart is required.")
+    String timeoutAwaitingInitialStability();
+
+    @Message(id = 13487, value = "Operation timed out awaiting service container stability")
+    String timeoutExecutingOperation();
+
+    @Message(id = 13488, value = "Timeout after %d seconds waiting for existing service %s to be removed so a new instance can be installed.")
+    IllegalStateException serviceInstallTimedOut(long timeout, ServiceName name);
 
     // 13499 IS END OF 134xx SERIES USABLE FOR NON-LOGGER MESSAGES
 }

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -28,6 +28,7 @@ import static org.jboss.as.controller.ControllerLogger.ROOT_LOGGER;
 import static org.jboss.as.controller.ControllerMessages.MESSAGES;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_MECHANISM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING_TIMEOUT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_UUID;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
@@ -53,6 +54,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -223,6 +226,8 @@ class ModelControllerImpl implements ModelController {
         if (restartResourceServices) {
             contextFlags.add(OperationContextImpl.ContextFlag.ALLOW_RESOURCE_SERVICE_RESTART);
         }
+        final ModelNode blockingTimeoutConfig = headers != null && headers.hasDefined(BLOCKING_TIMEOUT) ? headers.get(BLOCKING_TIMEOUT) : null;
+
         final ModelNode response = new ModelNode();
         // Report the correct operation response, otherwise the preparedResult would only contain
         // the result of the last active step in a composite operation
@@ -252,7 +257,7 @@ class ModelControllerImpl implements ModelController {
             final Integer operationID = new Random(new SecureRandom().nextLong()).nextInt();
             final OperationContextImpl context = new OperationContextImpl(this, processType, runningModeControl.getRunningMode(),
                     contextFlags, handler, attachments, model, originalResultTxControl, processState, auditLogger,
-                    bootingFlag.get(), operationID, hostServerGroupTracker);
+                    bootingFlag.get(), operationID, hostServerGroupTracker, blockingTimeoutConfig);
             // Try again if the operation-id is already taken
             if(activeOperations.putIfAbsent(operationID, context) == null) {
                 CurrentOperationIdHolder.setCurrentOperationID(operationID);
@@ -303,7 +308,7 @@ class ModelControllerImpl implements ModelController {
                 ? EnumSet.of(OperationContextImpl.ContextFlag.ROLLBACK_ON_FAIL)
                 : EnumSet.noneOf(OperationContextImpl.ContextFlag.class);
         final OperationContextImpl context = new OperationContextImpl(this, processType, runningModeControl.getRunningMode(),
-                contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), operationID, hostServerGroupTracker);
+                contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), operationID, hostServerGroupTracker, null);
 
         // Add to the context all ops prior to the first ExtensionAddHandler as well as all ExtensionAddHandlers; save the rest.
         // This gets extensions registered before proceeding to other ops that count on these registrations
@@ -321,7 +326,7 @@ class ModelControllerImpl implements ModelController {
 
             // Success. Now any extension handlers are registered. Continue with remaining ops
             final OperationContextImpl postExtContext = new OperationContextImpl(this, processType, runningModeControl.getRunningMode(),
-                    contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), operationID, hostServerGroupTracker);
+                    contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), operationID, hostServerGroupTracker, null);
 
             for (ParsedBootOp parsedOp : bootOperations.postExtensionOps) {
                 if (parsedOp.handler == null) {
@@ -594,7 +599,7 @@ class ModelControllerImpl implements ModelController {
         };
     }
 
-    void acquireLock(Integer permit, final boolean interruptibly, OperationContext context) throws InterruptedException {
+    void acquireLock(Integer permit, final boolean interruptibly) throws InterruptedException {
         if (interruptibly) {
             //noinspection LockAcquiredButNotSafelyReleased
             controllerLock.lockInterruptibly(permit);
@@ -604,28 +609,64 @@ class ModelControllerImpl implements ModelController {
         }
     }
 
+    boolean acquireLock(Integer permit, final boolean interruptibly, long timeout) throws InterruptedException {
+        if (interruptibly) {
+            //noinspection LockAcquiredButNotSafelyReleased
+            return controllerLock.lockInterruptibly(permit, timeout, TimeUnit.SECONDS);
+        } else {
+            //noinspection LockAcquiredButNotSafelyReleased
+            return controllerLock.lock(permit, timeout, TimeUnit.SECONDS);
+        }
+    }
+
     void releaseLock(Integer permit) {
         controllerLock.unlock(permit);
     }
 
-    void acquireContainerMonitor() {
-        stateMonitor.acquire();
+    /**
+     * Log a report of any problematic container state changes and reset container state change history
+     * so another run of this method or of {@link #awaitContainerStateChangeReport(long, java.util.concurrent.TimeUnit)}
+     * will produce a report not including any changes included in a report returned by this run.
+     */
+    void logContainerStateChangesAndReset() {
+        stateMonitor.logContainerStateChangesAndReset();
     }
 
-    void releaseContainerMonitor() {
-        stateMonitor.release();
-    }
-
-    void awaitContainerMonitor(final boolean interruptibly) throws InterruptedException {
+    /**
+     * Await service container stability.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     * @param interruptibly {@code true} if thread interruption should be ignored
+     *
+     * @throws java.lang.InterruptedException if {@code interruptibly} is {@code false} and the thread is interrupted while awaiting service container stability
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    void awaitContainerStability(long timeout, TimeUnit timeUnit, final boolean interruptibly)
+            throws InterruptedException, TimeoutException {
         if (interruptibly) {
-            stateMonitor.await();
+            stateMonitor.awaitStability(timeout, timeUnit);
         } else {
-            stateMonitor.awaitUninterruptibly();
+            stateMonitor.awaitStabilityUninterruptibly(timeout, timeUnit);
         }
     }
 
-    ContainerStateMonitor.ContainerStateChangeReport awaitContainerStateChangeReport() throws InterruptedException {
-        return stateMonitor.awaitContainerStateChangeReport();
+    /**
+     * Await service container stability and then report on container state changes. Does not reset change history,
+     * so another run of this method with no intervening call to {@link #logContainerStateChangesAndReset()} will produce a report including
+     * any changes included in a report returned by the first run.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     *
+     * @return a change report, or {@code null} if there is nothing to report
+     *
+     * @throws java.lang.InterruptedException if the thread is interrupted while awaiting service container stability
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    ContainerStateMonitor.ContainerStateChangeReport awaitContainerStateChangeReport(long timeout, TimeUnit timeUnit)
+            throws InterruptedException, TimeoutException {
+        return stateMonitor.awaitContainerStateChangeReport(timeout, timeUnit);
     }
 
     ServiceRegistry getServiceRegistry() {

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerLock.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerLock.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 
@@ -41,11 +42,28 @@ class ModelControllerLock {
         sync.acquire(permit);
     }
 
+    boolean lock(Integer permit, long timeout, TimeUnit unit) throws InterruptedException {
+        boolean result = false;
+        try {
+            result = lockInterruptibly(permit, timeout, unit);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return result;
+    }
+
     void lockInterruptibly(Integer permit) throws InterruptedException {
         if (permit == null) {
             throw new IllegalArgumentException();
         }
         sync.acquireInterruptibly(permit);
+    }
+
+    boolean lockInterruptibly(Integer permit, long timeout, TimeUnit unit) throws InterruptedException {
+        if (permit == null) {
+            throw new IllegalArgumentException();
+        }
+        return sync.tryAcquireNanos(permit, unit.toNanos(timeout));
     }
 
     void unlock(Integer permit) {

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -133,6 +133,8 @@ final class OperationContextImpl extends AbstractOperationContext {
     private final ConcurrentMap<AttachmentKey<?>, Object> valueAttachments = new ConcurrentHashMap<AttachmentKey<?>, Object>();
     private final Map<OperationId, AuthorizationResponseImpl> authorizations =
             new ConcurrentHashMap<OperationId, AuthorizationResponseImpl>();
+    private final ModelNode blockingTimeoutConfig;
+    private volatile BlockingTimeout blockingTimeout;
     /** Tracks whether any steps have gotten write access to the management resource registration*/
     private volatile boolean affectsResourceRegistration;
 
@@ -164,10 +166,11 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     OperationContextImpl(final ModelControllerImpl modelController, final ProcessType processType,
                          final RunningMode runningMode, final EnumSet<ContextFlag> contextFlags,
-                            final OperationMessageHandler messageHandler, final OperationAttachments attachments,
-                            final Resource model, final ModelController.OperationTransactionControl transactionControl,
-                            final ControlledProcessState processState, final AuditLogger auditLogger, final boolean booting,
-                            final Integer operationId, final HostServerGroupTracker hostServerGroupTracker) {
+                         final OperationMessageHandler messageHandler, final OperationAttachments attachments,
+                         final Resource model, final ModelController.OperationTransactionControl transactionControl,
+                         final ControlledProcessState processState, final AuditLogger auditLogger, final boolean booting,
+                         final Integer operationId, final HostServerGroupTracker hostServerGroupTracker,
+                         final ModelNode blockingTimeoutConfig) {
         super(processType, runningMode, transactionControl, processState, booting, auditLogger);
         this.model = model;
         this.originalModel = model;
@@ -179,6 +182,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         this.serviceTarget = new ContextServiceTarget(modelController);
         this.operationId = operationId;
         this.hostServerGroupTracker = hostServerGroupTracker;
+        this.blockingTimeoutConfig = blockingTimeoutConfig != null && blockingTimeoutConfig.isDefined() ? blockingTimeoutConfig : null;
     }
 
     public InputStream getAttachmentStream(final int index) {
@@ -193,27 +197,47 @@ final class OperationContextImpl extends AbstractOperationContext {
     }
 
     @Override
-    void awaitModelControllerContainerMonitor() throws InterruptedException {
+    void awaitServiceContainerStability() throws InterruptedException, TimeoutException {
         if (affectsRuntime) {
             MGMT_OP_LOGGER.debugf("Entered VERIFY stage; waiting for service container to settle");
-            // First wait until any removals we've initiated have begun processing, otherwise
-            // the ContainerStateMonitor may not have gotten the notification causing it to untick
-            waitForRemovals();
-            ContainerStateMonitor.ContainerStateChangeReport changeReport = modelController.awaitContainerStateChangeReport();
-            // If any services are missing, add a verification handler to see if we caused it
-            if (changeReport != null && !changeReport.getMissingServices().isEmpty()) {
-                ServiceRemovalVerificationHandler removalVerificationHandler = new ServiceRemovalVerificationHandler(changeReport);
-                addStep(new ModelNode(), new ModelNode(), PathAddress.EMPTY_ADDRESS, removalVerificationHandler, Stage.VERIFY);
+            long timeout = getBlockingTimeout().getBlockingTimeout();
+            try {
+                // First wait until any removals we've initiated have begun processing, otherwise
+                // the ContainerStateMonitor may not have gotten the notification causing it to untick
+                waitForRemovals();
+                ContainerStateMonitor.ContainerStateChangeReport changeReport =
+                        modelController.awaitContainerStateChangeReport(timeout, TimeUnit.MILLISECONDS);
+                // If any services are missing, add a verification handler to see if we caused it
+                if (changeReport != null && !changeReport.getMissingServices().isEmpty()) {
+                    ServiceRemovalVerificationHandler removalVerificationHandler = new ServiceRemovalVerificationHandler(changeReport);
+                    addStep(new ModelNode(), new ModelNode(), PathAddress.EMPTY_ADDRESS, removalVerificationHandler, Stage.VERIFY);
+                }
+            } catch (TimeoutException te) {
+                getBlockingTimeout().timeoutDetected();
+                // Deliberate log and throw; we want to log this but the caller method passes a slightly different
+                // message to the user as part of the operation response
+                MGMT_OP_LOGGER.timeoutExecutingOperation(timeout / 1000, containerMonitorStep.operationId.name, containerMonitorStep.address);
+                throw te;
             }
         }
     }
 
     @Override
-    protected void waitForRemovals() throws InterruptedException {
+    protected void waitForRemovals() throws InterruptedException, TimeoutException {
         if (affectsRuntime && !cancelled) {
             synchronized (realRemovingControllers) {
-                while (!realRemovingControllers.isEmpty() && !cancelled) {
-                    realRemovingControllers.wait();
+                long waitTime = getBlockingTimeout().getBlockingTimeout();
+                long end = System.currentTimeMillis() + waitTime;
+                boolean wait = !realRemovingControllers.isEmpty() && !cancelled;
+                while (wait && waitTime > 0) {
+                    realRemovingControllers.wait(waitTime);
+                    wait = !realRemovingControllers.isEmpty() && !cancelled;
+                    waitTime = end - System.currentTimeMillis();
+                }
+
+                if (wait) {
+                    getBlockingTimeout().timeoutDetected();
+                    throw new TimeoutException();
                 }
             }
         }
@@ -292,11 +316,8 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw MESSAGES.serviceRegistryRuntimeOperationsOnly();
         }
         authorize(false, modify ? READ_WRITE_RUNTIME : READ_RUNTIME);
-        if (modify && !affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
+        if (modify) {
+            ensureWriteLockForRuntime();
         }
         return new OperationContextServiceRegistry(modelController.getServiceRegistry());
     }
@@ -314,12 +335,7 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw MESSAGES.serviceRemovalRuntimeOperationsOnly();
         }
         authorize(false, WRITE_RUNTIME);
-        if (!affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
-        }
+        ensureWriteLockForRuntime();
         ServiceController<?> controller = modelController.getServiceRegistry().getService(name);
         if (controller != null) {
             doRemove(controller);
@@ -365,12 +381,7 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw MESSAGES.serviceRemovalRuntimeOperationsOnly();
         }
         authorize(false, WRITE_RUNTIME);
-        if (!affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
-        }
+        ensureWriteLockForRuntime();
         if (controller != null) {
             doRemove(controller);
         }
@@ -378,6 +389,7 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     private void doRemove(final ServiceController<?> controller) {
         final Step removalStep = activeStep;
+        removalStep.hasRemovals = true;
         controller.addListener(new AbstractServiceListener<Object>() {
             public void listenerAdded(final ServiceController<?> controller) {
                 synchronized (realRemovingControllers) {
@@ -417,12 +429,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         if (currentStage != Stage.RUNTIME && currentStage != Stage.VERIFY && !isRollingBack()) {
             throw MESSAGES.serviceTargetRuntimeOperationsOnly();
         }
-        if (!affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
-        }
+        ensureWriteLockForRuntime();
         return serviceTarget;
     }
 
@@ -432,7 +439,21 @@ final class OperationContextImpl extends AbstractOperationContext {
                 throw MESSAGES.invalidModificationAfterCompletedStep();
             }
             try {
-                modelController.acquireLock(operationId, respectInterruption, this);
+                // BES 2014/04/22 Ignore blocking timeout here. We risk some bug causing the
+                // lock to never be released. But we gain multiple ops being able to wait until they get
+                // a chance to run with no need to guess how long op 2 will take so we can
+                // let op 3 block for the time needed for both 1 and 2
+//                int timeout = blockingTimeout.getBlockingTimeout();
+//                if (timeout < 1) {
+                    modelController.acquireLock(operationId, respectInterruption);
+//                } else {
+//                    // Wait longer than the standard amount to get a chance to execute
+//                    // after whatever was holding the lock times out
+//                    timeout += 10;
+//                    if (!modelController.acquireLock(operationId, respectInterruption, timeout)) {
+//                        throw MESSAGES.operationTimeoutAwaitingControllerLock(timeout);
+//                    }
+//                }
                 lockStep = activeStep;
             } catch (InterruptedException e) {
                 cancelled = true;
@@ -442,26 +463,43 @@ final class OperationContextImpl extends AbstractOperationContext {
         }
     }
 
-    private void acquireContainerMonitor() {
-        if (containerMonitorStep == null) {
-            if (currentStage == Stage.DONE) {
-                throw MESSAGES.invalidModificationAfterCompletedStep();
-            }
-            modelController.acquireContainerMonitor();
-            containerMonitorStep = activeStep;
-        }
-    }
+    private void ensureWriteLockForRuntime() {
+        if (!affectsRuntime) {
+            takeWriteLock();
+            affectsRuntime = true;
+            if (containerMonitorStep == null) {
+                if (currentStage == Stage.DONE) {
+                    throw MESSAGES.invalidModificationAfterCompletedStep();
+                }
+                containerMonitorStep = activeStep;
+                int timeout = getBlockingTimeout().getBlockingTimeout();
+                try {
+                    modelController.awaitContainerStability(timeout, TimeUnit.MILLISECONDS, respectInterruption);
+                } catch (InterruptedException e) {
+                    if (resultAction != ResultAction.ROLLBACK) {
+                        // We're not on the way out, so we've been cancelled on the way in
+                        cancelled = true;
+                    }
+                    Thread.currentThread().interrupt();
+                    throw MESSAGES.operationCancelledAsynchronously();
+                } catch (TimeoutException te) {
 
-    private void awaitContainerMonitor() {
-        try {
-            modelController.awaitContainerMonitor(respectInterruption);
-        } catch (InterruptedException e) {
-            if (currentStage != Stage.DONE && resultAction != ResultAction.ROLLBACK) {
-                // We're not on the way out, so we've been cancelled on the way in
-                cancelled = true;
+                    getBlockingTimeout().timeoutDetected();
+                    // This is the first step trying to await stability for this op, so if it's
+                    // unstable some previous step must have messed it up and it can't recover.
+                    // So this process must restart.
+                    // The previous op should have set this in {@code releaseStepLocks}; doing it again
+                    // here is just a 2nd line of defense
+                    processState.setRestartRequired();// don't use our restartRequired() method as this is not reversible in rollback
+
+                    // Deliberate log and throw; we want this logged, we need to notify user, and I want slightly
+                    // different messages for both so just throwing a RuntimeException to get the automatic handling
+                    // in AbstractOperationContext.executeStep is not what I wanted
+                    MGMT_OP_LOGGER.timeoutAwaitingInitialStability(timeout / 1000, activeStep.operationId.name, activeStep.operationId.address);
+                    setRollbackOnly();
+                    throw new OperationFailedRuntimeException(MESSAGES.timeoutAwaitingInitialStability());
+                }
             }
-            Thread.currentThread().interrupt();
-            throw MESSAGES.operationCancelledAsynchronously();
         }
     }
 
@@ -840,11 +878,10 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     @Override
     void releaseStepLocks(AbstractOperationContext.Step step) {
+        boolean interrupted = false;
         try {
-            if (this.lockStep == step) {
-                modelController.releaseLock(operationId);
-                lockStep = null;
-            }
+            // Get container stability before releasing controller lock to ensure another
+            // op doesn't get in and destabilize the container.
             if (this.containerMonitorStep == step) {
                 // Note: If we allow this thread to be interrupted, an op that has been cancelled
                 // because of minor user impatience can release the controller lock while the
@@ -853,17 +890,38 @@ final class OperationContextImpl extends AbstractOperationContext {
                 // will not be cancellable. I (BES 2012/01/24) chose the former as the lesser evil.
                 // Any subsequent step that calls getServiceRegistry/getServiceTarget/removeService
                 // is going to have to await the monitor uninterruptibly anyway before proceeding.
+                long timeout = getBlockingTimeout().getBlockingTimeout();
                 try {
-                    modelController.awaitContainerMonitor(true);
+                    modelController.awaitContainerStability(timeout, TimeUnit.MILLISECONDS, true);
                 }  catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                    interrupted = true;
                     MGMT_OP_LOGGER.interruptedWaitingStability();
+                } catch (TimeoutException te) {
+                    // If we can't attain stability on the way out after rollback ops have run,
+                    // we can no longer have any sense of MSC state or how the model relates to the runtime and
+                    // we need to start from a fresh service container.
+                    processState.setRestartRequired(); // don't use our restartRequired() method as this is not reversible in rollback
+                    // Just log; this doesn't change the result of the op. And if we're not stable here
+                    // it's almost certain we never stabilized during execution or we are rolling back and destabilized there.
+                    // Either one means there is already a failure message associated with this op.
+                    MGMT_OP_LOGGER.timeoutCompletingOperation(timeout, activeStep.operationId.name, activeStep.operationId.address);
                 }
             }
+
+            if (this.lockStep == step) {
+                modelController.releaseLock(operationId);
+                lockStep = null;
+            }
         } finally {
-            if (this.containerMonitorStep == step) {
-                modelController.releaseContainerMonitor();
-                containerMonitorStep = null;
+            try {
+                if (this.containerMonitorStep == step) {
+                    modelController.logContainerStateChangesAndReset();
+                    containerMonitorStep = null;
+                }
+            } finally {
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }
@@ -973,7 +1031,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         if (authResp == null) {
             // Non-existent resource type or operation. This is permitted but will fail
             // later for reasons unrelated to authz
-            return authResp;
+            return null;
         }
         Environment callEnvironment = getCallEnvironment();
         if (authResp.getResourceResult(ActionEffect.ADDRESS) == null) {
@@ -1295,6 +1353,17 @@ final class OperationContextImpl extends AbstractOperationContext {
         }
     }
 
+    private BlockingTimeout getBlockingTimeout() {
+        if (blockingTimeout == null) {
+            synchronized (this) {
+                if (blockingTimeout == null) {
+                    blockingTimeout = new BlockingTimeout(blockingTimeoutConfig);
+                }
+            }
+        }
+        return blockingTimeout;
+    }
+
     class ContextServiceTarget implements ServiceTarget {
 
         private final ModelControllerImpl modelController;
@@ -1328,22 +1397,28 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceTarget addListener(final ServiceListener<Object> listener) {
             throw new UnsupportedOperationException();
         }
 
-        public ServiceTarget addListener(final ServiceListener<Object>... listeners) {
+        @SafeVarargs
+        @SuppressWarnings("deprecation")
+        public final ServiceTarget addListener(final ServiceListener<Object>... listeners) {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceTarget addListener(final Collection<ServiceListener<Object>> listeners) {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceTarget removeListener(final ServiceListener<Object> listener) {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public Set<ServiceListener<Object>> getListeners() {
             throw new UnsupportedOperationException();
         }
@@ -1472,29 +1547,36 @@ final class OperationContextImpl extends AbstractOperationContext {
             return this;
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceBuilder<T> addListener(final ServiceListener<? super T> listener) {
             realBuilder.addListener(listener);
             return this;
         }
 
-        public ServiceBuilder<T> addListener(final ServiceListener<? super T>... listeners) {
+        @SafeVarargs
+        @SuppressWarnings("deprecation")
+        public final ServiceBuilder<T> addListener(final ServiceListener<? super T>... listeners) {
             realBuilder.addListener(listeners);
             return this;
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceBuilder<T> addListener(final Collection<? extends ServiceListener<? super T>> listeners) {
             realBuilder.addListener(listeners);
             return this;
         }
 
         public ServiceController<T> install() throws ServiceRegistryException, IllegalStateException {
-            final Map<ServiceName, ServiceController<?>> map = realRemovingControllers;
-            synchronized (map) {
+            synchronized (realRemovingControllers) {
                 boolean intr = false;
                 try {
-                    while (map.containsKey(name)) {
+                    boolean containsKey = realRemovingControllers.containsKey(name);
+                    long timeout = getBlockingTimeout().getBlockingTimeout();
+                    long waitTime = timeout;
+                    long end = System.currentTimeMillis() + waitTime;
+                    while (containsKey && waitTime > 0) {
                         try {
-                            map.wait();
+                            realRemovingControllers.wait(waitTime);
                         } catch (InterruptedException e) {
                             intr = true;
                             if (respectInterruption) {
@@ -1502,6 +1584,13 @@ final class OperationContextImpl extends AbstractOperationContext {
                                 throw MESSAGES.serviceInstallCancelled();
                             } // else keep waiting and mark the thread interrupted at the end
                         }
+                        containsKey = realRemovingControllers.containsKey(name);
+                        waitTime = end - System.currentTimeMillis();
+                    }
+
+                    if (containsKey) {
+                        // We timed out
+                        throw MESSAGES.serviceInstallTimedOut(timeout, name);
                     }
 
                     // If a step removed this ServiceName before, it's no longer responsible
@@ -1665,10 +1754,12 @@ final class OperationContextImpl extends AbstractOperationContext {
             return controller.getAliases();
         }
 
+        @SuppressWarnings("deprecation")
         public void addListener(ServiceListener<? super S> serviceListener) {
             controller.addListener(serviceListener);
         }
 
+        @SuppressWarnings("deprecation")
         public void removeListener(ServiceListener<? super S> serviceListener) {
             controller.removeListener(serviceListener);
         }

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -205,7 +205,7 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     public void acquireControllerLock() {
         if(lockStep == null) {
             try {
-                controller.acquireLock(operationId, true, this);
+                controller.acquireLock(operationId, true);
                 lockStep = activeStep;
             } catch (InterruptedException e) {
                 cancelled = true;
@@ -311,7 +311,7 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     }
 
     @Override
-    void awaitModelControllerContainerMonitor() throws InterruptedException {
+    void awaitServiceContainerStability() throws InterruptedException {
         // ignored
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -66,7 +66,7 @@ class ReadOnlyContext extends AbstractOperationContext {
     }
 
     @Override
-    void awaitModelControllerContainerMonitor() throws InterruptedException {
+    void awaitServiceContainerStability() throws InterruptedException {
         // nothing here
     }
 
@@ -158,7 +158,7 @@ class ReadOnlyContext extends AbstractOperationContext {
     public void acquireControllerLock() {
         if (lockStep == null) {
             try {
-                controller.acquireLock(operationId, true, this);
+                controller.acquireLock(operationId, true);
                 lockStep = activeStep;
             } catch (InterruptedException e) {
                 cancelled = true;

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -67,6 +67,7 @@ public class ModelDescriptionConstants {
     public static final String BASE_DN = "base-dn";
     public static final String BASE_ROLE = "base-role";
     public static final String BLOCKING = "blocking";
+    public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BOOT_TIME = "boot-time";
     public static final String BYTES = "bytes";
     public static final String CALLER_TYPE = "caller-type";

--- a/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
@@ -1,0 +1,353 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING_TIMEOUT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests of ability to time out operations. WFLY-2741.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class OperationTimeoutUnitTestCase {
+
+    private static final Executor executor = Executors.newCachedThreadPool();
+
+    private static CountDownLatch blockObject;
+    private static CountDownLatch latch;
+    private ServiceContainer container;
+    private ModelControllerService controllerService;
+    private ModelControllerClient client;
+
+    @Before
+    public void setupController() throws InterruptedException {
+
+        // restore default
+        blockObject = new CountDownLatch(1);
+        latch = new CountDownLatch(1);
+
+        System.out.println("=========  New Test \n");
+        container = ServiceContainer.Factory.create("test");
+        ServiceTarget target = container.subTarget();
+        controllerService = new ModelControllerService();
+        ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), controllerService);
+        builder.install();
+        controllerService.awaitStartup(30, TimeUnit.SECONDS);
+        ModelController controller = controllerService.getValue();
+        ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
+        controller.execute(setup, null, null, null);
+
+        client = controller.createClient(executor);
+
+        System.setProperty(BlockingTimeout.SYSTEM_PROPERTY, "1");
+    }
+
+    @After
+    public void shutdownServiceContainer() {
+
+        System.clearProperty(BlockingTimeout.SYSTEM_PROPERTY);
+
+        releaseBlockingThreads();
+
+        if (client != null) {
+            try {
+                client.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+    }
+
+    @Test
+    public void testOperationHeaderConfig() throws InterruptedException, ExecutionException, TimeoutException {
+        blockInVerifyTest(new ModelNode(1));
+    }
+
+    @Test
+    public void testBlockInVerify() throws InterruptedException, ExecutionException, TimeoutException {
+        blockInVerifyTest(null);
+    }
+
+    private void blockInVerifyTest(ModelNode header) throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("start").set(true);
+        if (header != null) {
+            op.get(OPERATION_HEADERS, BLOCKING_TIMEOUT).set(1);
+            System.setProperty(BlockingTimeout.SYSTEM_PROPERTY, "300");
+        }
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerMessages.MESSAGES.timeoutExecutingOperation()));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testBlockInRollback() throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("fail").set(true);
+        op.get("stop").set(true);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("failfailfail"));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testBlockInBoth() throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("start").set(true);
+        op.get("stop").set(true);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerMessages.MESSAGES.timeoutExecutingOperation()));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testBlockAwaitingRuntimeLock() throws InterruptedException, ExecutionException, TimeoutException {
+
+        // Get the service container fubar
+        blockInVerifyTest(null);
+
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("start").set(false);
+        op.get("stop").set(false);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerMessages.MESSAGES.timeoutAwaitingInitialStability()));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testRepairInRollback() throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("fail").set(true);
+        op.get("start").set(true);
+        op.get("repair").set(true);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("failfailfail"));
+
+        // We should be in RUNNING state because stability could be obtained before the op completed
+        assertEquals(ControlledProcessState.State.RUNNING, controllerService.getCurrentProcessState());
+    }
+
+
+    private static void releaseBlockingThreads() {
+        if (blockObject != null) {
+            blockObject.countDown();
+        }
+    }
+
+    private static void block() {
+        latch.countDown();
+        try {
+            blockObject.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class ModelControllerService extends TestModelControllerService {
+
+        @Override
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+
+            rootRegistration.registerOperationHandler("setup", new SetupHandler(), DESC_PROVIDER, false);
+            rootRegistration.registerOperationHandler("block", new BlockingServiceHandler(), DESC_PROVIDER, false);
+
+            GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+        }
+    }
+
+    public static class SetupHandler implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) {
+            ModelNode model = new ModelNode();
+
+            //Atttributes
+            model.get("attr1").set(1);
+            model.get("attr2").set(2);
+
+            context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel().set(model);
+
+            final ModelNode child1 = new ModelNode();
+            child1.get("attribute1").set(1);
+            final ModelNode child2 = new ModelNode();
+            child2.get("attribute2").set(2);
+
+            context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "one"))).getModel().set(child1);
+            context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "two"))).getModel().set(child2);
+
+            context.stepCompleted();
+        }
+    }
+
+    public static class BlockingServiceHandler implements OperationStepHandler {
+        @Override
+        public void execute(OperationContext context, ModelNode operation) {
+
+            context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
+
+            context.addStep(new OperationStepHandler() {
+
+                @Override
+                public void execute(final OperationContext context, ModelNode operation) {
+
+                    boolean start = operation.get("start").asBoolean(false);
+                    boolean stop = operation.get("stop").asBoolean(false);
+                    boolean fail = operation.get("fail").asBoolean(false);
+                    final boolean repair = fail && operation.get("repair").asBoolean(false);
+
+                    BlockingService bad = start ? (stop ? BlockingService.BOTH : BlockingService.START)
+                                                : (stop ? BlockingService.STOP : BlockingService.NEITHER);
+
+                    final ServiceName svcName = ServiceName.JBOSS.append("bad-service");
+                    ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
+                    context.getServiceTarget().addService(svcName, bad)
+                            .addListener(verificationHandler)
+                            .install();
+                    context.addStep(verificationHandler, OperationContext.Stage.VERIFY);
+
+                    if (fail) {
+                        context.setRollbackOnly();
+                        context.getFailureDescription().set("failfailfail");
+                    }
+                    context.completeStep(new OperationContext.ResultHandler() {
+
+                        @Override
+                        public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                            if (repair) {
+                                releaseBlockingThreads();
+                            }
+                            context.removeService(svcName);
+                        }
+                    });
+
+                }
+            }, OperationContext.Stage.RUNTIME);
+
+            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        }
+    }
+
+    private static class BlockingService implements Service<Void> {
+
+        private static final BlockingService START = new BlockingService(true, false);
+        private static final BlockingService STOP = new BlockingService(false, true);
+        private static final BlockingService BOTH = new BlockingService(true, true);
+        private static final BlockingService NEITHER = new BlockingService(false, false);
+
+        private final boolean start;
+        private final boolean stop;
+
+        private BlockingService(boolean start, boolean stop) {
+            this.start = start;
+            this.stop = stop;
+        }
+
+        @Override
+        public Void getValue() throws IllegalStateException, IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public void start(StartContext context) throws StartException {
+            if (start) {
+                block();
+            }
+        }
+
+        @Override
+        public void stop(StopContext context) {
+            if (stop) {
+                block();
+            }
+        }
+    }
+}

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostShutdownHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostShutdownHandler.java
@@ -19,6 +19,8 @@
 package org.jboss.as.host.controller.operations;
 
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -26,6 +28,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.domain.controller.DomainController;
@@ -70,8 +73,15 @@ public class HostShutdownHandler implements OperationStepHandler {
         context.addStep(new OperationStepHandler() {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                // Even though we don't read from the service registry, we are modifying a service
-                context.getServiceRegistry(true);
+                // WFLY-2741 -- DO NOT call context.getServiceRegistry(true) as that will trigger blocking for
+                // service container stability and one use case for this op is to recover from a
+                // messed up service container from a previous op. Instead just ask for authorization.
+                // Note that we already have the exclusive lock, so we are just skipping waiting for stability.
+                // If another op that is a step in a composite step with this op needs to modify the container
+                // it will have to wait for container stability, so skipping this only matters for the case
+                // where this step is the only runtime change.
+//                context.getServiceRegistry(true);
+                context.authorize(operation, EnumSet.of(Action.ActionEffect.WRITE_RUNTIME));
                 if (restart) {
                     //Add the exit code so that we get respawned
                     domainController.stopLocalHost(ExitCodes.RESTART_PROCESS_FROM_STARTUP_SCRIPT);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/extension/remove/module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/extension/remove/module.xml
@@ -25,7 +25,7 @@
 <module xmlns="urn:jboss:module:1.1" name="extensionremovemodule">
 
     <resources>
-        <resource-root path="extension-remove-module.jar"/>
+        <resource-root path="test-extension.jar"/>
     </resources>
 
     <dependencies>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ManagementOpTimeoutTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ManagementOpTimeoutTestCase.java
@@ -1,0 +1,154 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.controller.ControllerMessages;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.extension.blocker.BlockerExtension;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.xnio.IoUtils;
+
+/**
+ * Integration test of management op timeout handling. This test focuses on the CLI handling
+ * of the 'blocking-timeout' operation header and on the ability to restart the server with
+ * a MSC thread hanging in start.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ManagementOpTimeoutTestCase extends AbstractCliTestBase {
+
+    public static final String DEFAULT_JBOSSAS = "default-jbossas";
+    public static final String DEPLOYMENT_NAME = "DUMMY";
+
+    @ArquillianResource
+    private static ContainerController container;
+
+    //NOTE: BeforeClass is not subject to ARQ injection.
+    @Before
+    public void initServer() throws Exception {
+        container.start(DEFAULT_JBOSSAS);
+        initCLI();
+        ExtensionUtils.createExtensionModule("org.wildfly.extension.blocker-test", BlockerExtension.class,
+                EmptySubsystemParser.class.getPackage());
+    }
+
+    @After
+    public void closeServer() throws Exception {
+        cli.sendLine("/subsystem=blocker-test:remove", true);
+        cli.sendLine("/extension=org.wildfly.extension.blocker-test:remove");
+        closeCLI();
+        container.stop(DEFAULT_JBOSSAS);
+        ExtensionUtils.deleteExtensionModule("org.wildfly.extension.blocker-test");
+    }
+
+    @Test
+    public void testTimeoutCausesRestartRequired() throws Exception {
+        // Add the extension and subsystem
+        cli.sendLine("/extension=org.wildfly.extension.blocker-test:add");
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        cli.sendLine("/subsystem=blocker-test:add");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+
+        // Trigger a hang, but with a short timeout
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Throwable[] holder = new Throwable[1];
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                block(latch, holder);
+            }
+        };
+        Thread t = new Thread(r);
+        t.setDaemon(true);
+        t.start();
+
+        assertTrue(latch.await(20, TimeUnit.SECONDS));
+        assertNull(holder[0]);
+    }
+
+    private void block(CountDownLatch latch, Throwable[] holder) {
+
+        try {
+            cli.sendLine("/subsystem=blocker-test:block(block-point=SERVICE_START,block-time=10000){blocking-timeout=1}", true);
+            CLIOpResult result = cli.readAllAsOpResult();
+            assertFalse(result.isIsOutcomeSuccess());
+            checkResponseHeadersForProcessState(result, "restart-required");
+            ModelNode response = result.getResponseNode();
+            assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerMessages.MESSAGES.timeoutExecutingOperation()));
+        } catch (Throwable t) {
+            holder[0] = t;
+        }
+        latch.countDown();
+    }
+
+    protected void checkResponseHeadersForProcessState(CLIOpResult result, String requiredState) {
+        assertNotNull("No response headers!", result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS));
+        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
+        Object processState = responseHeaders.get("process-state");
+        assertNotNull("No process state in response-headers!", processState);
+        assertTrue("Process state is of wrong type!", processState instanceof String);
+        assertEquals("Wrong content of process-state header", requiredState, (String) processState);
+
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/EmptySubsystemParser.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/EmptySubsystemParser.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension;
+
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+* Handles xml parsing/marshalling for a subsystem with no child elements or attributes.
+*
+* @author Brian Stansberry (c) 2014 Red Hat Inc.
+*/
+public class EmptySubsystemParser implements XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+
+    private final String namespace;
+
+    public EmptySubsystemParser(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public void readElement(XMLExtendedStreamReader reader, List<ModelNode> value) throws XMLStreamException {
+        ParseUtils.requireNoAttributes(reader);
+        ParseUtils.requireNoContent(reader);
+    }
+
+    @Override
+    public void writeContent(XMLExtendedStreamWriter streamWriter, SubsystemMarshallingContext context) throws XMLStreamException {
+        context.startSubsystemElement(namespace, false);
+        streamWriter.writeEndElement();
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/ExtensionUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/ExtensionUtils.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.StreamExporter;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.xnio.IoUtils;
+
+/**
+ * Utilities for manipulating extensions in integration tests.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class ExtensionUtils {
+
+    public static final String JAR_NAME = "test-extension.jar";
+
+    public static void createExtensionModule(String extensionName, Class<? extends Extension> extension) throws IOException {
+        createExtensionModule(getExtensionModuleRoot(extensionName), extension);
+    }
+
+    public static void createExtensionModule(String extensionName, Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
+        createExtensionModule(getExtensionModuleRoot(extensionName), extension, additionalPackages);
+    }
+
+    public static void createExtensionModule(File extensionModuleRoot, Class<? extends Extension> extension) throws IOException {
+        createExtensionModule(extensionModuleRoot, extension, new Package[0]);
+    }
+
+    public static void createExtensionModule(File extensionModuleRoot, Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
+
+        deleteRecursively(extensionModuleRoot);
+
+        if (extensionModuleRoot.exists()) {
+            throw new IllegalArgumentException(extensionModuleRoot + " already exists");
+        }
+        File file = new File(extensionModuleRoot, "main");
+        if (!file.mkdirs()) {
+            throw new IllegalArgumentException("Could not create " + file);
+        }
+        final InputStream is = createResourceRoot(extension, additionalPackages).exportAsInputStream();
+        try {
+            copyFile(new File(file, JAR_NAME), is);
+        } finally {
+            IoUtils.safeClose(is);
+        }
+
+        URL url = extension.getResource("module.xml");
+        if (url == null) {
+            throw new IllegalStateException("Could not find module.xml");
+        }
+        copyFile(new File(file, "module.xml"), url.openStream());
+    }
+
+    public static void deleteExtensionModule(String moduleName) {
+        deleteRecursively(getExtensionModuleRoot(moduleName));
+    }
+
+    public static void deleteExtensionModule(File extensionModuleRoot) {
+        deleteRecursively(extensionModuleRoot);
+    }
+
+    private static void copyFile(File target, InputStream src) throws IOException {
+        final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(target));
+        try {
+            int i = src.read();
+            while (i != -1) {
+                out.write(i);
+                i = src.read();
+            }
+        } finally {
+            IoUtils.safeClose(out);
+        }
+    }
+
+    public static File getModulePath() {
+        String modulePath = System.getProperty("module.path", null);
+        if (modulePath == null) {
+            String jbossHome = System.getProperty("jboss.home", null);
+            if (jbossHome == null) {
+                throw new IllegalStateException("Neither -Dmodule.path nor -Djboss.home were set");
+            }
+            modulePath = jbossHome + File.separatorChar + "modules";
+        }else{
+            modulePath = modulePath.split(File.pathSeparator)[0];
+        }
+        File moduleDir = new File(modulePath);
+        if (!moduleDir.exists()) {
+            throw new IllegalStateException("Determined module path does not exist");
+        }
+        if (!moduleDir.isDirectory()) {
+            throw new IllegalStateException("Determined module path is not a dir");
+        }
+        return moduleDir;
+    }
+
+    private static File getExtensionModuleRoot(String extensionName) {
+        File file = getModulePath();
+        for (String element : extensionName.split("\\.")) {
+            file = new File(file, element);
+        }
+        return file;
+    }
+
+    private static StreamExporter createResourceRoot(Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
+        archive.addPackage(extension.getPackage());
+        if (additionalPackages != null) {
+            for (Package pkg : additionalPackages) {
+                archive.addPackage(pkg);
+            }
+        }
+        archive.addAsServiceProvider(Extension.class, extension);
+        return archive.as(ZipExporter.class);
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file.exists()) {
+            if (file.isDirectory()) {
+                for (String name : file.list()) {
+                    deleteRecursively(new File(file, name));
+                }
+            }
+            assert file.delete();
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -1,0 +1,328 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension.blocker;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * Extension that can block threads.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class BlockerExtension implements Extension {
+
+    public static final String MODULE_NAME = "org.wildfly.extension.blocker-test";
+    public static final String SUBSYSTEM_NAME = "blocker-test";
+    public static final AttributeDefinition TARGET_HOST = SimpleAttributeDefinitionBuilder.create(HOST, ModelType.STRING, true).build();
+    public static final AttributeDefinition TARGET_SERVER = SimpleAttributeDefinitionBuilder.create(SERVER, ModelType.STRING, true).build();
+    public static final AttributeDefinition BLOCK_POINT = SimpleAttributeDefinitionBuilder.create("block-point", ModelType.STRING)
+            .setValidator(EnumValidator.create(BlockPoint.class, false, false))
+            .build();
+    public static final AttributeDefinition BLOCK_TIME = SimpleAttributeDefinitionBuilder.create("block-time", ModelType.LONG, true)
+            .setDefaultValue(new ModelNode(20000))
+            .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
+            .build();
+
+    public static final AttributeDefinition FOO = SimpleAttributeDefinitionBuilder.create("foo", ModelType.BOOLEAN, true).build();
+
+
+    private static final EmptySubsystemParser PARSER = new EmptySubsystemParser("urn:wildfly:extension:blocker-test:1.0");
+    private static final Logger log = Logger.getLogger(BlockerExtension.class.getCanonicalName());
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0, 0);
+        subsystem.registerSubsystemModel(new BlockerSubsystemResourceDefinition(context.getProcessType() == ProcessType.HOST_CONTROLLER));
+        subsystem.registerXMLElementWriter(PARSER);
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, PARSER.getNamespace(), PARSER);
+    }
+
+    private static class BlockerSubsystemResourceDefinition extends SimpleResourceDefinition {
+
+        private final boolean forHost;
+        private BlockerSubsystemResourceDefinition(boolean forHost) {
+            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
+                    new AbstractAddStepHandler(),
+                    ReloadRequiredRemoveStepHandler.INSTANCE);
+            this.forHost = forHost;
+        }
+
+        @Override
+        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+            super.registerOperations(resourceRegistration);
+            resourceRegistration.registerOperationHandler(BlockHandler.DEFINITION, new BlockHandler());
+            if (forHost) {
+                resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+            }
+            log.info("Registered blocker-test operations");
+        }
+
+        @Override
+        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+            super.registerAttributes(resourceRegistration);
+            resourceRegistration.registerReadWriteAttribute(FOO, null, new ModelOnlyWriteAttributeHandler(FOO));
+        }
+    }
+
+    public static enum BlockPoint {
+        MODEL,
+        RUNTIME,
+        SERVICE_START,
+        SERVICE_STOP,
+        VERIFY,
+        COMMIT,
+        ROLLBACK
+    }
+
+    private static class BlockHandler implements OperationStepHandler {
+
+        private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", new NonResolvingResourceDescriptionResolver())
+                .setParameters(TARGET_HOST, TARGET_SERVER, BLOCK_POINT, BLOCK_TIME)
+                .build();
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            log.info("block requested");
+            boolean forMe = false;
+            if (context.getProcessType() == ProcessType.STANDALONE_SERVER) {
+                forMe = true;
+            } else {
+                Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
+                ModelNode targetServer = TARGET_SERVER.resolveModelAttribute(context, operation);
+                if (targetServer.isDefined()) {
+                    if (context.getProcessType().isServer()) {
+                        String name = System.getProperty(ServerEnvironment.SERVER_NAME);
+                        log.info("name is " + name);
+                        forMe = targetServer.asString().equals(name);
+                    }
+                } else if (context.getProcessType() == ProcessType.HOST_CONTROLLER) {
+                    Set<String> hosts = rootResource.getChildrenNames(HOST);
+                    String name;
+                    if (hosts.size() > 1) {
+                        name = "master";
+                    } else {
+                        name = hosts.iterator().next();
+                    }
+                    log.info("name is " + name);
+                    ModelNode targetHost = TARGET_HOST.resolveModelAttribute(context, operation);
+                    if (!targetHost.isDefined()) {
+                        throw new OperationFailedException("target-host required");
+                    }
+                    forMe = targetHost.asString().equals(name);
+                }
+            }
+            if (forMe) {
+                final long blockTime = BLOCK_TIME.resolveModelAttribute(context, operation).asLong();
+                final BlockPoint blockPoint = BlockPoint.valueOf(BLOCK_POINT.resolveModelAttribute(context, operation).asString());
+                log.info("will block at " + blockPoint + " for " + blockTime);
+                switch (blockPoint) {
+                    case MODEL: {
+                        block(blockTime);
+                        break;
+                    }
+                    case RUNTIME: {
+                        context.addStep(new BlockStep(blockTime), OperationContext.Stage.RUNTIME);
+                        break;
+                    }
+                    case SERVICE_START:
+                    case SERVICE_STOP: {
+                        context.addStep(new OperationStepHandler() {
+                            @Override
+                            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                BlockingService service = new BlockingService(blockTime, blockPoint == BlockPoint.SERVICE_START);
+
+                                context.getServiceTarget().addService(BlockingService.SERVICE_NAME, service).install();
+
+                                context.completeStep(new OperationContext.ResultHandler() {
+                                    @Override
+                                    public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                                        log.info("BlockingService step completed: result = " + resultAction);
+                                        context.removeService(BlockingService.SERVICE_NAME);
+                                    }
+                                });
+                            }
+                        }, OperationContext.Stage.RUNTIME);
+                        break;
+                    }
+                    case VERIFY: {
+                        context.addStep(new BlockStep(blockTime), OperationContext.Stage.VERIFY);
+                        break;
+                    }
+                    case ROLLBACK:
+                        context.addStep(new OperationStepHandler() {
+                            @Override
+                            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                context.getFailureDescription().set("rollback");
+                                context.setRollbackOnly();
+                                context.stepCompleted();
+                            }
+                        }, OperationContext.Stage.MODEL);
+                        break;
+                    case COMMIT:
+                        break;
+                    default:
+                        throw new IllegalStateException(blockPoint.toString());
+                }
+                context.completeStep(new OperationContext.ResultHandler() {
+                    @Override
+                    public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                        if ((blockPoint == BlockPoint.COMMIT && resultAction == OperationContext.ResultAction.KEEP)
+                            || (blockPoint == BlockPoint.ROLLBACK && resultAction == OperationContext.ResultAction.ROLLBACK)) {
+                            block(blockTime);
+                        }
+                    }
+                });
+            } else {
+
+                context.stepCompleted();
+            }
+        }
+
+        private static void block(long time) {
+            try {
+                log.info("blocking");
+                Thread.sleep(time);
+            } catch (InterruptedException e) {
+                log.info("interrupted");
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static class BlockStep implements OperationStepHandler {
+            private final long blockTime;
+
+            private BlockStep(long blockTime) {
+                this.blockTime = blockTime;
+            }
+
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                block(blockTime);
+                context.stepCompleted();
+            }
+        }
+    }
+
+    private static class BlockingService implements Service<BlockingService> {
+
+        private static final ServiceName SERVICE_NAME = ServiceName.of("jboss", "test", "blocking-service");
+        private final long blockTime;
+        private final boolean blockStart;
+
+        private final Object waitObject = new Object();
+
+        private BlockingService(long blockTime, boolean blockStart) {
+            this.blockTime = blockTime;
+            this.blockStart = blockStart;
+        }
+
+        @Override
+        public void start(final StartContext context) throws StartException {
+            if (blockStart) {
+//                Runnable r = new Runnable() {
+//                    @Override
+//                    public void run() {
+                        try {
+                            synchronized (waitObject) {
+                                log.info("BlockService blocking in start");
+                                waitObject.wait(blockTime);
+                            }
+                            context.complete();
+                        } catch (InterruptedException e) {
+                            log.info("BlockService interrupted");
+//                            context.failed(new StartException(e));
+                            throw new StartException(e);
+                        }
+//                    }
+//                };
+//                Thread thread = new Thread(r);
+//                thread.start();
+//                context.asynchronous();
+            } else {
+                // Not yet used
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        @Override
+        public void stop(final StopContext context) {
+            if (!blockStart) {
+                // Not yet used
+                throw new UnsupportedOperationException();
+            } else {
+                synchronized (waitObject) {
+                    log.info("BlockService Stopping");
+                    waitObject.notifyAll();
+                }
+            }
+        }
+
+        @Override
+        public BlockingService getValue() throws IllegalStateException, IllegalArgumentException {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/blocker/module.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/blocker/module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.blocker-test">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="test-extension.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.msc"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
Limit the time operation execution can block in various places, 300 secs by default, with the overall setting configurable via sys prop and the ability to override on a per-op basis using an operation header.

If an op times out, further blocking points during rollback will only wait 5 secs. Otherwise the various blocking points that come up could result in waiting 300 secs several more times, which IMO is excessive.

If the service container cannot reach stability by the time the op releases locks, the process is placed in restart-required state. Not reload-required as a reload does not result in a new service container.
