### PR TITLE
[WFLY-3304] Fix fetching domain config from master in --admin-only mode

### DIFF
--- a/build/src/main/resources/docs/schema/jboss-as-config_2_1.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-config_2_1.xsd
@@ -1964,14 +1964,18 @@
         <xs:attribute name="host" type="xs:string" use="optional" >
             <xs:annotation>
                 <xs:documentation>
-                    The remote domain controller's host name. If not set, a discovery option must be provided.
+                    The remote domain controller's host name. If not set, a discovery option must be provided,
+                    or the --cached-dc startup option must be used, or the --admin-only startup option must be used
+                    with the 'admin-only-policy' attribute set to a value other than 'fetch-from-master'.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
         <xs:attribute name="port" type="xs:integer" use="optional" >
             <xs:annotation>
                 <xs:documentation>
-                    The remote domain controller's port. If not set, a discovery option must be provided.
+                    The remote domain controller's port. If not set, a discovery option must be provided,
+                    or the --cached-dc startup option must be used, or the --admin-only startup option must be used
+                    with the 'admin-only-policy' attribute set to a value other than 'fetch-from-master'.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -2023,9 +2027,9 @@
                 <xs:annotation>
                     <xs:documentation>
                         <![CDATA[
-                        Contact the master host controller to pull down the current domain wide configuration,
-                        but do not actually register with the master as a member of the domain. If the master
-                        cannot be reached, the start of the host controller will fail.
+                        Unless the --cached-dc startup option was used, contact the master host controller to pull down
+                        the current domain wide configuration, but do not actually register with the master as a member
+                        of the domain. If the master cannot be reached, the start of the host controller will fail.
                         ]]>
                     </xs:documentation>
                 </xs:annotation>

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -43,15 +43,15 @@ import javax.xml.stream.XMLStreamWriter;
 
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.NoSuchResourceException;
-import org.jboss.as.controller._private.OperationCancellationException;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller._private.OperationFailedRuntimeException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.UnauthorizedException;
+import org.jboss.as.controller._private.OperationCancellationException;
+import org.jboss.as.controller._private.OperationFailedRuntimeException;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.interfaces.InterfaceCriteria;
 import org.jboss.as.controller.parsing.Element;
