### PR TITLE
[WFLY-3315] Fix day of week computation

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
@@ -716,6 +716,9 @@ public class CalendarBasedTimeout {
                 copy.set(i, cal.get(i));
             }
         }
+        // set that week starts on SUNDAY (as is done in #setFirstTimeout())
+        // to be able to compare dates' day of week correctly
+        copy.setFirstDayOfWeek(Calendar.SUNDAY);
         return copy;
     }
 

--- a/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
@@ -86,7 +86,7 @@ public class CalendarBasedTimeoutTestCase {
      */
     @Test
     public void testNextDayOfWeek() {
-        // start date is SUN 2014-03-22 4:00:00, has to advance to SAT of next week
+        // start date is SAT 2014-03-22 4:00:00, has to advance to SAT of next week
         testNextDayOfWeek(new GregorianCalendar(2014,2,22,4,0,0).getTime());
         // start date is TUE 2014-03-25 2:00:00, has to advance to SAT of same week
         testNextDayOfWeek(new GregorianCalendar(2014,2,25,2,0,0).getTime());


### PR DESCRIPTION
CalendarBasedTimeout overrides the 1st day of week value (which is
Locale-dependent) when it computes its firstTimeout in setFirstTimeout().
However it must also override it in the truncate() method to make sure
that comparison between the firstTimeout and its truncated copy is
correct. Bugs will occur if the JVM's Locale has a different value for
the 1st day of the week (e.g. French week starts on monday, while
English week starts on sunday).

JIRA: https://issues.jboss.org/browse/WFLY-3315
