### PR TITLE
WFLY-3308 Upgrade jsf-impl to 2.2.6-jbossorg-4 to fix a JSF memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <version.com.google.guava>16.0.1</version.com.google.guava>
         <version.com.h2database>1.3.173</version.com.h2database>
         <version.com.sun.codemodel>2.6</version.com.sun.codemodel>
-        <version.com.sun.faces>2.2.6-jbossorg-3</version.com.sun.faces>
+        <version.com.sun.faces>2.2.6-jbossorg-4</version.com.sun.faces>
         <version.com.sun.istack>2.6.1</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>1.2.12</version.com.sun.xml.fastinfoset>
         <version.com.sun.xml.txw2>20110809</version.com.sun.xml.txw2>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3308