@@ -3031,8 +3031,11 @@ public interface ControllerLogger extends BasicLogger {
      *
      * @return a {@link XMLStreamException} for the error.
      */
-    @Message(id = 305, value = "%s must be declared or the %s and the %s need to be provided.")
-    XMLStreamException discoveryOptionsMustBeDeclared(String discoveryOptionsName, String hostName, String portName, @Param Location location);
+    @Message(id = 305, value = "Unless the Host Controller is started with command line option %s and the %s " +
+            "attribute is not set to %s, %s must be declared or the %s and the %s need to be provided.")
+    XMLStreamException discoveryOptionsMustBeDeclared(String adminOnlyCmd, String policyAttribute, String fetchValue,
+                                                      String discoveryOptionsName, String hostName, String portName,
+                                                      @Param Location location);
 
     @Message(id = 306, value = "read only context")
     IllegalStateException readOnlyContext();

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -317,7 +317,8 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
             @Override
             public void registerRemoteHost(String hostName, ManagementChannelHandler handler, Transformers transformers,
-                    Long remoteConnectionId, DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation) throws SlaveRegistrationException {
+                    Long remoteConnectionId, DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation,
+                    boolean registerProxyController) throws SlaveRegistrationException {
             }
 
             @Override
@@ -578,7 +579,8 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
         @Override
         public void registerRemoteHost(String hostName, ManagementChannelHandler handler, Transformers transformers,
-                Long remoteConnectionId, DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation) throws SlaveRegistrationException {
+                Long remoteConnectionId, DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation,
+                boolean registerProxyController) throws SlaveRegistrationException {
         }
 
         @Override

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestParser.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestParser.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 
+import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.parsing.Namespace;
@@ -71,7 +72,7 @@ public class TestParser implements ModelTestParser {
             testParser = new TestParser(type, domainXml, domainXml);
             root = "domain";
         } else if (type == TestModelType.HOST) {
-            HostXml hostXml = new HostXml("master");
+            HostXml hostXml = new HostXml("master", RunningMode.NORMAL, false);
             testParser = new TestParser(type, hostXml, hostXml);
             root = "host";
         } else {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/DomainController.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/DomainController.java
@@ -74,9 +74,13 @@ public interface DomainController {
      * @param transformers transformation handler for converting resources and operations to forms appropriate for the slave
      * @param remoteConnectionId long identifying this specific connection to the host, or {@code null} if the host did not provide such an id
      * @param runtimeIgnoreTransformation The runtime ignore transformation utility for the host
+     * @param registerProxyController {@code true} if a proxy controller should be registered for the host; {@code false}
+     *                                             if the host is in --admin-only mode and should not be visible to outside users
      * @throws SlaveRegistrationException  if there is a problem registering the host
      */
-    void registerRemoteHost(final String hostName, final ManagementChannelHandler handler, final Transformers transformers, Long remoteConnectionId, DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation) throws SlaveRegistrationException;
+    void registerRemoteHost(final String hostName, final ManagementChannelHandler handler, final Transformers transformers,
+                            final Long remoteConnectionId, final DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation,
+                            final boolean registerProxyController) throws SlaveRegistrationException;
 
     /**
      * Check if a Host Controller is already registered with this domain controller.

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/ReadMasterDomainModelHandler.java
@@ -64,7 +64,9 @@ public class ReadMasterDomainModelHandler implements OperationStepHandler {
         context.completeStep(new OperationContext.ResultHandler() {
             @Override
             public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
-                runtimeIgnoreTransformationRegistry.addKnownDataForSlave(host, readUtil.getNewKnownRootResources());
+                if (resultAction == OperationContext.ResultAction.KEEP) {
+                    runtimeIgnoreTransformationRegistry.addKnownDataForSlave(host, readUtil.getNewKnownRootResources());
+                }
             }
         });
     }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/ConfigurationPersisterFactory.java
@@ -31,18 +31,18 @@ import javax.xml.namespace.QName;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.extension.ExtensionRegistry;
-import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
-import org.jboss.as.controller.persistence.ConfigurationPersister;
-import org.jboss.as.controller.persistence.ModelMarshallingContext;
-import org.jboss.as.host.controller.logging.HostControllerLogger;
-import org.jboss.as.host.controller.parsing.DomainXml;
-import org.jboss.as.host.controller.parsing.HostXml;
 import org.jboss.as.controller.parsing.Namespace;
 import org.jboss.as.controller.persistence.BackupXmlConfigurationPersister;
 import org.jboss.as.controller.persistence.ConfigurationFile;
+import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
+import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.persistence.ExtensibleConfigurationPersister;
+import org.jboss.as.controller.persistence.ModelMarshallingContext;
 import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.persistence.XmlConfigurationPersister;
+import org.jboss.as.host.controller.logging.HostControllerLogger;
+import org.jboss.as.host.controller.parsing.DomainXml;
+import org.jboss.as.host.controller.parsing.HostXml;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
 import org.jboss.staxmapper.XMLElementReader;
@@ -58,8 +58,9 @@ public class ConfigurationPersisterFactory {
     static final String CACHED_DOMAIN_XML = "domain.cached-remote.xml";
 
     // host.xml
-    public static ExtensibleConfigurationPersister createHostXmlConfigurationPersister(final ConfigurationFile file, String defaultHostControllerName) {
-        HostXml hostXml = new HostXml(defaultHostControllerName);
+    public static ExtensibleConfigurationPersister createHostXmlConfigurationPersister(final ConfigurationFile file, final HostControllerEnvironment environment) {
+        HostXml hostXml = new HostXml(environment.getHostControllerName(), environment.getRunningModeControl().getRunningMode(),
+                environment.isUseCachedDc());
         BackupXmlConfigurationPersister persister =  new BackupXmlConfigurationPersister(file, new QName(Namespace.CURRENT.getUriString(), "host"), hostXml, hostXml);
         for (Namespace namespace : Namespace.domainValues()) {
             if (!namespace.equals(Namespace.CURRENT)) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostControllerConfigurationPersister.java
@@ -67,7 +67,7 @@ public class HostControllerConfigurationPersister implements ExtensibleConfigura
         if (environment.getRunningModeControl().isReloaded()) {
             configurationFile.resetBootFile(environment.getRunningModeControl().isUseCurrentConfig());
         }
-        this.hostPersister = ConfigurationPersisterFactory.createHostXmlConfigurationPersister(configurationFile, environment.getHostControllerName());
+        this.hostPersister = ConfigurationPersisterFactory.createHostXmlConfigurationPersister(configurationFile, environment);
     }
 
     public void initializeDomainConfigurationPersister(boolean slave) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnection.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/RemoteDomainConnection.java
@@ -352,8 +352,6 @@ class RemoteDomainConnection extends FutureManagementChannel {
       */
      private abstract class HostControllerConnectRequest extends AbstractManagementRequest<Void, Void> {
 
-         abstract boolean isRegisterOnComplete();
-
          @Override
          protected void sendRequest(final ActiveOperation.ResultHandler<Void> resultHandler, final ManagementRequestContext<Void> context, final FlushableDataOutput output) throws IOException {
              output.write(DomainControllerProtocol.PARAM_HOST_ID);
@@ -385,7 +383,7 @@ class RemoteDomainConnection extends FutureManagementChannel {
                      //
                      final ModelNode subsystems = resolveSubsystemVersions(extensions);
                      channelHandler.executeRequest(context.getOperationId(),
-                             new RegisterSubsystemsRequest(subsystems, isRegisterOnComplete()));
+                             new RegisterSubsystemsRequest(subsystems));
                  }
              });
          }
@@ -400,11 +398,6 @@ class RemoteDomainConnection extends FutureManagementChannel {
         public byte getOperationType() {
             return DomainControllerProtocol.REGISTER_HOST_CONTROLLER_REQUEST;
         }
-
-        @Override
-        boolean isRegisterOnComplete() {
-            return true;
-        }
     }
 
     /**
@@ -416,21 +409,14 @@ class RemoteDomainConnection extends FutureManagementChannel {
         public byte getOperationType() {
             return DomainControllerProtocol.FETCH_DOMAIN_CONFIGURATION_REQUEST;
         }
-
-        @Override
-        boolean isRegisterOnComplete() {
-            return false;
-        }
     }
 
      private class RegisterSubsystemsRequest extends AbstractManagementRequest<Void, Void> {
 
          private final ModelNode subsystems;
-         private final boolean registerOnCompletion;
 
-         private RegisterSubsystemsRequest(ModelNode subsystems, boolean registerOnCompletion) {
+         private RegisterSubsystemsRequest(ModelNode subsystems) {
              this.subsystems = subsystems;
-             this.registerOnCompletion = registerOnCompletion;
          }
 
          @Override
@@ -460,22 +446,12 @@ class RemoteDomainConnection extends FutureManagementChannel {
                  @Override
                  public void execute(ManagementRequestContext<Void> voidManagementRequestContext) throws Exception {
                      // Apply the domain model
-                     final boolean success = applyDomainModel(domainModel);
-                     if (registerOnCompletion) {
-                         if(success) {
-                             channelHandler.executeRequest(context.getOperationId(), new CompleteRegistrationRequest(DomainControllerProtocol.PARAM_OK));
-                         } else {
-                             channelHandler.executeRequest(context.getOperationId(), new CompleteRegistrationRequest(DomainControllerProtocol.PARAM_ERROR));
-                             resultHandler.failed(new SlaveRegistrationException(SlaveRegistrationException.ErrorCode.UNKNOWN, ""));
-                         }
+                     if (applyDomainModel(domainModel)) {
+                         channelHandler.executeRequest(context.getOperationId(), new CompleteRegistrationRequest(DomainControllerProtocol.PARAM_OK));
                      } else {
-                         if (success) {
-                             throw new UnsupportedOperationException("TODO");
-                         } else {
-                             resultHandler.failed(new SlaveRegistrationException(SlaveRegistrationException.ErrorCode.UNKNOWN, ""));
-                         }
+                         channelHandler.executeRequest(context.getOperationId(), new CompleteRegistrationRequest(DomainControllerProtocol.PARAM_ERROR));
+                         resultHandler.failed(new SlaveRegistrationException(SlaveRegistrationException.ErrorCode.UNKNOWN, ""));
                      }
-
                  }
              });
          }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/logging/HostControllerLogger.java
@@ -1182,4 +1182,11 @@ public interface HostControllerLogger extends BasicLogger {
     @LogMessage(level = Level.INFO)
     @Message(id = 150, value = "Trying to reconnect to master host controller.")
     void reconnectingToMaster();
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 151, value = "No domain controller discovery configuration was provided and the '%s' attribute was " +
+            "set to '%s'. Startup will be aborted. Use the %s command line argument to start in %s mode if you need to " +
+            "start without a domain controller connection and then use the management tools to configure one.")
+    void noDomainControllerConfigurationProvidedForAdminOnly(String policyAttribute, AdminOnlyDomainConfigPolicy policy,
+                                                             String cachedDcCmdLineArg, RunningMode desiredRunningMode);
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/DomainControllerRuntimeIgnoreTransformationRegistry.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/mgmt/DomainControllerRuntimeIgnoreTransformationRegistry.java
@@ -254,9 +254,9 @@ public class DomainControllerRuntimeIgnoreTransformationRegistry {
     /**
      * Gets all the unknown extensions for a profile's subsystems on a host
      *
-     * @param domainResource the root domain resource
+     * @param domainRoot the root domain resource
      * @param hostName the name of the host
-     * @param profileElement the profile address to check
+     * @param profile the profile address to check
      * @return the unknown extensions
      */
     public Set<PathElement> getUnknownExtensionsForProfile(Resource domainRoot, String hostName, String profile) {

--- a/host-controller/src/main/java/org/jboss/as/host/controller/model/host/AdminOnlyDomainConfigPolicy.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/model/host/AdminOnlyDomainConfigPolicy.java
@@ -49,6 +49,8 @@ public enum AdminOnlyDomainConfigPolicy {
      */
     REQUIRE_LOCAL_CONFIG("require-local-config");
 
+    public static final AdminOnlyDomainConfigPolicy DEFAULT = ALLOW_NO_CONFIG;
+
     private final String toString;
 
     private AdminOnlyDomainConfigPolicy(String toString) {

--- a/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandlerTestCase.java
+++ b/host-controller/src/test/java/org/jboss/as/domain/controller/operations/ApplyRemoteMasterDomainModelHandlerTestCase.java
@@ -315,7 +315,9 @@ public class ApplyRemoteMasterDomainModelHandlerTestCase extends AbstractOperati
         }
 
         @Override
-        public void registerRemoteHost(String hostName, ManagementChannelHandler handler, Transformers transformers, Long remoteConnectionId, DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation) throws SlaveRegistrationException {
+        public void registerRemoteHost(String hostName, ManagementChannelHandler handler, Transformers transformers,
+                                       Long remoteConnectionId, DomainControllerRuntimeIgnoreTransformationEntry runtimeIgnoreTransformation,
+                                       boolean registerProxyController) throws SlaveRegistrationException {
             //To change body of implemented methods use File | Settings | File Templates.
         }
 

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/AdminOnlyPolicyTestCase.java
@@ -1,0 +1,226 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.host.controller.model.host.AdminOnlyDomainConfigPolicy;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.JBossAsManagedConfiguration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Tests of running domain hosts in admin-only move.
+ */
+public class AdminOnlyPolicyTestCase {
+
+    private static DomainTestSupport testSupport;
+    private static DomainLifecycleUtil domainSlaveLifecycleUtil;
+
+    private static final long initTime = System.currentTimeMillis();
+    private static int slaveCount;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+
+        testSupport = DomainTestSupport.createAndStartSupport(DomainTestSupport.Configuration.create(AdminOnlyPolicyTestCase.class.getSimpleName(),
+                "domain-configs/domain-standard.xml", "host-configs/host-master.xml", null));
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        testSupport.stop();
+
+        testSupport = null;
+    }
+
+    @After
+    public void stopSecondSlave() throws Exception {
+        if (domainSlaveLifecycleUtil != null) {
+            domainSlaveLifecycleUtil.stop();
+            domainSlaveLifecycleUtil = null;
+        }
+    }
+
+    @Test
+    public void testAllowNoConfigWithDiscovery() throws URISyntaxException, IOException {
+        createSecondSlave(AdminOnlyDomainConfigPolicy.ALLOW_NO_CONFIG, true, false);
+        validateProfiles();
+    }
+
+    @Test
+    public void testAllowNoConfigWithoutDiscovery() throws URISyntaxException, IOException {
+        createSecondSlave(AdminOnlyDomainConfigPolicy.ALLOW_NO_CONFIG, false, false);
+        validateProfiles();
+    }
+
+    @Test
+    public void testAllowNoConfigWithCachedDC() throws URISyntaxException, IOException {
+        createSecondSlave(AdminOnlyDomainConfigPolicy.ALLOW_NO_CONFIG, false, true);
+        validateProfiles("cached-remote-test");
+    }
+
+    @Test
+    public void testFetchFromMasterWithDiscovery() throws URISyntaxException, IOException {
+        String hostName = createSecondSlave(AdminOnlyDomainConfigPolicy.FETCH_FROM_MASTER, true, false);
+        validateProfiles("default");
+
+        // Now we validate that we can pull down further data if needed
+        PathAddress pa = PathAddress.pathAddress(PathElement.pathElement(HOST, hostName), PathElement.pathElement(SERVER_CONFIG, "other1"));
+        ModelNode op = Util.createAddOperation(pa);
+        op.get(GROUP).set("other-server-group");
+        executeForResult(domainSlaveLifecycleUtil.getDomainClient(), op);
+        // This should have pulled down the 'other' profile
+        validateProfiles("default", "other");
+    }
+
+    @Test
+    public void testFetchFromMasterWithoutDiscovery() throws URISyntaxException {
+        try {
+            createSecondSlave(AdminOnlyDomainConfigPolicy.FETCH_FROM_MASTER, false, false);
+            Assert.fail("secondSlaveLifecyleUtil should not have started");
+        } catch (RuntimeException e) {
+            Assert.assertTrue(domainSlaveLifecycleUtil.getProcessExitCode() >= 0);
+        }
+    }
+
+    @Test
+    public void testFetchFromMasterWithCachedDC() throws URISyntaxException, IOException {
+        createSecondSlave(AdminOnlyDomainConfigPolicy.FETCH_FROM_MASTER, false, true);
+        validateProfiles("cached-remote-test");
+    }
+
+    @Test
+    public void testRequireLocalConfigWithDiscovery() throws URISyntaxException {
+        try {
+            createSecondSlave(AdminOnlyDomainConfigPolicy.REQUIRE_LOCAL_CONFIG, true, false);
+            Assert.fail("secondSlaveLifecyleUtil should not have started");
+        } catch (RuntimeException e) {
+            Assert.assertTrue(domainSlaveLifecycleUtil.getProcessExitCode() >= 0);
+        }
+    }
+
+    @Test
+    public void testRequireLocalConfigWithoutDiscovery() throws URISyntaxException {
+        try {
+            createSecondSlave(AdminOnlyDomainConfigPolicy.REQUIRE_LOCAL_CONFIG, false, false);
+            Assert.fail("secondSlaveLifecyleUtil should not have started");
+        } catch (RuntimeException e) {
+            Assert.assertTrue(domainSlaveLifecycleUtil.getProcessExitCode() >= 0);
+        }
+    }
+
+    @Test
+    public void testRequireLocalConfigWithCachedDC() throws URISyntaxException, IOException {
+        createSecondSlave(AdminOnlyDomainConfigPolicy.REQUIRE_LOCAL_CONFIG, false, true);
+        validateProfiles("cached-remote-test");
+    }
+
+    private String createSecondSlave(AdminOnlyDomainConfigPolicy policy, boolean discovery, boolean cachedDC) throws URISyntaxException {
+
+        String hostName = "slave-" + initTime + "-" + (slaveCount++);
+
+        String hostConfigPath = "host-configs/" + (discovery ? "admin-only-discovery.xml" : "admin-only-no-discovery.xml");
+
+        JBossAsManagedConfiguration slaveConfig = DomainTestSupport.getSlaveConfiguration(hostName, hostConfigPath,
+                getClass().getSimpleName(), false);
+        slaveConfig.setHostControllerManagementPort(29999);
+        slaveConfig.setAdminOnly(true);
+        slaveConfig.addHostCommandLineProperty("-Djboss.test.admin-only-policy=" + policy.toString());
+        slaveConfig.addHostCommandLineProperty("-Djboss.host.name=" + hostName);
+        if (cachedDC) {
+            slaveConfig.setCachedDC(true);
+            ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+            URL url = tccl.getResource("domain-configs/domain.cached-remote.xml");
+            assert url != null;
+            slaveConfig.setDomainConfigFile(new File(url.toURI()).getAbsolutePath());
+        }
+        domainSlaveLifecycleUtil = new DomainLifecycleUtil(slaveConfig, testSupport.getSharedClientConfiguration());
+        domainSlaveLifecycleUtil.start();
+
+        return hostName;
+    }
+
+    private void validateProfiles(String... expectedNames) throws IOException {
+        Set<String> set = new HashSet<String>(Arrays.asList(expectedNames));
+        ModelNode op = Util.createEmptyOperation(ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
+        op.get(ModelDescriptionConstants.CHILD_TYPE).set(ModelDescriptionConstants.PROFILE);
+        ModelNode result = executeForResult(domainSlaveLifecycleUtil.getDomainClient(), op);
+        Assert.assertEquals(result.toString(), ModelType.LIST, result.getType());
+        Assert.assertEquals(result.toString(), set.size(), result.asInt());
+        for (ModelNode profile : result.asList()) {
+            String name = profile.asString();
+            Assert.assertTrue(name, set.remove(name));
+        }
+        Assert.assertTrue(set.toString(), set.isEmpty());
+    }
+
+    private ModelNode executeForResult(final ModelControllerClient client, final ModelNode operation) throws IOException {
+        final ModelNode result = client.execute(operation);
+        return validateResponse(result);
+    }
+
+    private ModelNode validateResponse(ModelNode response) {
+        return validateResponse(response, true);
+    }
+
+    private ModelNode validateResponse(ModelNode response, boolean validateResult) {
+
+        if(! SUCCESS.equals(response.get(OUTCOME).asString())) {
+            System.out.println("Failed response:");
+            System.out.println(response);
+            Assert.fail(response.get(FAILURE_DESCRIPTION).toString());
+        }
+
+        if (validateResult) {
+            Assert.assertTrue("result exists", response.has(RESULT));
+        }
+        return response.get(RESULT);
+    }
+}

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/BasicOpsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/BasicOpsTestCase.java
@@ -22,11 +22,15 @@
 package org.jboss.as.test.integration.domain.management.cli;
 
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.suites.CLITestSuite;
 import org.jboss.as.test.integration.management.util.CLIOpResult;
 import org.jboss.as.test.integration.management.util.CLIWrapper;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.List;
@@ -35,6 +39,16 @@ import java.util.List;
  * @author Dominik Pospisil <dpospisi@redhat.com>
  */
 public class BasicOpsTestCase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        CLITestSuite.createSupport(BasicOpsTestCase.class.getSimpleName());
+    }
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        CLITestSuite.stopSupport();
+    }
 
     @Test
     public void testConnect() throws Exception {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DataSourceTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DataSourceTestCase.java
@@ -50,12 +50,15 @@ public class DataSourceTestCase extends AbstractCliTestBase {
 
     @BeforeClass
     public static void before() throws Exception {
+
+        CLITestSuite.createSupport(DataSourceTestCase.class.getSimpleName());
         AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
     }
 
     @AfterClass
     public static void after() throws Exception {
         AbstractCliTestBase.closeCLI();
+        CLITestSuite.stopSupport();
     }
 
     @Before

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllServerGroupsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeployAllServerGroupsTestCase.java
@@ -54,6 +54,9 @@ public class DeployAllServerGroupsTestCase extends AbstractCliTestBase {
 
     @BeforeClass
     public static void before() throws Exception {
+
+        CLITestSuite.createSupport(DeployAllServerGroupsTestCase.class.getSimpleName());
+
         war = ShrinkWrap.create(WebArchive.class, "SimpleServlet.war");
         war.addClass(SimpleServlet.class);
         war.addAsWebResource(new StringAsset("Version1"), "page.html");
@@ -68,6 +71,8 @@ public class DeployAllServerGroupsTestCase extends AbstractCliTestBase {
     public static void after() throws Exception {
         AbstractCliTestBase.closeCLI();
         Assert.assertTrue(warFile.delete());
+
+        CLITestSuite.stopSupport();
     }
 
     @Test

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeploySingleServerGroupTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeploySingleServerGroupTestCase.java
@@ -58,6 +58,9 @@ public class DeploySingleServerGroupTestCase extends AbstractCliTestBase {
 
     @BeforeClass
     public static void before() throws Exception {
+
+        CLITestSuite.createSupport(DeploySingleServerGroupTestCase.class.getSimpleName());
+
         war = ShrinkWrap.create(WebArchive.class, "SimpleServlet.war");
         war.addClass(SimpleServlet.class);
         war.addAsWebResource(new StringAsset("Version1"), "page.html");
@@ -74,6 +77,8 @@ public class DeploySingleServerGroupTestCase extends AbstractCliTestBase {
     public static void after() throws Exception {
         AbstractCliTestBase.closeCLI();
         Assert.assertTrue(warFile.delete());
+
+        CLITestSuite.stopSupport();
     }
 
     @Test

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeployWithRuntimeNameTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeployWithRuntimeNameTestCase.java
@@ -60,6 +60,8 @@ public class DomainDeployWithRuntimeNameTestCase extends AbstractCliTestBase {
 
     @BeforeClass
     public static void setup() throws Exception {
+
+        CLITestSuite.createSupport(DomainDeployWithRuntimeNameTestCase.class.getSimpleName());
         serverGroups = CLITestSuite.serverGroups.keySet().toArray(new String[CLITestSuite.serverGroups.size()]);
         AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
     }
@@ -77,6 +79,7 @@ public class DomainDeployWithRuntimeNameTestCase extends AbstractCliTestBase {
     @AfterClass
     public static void cleanup() throws Exception {
         AbstractCliTestBase.closeCLI();
+        CLITestSuite.stopSupport();
     }
 
     @After

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DomainDeploymentOverlayTestCase.java
@@ -44,6 +44,7 @@ import org.jboss.as.cli.CommandContext;
 import org.jboss.as.controller.client.helpers.domain.DomainClient;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.suites.CLITestSuite;
 import org.jboss.as.test.integration.domain.suites.DomainTestSuite;
 import org.jboss.as.test.integration.management.util.CLITestUtil;
 import org.jboss.as.test.integration.management.util.SimpleServlet;
@@ -122,13 +123,13 @@ public class DomainDeploymentOverlayTestCase {
         }
 
         // Launch the domain
-        testSupport = DomainTestSupport.createAndStartDefaultSupport(DomainDeploymentOverlayTestCase.class.getSimpleName());
+        testSupport = CLITestSuite.createSupport(DomainDeploymentOverlayTestCase.class.getSimpleName());
     }
 
     @AfterClass
     public static void after() throws Exception {
         try {
-            testSupport.stop();
+            CLITestSuite.stopSupport();
             testSupport = null;
         } finally {
             war1.delete();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/JmsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/JmsTestCase.java
@@ -42,12 +42,15 @@ public class JmsTestCase extends AbstractCliTestBase {
 
     @BeforeClass
     public static void before() throws Exception {
+
+        CLITestSuite.createSupport(JmsTestCase.class.getSimpleName());
         AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
     }
 
     @AfterClass
     public static void after() throws Exception {
         AbstractCliTestBase.closeCLI();
+        CLITestSuite.stopSupport();
     }
 
     @Before

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
@@ -58,6 +58,8 @@ public class RolloutPlanTestCase extends AbstractCliTestBase {
 
     @BeforeClass
     public static void before() throws Exception {
+
+        CLITestSuite.createSupport(RolloutPlanTestCase.class.getSimpleName());
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "RolloutPlanTestCase.war");
         war.addClass(RolloutPlanTestServlet.class);
         String tempDir = System.getProperty("java.io.tmpdir");
@@ -108,6 +110,8 @@ public class RolloutPlanTestCase extends AbstractCliTestBase {
         waitUntilState("main-two", "DISABLED");
 
         AbstractCliTestBase.closeCLI();
+
+        CLITestSuite.stopSupport();
     }
 
     @After

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/UndeployWildcardDomainTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/UndeployWildcardDomainTestCase.java
@@ -64,6 +64,9 @@ public class UndeployWildcardDomainTestCase {
 
     @BeforeClass
     public static void before() throws Exception {
+
+        CLITestSuite.createSupport(UndeployWildcardDomainTestCase.class.getSimpleName());
+
         String tempDir = System.getProperty("java.io.tmpdir");
 
         // deployment1
@@ -109,6 +112,9 @@ public class UndeployWildcardDomainTestCase {
 
     @AfterClass
     public static void after() throws Exception {
+
+        CLITestSuite.stopSupport();
+
         cliTestApp1War.delete();
         cliTestApp2War.delete();
         cliTestAnotherWar.delete();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/WildCardReadsTestCase.java
@@ -50,12 +50,15 @@ public class WildCardReadsTestCase extends AbstractCliTestBase {
 
     @BeforeClass
     public static void setup() throws Exception {
+
+        CLITestSuite.createSupport(WildCardReadsTestCase.class.getSimpleName());
         AbstractCliTestBase.initCLI(DomainTestSupport.masterAddress);
     }
 
     @AfterClass
     public static void cleanup() throws Exception {
         AbstractCliTestBase.closeCLI();
+        CLITestSuite.stopSupport();
     }
 
     /**

--- a/testsuite/domain/src/test/resources/domain-configs/domain.cached-remote.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain.cached-remote.xml
@@ -1,0 +1,86 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<domain xmlns="urn:jboss:domain:2.1"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+    <extensions>
+        <extension module="org.jboss.as.logging"/>
+    </extensions>
+
+    <profiles>
+
+        <profile name="cached-remote-test">
+
+            <subsystem xmlns="urn:jboss:domain:logging:1.2">
+                <console-handler name="CONSOLE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                </console-handler>
+
+                <periodic-rotating-file-handler name="FILE">
+                    <level name="INFO"/>
+                    <formatter>
+                        <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                    </formatter>
+                    <file relative-to="jboss.server.log.dir" path="server.log"/>
+                    <suffix value=".yyyy-MM-dd"/>
+                </periodic-rotating-file-handler>
+
+                <root-logger>
+                    <level name="INFO"/>
+                    <handlers>
+                        <handler name="CONSOLE"/>
+                        <handler name="FILE"/>
+                    </handlers>
+                </root-logger>
+            </subsystem>
+        </profile>
+
+    </profiles>
+
+    <!--
+         Named interfaces that can be referenced elsewhere. Different
+         mechanisms for associating an IP address with the interface
+         are shown.
+    -->
+    <interfaces>
+        <interface name="management"/>
+        <interface name="public"/>
+    </interfaces>
+
+    <socket-binding-groups>
+        <socket-binding-group name="standard-sockets" default-interface="public">
+            <socket-binding name="http" port="8080"/>
+        </socket-binding-group>
+    </socket-binding-groups>
+
+    <server-groups>
+        <server-group name="main-server-group" profile="cached-remote-test">
+            <socket-binding-group ref="standard-sockets"/>
+        </server-group>
+    </server-groups>
+
+
+</domain>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-discovery.xml
@@ -1,0 +1,84 @@
+<!--
+  ~ /*
+  ~  * JBoss, Home of Professional Open Source.
+  ~  * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~  * as indicated by the @author tags. See the copyright.txt file in the
+  ~  * distribution for a full listing of individual contributors.
+  ~  *
+  ~  * This is free software; you can redistribute it and/or modify it
+  ~  * under the terms of the GNU Lesser General Public License as
+  ~  * published by the Free Software Foundation; either version 2.1 of
+  ~  * the License, or (at your option) any later version.
+  ~  *
+  ~  * This software is distributed in the hope that it will be useful,
+  ~  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~  * Lesser General Public License for more details.
+  ~  *
+  ~  * You should have received a copy of the GNU Lesser General Public
+  ~  * License along with this software; if not, write to the Free
+  ~  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~  */
+  -->
+
+<host xmlns="urn:jboss:domain:2.1"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:2.1 jboss-as-config_2_0.xsd">
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                    <secret value="c2xhdmVfdXNlcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true" />
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="29999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" console-enabled="false"  http-upgrade-enabled="true">
+                <socket interface="management" port="29990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote security-realm="ManagementRealm" ignore-unused-configuration="true" admin-only-policy="${jboss.test.admin-only-policy}">
+            <discovery-options>
+                <static-discovery name="primary" host="${jboss.test.host.master.address}" port="9999"/>
+            </discovery-options>
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="128m"/>
+        </jvm>
+    </jvms>
+
+    <servers>
+        <server name="server1" group="main-server-group"/>
+    </servers>
+</host>

--- a/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
+++ b/testsuite/domain/src/test/resources/host-configs/admin-only-no-discovery.xml
@@ -1,0 +1,84 @@
+<!--
+  ~ /*
+  ~  * JBoss, Home of Professional Open Source.
+  ~  * Copyright 2013, Red Hat, Inc., and individual contributors
+  ~  * as indicated by the @author tags. See the copyright.txt file in the
+  ~  * distribution for a full listing of individual contributors.
+  ~  *
+  ~  * This is free software; you can redistribute it and/or modify it
+  ~  * under the terms of the GNU Lesser General Public License as
+  ~  * published by the Free Software Foundation; either version 2.1 of
+  ~  * the License, or (at your option) any later version.
+  ~  *
+  ~  * This software is distributed in the hope that it will be useful,
+  ~  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~  * Lesser General Public License for more details.
+  ~  *
+  ~  * You should have received a copy of the GNU Lesser General Public
+  ~  * License along with this software; if not, write to the Free
+  ~  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  ~  */
+  -->
+
+<host xmlns="urn:jboss:domain:2.1"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:domain:2.1 jboss-as-config_2_0.xsd">
+
+    <management>
+        <security-realms>
+            <security-realm name="ManagementRealm">
+                <server-identities>
+                    <secret value="c2xhdmVfdXNlcl9wYXNzd29yZA==" />
+                </server-identities>
+                <authentication>
+                    <local default-user="$local" skip-group-loading="true" />
+                    <properties path="mgmt-users.properties" relative-to="jboss.domain.config.dir" />
+                </authentication>
+            </security-realm>
+            <security-realm name="ApplicationRealm">
+                <authentication>
+                    <local default-user="$local" allowed-users="*" skip-group-loading="true" />
+                    <properties path="domain/configuration/application-users.properties" relative-to="jboss.home.dir" />
+                </authentication>
+            </security-realm>
+        </security-realms>
+        <management-interfaces>
+            <native-interface security-realm="ManagementRealm">
+                <socket interface="management" port="29999"/>
+            </native-interface>
+            <http-interface security-realm="ManagementRealm" console-enabled="false"  http-upgrade-enabled="true">
+                <socket interface="management" port="29990"/>
+            </http-interface>
+        </management-interfaces>
+    </management>
+
+    <domain-controller>
+        <!-- Remote domain controller configuration with a host and port -->
+        <remote security-realm="ManagementRealm" ignore-unused-configuration="true" admin-only-policy="${jboss.test.admin-only-policy}">
+            <!--<discovery-options>
+                <static-discovery name="primary" host="${jboss.test.host.master.address}" port="9999"/>
+            </discovery-options>-->
+        </remote>
+    </domain-controller>
+
+    <interfaces>
+        <interface name="management">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+        <interface name="public">
+            <inet-address value="${jboss.test.host.slave.address}"/>
+        </interface>
+    </interfaces>
+
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="128m"/>
+        </jvm>
+    </jvms>
+
+    <servers>
+        <server name="server1" group="main-server-group"/>
+    </servers>
+</host>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -680,7 +680,7 @@ public class ParseAndMarshalModelsTestCase {
     //TODO use HostInitializer & TestModelControllerService
     private ModelNode loadHostModel(final File file) throws Exception {
         final QName rootElement = new QName(Namespace.CURRENT.getUriString(), "host");
-        final HostXml parser = new HostXml("host-controller");
+        final HostXml parser = new HostXml("host-controller", RunningMode.NORMAL, false);
         final XmlConfigurationPersister persister = new XmlConfigurationPersister(file, rootElement, parser, parser);
         for (Namespace namespace : Namespace.domainValues()) {
             if (namespace != Namespace.CURRENT) {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/DomainTestSupport.java
@@ -115,13 +115,24 @@ public class DomainTestSupport {
 
     public static JBossAsManagedConfiguration getSlaveConfiguration(String hostConfigPath, String testName,
                                                                     boolean readOnlyHost) {
-        return getSlaveConfiguration(hostConfigPath, testName, new JBossAsManagedConfiguration(), readOnlyHost);
+        return getSlaveConfiguration("slave", hostConfigPath, testName, new JBossAsManagedConfiguration(), readOnlyHost);
+    }
+
+    public static JBossAsManagedConfiguration getSlaveConfiguration(String hostName, String hostConfigPath, String testName,
+                                                                    boolean readOnlyHost) {
+        return getSlaveConfiguration(hostName, hostConfigPath, testName, new JBossAsManagedConfiguration(), readOnlyHost);
     }
 
     public static JBossAsManagedConfiguration getSlaveConfiguration(String hostConfigPath, String testName,
                                                                     JBossAsManagedConfiguration baseConfig,
                                                                     boolean readOnlyHost) {
-        return Configuration.getSlaveConfiguration(hostConfigPath, testName, baseConfig, readOnlyHost);
+        return getSlaveConfiguration("slave", hostConfigPath, testName, baseConfig, readOnlyHost);
+    }
+
+    public static JBossAsManagedConfiguration getSlaveConfiguration(String hostName, String hostConfigPath, String testName,
+                                                                    JBossAsManagedConfiguration baseConfig,
+                                                                    boolean readOnlyHost) {
+        return Configuration.getSlaveConfiguration(hostConfigPath, testName, hostName, baseConfig, readOnlyHost);
     }
 
     private static URI toURI(URL url) {
@@ -336,6 +347,8 @@ public class DomainTestSupport {
         return domainSlaveLifecycleUtil;
     }
 
+    public DomainControllerClientConfig getSharedClientConfiguration() { return sharedClientConfig; }
+
     public void start() {
         domainMasterLifecycleUtil.start();
         if (domainSlaveLifecycleUtil != null) {
@@ -413,7 +426,7 @@ public class DomainTestSupport {
                                            boolean readOnlySlaveHost) {
 
             JBossAsManagedConfiguration masterConfiguration = getMasterConfiguration(domainConfig, masterConfig, testName, null, readOnlyMasterDomain, readOnlyMasterHost);
-            JBossAsManagedConfiguration slaveConfiguration = slaveConfig == null ? null : getSlaveConfiguration(slaveConfig, testName, null, readOnlySlaveHost);
+            JBossAsManagedConfiguration slaveConfiguration = slaveConfig == null ? null : getSlaveConfiguration(slaveConfig, testName, "slave", null, readOnlySlaveHost);
             return new Configuration(testName, masterConfiguration, slaveConfiguration);
         }
 
@@ -447,9 +460,8 @@ public class DomainTestSupport {
         }
 
         private static JBossAsManagedConfiguration getSlaveConfiguration(String hostConfigPath, String testName,
-                                                                        JBossAsManagedConfiguration baseConfig,
-                                                                        boolean readOnlyHost) {
-            final String hostName = "slave";
+                                                                         String hostName, JBossAsManagedConfiguration baseConfig,
+                                                                         boolean readOnlyHost) {
             File domains = getBaseDir(testName);
             File extraModules = getAddedModulesDir(testName);
             File overrideModules = getHostOverrideModulesDir(testName, hostName);

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/JBossAsManagedConfiguration.java
@@ -107,6 +107,8 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
 
     private boolean backupDC;
 
+    private boolean cachedDC;
+
     public JBossAsManagedConfiguration(String jbossHome) {
         if (jbossHome != null) {
             this.jbossHome = jbossHome;
@@ -290,6 +292,11 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
         this.hostCommandLineProperties = hostCommandLineProperties;
     }
 
+    public void addHostCommandLineProperty(String hostCommandLineProperty) {
+        this.hostCommandLineProperties = this.hostCommandLineProperties == null
+                ? hostCommandLineProperty : this.hostCommandLineProperties + " " + hostCommandLineProperty;
+    }
+
     public String getHostName() {
         return hostName;
     }
@@ -344,5 +351,13 @@ public class JBossAsManagedConfiguration extends CommonContainerConfiguration {
 
     public void setBackupDC(boolean backupDC) {
         this.backupDC = backupDC;
+    }
+
+    public boolean isCachedDC() {
+        return cachedDC;
+    }
+
+    public void setCachedDC(boolean cachedDC) {
+        this.cachedDC = cachedDC;
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/ProcessWrapper.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/domain/management/util/ProcessWrapper.java
@@ -67,7 +67,11 @@ class ProcessWrapper {
 
     int getExitValue() {
         synchronized (this) {
-            return process.exitValue();
+            try {
+                return process.exitValue();
+            } catch (IllegalThreadStateException e) {
+                return -1;
+            }
         }
     }
 


### PR DESCRIPTION
Also correct the way the CLITestSuite tests work. I don't know how DomainDeploymentOverlayTestCase ever worked given it would launch HC processes on the same ports as the ones spawned by the suite.
