### PR TITLE
Fix WeldClassFileServicesTest - ClassLoader.getResource() is not using f...

### DIFF
--- a/weld/src/test/java/org/jboss/as/weld/discovery/IndexUtils.java
+++ b/weld/src/test/java/org/jboss/as/weld/discovery/IndexUtils.java
@@ -21,7 +21,6 @@
  */
 package org.jboss.as.weld.discovery;
 
-import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 
@@ -44,7 +43,7 @@ class IndexUtils {
     private static void addResource(Object resource, Indexer indexer, ClassLoader classLoader) throws IOException {
         final String resourceName;
         if (resource instanceof Class<?>) {
-            resourceName = ((Class<?>) resource).getName().replace(".", File.separator) + ".class";
+            resourceName = ((Class<?>) resource).getName().replace(".", "/") + ".class";
         } else if (resource instanceof String) {
             resourceName = resource.toString();
         } else {


### PR DESCRIPTION
...ile separator
