### PR TITLE
[WFLY-3306] Don't fail in read-children-names/resources for valid child ...

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -419,6 +419,14 @@ public class GlobalOperationHandlers {
             }
         }
 
+        // WFLY-3306 Ensure we have an entry for any valid child type
+        for (String type : registry.getChildNames(PathAddress.EMPTY_ADDRESS)) {
+            if ((validChildType == null || validChildType.equals(validChildType))
+                && !result.containsKey(type)) {
+                result.put(type, Collections.<String>emptySet());
+            }
+        }
+
         return result;
     }
 


### PR DESCRIPTION
...types with no actual registrations
