### PR TITLE
[WFLY-3305] : :deploy after :undeploy is broken

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deployment/StandaloneDeploymentTestCase.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/deployment/StandaloneDeploymentTestCase.java
@@ -437,7 +437,11 @@ public class StandaloneDeploymentTestCase extends AbstractCoreModelTest {
         op = Util.createOperation(DeploymentFullReplaceHandler.OPERATION_NAME, PathAddress.EMPTY_ADDRESS);
         op.get(NAME).set("Test1");
         op.get(CONTENT).add(getByteContent(6, 7, 8, 9, 10));
+        boolean persistent = op.get(PERSISTENT).asBoolean(true);
+        //we need to remove the persistent atrtribute as it is masked from the user
+        op.remove(PERSISTENT);
         kernelServices.validateOperation(op);
+        op.get(PERSISTENT).set(persistent);
         ModelTestUtils.checkOutcome(kernelServices.executeOperation(op));
         ModelNode newHash = checkSingleDeployment(kernelServices, "Test1", false);
         Assert.assertFalse(originalHash.equals(newHash));
@@ -447,14 +451,20 @@ public class StandaloneDeploymentTestCase extends AbstractCoreModelTest {
         ModelNode hashContent = new ModelNode();
         hashContent.get(HASH).set(newHash);
         op.get(CONTENT).add(hashContent);
+         //we need to remove the persistent atrtribute as it is masked from the user
+        op.remove(PERSISTENT);
         kernelServices.validateOperation(op);
+        op.get(PERSISTENT).set(persistent);
         ModelTestUtils.checkOutcome(kernelServices.executeOperation(op));
         Assert.assertEquals(newHash, checkSingleDeployment(kernelServices, "Test1", false));
 
         op = op.clone();
         op.get(CONTENT).clear();
         op.get(CONTENT).add(getFileUrl("Test1", 1, 2, 3, 4, 5));
+         //we need to remove the persistent atrtribute as it is masked from the user
+        op.remove(PERSISTENT);
         kernelServices.validateOperation(op);
+        op.get(PERSISTENT).set(persistent);
         ModelTestUtils.checkOutcome(kernelServices.executeOperation(op));
         Assert.assertEquals(originalHash, checkSingleDeployment(kernelServices, "Test1", false));
 
@@ -467,7 +477,10 @@ public class StandaloneDeploymentTestCase extends AbstractCoreModelTest {
         op.get(CONTENT).clear();
         op.get(CONTENT).add(getInputStreamIndexContent());
         op.get(RUNTIME_NAME).set("number1");
+        //we need to remove the persistent atrtribute as it is masked from the user
+        op.remove(PERSISTENT);
         kernelServices.validateOperation(op);
+        op.get(PERSISTENT).set(persistent);
         ModelTestUtils.checkOutcome(kernelServices.executeOperation(op, new ByteArrayInputStream(new byte[] {6, 7, 8, 9, 10})));
         ModelNode deployments = getDeploymentParentResource(kernelServices);
         Assert.assertEquals(1, deployments.keys().size());
@@ -522,7 +535,11 @@ public class StandaloneDeploymentTestCase extends AbstractCoreModelTest {
         contentNode.get(PATH).set(file1.getName());
         op.get(CONTENT).clear();
         op.get(CONTENT).add(contentNode);
+        boolean persistent = op.get(PERSISTENT).asBoolean(false);
+        //we need to remove the persistent atrtribute as it is masked from the user
+        op.remove(PERSISTENT);
         kernelServices.validateOperation(op);
+        op.get(PERSISTENT).set(persistent);
         ModelTestUtils.checkOutcome(kernelServices.executeOperation(op));
         currentContent = checkSingleUnmanagedDeployment(kernelServices, "Test1", false);
         checkUnmanagedContents(file1, currentContent, true, false);

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentOperations.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentOperations.java
@@ -24,6 +24,7 @@ package org.jboss.as.server.deployment.scanner;
 
 import java.io.Closeable;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -40,6 +41,8 @@ public interface DeploymentOperations extends Closeable {
     Future<ModelNode> deploy(final ModelNode operation, final ScheduledExecutorService scheduledExecutor);
 
     Map<String, Boolean> getDeploymentsStatus();
+
+    Set<String> getPersistentDeployments();
 
     interface Factory {
         DeploymentOperations create();

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/DeploymentScannerAdd.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
@@ -302,6 +303,11 @@ class DeploymentScannerAdd implements OperationStepHandler {
         @Override
         public void close() throws IOException {
 
+        }
+
+        @Override
+        public Set<String> getPersistentDeployments() {
+            return Collections.emptySet();
         }
     }
 }

--- a/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/logging/DeploymentScannerLogger.java
+++ b/deployment-scanner/src/main/java/org/jboss/as/server/deployment/scanner/logging/DeploymentScannerLogger.java
@@ -376,4 +376,13 @@ public interface DeploymentScannerLogger extends BasicLogger {
 
     @Message(id = 32, value = "Failed to list files in directory %s. Check that the contents of the directory are readable.")
     RuntimeException cannotListDirectoryFiles(File directory);
+
+    @LogMessage(level = INFO)
+    @Message(id = 33, value = "Deployment %s was previously undeployed by this scanner but has been redeployed by another "
+            + "management tool. Marker file %s is being removed to record this fact.")
+    void scannerDeploymentRedeployedButNotByScanner(String deploymentName, File marker);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 34, value = "Failed synchronizing status of deployment %s.")
+    void failedStatusSynchronization(@Cause Throwable cause, String deploymentName);
 }

--- a/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
+++ b/server/src/main/java/org/jboss/as/server/deployment/DeploymentFullReplaceHandler.java
@@ -26,6 +26,7 @@ import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONT
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_PATH;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.CONTENT_RELATIVE_TO;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.ENABLED;
+import static org.jboss.as.server.controller.resources.DeploymentAttributes.PERSISTENT;
 import static org.jboss.as.server.controller.resources.DeploymentAttributes.RUNTIME_NAME;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.asString;
 import static org.jboss.as.server.deployment.DeploymentHandlerUtils.createFailureException;
@@ -134,7 +135,16 @@ public class DeploymentFullReplaceHandler implements OperationStepHandler {
         // deploymentModel.get(NAME).set(name); // already there
         deploymentModel.get(RUNTIME_NAME.getName()).set(runtimeName);
         deploymentModel.get(CONTENT).set(content);
-        // ENABLED stays as is
+        //Persistent is hidden from CLI users so let's set this to true here if it is not defined
+        if (!operation.hasDefined(PERSISTENT.getName())) {
+            operation.get(PERSISTENT.getName()).set(true);
+        }
+        PERSISTENT.validateAndSet(operation, deploymentModel);
+
+        // ENABLED stays as is if not present in operation
+        if (operation.hasDefined(ENABLED.getName())) {
+            ENABLED.validateAndSet(operation, deploymentModel);
+        }
 
         // Do the runtime part if the deployment is enabled
         if (ENABLED.resolveModelAttribute(context, deploymentModel).asBoolean()) {


### PR DESCRIPTION
Fixing issue by updating the marker files for the scanner using the runtime status from the ScannerContext.
Logging a message in case the deployment managed by the scanner was updated through another management tool.
Don't touch the undeployed flag if the deployment is persistent.
Fix issue with persistent flag not being changed during replacement.
Enabling deployment when replacing from the scanner.

Jira: https://issues.jboss.org/browse/WFLY-3305
