### PR TITLE
[WFLY-3294] Improve wildfly-init-debian.sh

### DIFF
--- a/build/src/main/resources/bin/init.d/wildfly.conf
+++ b/build/src/main/resources/bin/init.d/wildfly.conf
@@ -2,39 +2,30 @@
 # not necessarily for JBoss AS itself.
 # default location: /etc/default/wildfly
 
-# Location of JDK	
-#
-# JAVA_HOME=/usr/lib/jvm/default-java
+## Location of JDK	
+# JAVA_HOME="/usr/lib/jvm/default-java"
 
-# Location of WildFly
-#
-# JBOSS_HOME=/opt/wildfly
+## Location of WildFly
+# JBOSS_HOME="/opt/wildfly"
 
-# The username who should own the process.
-#
+## The username who should own the process.
 # JBOSS_USER=wildfly
 
-# The mode WildFly should start, standalone or domain
-#
+## The mode WildFly should start, standalone or domain
 # JBOSS_MODE=standalone
 
-# Configuration for standalone mode
-#
+## Configuration for standalone mode
 # JBOSS_CONFIG=standalone.xml
 
-# Configuration for domain mode
-#
+## Configuration for domain mode
 # JBOSS_DOMAIN_CONFIG=domain.xml
 # JBOSS_HOST_CONFIG=host-master.xml
 
-# The amount of time to wait for startup
-#
+## The amount of time to wait for startup
 # STARTUP_WAIT=60
 
-# The amount of time to wait for shutdown
-#
+## The amount of time to wait for shutdown
 # SHUTDOWN_WAIT=60
 
-# Location to keep the console log
-#
-# JBOSS_CONSOLE_LOG=/var/log/wildfly/console.log
+## Location to keep the console log
+# JBOSS_CONSOLE_LOG="/var/log/wildfly/console.log"


### PR DESCRIPTION
The script wildfly-init-debian.sh needs to check if the user running the server is owner of the wildfly folder and add the possibility to run even if the path has spaces.

This should be a low impact change, so is possible to include it in 8.1.0.Final
