### PR TITLE
[WFLY-2741][WFLY-3058] Management op administrative cancellation and timeouts

### DIFF
--- a/cli/src/main/java/org/jboss/as/cli/Util.java
+++ b/cli/src/main/java/org/jboss/as/cli/Util.java
@@ -59,6 +59,7 @@ public class Util {
     public static final String ALLOW_RESOURCE_SERVICE_RESTART = "allow-resource-service-restart";
     public static final String ARCHIVE = "archive";
     public static final String ATTRIBUTES = "attributes";
+    public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BYTES = "bytes";
     public static final String CHILDREN = "children";
     public static final String CHILD_TYPE = "child-type";

--- a/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
+++ b/cli/src/main/java/org/jboss/as/cli/operation/impl/DefaultOperationCandidatesProvider.java
@@ -79,6 +79,28 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
             return parsedOp.getLastChunkIndex() + result;
         }};
 
+    private static final CommandLineCompleter INT_HEADER_COMPLETER = new CommandLineCompleter(){
+
+        private final DefaultCallbackHandler parsedOp = new DefaultCallbackHandler();
+
+        @Override
+        public int complete(CommandContext ctx, String buffer, int cursor, List<String> candidates) {
+            try {
+                ParserUtil.parseHeaders(buffer, parsedOp);
+            } catch (CommandFormatException e) {
+                //e.printStackTrace();
+                return -1;
+            }
+            if(parsedOp.endsOnSeparator()) {
+                return buffer.length();
+            }
+            if(parsedOp.getLastHeader() == null) {
+                candidates.add("=");
+                return buffer.length();
+            }
+            return buffer.length();
+        }};
+
     private static final Map<String, OperationRequestHeader> HEADERS;
     static {
         HEADERS = new HashMap<String, OperationRequestHeader>();
@@ -86,6 +108,7 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
 
         addBooleanHeader(Util.ALLOW_RESOURCE_SERVICE_RESTART);
         addBooleanHeader(Util.ROLLBACK_ON_RUNTIME_FAILURE);
+        addIntHeader(Util.BLOCKING_TIMEOUT);
     }
 
     private static void addBooleanHeader(final String name) {
@@ -98,6 +121,20 @@ public class DefaultOperationCandidatesProvider implements OperationCandidatesPr
             @Override
             public CommandLineCompleter getCompleter() {
                 return BOOLEAN_HEADER_COMPLETER;
+            }};
+        HEADERS.put(header.getName(), header);
+    }
+
+    private static void addIntHeader(final String name) {
+        OperationRequestHeader header = new OperationRequestHeader(){
+            @Override
+            public String getName() {
+                return name;
+            }
+
+            @Override
+            public CommandLineCompleter getCompleter() {
+                return INT_HEADER_COMPLETER;
             }};
         HEADERS.put(header.getName(), header);
     }

--- a/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractControllerService.java
@@ -245,7 +245,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
                 processState, executorService, expressionResolver, authorizer, auditLogger);
 
         // Initialize the model
-        initModel(controller.getRootResource(), controller.getRootRegistration());
+        initModel(controller.getRootResource(), controller.getRootRegistration(), controller.getModelControllerResource());
         this.controller = controller;
 
         final long bootStackSize = getBootStackSize();
@@ -396,7 +396,7 @@ public abstract class AbstractControllerService implements Service<ModelControll
         //
     }
 
-    protected abstract void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration);
+    protected abstract void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource);
 
     protected ManagedAuditLogger getAuditLogger() {
         return auditLogger;

--- a/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/AbstractOperationContext.java
@@ -54,6 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingDeque;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.security.auth.Subject;
@@ -89,7 +90,7 @@ abstract class AbstractOperationContext implements OperationContext {
     final Thread initiatingThread;
     private final EnumMap<Stage, Deque<Step>> steps;
     private final ModelController.OperationTransactionControl transactionControl;
-    private final ControlledProcessState processState;
+    final ControlledProcessState processState;
     private final boolean booting;
     private final ProcessType processType;
     private final RunningMode runningMode;
@@ -319,12 +320,13 @@ abstract class AbstractOperationContext implements OperationContext {
 
     /**
      * If appropriate for this implementation, block waiting for the
-     * {@link ModelControllerImpl#acquireContainerMonitor()} method to return, ensuring that the controller's
-     * MSC ServiceContainer is settled and it is safe to proceed to service status verification.
+     * {@link ModelControllerImpl#awaitContainerStability(long, java.util.concurrent.TimeUnit, boolean)} method to return,
+     * ensuring that the controller's MSC ServiceContainer is settled and it is safe to proceed to service status verification.
      *
      * @throws InterruptedException if the thread is interrupted while blocking
+     * @throws java.util.concurrent.TimeoutException if attaining container stability takes an unacceptable amount of time
      */
-    abstract void awaitModelControllerContainerMonitor() throws InterruptedException;
+    abstract void awaitServiceContainerStability() throws InterruptedException, TimeoutException;
 
     /**
      * Create a persistence resource (if appropriate for this implementation) for use in persisting the configuration
@@ -350,7 +352,7 @@ abstract class AbstractOperationContext implements OperationContext {
      *
      * @throws InterruptedException if the thread is interrupted while waiting
      */
-    abstract void waitForRemovals() throws InterruptedException;
+    abstract void waitForRemovals() throws InterruptedException, TimeoutException;
 
     /**
      * Gets whether any steps have taken actions that indicate a wish to write to the model or the service container.
@@ -455,22 +457,17 @@ abstract class AbstractOperationContext implements OperationContext {
                         // a change was made to the runtime. Thus, we must wait
                         // for stability before resuming in to verify.
                         try {
-                            awaitModelControllerContainerMonitor();
+                            awaitServiceContainerStability();
                         } catch (InterruptedException e) {
                             cancelled = true;
-                            if (response != null) {
-                                response.get(OUTCOME).set(CANCELLED);
-                                response.get(FAILURE_DESCRIPTION).set(ControllerLogger.ROOT_LOGGER.operationCancelled());
-                                response.get(ROLLED_BACK).set(true);
-                            }
-                            resultAction = ResultAction.ROLLBACK;
-                            respectInterruption = false;
-                            logAuditRecord();
-                            Thread.currentThread().interrupt();
-                            if (activeStep != null && activeStep.resultHandler != null) {
-                                // Finalize
-                                activeStep.finalizeStep(null);
-                            }
+                            handleContainerStabilityFailure(response, e);
+                            return;
+                        }  catch (TimeoutException te) {
+                            // The service container is in an unknown state; but we don't require restart
+                            // because rollback may allow the container to stabilize. We force require-restart
+                            // in the rollback handling if the container cannot stabilize (see OperationContextImpl.releaseStepLocks)
+                            //processState.setRestartRequired();  // don't use our restartRequired() method as this is not reversible in rollback
+                            handleContainerStabilityFailure(response, te);
                             return;
                         }
                     }
@@ -646,7 +643,7 @@ abstract class AbstractOperationContext implements OperationContext {
                 // This can happen with an operation with many, many steps that use the recursive no-arg completeStep()
                 // variant. This should be rare now as handlers are largely migrated from this variant.
                 // But, log a special message for this case
-                MGMT_OP_LOGGER.operationFailed(t, step.operation.get(OP), step.operation.get(OP_ADDR),
+                MGMT_OP_LOGGER.operationFailedInsufficientStackSpace(t, step.operation.get(OP), step.operation.get(OP_ADDR),
                         AbstractControllerService.BOOT_STACK_SIZE_PROPERTY, AbstractControllerService.DEFAULT_BOOT_STACK_SIZE);
             } else {
                 MGMT_OP_LOGGER.operationFailed(t, step.operation.get(OP), step.operation.get(OP_ADDR));
@@ -722,6 +719,28 @@ abstract class AbstractOperationContext implements OperationContext {
                 throwThrowable(toThrow);
             }
         }
+    }
+
+    private void handleContainerStabilityFailure(ModelNode response, Exception cause) {
+        boolean interrupted = cause instanceof InterruptedException;
+        assert interrupted || cause instanceof TimeoutException;
+
+        if (response != null) {
+            response.get(OUTCOME).set(CANCELLED);
+            response.get(FAILURE_DESCRIPTION).set(interrupted ? ControllerLogger.ROOT_LOGGER.operationCancelled(): ControllerLogger.ROOT_LOGGER.timeoutExecutingOperation());
+            response.get(ROLLED_BACK).set(true);
+        }
+        resultAction = ResultAction.ROLLBACK;
+        respectInterruption = false;
+        logAuditRecord();
+        if (interrupted) {
+            Thread.currentThread().interrupt();
+        }
+        if (activeStep != null && activeStep.resultHandler != null) {
+            // Finalize
+            activeStep.finalizeStep(null);
+        }
+
     }
 
     private static void throwThrowable(Throwable toThrow) {
@@ -875,6 +894,7 @@ abstract class AbstractOperationContext implements OperationContext {
         private Object restartStamp;
         private ResultHandler resultHandler;
         Step predecessor;
+        boolean hasRemovals;
 
         private Step(final OperationStepHandler handler, final ModelNode response, final ModelNode operation,
                 final PathAddress address) {
@@ -939,7 +959,7 @@ abstract class AbstractOperationContext implements OperationContext {
             AbstractOperationContext.this.activeStep = this;
 
             try {
-                handleRollback();
+                handleResult();
 
                 if (currentStage != null && currentStage != Stage.DONE) {
                     // This is a failure because the next step failed to call
@@ -976,15 +996,18 @@ abstract class AbstractOperationContext implements OperationContext {
             }
         }
 
-        private void handleRollback() {
+        private void handleResult() {
             if (resultHandler != null) {
+                hasRemovals = false;
                 try {
                     ClassLoader oldTccl = WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(handler.getClass());
                     try {
                         resultHandler.handleResult(resultAction, AbstractOperationContext.this, operation);
                     } finally {
                         WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
-                        waitForRemovals();
+                        if (hasRemovals) {
+                            waitForRemovals();
+                        }
                     }
                 } catch (Exception e) {
                     report(MessageSeverity.ERROR,

--- a/controller/src/main/java/org/jboss/as/controller/BlockingTimeout.java
+++ b/controller/src/main/java/org/jboss/as/controller/BlockingTimeout.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING_TIMEOUT;
+
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * Encapsulates information about how long management operation execution should block
+ * before timing out.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+class BlockingTimeout {
+
+    public static final String SYSTEM_PROPERTY = "jboss.as.management.blocking.timeout";
+    private static final int DEFAULT_TIMEOUT = 300;  // seconds
+    private static final String DEFAULT_TIMEOUT_STRING = Long.toString(DEFAULT_TIMEOUT);
+    private static final int SHORT_TIMEOUT = 5000;
+    private static String sysPropValue;
+    private static int defaultValue;
+
+    private final int blockingTimeout;
+    private final int shortTimeout;
+    private volatile boolean timeoutDetected;
+
+    BlockingTimeout(final ModelNode headerValue) {
+        Integer opHeaderValue;
+        if (headerValue != null && headerValue.isDefined()) {
+            opHeaderValue = headerValue.asInt();
+            if (opHeaderValue < 1) {
+                throw ControllerLogger.MGMT_OP_LOGGER.invalidBlockingTimeout(opHeaderValue.longValue(), BLOCKING_TIMEOUT);
+            }
+            blockingTimeout = opHeaderValue * 1000;
+        } else {
+            blockingTimeout = resolveDefaultTimeout();
+        }
+        shortTimeout = Math.min(blockingTimeout, SHORT_TIMEOUT);
+    }
+
+    private static int resolveDefaultTimeout() {
+        String propValue = WildFlySecurityManager.getPropertyPrivileged(SYSTEM_PROPERTY, DEFAULT_TIMEOUT_STRING);
+        if (sysPropValue == null || !sysPropValue.equals(propValue)) {
+            // First call or the system property changed
+            sysPropValue = propValue;
+            int number = -1;
+            try {
+                number = Integer.valueOf(sysPropValue);
+            } catch (NumberFormatException nfe) {
+                // ignored
+            }
+
+            if (number > 0) {
+                defaultValue = number * 1000; // seconds to ms
+            } else {
+                ControllerLogger.MGMT_OP_LOGGER.invalidDefaultBlockingTimeout(sysPropValue, SYSTEM_PROPERTY, DEFAULT_TIMEOUT);
+                defaultValue = DEFAULT_TIMEOUT * 1000; // seconds to ms
+            }
+        }
+        return defaultValue;
+    }
+
+    /**
+     * Gets the maximum period, in ms, a blocking call should block.
+     * @return the maximum period. Will be a value greater than zero.
+     */
+    int getBlockingTimeout() {
+        return timeoutDetected ? shortTimeout : blockingTimeout;
+    }
+
+    /**
+     * Notifies this object that a timeout has occurred, allowing shorter timeouts values
+     * to be returned from {@link #getBlockingTimeout()}
+     */
+    void timeoutDetected() {
+        timeoutDetected = true;
+    }
+}

--- a/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
+++ b/controller/src/main/java/org/jboss/as/controller/ContainerStateMonitor.java
@@ -29,6 +29,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.msc.service.AbstractServiceListener;
@@ -57,11 +59,12 @@ public final class ContainerStateMonitor extends AbstractServiceListener<Object>
         serviceRegistry = registry;
     }
 
-    void acquire() {
-        // does nothing
-    }
-
-    void release() {
+    /**
+     * Log a report of any problematic container state changes and reset container state change history
+     * so another run of this method or of {@link #awaitContainerStateChangeReport(long, java.util.concurrent.TimeUnit)}
+     * will produce a report not including any changes included in a report returned by this run.
+     */
+    void logContainerStateChangesAndReset() {
         ContainerStateChangeReport changeReport = createContainerStateChangeReport(true);
 
         if (changeReport != null) {
@@ -76,31 +79,72 @@ public final class ContainerStateMonitor extends AbstractServiceListener<Object>
         controller.removeListener(this);
     }
 
-    void awaitUninterruptibly() {
-        boolean interruped = false;
+    /**
+     * Await service container stability ignoring thread interruption.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     *
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    void awaitStabilityUninterruptibly(long timeout, TimeUnit timeUnit) throws TimeoutException {
+        boolean interrupted = false;
         try {
+            long toWait = timeUnit.toMillis(timeout);
+            long msTimeout = System.currentTimeMillis() + toWait;
             while (true) {
+                if (interrupted) {
+                    toWait = msTimeout - System.currentTimeMillis();
+                }
                 try {
-                    monitor.awaitStability(failed, problems);
+                    if (toWait <= 0 || !monitor.awaitStability(toWait, TimeUnit.MILLISECONDS, failed, problems)) {
+                        throw new TimeoutException();
+                    }
                     break;
                 } catch (InterruptedException e) {
-                    interruped = true;
+                    interrupted = true;
                 }
             }
         } finally {
-            if (interruped) {
+            if (interrupted) {
                 Thread.currentThread().interrupt();
             }
         }
     }
 
-    void await() throws InterruptedException {
-        monitor.awaitStability(failed, problems);
+    /**
+     * Await service container stability.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     *
+     * @throws java.lang.InterruptedException if the thread is interrupted while awaiting service container stability
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    void awaitStability(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+        if (!monitor.awaitStability(timeout, timeUnit, failed, problems)) {
+            throw new TimeoutException();
+        }
     }
 
-    ContainerStateChangeReport awaitContainerStateChangeReport() throws InterruptedException {
-        monitor.awaitStability(failed, problems);
-        return createContainerStateChangeReport(false);
+    /**
+     * Await service container stability and then report on container state changes. Does not reset change history,
+     * so another run of this method with no intervening call to {@link #logContainerStateChangesAndReset()}
+     * will produce a report including any changes included in a report returned by the first run.
+     *
+     * @param timeout maximum period to wait for service container stability
+     * @param timeUnit unit in which {@code timeout} is expressed
+     *
+     * @return a change report, or {@code null} if there is nothing to report
+     *
+     * @throws java.lang.InterruptedException if the thread is interrupted while awaiting service container stability
+     * @throws java.util.concurrent.TimeoutException if service container stability is not reached before the specified timeout
+     */
+    ContainerStateChangeReport awaitContainerStateChangeReport(long timeout, TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+        if (monitor.awaitStability(timeout, timeUnit, failed, problems)) {
+            return createContainerStateChangeReport(false);
+        }
+        throw new TimeoutException();
     }
 
     /**
@@ -190,6 +234,7 @@ public final class ContainerStateMonitor extends AbstractServiceListener<Object>
             msg.append(ControllerLogger.ROOT_LOGGER.serviceStatusReportFailed());
             for (ServiceController<?> controller : changeReport.getFailedControllers()) {
                 msg.append("      ").append(controller.getName());
+                //noinspection ThrowableResultOfMethodCallIgnored
                 final StartException startException = controller.getStartException();
                 if (startException != null) {
                     msg.append(": ").append(startException.toString());

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerImpl.java
@@ -26,12 +26,14 @@ import static java.security.AccessController.doPrivileged;
 import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_MECHANISM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING_TIMEOUT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DOMAIN_UUID;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -39,13 +41,16 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROCESS_STATE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESPONSE_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 
 import java.io.IOException;
 import java.security.AccessControlContext;
 import java.security.PrivilegedAction;
 import java.security.SecureRandom;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
@@ -73,6 +78,7 @@ import org.jboss.as.controller.persistence.ConfigurationPersister;
 import org.jboss.as.controller.registry.ImmutableManagementResourceRegistration;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.registry.PlaceholderResource;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.core.security.AccessMechanism;
 import org.jboss.dmr.ModelNode;
@@ -90,6 +96,14 @@ import org.wildfly.security.manager.action.GetAccessControlContextAction;
  */
 class ModelControllerImpl implements ModelController {
 
+    private static final String INITIAL_BOOT_OPERATION = "initial-boot-operation";
+    private static final String POST_EXTENSION_BOOT_OPERATION = "post-extension-boot-operation";
+    static final ModelNode EMPTY_ADDRESS = new ModelNode().setEmptyList();
+
+    static {
+        EMPTY_ADDRESS.protect();
+    }
+
     private final ServiceRegistry serviceRegistry;
     private final ServiceTarget serviceTarget;
     private final ManagementResourceRegistration rootRegistration;
@@ -106,11 +120,12 @@ class ModelControllerImpl implements ModelController {
     private final ExpressionResolver expressionResolver;
     private final Authorizer authorizer;
 
-    private final ConcurrentMap<Integer, AbstractOperationContext> activeOperations = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Integer, OperationContextImpl> activeOperations = new ConcurrentHashMap<>();
     private final ManagedAuditLogger auditLogger;
 
     /** Tracks the relationship between domain resources and hosts and server groups */
     private final HostServerGroupTracker hostServerGroupTracker;
+    private final Resource.ResourceEntry modelControllerResource;
 
     ModelControllerImpl(final ServiceRegistry serviceRegistry, final ServiceTarget serviceTarget, final ManagementResourceRegistration rootRegistration,
                         final ContainerStateMonitor stateMonitor, final ConfigurationPersister persister,
@@ -133,6 +148,7 @@ class ModelControllerImpl implements ModelController {
         this.authorizer = authorizer;
         this.auditLogger = auditLogger;
         this.hostServerGroupTracker = processType.isManagedDomain() ? new HostServerGroupTracker() : null;
+        this.modelControllerResource = new ModelControllerResource();
         auditLogger.startBoot();
     }
 
@@ -238,6 +254,7 @@ class ModelControllerImpl implements ModelController {
             }
         };
 
+        AccessMechanism accessMechanism = null;
         AccessAuditContext accessContext = SecurityActions.currentAccessAuditContext();
         if (accessContext != null) {
             if (operation.hasDefined(OPERATION_HEADERS)) {
@@ -250,14 +267,16 @@ class ModelControllerImpl implements ModelController {
                             .setAccessMechanism(AccessMechanism.valueOf(operationHeaders.get(ACCESS_MECHANISM).asString()));
                 }
             }
+            accessMechanism = accessContext.getAccessMechanism();
         }
 
         for (;;) {
             // Create a random operation-id
             final Integer operationID = new Random(new SecureRandom().nextLong()).nextInt();
-            final OperationContextImpl context = new OperationContextImpl(this, processType, runningModeControl.getRunningMode(),
+            final OperationContextImpl context = new OperationContextImpl(operationID, operation.get(OP).asString(),
+                    operation.get(OP_ADDR), this, processType, runningModeControl.getRunningMode(),
                     contextFlags, handler, attachments, model, originalResultTxControl, processState, auditLogger,
-                    bootingFlag.get(), operationID, hostServerGroupTracker, blockingTimeoutConfig);
+                    bootingFlag.get(), hostServerGroupTracker, blockingTimeoutConfig, accessMechanism);
             // Try again if the operation-id is already taken
             if(activeOperations.putIfAbsent(operationID, context) == null) {
                 CurrentOperationIdHolder.setCurrentOperationID(operationID);
@@ -275,6 +294,19 @@ class ModelControllerImpl implements ModelController {
                     context.addStep(response, operation, prepareStep, OperationContext.Stage.MODEL);
                     context.executeOperation();
                 } finally {
+
+                    if (!response.hasDefined(RESPONSE_HEADERS) || !response.get(RESPONSE_HEADERS).hasDefined(PROCESS_STATE)) {
+                        ControlledProcessState.State state = processState.getState();
+                        switch (state) {
+                            case RELOAD_REQUIRED:
+                            case RESTART_REQUIRED:
+                                response.get(RESPONSE_HEADERS, PROCESS_STATE).set(state.toString());
+                                break;
+                            default:
+                                break;
+                        }
+                    }
+
                     if (shouldUnlock) {
                         controllerLock.unlock(operationID);
                     }
@@ -282,18 +314,6 @@ class ModelControllerImpl implements ModelController {
                     CurrentOperationIdHolder.setCurrentOperationID(null);
                 }
                 break;
-            }
-        }
-
-        if (!response.hasDefined(RESPONSE_HEADERS) || !response.get(RESPONSE_HEADERS).hasDefined(PROCESS_STATE)) {
-            ControlledProcessState.State state = processState.getState();
-            switch (state) {
-                case RELOAD_REQUIRED:
-                case RESTART_REQUIRED:
-                    response.get(RESPONSE_HEADERS, PROCESS_STATE).set(state.toString());
-                    break;
-                default:
-                    break;
             }
         }
         return response;
@@ -307,8 +327,10 @@ class ModelControllerImpl implements ModelController {
         EnumSet<OperationContextImpl.ContextFlag> contextFlags = rollbackOnRuntimeFailure
                 ? EnumSet.of(OperationContextImpl.ContextFlag.ROLLBACK_ON_FAIL)
                 : EnumSet.noneOf(OperationContextImpl.ContextFlag.class);
-        final OperationContextImpl context = new OperationContextImpl(this, processType, runningModeControl.getRunningMode(),
-                contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), operationID, hostServerGroupTracker, null);
+        final OperationContextImpl context = new OperationContextImpl(operationID, INITIAL_BOOT_OPERATION, EMPTY_ADDRESS,
+                this, processType, runningModeControl.getRunningMode(),
+                contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(),
+                hostServerGroupTracker, null, null);
 
         // Add to the context all ops prior to the first ExtensionAddHandler as well as all ExtensionAddHandlers; save the rest.
         // This gets extensions registered before proceeding to other ops that count on these registrations
@@ -325,8 +347,9 @@ class ModelControllerImpl implements ModelController {
         if (resultAction == OperationContext.ResultAction.KEEP && bootOperations.postExtensionOps != null) {
 
             // Success. Now any extension handlers are registered. Continue with remaining ops
-            final OperationContextImpl postExtContext = new OperationContextImpl(this, processType, runningModeControl.getRunningMode(),
-                    contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), operationID, hostServerGroupTracker, null);
+            final OperationContextImpl postExtContext = new OperationContextImpl(operationID, POST_EXTENSION_BOOT_OPERATION,
+                    EMPTY_ADDRESS, this, processType, runningModeControl.getRunningMode(),
+                    contextFlags, handler, null, model, control, processState, auditLogger, bootingFlag.get(), hostServerGroupTracker, null, null);
 
             for (ParsedBootOp parsedOp : bootOperations.postExtensionOps) {
                 if (parsedOp.handler == null) {
@@ -454,6 +477,10 @@ class ModelControllerImpl implements ModelController {
 
     public Resource getRootResource() {
         return model;
+    }
+
+    public Resource.ResourceEntry getModelControllerResource() {
+        return modelControllerResource;
     }
 
     ManagementResourceRegistration getRootRegistration() {
@@ -856,6 +883,76 @@ class ModelControllerImpl implements ModelController {
             this.initialOps = initialOps;
             this.postExtensionOps = postExtensionOps;
             this.invalid = invalid;
+        }
+    }
+
+    private final class ModelControllerResource extends PlaceholderResource.PlaceholderResourceEntry {
+
+        private ModelControllerResource() {
+            super(SERVICE, MANAGEMENT_OPERATIONS);
+        }
+
+        @Override
+        public boolean hasChild(PathElement element) {
+            try {
+                return ACTIVE_OPERATION.equals(element.getKey())
+                        && activeOperations.containsKey(Integer.valueOf(element.getValue()));
+            } catch (NumberFormatException e) {
+                return false;
+            }
+        }
+
+        @Override
+        public Resource getChild(PathElement element) {
+            Resource result = null;
+            if (ACTIVE_OPERATION.equals(element.getKey())) {
+                try {
+                    OperationContextImpl context = activeOperations.get(Integer.valueOf(element.getValue()));
+                    if (context != null) {
+                        result = context.getActiveOperationResource();
+                    }
+                } catch (NumberFormatException e) {
+                    // just return null
+                }
+            }
+            return result;
+        }
+
+        @Override
+        public Resource requireChild(PathElement element) {
+            final Resource resource = getChild(element);
+            if(resource == null) {
+                throw new NoSuchResourceException(element);
+            }
+            return resource;
+        }
+
+        @Override
+        public boolean hasChildren(String childType) {
+            return ACTIVE_OPERATION.equals(childType) && activeOperations.size() > 0;
+        }
+
+        @Override
+        public Set<String> getChildTypes() {
+            return Collections.singleton(ACTIVE_OPERATION);
+        }
+
+        @Override
+        public Set<String> getChildrenNames(String childType) {
+            Set<String> result = new HashSet<String>(activeOperations.size());
+            for (Integer id : activeOperations.keySet()) {
+                result.add(id.toString());
+            }
+            return result;
+        }
+
+        @Override
+        public Set<ResourceEntry> getChildren(String childType) {
+            Set<ResourceEntry> result = new HashSet<ResourceEntry>(activeOperations.size());
+            for (OperationContextImpl context : activeOperations.values()) {
+                result.add(context.getActiveOperationResource());
+            }
+            return result;
         }
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/ModelControllerLock.java
+++ b/controller/src/main/java/org/jboss/as/controller/ModelControllerLock.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.controller;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.AbstractQueuedSynchronizer;
 
@@ -41,11 +42,28 @@ class ModelControllerLock {
         sync.acquire(permit);
     }
 
+    boolean lock(Integer permit, long timeout, TimeUnit unit) throws InterruptedException {
+        boolean result = false;
+        try {
+            result = lockInterruptibly(permit, timeout, unit);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        return result;
+    }
+
     void lockInterruptibly(Integer permit) throws InterruptedException {
         if (permit == null) {
             throw new IllegalArgumentException();
         }
         sync.acquireInterruptibly(permit);
+    }
+
+    boolean lockInterruptibly(Integer permit, long timeout, TimeUnit unit) throws InterruptedException {
+        if (permit == null) {
+            throw new IllegalArgumentException();
+        }
+        return sync.tryAcquireNanos(permit, unit.toNanos(timeout));
     }
 
     void unlock(Integer permit) {

--- a/controller/src/main/java/org/jboss/as/controller/OperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContext.java
@@ -891,4 +891,24 @@ public interface OperationContext extends ExpressionResolver {
             return new AttachmentKey(valueClass);
         }
     }
+
+    /** The current activity of an operation. */
+    public static enum ExecutionStatus {
+        EXECUTING("executing"),
+        AWAITING_OTHER_OPERATION("awaiting-other-operation"),
+        AWAITING_STABILITY("awaiting-stability"),
+        COMPLETING("completing"),
+        ROLLING_BACK("rolling-back");
+
+        private final String name;
+
+        private ExecutionStatus(String name) {
+            this.name = name;
+        }
+
+        @Override
+        public String toString() {
+            return name;
+        }
+    }
 }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -29,6 +29,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CALLER_THREAD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CALLER_TYPE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXCLUSIVE_RUNNING_TIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXECUTION_STATUS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
@@ -37,6 +38,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_TIME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_GROUP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.USER;
@@ -142,6 +144,9 @@ final class OperationContextImpl extends AbstractOperationContext {
             new ConcurrentHashMap<OperationId, AuthorizationResponseImpl>();
     private final ModelNode blockingTimeoutConfig;
     private volatile BlockingTimeout blockingTimeout;
+    private final long startTime = System.nanoTime();
+    private volatile long exclusiveStartTime = -1;
+
     /** Tracks whether any steps have gotten write access to the management resource registration*/
     private volatile boolean affectsResourceRegistration;
 
@@ -484,6 +489,7 @@ final class OperationContextImpl extends AbstractOperationContext {
 //                        throw MESSAGES.operationTimeoutAwaitingControllerLock(timeout);
 //                    }
 //                }
+                exclusiveStartTime = System.nanoTime();
                 lockStep = activeStep;
             } catch (InterruptedException e) {
                 cancelled = true;
@@ -870,6 +876,7 @@ final class OperationContextImpl extends AbstractOperationContext {
 
             if (this.lockStep == step) {
                 modelController.releaseLock(operationId);
+                exclusiveStartTime = -1;
                 lockStep = null;
             }
         } finally {
@@ -1987,6 +1994,12 @@ final class OperationContextImpl extends AbstractOperationContext {
                 accessMechanismNode.set(accessMechanismNode.toString());
             }
             model.get(EXECUTION_STATUS).set(getExecutionStatus());
+            model.get(RUNNING_TIME).set(System.nanoTime() - startTime);
+            long exclusive = exclusiveStartTime;
+            if (exclusive > -1) {
+                exclusive = System.nanoTime() - exclusive;
+            }
+            model.get(EXCLUSIVE_RUNNING_TIME).set(exclusive);
             model.get(CANCELLED).set(cancelled);
             return model;
         }

--- a/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/OperationContextImpl.java
@@ -52,6 +52,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.jboss.as.controller._private.OperationFailedRuntimeException;
 import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.access.Action.ActionEffect;
 import org.jboss.as.controller.access.AuthorizationResult;
@@ -133,6 +134,8 @@ final class OperationContextImpl extends AbstractOperationContext {
     private final ConcurrentMap<AttachmentKey<?>, Object> valueAttachments = new ConcurrentHashMap<AttachmentKey<?>, Object>();
     private final Map<OperationId, AuthorizationResponseImpl> authorizations =
             new ConcurrentHashMap<OperationId, AuthorizationResponseImpl>();
+    private final ModelNode blockingTimeoutConfig;
+    private volatile BlockingTimeout blockingTimeout;
     /** Tracks whether any steps have gotten write access to the management resource registration*/
     private volatile boolean affectsResourceRegistration;
 
@@ -164,10 +167,11 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     OperationContextImpl(final ModelControllerImpl modelController, final ProcessType processType,
                          final RunningMode runningMode, final EnumSet<ContextFlag> contextFlags,
-                            final OperationMessageHandler messageHandler, final OperationAttachments attachments,
-                            final Resource model, final ModelController.OperationTransactionControl transactionControl,
-                            final ControlledProcessState processState, final AuditLogger auditLogger, final boolean booting,
-                            final Integer operationId, final HostServerGroupTracker hostServerGroupTracker) {
+                         final OperationMessageHandler messageHandler, final OperationAttachments attachments,
+                         final Resource model, final ModelController.OperationTransactionControl transactionControl,
+                         final ControlledProcessState processState, final AuditLogger auditLogger, final boolean booting,
+                         final Integer operationId, final HostServerGroupTracker hostServerGroupTracker,
+                         final ModelNode blockingTimeoutConfig) {
         super(processType, runningMode, transactionControl, processState, booting, auditLogger);
         this.model = model;
         this.originalModel = model;
@@ -179,6 +183,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         this.serviceTarget = new ContextServiceTarget(modelController);
         this.operationId = operationId;
         this.hostServerGroupTracker = hostServerGroupTracker;
+        this.blockingTimeoutConfig = blockingTimeoutConfig != null && blockingTimeoutConfig.isDefined() ? blockingTimeoutConfig : null;
     }
 
     public InputStream getAttachmentStream(final int index) {
@@ -193,27 +198,47 @@ final class OperationContextImpl extends AbstractOperationContext {
     }
 
     @Override
-    void awaitModelControllerContainerMonitor() throws InterruptedException {
+    void awaitServiceContainerStability() throws InterruptedException, TimeoutException {
         if (affectsRuntime) {
             MGMT_OP_LOGGER.debugf("Entered VERIFY stage; waiting for service container to settle");
-            // First wait until any removals we've initiated have begun processing, otherwise
-            // the ContainerStateMonitor may not have gotten the notification causing it to untick
-            waitForRemovals();
-            ContainerStateMonitor.ContainerStateChangeReport changeReport = modelController.awaitContainerStateChangeReport();
-            // If any services are missing, add a verification handler to see if we caused it
-            if (changeReport != null && !changeReport.getMissingServices().isEmpty()) {
-                ServiceRemovalVerificationHandler removalVerificationHandler = new ServiceRemovalVerificationHandler(changeReport);
-                addStep(new ModelNode(), new ModelNode(), PathAddress.EMPTY_ADDRESS, removalVerificationHandler, Stage.VERIFY);
+            long timeout = getBlockingTimeout().getBlockingTimeout();
+            try {
+                // First wait until any removals we've initiated have begun processing, otherwise
+                // the ContainerStateMonitor may not have gotten the notification causing it to untick
+                waitForRemovals();
+                ContainerStateMonitor.ContainerStateChangeReport changeReport =
+                        modelController.awaitContainerStateChangeReport(timeout, TimeUnit.MILLISECONDS);
+                // If any services are missing, add a verification handler to see if we caused it
+                if (changeReport != null && !changeReport.getMissingServices().isEmpty()) {
+                    ServiceRemovalVerificationHandler removalVerificationHandler = new ServiceRemovalVerificationHandler(changeReport);
+                    addStep(new ModelNode(), new ModelNode(), PathAddress.EMPTY_ADDRESS, removalVerificationHandler, Stage.VERIFY);
+                }
+            } catch (TimeoutException te) {
+                getBlockingTimeout().timeoutDetected();
+                // Deliberate log and throw; we want to log this but the caller method passes a slightly different
+                // message to the user as part of the operation response
+                MGMT_OP_LOGGER.timeoutExecutingOperation(timeout / 1000, containerMonitorStep.operationId.name, containerMonitorStep.address);
+                throw te;
             }
         }
     }
 
     @Override
-    protected void waitForRemovals() throws InterruptedException {
+    protected void waitForRemovals() throws InterruptedException, TimeoutException {
         if (affectsRuntime && !cancelled) {
             synchronized (realRemovingControllers) {
-                while (!realRemovingControllers.isEmpty() && !cancelled) {
-                    realRemovingControllers.wait();
+                long waitTime = getBlockingTimeout().getBlockingTimeout();
+                long end = System.currentTimeMillis() + waitTime;
+                boolean wait = !realRemovingControllers.isEmpty() && !cancelled;
+                while (wait && waitTime > 0) {
+                    realRemovingControllers.wait(waitTime);
+                    wait = !realRemovingControllers.isEmpty() && !cancelled;
+                    waitTime = end - System.currentTimeMillis();
+                }
+
+                if (wait) {
+                    getBlockingTimeout().timeoutDetected();
+                    throw new TimeoutException();
                 }
             }
         }
@@ -292,11 +317,8 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw ControllerLogger.ROOT_LOGGER.serviceRegistryRuntimeOperationsOnly();
         }
         authorize(false, modify ? READ_WRITE_RUNTIME : READ_RUNTIME);
-        if (modify && !affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
+        if (modify) {
+            ensureWriteLockForRuntime();
         }
         return new OperationContextServiceRegistry(modelController.getServiceRegistry());
     }
@@ -314,12 +336,7 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw ControllerLogger.ROOT_LOGGER.serviceRemovalRuntimeOperationsOnly();
         }
         authorize(false, WRITE_RUNTIME);
-        if (!affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
-        }
+        ensureWriteLockForRuntime();
         ServiceController<?> controller = modelController.getServiceRegistry().getService(name);
         if (controller != null) {
             doRemove(controller);
@@ -365,12 +382,7 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw ControllerLogger.ROOT_LOGGER.serviceRemovalRuntimeOperationsOnly();
         }
         authorize(false, WRITE_RUNTIME);
-        if (!affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
-        }
+        ensureWriteLockForRuntime();
         if (controller != null) {
             doRemove(controller);
         }
@@ -378,6 +390,7 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     private void doRemove(final ServiceController<?> controller) {
         final Step removalStep = activeStep;
+        removalStep.hasRemovals = true;
         controller.addListener(new AbstractServiceListener<Object>() {
             public void listenerAdded(final ServiceController<?> controller) {
                 synchronized (realRemovingControllers) {
@@ -417,12 +430,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         if (currentStage != Stage.RUNTIME && currentStage != Stage.VERIFY && !isRollingBack()) {
             throw ControllerLogger.ROOT_LOGGER.serviceTargetRuntimeOperationsOnly();
         }
-        if (!affectsRuntime) {
-            takeWriteLock();
-            affectsRuntime = true;
-            acquireContainerMonitor();
-            awaitContainerMonitor();
-        }
+        ensureWriteLockForRuntime();
         return serviceTarget;
     }
 
@@ -432,7 +440,21 @@ final class OperationContextImpl extends AbstractOperationContext {
                 throw ControllerLogger.ROOT_LOGGER.invalidModificationAfterCompletedStep();
             }
             try {
-                modelController.acquireLock(operationId, respectInterruption, this);
+                // BES 2014/04/22 Ignore blocking timeout here. We risk some bug causing the
+                // lock to never be released. But we gain multiple ops being able to wait until they get
+                // a chance to run with no need to guess how long op 2 will take so we can
+                // let op 3 block for the time needed for both 1 and 2
+//                int timeout = blockingTimeout.getBlockingTimeout();
+//                if (timeout < 1) {
+                    modelController.acquireLock(operationId, respectInterruption);
+//                } else {
+//                    // Wait longer than the standard amount to get a chance to execute
+//                    // after whatever was holding the lock times out
+//                    timeout += 10;
+//                    if (!modelController.acquireLock(operationId, respectInterruption, timeout)) {
+//                        throw MESSAGES.operationTimeoutAwaitingControllerLock(timeout);
+//                    }
+//                }
                 lockStep = activeStep;
             } catch (InterruptedException e) {
                 cancelled = true;
@@ -442,26 +464,43 @@ final class OperationContextImpl extends AbstractOperationContext {
         }
     }
 
-    private void acquireContainerMonitor() {
-        if (containerMonitorStep == null) {
-            if (currentStage == Stage.DONE) {
-                throw ControllerLogger.ROOT_LOGGER.invalidModificationAfterCompletedStep();
-            }
-            modelController.acquireContainerMonitor();
-            containerMonitorStep = activeStep;
-        }
-    }
+    private void ensureWriteLockForRuntime() {
+        if (!affectsRuntime) {
+            takeWriteLock();
+            affectsRuntime = true;
+            if (containerMonitorStep == null) {
+                if (currentStage == Stage.DONE) {
+                    throw ControllerLogger.ROOT_LOGGER.invalidModificationAfterCompletedStep();
+                }
+                containerMonitorStep = activeStep;
+                int timeout = getBlockingTimeout().getBlockingTimeout();
+                try {
+                    modelController.awaitContainerStability(timeout, TimeUnit.MILLISECONDS, respectInterruption);
+                } catch (InterruptedException e) {
+                    if (resultAction != ResultAction.ROLLBACK) {
+                        // We're not on the way out, so we've been cancelled on the way in
+                        cancelled = true;
+                    }
+                    Thread.currentThread().interrupt();
+                    throw ControllerLogger.ROOT_LOGGER.operationCancelledAsynchronously();
+                } catch (TimeoutException te) {
 
-    private void awaitContainerMonitor() {
-        try {
-            modelController.awaitContainerMonitor(respectInterruption);
-        } catch (InterruptedException e) {
-            if (currentStage != Stage.DONE && resultAction != ResultAction.ROLLBACK) {
-                // We're not on the way out, so we've been cancelled on the way in
-                cancelled = true;
+                    getBlockingTimeout().timeoutDetected();
+                    // This is the first step trying to await stability for this op, so if it's
+                    // unstable some previous step must have messed it up and it can't recover.
+                    // So this process must restart.
+                    // The previous op should have set this in {@code releaseStepLocks}; doing it again
+                    // here is just a 2nd line of defense
+                    processState.setRestartRequired();// don't use our restartRequired() method as this is not reversible in rollback
+
+                    // Deliberate log and throw; we want this logged, we need to notify user, and I want slightly
+                    // different messages for both so just throwing a RuntimeException to get the automatic handling
+                    // in AbstractOperationContext.executeStep is not what I wanted
+                    MGMT_OP_LOGGER.timeoutAwaitingInitialStability(timeout / 1000, activeStep.operationId.name, activeStep.operationId.address);
+                    setRollbackOnly();
+                    throw new OperationFailedRuntimeException(ControllerLogger.ROOT_LOGGER.timeoutAwaitingInitialStability());
+                }
             }
-            Thread.currentThread().interrupt();
-            throw ControllerLogger.ROOT_LOGGER.operationCancelledAsynchronously();
         }
     }
 
@@ -764,11 +803,10 @@ final class OperationContextImpl extends AbstractOperationContext {
 
     @Override
     void releaseStepLocks(AbstractOperationContext.Step step) {
+        boolean interrupted = false;
         try {
-            if (this.lockStep == step) {
-                modelController.releaseLock(operationId);
-                lockStep = null;
-            }
+            // Get container stability before releasing controller lock to ensure another
+            // op doesn't get in and destabilize the container.
             if (this.containerMonitorStep == step) {
                 // Note: If we allow this thread to be interrupted, an op that has been cancelled
                 // because of minor user impatience can release the controller lock while the
@@ -777,17 +815,38 @@ final class OperationContextImpl extends AbstractOperationContext {
                 // will not be cancellable. I (BES 2012/01/24) chose the former as the lesser evil.
                 // Any subsequent step that calls getServiceRegistry/getServiceTarget/removeService
                 // is going to have to await the monitor uninterruptibly anyway before proceeding.
+                long timeout = getBlockingTimeout().getBlockingTimeout();
                 try {
-                    modelController.awaitContainerMonitor(true);
+                    modelController.awaitContainerStability(timeout, TimeUnit.MILLISECONDS, true);
                 }  catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                    interrupted = true;
                     MGMT_OP_LOGGER.interruptedWaitingStability();
+                } catch (TimeoutException te) {
+                    // If we can't attain stability on the way out after rollback ops have run,
+                    // we can no longer have any sense of MSC state or how the model relates to the runtime and
+                    // we need to start from a fresh service container.
+                    processState.setRestartRequired(); // don't use our restartRequired() method as this is not reversible in rollback
+                    // Just log; this doesn't change the result of the op. And if we're not stable here
+                    // it's almost certain we never stabilized during execution or we are rolling back and destabilized there.
+                    // Either one means there is already a failure message associated with this op.
+                    MGMT_OP_LOGGER.timeoutCompletingOperation(timeout, activeStep.operationId.name, activeStep.operationId.address);
                 }
             }
+
+            if (this.lockStep == step) {
+                modelController.releaseLock(operationId);
+                lockStep = null;
+            }
         } finally {
-            if (this.containerMonitorStep == step) {
-                modelController.releaseContainerMonitor();
-                containerMonitorStep = null;
+            try {
+                if (this.containerMonitorStep == step) {
+                    modelController.logContainerStateChangesAndReset();
+                    containerMonitorStep = null;
+                }
+            } finally {
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }
@@ -897,7 +956,7 @@ final class OperationContextImpl extends AbstractOperationContext {
         if (authResp == null) {
             // Non-existent resource type or operation. This is permitted but will fail
             // later for reasons unrelated to authz
-            return authResp;
+            return null;
         }
         Environment callEnvironment = getCallEnvironment();
         if (authResp.getResourceResult(ActionEffect.ADDRESS) == null) {
@@ -1219,6 +1278,17 @@ final class OperationContextImpl extends AbstractOperationContext {
         }
     }
 
+    private BlockingTimeout getBlockingTimeout() {
+        if (blockingTimeout == null) {
+            synchronized (this) {
+                if (blockingTimeout == null) {
+                    blockingTimeout = new BlockingTimeout(blockingTimeoutConfig);
+                }
+            }
+        }
+        return blockingTimeout;
+    }
+
     class ContextServiceTarget implements ServiceTarget {
 
         private final ModelControllerImpl modelController;
@@ -1252,22 +1322,28 @@ final class OperationContextImpl extends AbstractOperationContext {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceTarget addListener(final ServiceListener<Object> listener) {
             throw new UnsupportedOperationException();
         }
 
-        public ServiceTarget addListener(final ServiceListener<Object>... listeners) {
+        @SafeVarargs
+        @SuppressWarnings("deprecation")
+        public final ServiceTarget addListener(final ServiceListener<Object>... listeners) {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceTarget addListener(final Collection<ServiceListener<Object>> listeners) {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceTarget removeListener(final ServiceListener<Object> listener) {
             throw new UnsupportedOperationException();
         }
 
+        @SuppressWarnings("deprecation")
         public Set<ServiceListener<Object>> getListeners() {
             throw new UnsupportedOperationException();
         }
@@ -1396,29 +1472,36 @@ final class OperationContextImpl extends AbstractOperationContext {
             return this;
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceBuilder<T> addListener(final ServiceListener<? super T> listener) {
             realBuilder.addListener(listener);
             return this;
         }
 
-        public ServiceBuilder<T> addListener(final ServiceListener<? super T>... listeners) {
+        @SafeVarargs
+        @SuppressWarnings("deprecation")
+        public final ServiceBuilder<T> addListener(final ServiceListener<? super T>... listeners) {
             realBuilder.addListener(listeners);
             return this;
         }
 
+        @SuppressWarnings("deprecation")
         public ServiceBuilder<T> addListener(final Collection<? extends ServiceListener<? super T>> listeners) {
             realBuilder.addListener(listeners);
             return this;
         }
 
         public ServiceController<T> install() throws ServiceRegistryException, IllegalStateException {
-            final Map<ServiceName, ServiceController<?>> map = realRemovingControllers;
-            synchronized (map) {
+            synchronized (realRemovingControllers) {
                 boolean intr = false;
                 try {
-                    while (map.containsKey(name)) {
+                    boolean containsKey = realRemovingControllers.containsKey(name);
+                    long timeout = getBlockingTimeout().getBlockingTimeout();
+                    long waitTime = timeout;
+                    long end = System.currentTimeMillis() + waitTime;
+                    while (containsKey && waitTime > 0) {
                         try {
-                            map.wait();
+                            realRemovingControllers.wait(waitTime);
                         } catch (InterruptedException e) {
                             intr = true;
                             if (respectInterruption) {
@@ -1426,6 +1509,13 @@ final class OperationContextImpl extends AbstractOperationContext {
                                 throw ControllerLogger.ROOT_LOGGER.serviceInstallCancelled();
                             } // else keep waiting and mark the thread interrupted at the end
                         }
+                        containsKey = realRemovingControllers.containsKey(name);
+                        waitTime = end - System.currentTimeMillis();
+                    }
+
+                    if (containsKey) {
+                        // We timed out
+                        throw ControllerLogger.ROOT_LOGGER.serviceInstallTimedOut(timeout, name);
                     }
 
                     // If a step removed this ServiceName before, it's no longer responsible
@@ -1589,10 +1679,12 @@ final class OperationContextImpl extends AbstractOperationContext {
             return controller.getAliases();
         }
 
+        @SuppressWarnings("deprecation")
         public void addListener(ServiceListener<? super S> serviceListener) {
             controller.addListener(serviceListener);
         }
 
+        @SuppressWarnings("deprecation")
         public void removeListener(ServiceListener<? super S> serviceListener) {
             controller.removeListener(serviceListener);
         }

--- a/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ParallelBootOperationContext.java
@@ -190,7 +190,7 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     public void acquireControllerLock() {
         if(lockStep == null) {
             try {
-                controller.acquireLock(operationId, true, this);
+                controller.acquireLock(operationId, true);
                 lockStep = activeStep;
             } catch (InterruptedException e) {
                 cancelled = true;
@@ -290,7 +290,7 @@ class ParallelBootOperationContext extends AbstractOperationContext {
     }
 
     @Override
-    void awaitModelControllerContainerMonitor() throws InterruptedException {
+    void awaitServiceContainerStability() throws InterruptedException {
         // ignored
     }
 

--- a/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/ProxyStepHandler.java
@@ -158,12 +158,12 @@ public class ProxyStepHandler implements OperationStepHandler {
             context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
         } else {
 
-            completeRemoteTransaction(context, operation, txRef, preparedResultRef, finalResultRef);
+            completeRemoteTransaction(context, txRef, preparedResultRef, finalResultRef);
 
         }
     }
 
-    private void completeRemoteTransaction(OperationContext context, ModelNode operation, final AtomicReference<ModelController.OperationTransaction> txRef,
+    private void completeRemoteTransaction(OperationContext context, final AtomicReference<ModelController.OperationTransaction> txRef,
                                            final AtomicReference<ModelNode> preparedResultRef, final AtomicReference<ModelNode> finalResultRef) {
 
         boolean completeStepCalled = false;

--- a/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
+++ b/controller/src/main/java/org/jboss/as/controller/ReadOnlyContext.java
@@ -65,7 +65,7 @@ class ReadOnlyContext extends AbstractOperationContext {
     }
 
     @Override
-    void awaitModelControllerContainerMonitor() throws InterruptedException {
+    void awaitServiceContainerStability() throws InterruptedException {
         // nothing here
     }
 
@@ -146,7 +146,7 @@ class ReadOnlyContext extends AbstractOperationContext {
     public void acquireControllerLock() {
         if (lockStep == null) {
             try {
-                controller.acquireLock(operationId, true, this);
+                controller.acquireLock(operationId, true);
                 lockStep = activeStep;
             } catch (InterruptedException e) {
                 cancelled = true;

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -36,6 +36,7 @@ public class ModelDescriptionConstants {
     public static final String ACCESS_MECHANISM = "access-mechanism";
     /** The key for {@link org.jboss.as.controller.registry.AttributeAccess.AccessType} fields. */
     public static final String ACCESS_TYPE = "access-type";
+    public static final String ACTIVE_OPERATION = "active-operation";
     public static final String ADD = "add";
     public static final String ADDRESS = "address";
     public static final String ADMIN_ONLY = "admin-only";
@@ -70,6 +71,7 @@ public class ModelDescriptionConstants {
     public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BOOT_TIME = "boot-time";
     public static final String BYTES = "bytes";
+    public static final String CALLER_THREAD = "caller-thread";
     public static final String CALLER_TYPE = "caller-type";
     public static final String CANCELLED = "cancelled";
     public static final String CHILD_TYPE = "child-type";
@@ -133,6 +135,7 @@ public class ModelDescriptionConstants {
     public static final String ESCAPE_CONTROL_CHARACTERS = "escape-control-characters";
     public static final String ESCAPE_NEW_LINE = "escape-new-line";
     public static final String EXECUTE_FOR_COORDINATOR = "execute-for-coordinator";
+    public static final String EXECUTION_STATUS = "execution-status";
     public static final String EXPRESSIONS_ALLOWED = "expressions-allowed";
     public static final String EXTENSION = "extension";
     public static final String FAILED = "failed";
@@ -202,13 +205,14 @@ public class ModelDescriptionConstants {
     public static final String LOGGER = "logger";
     public static final String LOG_BOOT = "log-boot";
     public static final String LOG_READ_ONLY = "log-read-only";
-    public static final String MANAGEMENT_SUBSYSTEM_ENDPOINT = "management-subsystem-endpoint";
     public static final String MANAGEMENT = "management";
     public static final String MANAGEMENT_CLIENT_CONTENT = "management-client-content";
     public static final String MANAGEMENT_INTERFACE = "management-interface";
     public static final String MANAGEMENT_MAJOR_VERSION = "management-major-version";
     public static final String MANAGEMENT_MINOR_VERSION = "management-minor-version";
     public static final String MANAGEMENT_MICRO_VERSION = "management-micro-version";
+    public static final String MANAGEMENT_OPERATIONS = "management-operations";
+    public static final String MANAGEMENT_SUBSYSTEM_ENDPOINT = "management-subsystem-endpoint";
     public static final String MAP_GROUPS_TO_ROLES = "map-groups-to-roles";
     public static final String MASK = "mask";
     public static final String MASTER = "master";
@@ -318,6 +322,7 @@ public class ModelDescriptionConstants {
     public static final String ROLE_MAPPING = "role-mapping";
     public static final String ROLLBACK_ACROSS_GROUPS = "rollback-across-groups";
     public static final String ROLLBACK_FAILURE_DESCRIPTION = "rollback-failure-description";
+    public static final String ROLLBACK_ONLY = "rollback-only";
     public static final String ROLLBACK_ON_RUNTIME_FAILURE = "rollback-on-runtime-failure";
     public static final String ROLLED_BACK = "rolled-back";
     public static final String ROLLING_TO_SERVERS = "rolling-to-servers";
@@ -349,6 +354,7 @@ public class ModelDescriptionConstants {
     public static final String SERVER_IDENTITIES = "server-identities";
     public static final String SERVER_IDENTITY = "server-identity";
     public static final String SERVER_OPERATIONS = "server-operations";
+    public static final String SERVICE = "service";
     public static final String SERVICE_CONTAINER = "service-container";
     public static final String SINCE = "since";
     public static final String SOURCE_NETWORK = "source-network";

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -134,6 +134,7 @@ public class ModelDescriptionConstants {
     public static final String EXCLUDE = "exclude";
     public static final String ESCAPE_CONTROL_CHARACTERS = "escape-control-characters";
     public static final String ESCAPE_NEW_LINE = "escape-new-line";
+    public static final String EXCLUSIVE_RUNNING_TIME = "exclusive-running-time";
     public static final String EXECUTE_FOR_COORDINATOR = "execute-for-coordinator";
     public static final String EXECUTION_STATUS = "execution-status";
     public static final String EXPRESSIONS_ALLOWED = "expressions-allowed";
@@ -331,6 +332,7 @@ public class ModelDescriptionConstants {
     public static final String ROLES_FILTER = "roles-filter";
     public static final String RUNNING_MODE = "running-mode";
     public static final String RUNNING_SERVER = "server";
+    public static final String RUNNING_TIME = "running-time";
     public static final String RUNTIME_NAME = "runtime-name";
     public static final String RUNTIME_ONLY = "runtime-only";
     public static final String RUNTIME_UPDATE_SKIPPED = "runtime-update-skipped";

--- a/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
+++ b/controller/src/main/java/org/jboss/as/controller/descriptions/ModelDescriptionConstants.java
@@ -67,6 +67,7 @@ public class ModelDescriptionConstants {
     public static final String BASE_DN = "base-dn";
     public static final String BASE_ROLE = "base-role";
     public static final String BLOCKING = "blocking";
+    public static final String BLOCKING_TIMEOUT = "blocking-timeout";
     public static final String BOOT_TIME = "boot-time";
     public static final String BYTES = "bytes";
     public static final String CALLER_TYPE = "caller-type";

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3175,4 +3175,9 @@ public interface ControllerLogger extends BasicLogger {
     @LogMessage(level = Level.ERROR)
     @Message(id = 349, value = "Timeout after [%d] seconds waiting for service container stability while finalizing an operation. Process must be restarted. Step that first updated the service container was '%s' at address '%s'")
     void timeoutCompletingOperation(long blockingTimeout, String name, PathAddress address);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 350, value = "Cancelling operation '%s' with id '%d' running on thread '%s'")
+    void cancellingOperation(String operation, int id, String thread);
+
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3177,7 +3177,15 @@ public interface ControllerLogger extends BasicLogger {
     void timeoutCompletingOperation(long blockingTimeout, String name, PathAddress address);
 
     @LogMessage(level = Level.INFO)
-    @Message(id = 350, value = "Cancelling operation '%s' with id '%d' running on thread '%s'")
+    @Message(id = 350, value = "Execution of operation '%s' on remote process at address '%s' interrupted while awaiting initial response; remote process has been notified to cancel operation")
+    void interruptedAwaitingInitialResponse(String operation, PathAddress proxyNodeAddress);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 351, value = "Execution of operation '%s' on remote process at address '%s' interrupted while awaiting final response; remote process has been notified to terminate operation")
+    void interruptedAwaitingFinalResponse(String operation, PathAddress proxyNodeAddress);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 352, value = "Cancelling operation '%s' with id '%d' running on thread '%s'")
     void cancellingOperation(String operation, int id, String thread);
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -299,7 +299,7 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 14, value = "Operation (%s) failed - address: (%s) -- due to insufficient stack space for the thread used to " +
             "execute operations. If this error is occurring during server boot, setting " +
             "system property %s to a value higher than [%d] may resolve this problem.")
-    void operationFailed(@Cause Throwable cause, ModelNode op, ModelNode opAddress, String propertyName, int defaultSize);
+    void operationFailedInsufficientStackSpace(@Cause Throwable cause, ModelNode op, ModelNode opAddress, String propertyName, int defaultSize);
 
     /**
      * Logs a warning message indicating a wildcard address was detected and will ignore other interface criteria.
@@ -3147,4 +3147,32 @@ public interface ControllerLogger extends BasicLogger {
 
     @Message(id = 341, value="A uri with bad syntax '%s' was passed for validation.")
     OperationFailedException badUriSyntax(String uri);
+
+    @Message(id = 342, value = "Illegal value %d for operation header %s; value must be greater than zero")
+    IllegalStateException invalidBlockingTimeout(long timeout, String headerName);
+
+    @Message(id = 343, value = "The service container has been destabilized by a previous operation and further runtime updates cannot be processed. Restart is required.")
+    String timeoutAwaitingInitialStability();
+
+    @Message(id = 344, value = "Operation timed out awaiting service container stability")
+    String timeoutExecutingOperation();
+
+    @Message(id = 345, value = "Timeout after %d seconds waiting for existing service %s to be removed so a new instance can be installed.")
+    IllegalStateException serviceInstallTimedOut(long timeout, ServiceName name);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 346, value = "Invalid value %s for property %s; must be a numeric value greater than zero. Default value of %d will be used.")
+    void invalidDefaultBlockingTimeout(String sysPropValue, String sysPropName, long defaultUsed);
+
+    @LogMessage(level = Level.DEBUG)
+    @Message(id = 347, value = "Timeout after [%d] seconds waiting for initial service container stability before allowing runtime changes for operation '%s' at address '%s'. Operation will roll back; process restart is required.")
+    void timeoutAwaitingInitialStability(long blockingTimeout, String name, PathAddress address);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 348, value = "Timeout after [%d] seconds waiting for service container stability. Operation will roll back. Step that first updated the service container was '%s' at address '%s'")
+    void timeoutExecutingOperation(long blockingTimeout, String name, PathAddress address);
+
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 349, value = "Timeout after [%d] seconds waiting for service container stability while finalizing an operation. Process must be restarted. Step that first updated the service container was '%s' at address '%s'")
+    void timeoutCompletingOperation(long blockingTimeout, String name, PathAddress address);
 }

--- a/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
+++ b/controller/src/main/java/org/jboss/as/controller/logging/ControllerLogger.java
@@ -3188,4 +3188,7 @@ public interface ControllerLogger extends BasicLogger {
     @Message(id = 352, value = "Cancelling operation '%s' with id '%d' running on thread '%s'")
     void cancellingOperation(String operation, int id, String thread);
 
+    @Message(id = 353, value = "No response handler for request %s")
+    IOException responseHandlerNotFound(int id);
+
 }

--- a/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/ModelControllerClientOperationHandler.java
@@ -22,6 +22,7 @@
 package org.jboss.as.controller.remote;
 
 import static java.security.AccessController.doPrivileged;
+import static org.jboss.as.controller.logging.ControllerLogger.MGMT_OP_LOGGER;
 import static org.jboss.as.controller.logging.ControllerLogger.ROOT_LOGGER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACCESS_MECHANISM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CALLER_TYPE;
@@ -49,6 +50,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.CountDownLatch;
 
 import javax.security.auth.Subject;
 
@@ -56,6 +58,7 @@ import org.jboss.as.controller.AccessAuditContext;
 import org.jboss.as.controller.ModelController;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.client.impl.ModelControllerProtocol;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.core.security.AccessMechanism;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.as.protocol.mgmt.ActiveOperation;
@@ -131,6 +134,7 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
 
         @Override
         public void handleRequest(final DataInput input, final ActiveOperation.ResultHandler<ModelNode> resultHandler, final ManagementRequestContext<Void> context) throws IOException {
+            ControllerLogger.MGMT_OP_LOGGER.tracef("Handling ExecuteRequest for %d", context.getOperationId());
             final ModelNode operation = new ModelNode();
             ProtocolUtils.expectHeader(input, ModelControllerProtocol.PARAM_OPERATION);
             operation.readExternal(input);
@@ -160,6 +164,7 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
 
         private void doExecute(final ModelNode operation, final int attachmentsLength, final ManagementRequestContext<Void> context, final CompletedCallback callback) {
 
+            ControllerLogger.MGMT_OP_LOGGER.tracef("Executing ExecuteRequest for %d", context.getOperationId());
             // Header manipulation
             final ModelNode headers = operation.get(OPERATION_HEADERS);
             //Add a header to show that this operation comes from a user. If this is a host controller and the operation needs propagating to the
@@ -264,19 +269,41 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
                 return;
             }
             completed = true;
-            try {
-                final FlushableDataOutput output = responseContext.writeMessage(response);
-                try {
-                    output.write(ModelControllerProtocol.PARAM_RESPONSE);
-                    result.writeExternal(output);
-                    output.writeByte(ManagementProtocol.RESPONSE_END);
-                    output.close();
-                } finally {
-                    StreamUtils.safeClose(output);
+            // WFLY-3090 Protect the communication channel from getting closed due to administrative
+            // cancellation of the management op by using a separate thread to send
+            final CountDownLatch latch = new CountDownLatch(1);
+            final IOExceptionHolder exceptionHolder = new IOExceptionHolder();
+            responseContext.executeAsync(new ManagementRequestContext.AsyncTask<Void>() {
+
+                @Override
+                public void execute(final ManagementRequestContext<Void> context) throws Exception {
+                    MGMT_OP_LOGGER.tracef("Transmitting response for %d", context.getOperationId());
+                    try {
+                        final FlushableDataOutput output = responseContext.writeMessage(response);
+                        try {
+                            output.write(ModelControllerProtocol.PARAM_RESPONSE);
+                            result.writeExternal(output);
+                            output.writeByte(ManagementProtocol.RESPONSE_END);
+                            output.close();
+                        } finally {
+                            StreamUtils.safeClose(output);
+                            latch.countDown();
+                        }
+                    } catch (IOException e) {
+                        exceptionHolder.exception = e;
+                    }
                 }
+            }, false);
+
+            try {
+                latch.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            if (exceptionHolder.exception != null) {
+                resultHandler.failed(exceptionHolder.exception);
+            } else {
                 resultHandler.done(result);
-            } catch (IOException e) {
-                resultHandler.failed(e);
             }
         }
 
@@ -286,6 +313,7 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
 
         @Override
         public void handleRequest(final DataInput input, final ActiveOperation.ResultHandler<ModelNode> resultHandler, final ManagementRequestContext<Void> context) throws IOException {
+            ControllerLogger.MGMT_OP_LOGGER.tracef("Cancellation of %d requested", context.getOperationId());
             context.executeAsync(new ManagementRequestContext.AsyncTask<Void>() {
                 @Override
                 public void execute(ManagementRequestContext<Void> context) throws Exception {
@@ -298,9 +326,13 @@ public class ModelControllerClientOperationHandler implements ManagementRequestH
                         StreamUtils.safeClose(output);
                     }
                 }
-            });
+            }, false);
             resultHandler.cancel();
         }
+    }
+
+    private static class IOExceptionHolder {
+        private IOException exception;
     }
 
 }

--- a/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolClientImpl.java
+++ b/controller/src/main/java/org/jboss/as/controller/remote/TransactionalProtocolClientImpl.java
@@ -48,6 +48,7 @@ import org.jboss.as.controller.client.OperationAttachments;
 import org.jboss.as.controller.client.OperationMessageHandler;
 import org.jboss.as.controller.client.impl.AbstractDelegatingAsyncFuture;
 import org.jboss.as.controller.client.impl.ModelControllerProtocol;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.protocol.StreamUtils;
 import org.jboss.as.protocol.mgmt.AbstractManagementRequest;
 import org.jboss.as.protocol.mgmt.ActiveOperation;
@@ -117,7 +118,7 @@ class TransactionalProtocolClientImpl implements ManagementRequestHandlerFactory
                 try {
                     // Execute
                     channelAssociation.executeRequest(op, new CompleteTxRequest(ModelControllerProtocol.PARAM_ROLLBACK));
-                } catch (Exception e) {
+                } catch (IOException e) {
                     throw new RuntimeException(e);
                 }
             }
@@ -142,9 +143,28 @@ class TransactionalProtocolClientImpl implements ManagementRequestHandlerFactory
         }
 
         @Override
+        public void sendRequest(final ActiveOperation.ResultHandler<ModelNode> resultHandler,
+                                final ManagementRequestContext<ExecuteRequestContext> context) throws IOException {
+
+            ControllerLogger.MGMT_OP_LOGGER.tracef("sending ExecuteRequest for %d", context.getOperationId());
+            // WFLY-3090 Protect the communication channel from getting closed due to administrative
+            // cancellation of the management op by using a separate thread to send
+            context.executeAsync(new ManagementRequestContext.AsyncTask<ExecuteRequestContext>() {
+                @Override
+                public void execute(ManagementRequestContext<ExecuteRequestContext> context) throws Exception {
+                    sendRequestInternal(resultHandler, context);
+                }
+            }, false);
+
+        }
+
+        @Override
         protected void sendRequest(final ActiveOperation.ResultHandler<ModelNode> resultHandler,
                                    final ManagementRequestContext<ExecuteRequestContext> context,
                                    final FlushableDataOutput output) throws IOException {
+
+            ControllerLogger.MGMT_OP_LOGGER.tracef("transmitting ExecuteRequest for %d", context.getOperationId());
+
             // Write the operation
             final ExecuteRequestContext executionContext = context.getAttachment();
             final List<InputStream> streams = executionContext.getInputStreams();
@@ -167,6 +187,7 @@ class TransactionalProtocolClientImpl implements ManagementRequestHandlerFactory
 
         @Override
         public void handleRequest(final DataInput input, final ActiveOperation.ResultHandler<ModelNode> resultHandler, final ManagementRequestContext<ExecuteRequestContext> context) throws IOException {
+            ControllerLogger.MGMT_OP_LOGGER.tracef("received response to ExecuteRequest for %d", context.getOperationId());
             final byte responseType = input.readByte();
             final ModelNode response = new ModelNode();
             response.readExternal(input);
@@ -202,6 +223,11 @@ class TransactionalProtocolClientImpl implements ManagementRequestHandlerFactory
                 resultHandler.done(response);
             }
         }
+
+        private void sendRequestInternal(ActiveOperation.ResultHandler<ModelNode> resultHandler,
+                                         ManagementRequestContext<ExecuteRequestContext> context) throws IOException {
+            super.sendRequest(resultHandler, context);
+        }
     }
 
     /**
@@ -222,18 +248,40 @@ class TransactionalProtocolClientImpl implements ManagementRequestHandlerFactory
         }
 
         @Override
+        public void sendRequest(final ActiveOperation.ResultHandler<ModelNode> resultHandler,
+                                final ManagementRequestContext<ExecuteRequestContext> context) throws IOException {
+
+            ControllerLogger.MGMT_OP_LOGGER.tracef("sending CompleteTxRequest for %d", context.getOperationId());
+            context.executeAsync(new ManagementRequestContext.AsyncTask<ExecuteRequestContext>() {
+                @Override
+                public void execute(ManagementRequestContext<ExecuteRequestContext> context) throws Exception {
+                    sendRequestInternal(resultHandler, context);
+                }
+            }, false);
+
+        }
+
+        @Override
         protected void sendRequest(final ActiveOperation.ResultHandler<ModelNode> resultHandler, final ManagementRequestContext<ExecuteRequestContext> context, final FlushableDataOutput output) throws IOException {
+
+            ControllerLogger.MGMT_OP_LOGGER.tracef("transmitting CompleteTxRequest (%s) for %d", status != ModelControllerProtocol.PARAM_ROLLBACK, context.getOperationId());
             output.write(status);
         }
 
         @Override
         public void handleRequest(final DataInput input, final ActiveOperation.ResultHandler<ModelNode> resultHandler, final ManagementRequestContext<ExecuteRequestContext> context) throws IOException {
+            ControllerLogger.MGMT_OP_LOGGER.tracef("received response to CompleteTxRequest (%s) for %d", status != ModelControllerProtocol.PARAM_ROLLBACK, context.getOperationId());
             // We only accept operationCompleted responses
             expectHeader(input, ModelControllerProtocol.PARAM_OPERATION_COMPLETED);
             final ModelNode response = new ModelNode();
             response.readExternal(input);
             // Complete the operation
             resultHandler.done(response);
+        }
+
+        private void sendRequestInternal(ActiveOperation.ResultHandler<ModelNode> resultHandler,
+                                         ManagementRequestContext<ExecuteRequestContext> context) throws IOException {
+            super.sendRequest(resultHandler, context);
         }
     }
 

--- a/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/InterleavedSubsystemTestCase.java
@@ -134,7 +134,7 @@ public class InterleavedSubsystemTestCase {
         }
 
         @Override
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
 
             /*ManagementResourceRegistration extensions = rootRegistration.registerSubModel(PathElement.pathElement(EXTENSION), ModelControllerImplUnitTestCase.DESC_PROVIDER);

--- a/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/ModelControllerImplUnitTestCase.java
@@ -29,9 +29,6 @@ import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
-import org.jboss.as.controller.persistence.ConfigurationPersistenceException;
-import org.jboss.as.controller.persistence.ConfigurationPersister;
-import org.jboss.as.controller.persistence.NullConfigurationPersister;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
@@ -50,7 +47,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Locale;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -607,7 +603,7 @@ public class ModelControllerImplUnitTestCase {
     static class ModelControllerService extends TestModelControllerService {
 
         @Override
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
 
             rootRegistration.registerOperationHandler("setup", new ModelControllerImplUnitTestCase.SetupHandler(), ModelControllerImplUnitTestCase.DESC_PROVIDER, false);
             rootRegistration.registerOperationHandler("composite", CompositeOperationHandler.INSTANCE, ModelControllerImplUnitTestCase.DESC_PROVIDER, false);

--- a/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationCancellationUnitTestCase.java
@@ -25,6 +25,9 @@
  */
 package org.jboss.as.controller;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXECUTION_STATUS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
@@ -37,7 +40,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -76,6 +81,7 @@ public class OperationCancellationUnitTestCase {
     private ServiceContainer container;
     private ModelController controller;
     private ModelControllerClient client;
+    private Resource managementControllerResource;
 
     public static void toggleRuntimeState(AtomicBoolean state) {
         boolean runtimeVal = false;
@@ -103,6 +109,8 @@ public class OperationCancellationUnitTestCase {
         controller.execute(setup, null, null, null);
 
         client = controller.createClient(executor);
+
+        managementControllerResource = svc.managementControllerResource;
     }
 
     @After
@@ -148,8 +156,10 @@ public class OperationCancellationUnitTestCase {
 
     public static class ModelControllerService extends TestModelControllerService {
 
+        private volatile Resource managementControllerResource;
+
         @Override
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
 
             rootRegistration.registerOperationHandler("setup", new SetupHandler(), DESC_PROVIDER, false);
             rootRegistration.registerOperationHandler("composite", CompositeOperationHandler.INSTANCE, DESC_PROVIDER, false);
@@ -162,19 +172,34 @@ public class OperationCancellationUnitTestCase {
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
 
             rootRegistration.registerSubModel(PathElement.pathElement("child"), DESC_PROVIDER);
+
+            this.managementControllerResource = modelControllerResource;
         }
     }
 
     @Test
     public void testModelStageInterruption() throws Exception {
+        modelStageInterruptionTest(false);
+    }
+
+    @Test
+    public void testModelStageMgmtCancellation() throws Exception {
+        modelStageInterruptionTest(true);
+    }
+
+    private void modelStageInterruptionTest(boolean cancelViaResource) throws Exception {
         ModelNode step1 = getOperation("good", "attr1", 2);
         ModelNode step2 = getOperation("block-model", "attr2", 1);
         Future<ModelNode> future = client.executeAsync(getCompositeOperation(null, step1, step2), null);
 
         latch.await();
 
-        // cancel should return false becase interrupting here will result in a RuntimeException in the block-model handler
-        assertFalse(future.cancel(true));
+        if (cancelViaResource) {
+            testCancelViaMmgtOpResource(COMPOSITE, OperationContext.ExecutionStatus.EXECUTING, future, false);
+        } else {
+            // cancel should return false becase interrupting here will result in a RuntimeException in the block-model handler
+            assertFalse(future.cancel(true));
+        }
 
         // Confirm model was unchanged
         ModelNode result = controller.execute(getOperation("good", "attr1", 1), null, null, null);
@@ -183,16 +208,61 @@ public class OperationCancellationUnitTestCase {
 
     }
 
+    private void testCancelViaMmgtOpResource(String expectedOpName, OperationContext.ExecutionStatus expectedExecutionStatus, Future<ModelNode> future, boolean expectCancellationException) throws ExecutionException, InterruptedException {
+        boolean cancelled = false;
+        long timeout = System.currentTimeMillis() + 10000;
+        String matchedStatus = null;
+        OUT:
+        while (System.currentTimeMillis() < timeout) {
+            for (Resource resource : managementControllerResource.getChildren(ACTIVE_OPERATION)) {
+                if (resource.getModel().get(OP).asString().equals(expectedOpName)) {
+                    matchedStatus = resource.getModel().get(EXECUTION_STATUS).asString();
+                    if (expectedExecutionStatus.toString().equals(matchedStatus)) {
+                        cancelled = Cancellable.class.cast(resource).cancel();
+                        break OUT;
+                    }
+                    break;
+                }
+            }
+            if (matchedStatus != null) {
+                // The op thread may have tripped the latch but still hasn't
+                // gotten to the blocking code. So give it time
+                Thread.sleep(100);
+            }
+        }
+        assertEquals(expectedExecutionStatus.toString(), matchedStatus);
+        assertTrue(cancelled);
+        try {
+            future.get();
+            assertFalse(expectCancellationException);
+        } catch (CancellationException e) {
+            assertTrue(expectCancellationException);
+        }
+    }
+
     @Test
     public void testRuntimeStageInterruption() throws Exception {
+        runtimeStageInterruptionTest(false);
+    }
+
+    @Test
+    public void testRuntimeStageMgmtCancellation() throws Exception {
+        runtimeStageInterruptionTest(true);
+    }
+
+    private void runtimeStageInterruptionTest(boolean cancelViaResource) throws Exception {
         ModelNode step1 = getOperation("good", "attr1", 2);
         ModelNode step2 = getOperation("block-runtime", "attr2", 1);
         Future<ModelNode> future = client.executeAsync(getCompositeOperation(null, step1, step2), null);
 
         latch.await();
 
-        // cancel should return false becase interrupting here will result in a RuntimeException in the block-runtime handler
-        assertFalse(future.cancel(true));
+        if (cancelViaResource) {
+            testCancelViaMmgtOpResource(COMPOSITE, OperationContext.ExecutionStatus.EXECUTING, future, false);
+        } else {
+            // cancel should return false becase interrupting here will result in a RuntimeException in the block-model handler
+            assertFalse(future.cancel(true));
+        }
 
         // Confirm model was unchanged
         ModelNode result = controller.execute(getOperation("good", "attr1", 1), null, null, null);
@@ -203,6 +273,15 @@ public class OperationCancellationUnitTestCase {
 
     @Test
     public void testVerifyStageInterruption() throws Exception {
+        verifyStageInterruptionTest(false);
+    }
+
+    @Test
+    public void testVerifyStageMgmtCancellation() throws Exception {
+        verifyStageInterruptionTest(true);
+    }
+
+    private void verifyStageInterruptionTest(boolean cancelViaResource) throws Exception {
         ModelNode step1 = getOperation("good", "attr1", 2);
         ModelNode step2 = getOperation("good-service", "attr1", 2);
         ModelNode step3 = getOperation("block-verify", "attr2", 1);
@@ -210,7 +289,11 @@ public class OperationCancellationUnitTestCase {
 
         latch.await();
 
-        assertTrue(future.cancel(true));
+        if (cancelViaResource) {
+            testCancelViaMmgtOpResource(COMPOSITE, OperationContext.ExecutionStatus.AWAITING_STABILITY, future, true);
+        } else {
+            assertTrue(future.cancel(true));
+        }
 
         // Confirm model was unchanged
         ModelNode result = controller.execute(getOperation("good", "attr1", 1), null, null, null);
@@ -220,6 +303,15 @@ public class OperationCancellationUnitTestCase {
 
     @Test
     public void testReadResourceForUpdateInterruption() throws Exception {
+        readResourceForUpdateInterruptionTest(false);
+    }
+
+    @Test
+    public void testReadResourceForUpdateMgmtCancellation() throws Exception {
+        readResourceForUpdateInterruptionTest(true);
+    }
+
+    private void readResourceForUpdateInterruptionTest(boolean cancelViaResource) throws Exception {
 
         ModelNode blocker = getOperation("block-model", "attr2", 1);
         client.executeAsync(blocker, null);
@@ -229,8 +321,13 @@ public class OperationCancellationUnitTestCase {
         ModelNode blockee = getOperation("good", "attr1", 2);
         Future<ModelNode> future = client.executeAsync(blockee, null);
         ModelStageGoodHandler.goodHandlerLatch.await(5, TimeUnit.SECONDS);
-        // cancel should return true
-        assertTrue(future.cancel(true));
+
+        if (cancelViaResource) {
+            testCancelViaMmgtOpResource("good", OperationContext.ExecutionStatus.AWAITING_OTHER_OPERATION, future, true);
+        } else {
+            // cancel should return true
+            assertTrue(future.cancel(true));
+        }
 
         releaseBlockingThreads();
 

--- a/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
@@ -236,7 +236,7 @@ public class OperationTimeoutUnitTestCase {
     public static class ModelControllerService extends TestModelControllerService {
 
         @Override
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
 
             rootRegistration.registerOperationHandler("setup", new SetupHandler(), DESC_PROVIDER, false);
             rootRegistration.registerOperationHandler("block", new BlockingServiceHandler(), DESC_PROVIDER, false);

--- a/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/OperationTimeoutUnitTestCase.java
@@ -1,0 +1,363 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.BLOCKING_TIMEOUT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceContainer;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests of ability to time out operations. WFLY-2741.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class OperationTimeoutUnitTestCase {
+
+    private static final Executor executor = Executors.newCachedThreadPool();
+
+    private static CountDownLatch blockObject;
+    private static CountDownLatch latch;
+    private ServiceContainer container;
+    private ModelControllerService controllerService;
+    private ModelControllerClient client;
+
+    @Before
+    public void setupController() throws InterruptedException {
+
+        // restore default
+        blockObject = new CountDownLatch(1);
+        latch = new CountDownLatch(1);
+
+        System.out.println("=========  New Test \n");
+        container = ServiceContainer.Factory.create("test");
+        ServiceTarget target = container.subTarget();
+        controllerService = new ModelControllerService();
+        ServiceBuilder<ModelController> builder = target.addService(ServiceName.of("ModelController"), controllerService);
+        builder.install();
+        controllerService.awaitStartup(30, TimeUnit.SECONDS);
+        ModelController controller = controllerService.getValue();
+        ModelNode setup = Util.getEmptyOperation("setup", new ModelNode());
+        controller.execute(setup, null, null, null);
+
+        client = controller.createClient(executor);
+
+        System.setProperty(BlockingTimeout.SYSTEM_PROPERTY, "1");
+    }
+
+    @After
+    public void shutdownServiceContainer() {
+
+        System.clearProperty(BlockingTimeout.SYSTEM_PROPERTY);
+
+        releaseBlockingThreads();
+
+        if (client != null) {
+            try {
+                client.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (container != null) {
+            container.shutdown();
+            try {
+                container.awaitTermination(5, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            finally {
+                container = null;
+            }
+        }
+    }
+
+    @Test
+    public void testOperationHeaderConfig() throws InterruptedException, ExecutionException, TimeoutException {
+        blockInVerifyTest(new ModelNode(1));
+    }
+
+    @Test
+    public void testBlockInVerify() throws InterruptedException, ExecutionException, TimeoutException {
+        blockInVerifyTest(null);
+    }
+
+    private void blockInVerifyTest(ModelNode header) throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("start").set(true);
+        if (header != null) {
+            op.get(OPERATION_HEADERS, BLOCKING_TIMEOUT).set(1);
+            System.setProperty(BlockingTimeout.SYSTEM_PROPERTY, "300");
+        }
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerLogger.MGMT_OP_LOGGER.timeoutExecutingOperation()));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testBlockInRollback() throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("fail").set(true);
+        op.get("stop").set(true);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("failfailfail"));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testBlockInBoth() throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("start").set(true);
+        op.get("stop").set(true);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerLogger.MGMT_OP_LOGGER.timeoutExecutingOperation()));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testBlockAwaitingRuntimeLock() throws InterruptedException, ExecutionException, TimeoutException {
+
+        // Get the service container fubar
+        blockInVerifyTest(null);
+
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("start").set(false);
+        op.get("stop").set(false);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerLogger.MGMT_OP_LOGGER.timeoutAwaitingInitialStability()));
+
+        assertEquals(ControlledProcessState.State.RESTART_REQUIRED, controllerService.getCurrentProcessState());
+    }
+
+    @Test
+    public void testRepairInRollback() throws InterruptedException, ExecutionException, TimeoutException {
+        ModelNode op = Util.createEmptyOperation("block", null);
+        op.get("fail").set(true);
+        op.get("start").set(true);
+        op.get("repair").set(true);
+
+        Future<ModelNode> future = client.executeAsync(op, null);
+
+        ModelNode response = future.get(20, TimeUnit.SECONDS);
+        assertEquals(response.toString(), FAILED, response.get(OUTCOME).asString());
+        assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains("failfailfail"));
+
+        // We should be in RUNNING state because stability could be obtained before the op completed
+        assertEquals(ControlledProcessState.State.RUNNING, controllerService.getCurrentProcessState());
+    }
+
+
+    private static void releaseBlockingThreads() {
+        if (blockObject != null) {
+            blockObject.countDown();
+        }
+    }
+
+    private static void block() {
+        latch.countDown();
+        try {
+            blockObject.await();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class ModelControllerService extends TestModelControllerService {
+
+        @Override
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+
+            rootRegistration.registerOperationHandler("setup", new SetupHandler(), DESC_PROVIDER, false);
+            rootRegistration.registerOperationHandler("block", new BlockingServiceHandler(), DESC_PROVIDER, false);
+
+            GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
+        }
+    }
+
+    public static class SetupHandler implements OperationStepHandler {
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) {
+            ModelNode model = new ModelNode();
+
+            //Atttributes
+            model.get("attr1").set(1);
+            model.get("attr2").set(2);
+
+            context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS).getModel().set(model);
+
+            final ModelNode child1 = new ModelNode();
+            child1.get("attribute1").set(1);
+            final ModelNode child2 = new ModelNode();
+            child2.get("attribute2").set(2);
+
+            context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "one"))).getModel().set(child1);
+            context.createResource(PathAddress.EMPTY_ADDRESS.append(PathElement.pathElement("child", "two"))).getModel().set(child2);
+
+            context.stepCompleted();
+        }
+    }
+
+    public static class BlockingServiceHandler implements OperationStepHandler {
+        @Override
+        public void execute(OperationContext context, ModelNode operation) {
+
+            context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
+
+            context.addStep(new OperationStepHandler() {
+
+                @Override
+                public void execute(final OperationContext context, ModelNode operation) {
+
+                    boolean start = operation.get("start").asBoolean(false);
+                    boolean stop = operation.get("stop").asBoolean(false);
+                    boolean fail = operation.get("fail").asBoolean(false);
+                    final boolean repair = fail && operation.get("repair").asBoolean(false);
+
+                    BlockingService bad = start ? (stop ? BlockingService.BOTH : BlockingService.START)
+                                                : (stop ? BlockingService.STOP : BlockingService.NEITHER);
+
+                    final ServiceName svcName = ServiceName.JBOSS.append("bad-service");
+                    ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
+                    context.getServiceTarget().addService(svcName, bad)
+                            .addListener(verificationHandler)
+                            .install();
+                    context.addStep(verificationHandler, OperationContext.Stage.VERIFY);
+
+                    try {
+                        bad.startLatch.await(20, TimeUnit.SECONDS);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException(e);
+                    }
+
+                    if (fail) {
+                        context.setRollbackOnly();
+                        context.getFailureDescription().set("failfailfail");
+                    }
+                    context.completeStep(new OperationContext.ResultHandler() {
+
+                        @Override
+                        public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                            if (repair) {
+                                releaseBlockingThreads();
+                            }
+                            context.removeService(svcName);
+                        }
+                    });
+
+                }
+            }, OperationContext.Stage.RUNTIME);
+
+            context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+        }
+    }
+
+    private static class BlockingService implements Service<Void> {
+
+        private static final BlockingService START = new BlockingService(true, false);
+        private static final BlockingService STOP = new BlockingService(false, true);
+        private static final BlockingService BOTH = new BlockingService(true, true);
+        private static final BlockingService NEITHER = new BlockingService(false, false);
+
+        private final boolean start;
+        private final boolean stop;
+        private final CountDownLatch startLatch = new CountDownLatch(1);
+
+        private BlockingService(boolean start, boolean stop) {
+            this.start = start;
+            this.stop = stop;
+        }
+
+        @Override
+        public Void getValue() throws IllegalStateException, IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public void start(StartContext context) throws StartException {
+            startLatch.countDown();
+            if (start) {
+                block();
+            }
+        }
+
+        @Override
+        public void stop(StopContext context) {
+            if (stop) {
+                block();
+            }
+        }
+    }
+}

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractControllerTestBase.java
@@ -180,7 +180,7 @@ public abstract class AbstractControllerTestBase {
             return super.boot(bootOperations, rollbackOnRuntimeFailure);
         }
 
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             try {
                 AbstractControllerTestBase.this.initModel(rootResource, rootRegistration);
             } catch (Exception e) {

--- a/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/test/AbstractProxyControllerTest.java
@@ -583,7 +583,7 @@ public abstract class AbstractProxyControllerTest {
                     ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
         }
 
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
             rootRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
 
@@ -616,7 +616,7 @@ public abstract class AbstractProxyControllerTest {
                     ResourceBuilder.Factory.create(PathElement.pathElement("root"), new NonResolvingResourceDescriptionResolver()).build());
         }
 
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
             rootRegistration.registerOperationHandler(ValidateOperationHandler.DEFINITION, ValidateOperationHandler.INSTANCE);
             rootRegistration.registerOperationHandler("Test",

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -156,17 +156,17 @@ class TestModelControllerService extends ModelTestModelControllerService {
     }
 
     @Override
-    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         //See server HttpManagementAddHandler
         System.setProperty("jboss.as.test.disable.runtime", "1");
         if (type == TestModelType.STANDALONE) {
-            initializer.initCoreModel(rootResource, rootRegistration);
+            initializer.initCoreModel(rootResource, rootRegistration, modelControllerResource);
 
         } else if (type == TestModelType.HOST){
-            initializer.initCoreModel(rootResource, rootRegistration);
+            initializer.initCoreModel(rootResource, rootRegistration, modelControllerResource);
 
         } else if (type == TestModelType.DOMAIN){
-            initializer.initCoreModel(rootResource, rootRegistration);
+            initializer.initCoreModel(rootResource, rootRegistration, modelControllerResource);
         }
         if (modelInitializer != null) {
             modelInitializer.populateModel(rootResource);
@@ -392,7 +392,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
 
     private interface Initializer {
         void setRootResourceDefinitionDelegate();
-        void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration);
+        void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource);
     }
 
     private class ServerInitializer implements Initializer {
@@ -417,7 +417,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
         }
 
         @Override
-        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             VersionModelInitializer.registerRootResource(rootResource, null);
             Resource managementResource = Resource.Factory.create();
             rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), managementResource);
@@ -462,7 +462,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
         }
 
         @Override
-        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             HostModelUtil.createRootRegistry(
                     rootRegistration,
                     env,
@@ -471,7 +471,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
                         @Override
                         public void registerHostModel(String hostName, ManagementResourceRegistration rootRegistration) {
                         }
-                    },ProcessType.HOST_CONTROLLER, authorizer);
+                    },ProcessType.HOST_CONTROLLER, authorizer, modelControllerResource);
 
             HostModelUtil.createHostRegistry(
                     hostName,
@@ -502,7 +502,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
         }
 
         @Override
-        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        public void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             VersionModelInitializer.registerRootResource(rootResource, null);
             final HostControllerEnvironment env = createHostControllerEnvironment();
             final LocalHostControllerInfoImpl info = createLocalHostControllerInfo(env);
@@ -524,7 +524,7 @@ class TestModelControllerService extends ModelTestModelControllerService {
                         @Override
                         public void registerHostModel(String hostName, ManagementResourceRegistration root) {
                         }
-                    },processType, authorizer);
+                    },processType, authorizer, modelControllerResource);
 
             CoreManagementResourceDefinition.registerDomainResource(rootResource, null);
 

--- a/core-model-test/test-controller-7.1.2/src/main/java/org/jboss/as/core/model/test/controller7_1_2/TestModelControllerService7_1_2.java
+++ b/core-model-test/test-controller-7.1.2/src/main/java/org/jboss/as/core/model/test/controller7_1_2/TestModelControllerService7_1_2.java
@@ -84,8 +84,12 @@ class TestModelControllerService7_1_2 extends ModelTestModelControllerService {
         this.extensionRegistry = extensionRegistry;
     }
 
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        initModel(rootResource, rootRegistration, null);
+    }
+
     @Override
-    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         //See server HttpManagementAddHandler
         System.setProperty("jboss.as.test.disable.runtime", "1");
         final HostControllerEnvironment env = createHostControllerEnvironment();

--- a/core-model-test/test-controller-7.2.0/src/main/java/org/jboss/as/core/model/test/controller7_2_0/TestModelControllerService7_2_0.java
+++ b/core-model-test/test-controller-7.2.0/src/main/java/org/jboss/as/core/model/test/controller7_2_0/TestModelControllerService7_2_0.java
@@ -146,8 +146,12 @@ class TestModelControllerService7_2_0 extends ModelTestModelControllerService {
         super.start(context);
     }
 
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        initModel(rootResource, rootRegistration, null);
+    }
+
     @Override
-    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         //See server HttpManagementAddHandler
         System.setProperty("jboss.as.test.disable.runtime", "1");
         if (type == TestModelType.STANDALONE) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/CoreManagementResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/CoreManagementResourceDefinition.java
@@ -44,6 +44,7 @@ import org.jboss.as.domain.management.access.AccessAuthorizationResourceDefiniti
 import org.jboss.as.domain.management.audit.AccessAuditResourceDefinition;
 import org.jboss.as.domain.management.audit.EnvironmentNameReader;
 import org.jboss.as.domain.management.connections.ldap.LdapConnectionResourceDefinition;
+import org.jboss.as.domain.management.controller.ManagementControllerResourceDefinition;
 import org.jboss.as.domain.management.security.SecurityRealmResourceDefinition;
 
 /**
@@ -87,6 +88,7 @@ public class CoreManagementResourceDefinition extends SimpleResourceDefinition {
     @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         if (environment != Environment.DOMAIN) {
+            resourceRegistration.registerSubModel(ManagementControllerResourceDefinition.INSTANCE);
             resourceRegistration.registerSubModel(SecurityRealmResourceDefinition.INSTANCE);
             resourceRegistration.registerSubModel(LdapConnectionResourceDefinition.newInstance());
         }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
@@ -35,6 +35,7 @@ import org.jboss.as.controller.PrimitiveListAttributeDefinition;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -71,6 +72,14 @@ public class ActiveOperationResourceDefinition extends SimpleResourceDefinition 
                     .build();
     private static final AttributeDefinition CANCELLED =
             SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.CANCELLED, ModelType.BOOLEAN).build();
+    private static final AttributeDefinition RUNNING_TIME =
+            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.RUNNING_TIME, ModelType.LONG)
+                    .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
+                    .build();
+    private static final AttributeDefinition EXCLUSIVE_RUNNING_TIME =
+            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.EXCLUSIVE_RUNNING_TIME, ModelType.LONG)
+                    .setMeasurementUnit(MeasurementUnit.NANOSECONDS)
+                    .build();
 
     private ActiveOperationResourceDefinition() {
         super(PATH_ELEMENT, DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS, ACTIVE_OPERATION));
@@ -91,6 +100,8 @@ public class ActiveOperationResourceDefinition extends SimpleResourceDefinition 
         resourceRegistration.registerReadOnlyAttribute(CALLER_THREAD, null);
         resourceRegistration.registerReadOnlyAttribute(ACCESS_MECHANISM, null);
         resourceRegistration.registerReadOnlyAttribute(EXECUTION_STATUS, null);
+        resourceRegistration.registerReadOnlyAttribute(RUNNING_TIME, null);
+        resourceRegistration.registerReadOnlyAttribute(EXCLUSIVE_RUNNING_TIME, null);
         resourceRegistration.registerReadOnlyAttribute(CANCELLED, null);
 
         // HACK -- workaround WFLY-3057

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/ActiveOperationResourceDefinition.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.PrimitiveListAttributeDefinition;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.core.security.AccessMechanism;
+import org.jboss.as.domain.management._private.DomainManagementResolver;
+import org.jboss.dmr.ModelType;
+
+/**
+ * {@code ResourceDefinition} for a currently executing operation.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class ActiveOperationResourceDefinition extends SimpleResourceDefinition {
+
+    public static final PathElement PATH_ELEMENT = PathElement.pathElement(ACTIVE_OPERATION);
+
+    static final ResourceDefinition INSTANCE = new ActiveOperationResourceDefinition();
+
+    static final AttributeDefinition OPERATION_NAME =
+            SimpleAttributeDefinitionBuilder.create(OP, ModelType.STRING).build();
+    static final AttributeDefinition ADDRESS =
+            PrimitiveListAttributeDefinition.Builder.of(OP_ADDR, ModelType.PROPERTY)
+                    .build();
+    private static final AttributeDefinition CALLER_THREAD =
+            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.CALLER_THREAD, ModelType.STRING).build();
+    private static final AttributeDefinition ACCESS_MECHANISM =
+            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.ACCESS_MECHANISM, ModelType.STRING)
+                    .setAllowNull(true)
+                    .setValidator(EnumValidator.create(AccessMechanism.class, true, false))
+                    .build();
+    private static final AttributeDefinition EXECUTION_STATUS =
+            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.EXECUTION_STATUS, ModelType.STRING)
+                    .setValidator(EnumValidator.create(OperationContext.ExecutionStatus.class, false, false))
+                    .build();
+    private static final AttributeDefinition CANCELLED =
+            SimpleAttributeDefinitionBuilder.create(ModelDescriptionConstants.CANCELLED, ModelType.BOOLEAN).build();
+
+    private ActiveOperationResourceDefinition() {
+        super(PATH_ELEMENT, DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS, ACTIVE_OPERATION));
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+
+        resourceRegistration.registerOperationHandler(CancelActiveOperationHandler.DEFINITION, CancelActiveOperationHandler.INSTANCE);
+    }
+
+    @Override
+    public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+        super.registerAttributes(resourceRegistration);
+        resourceRegistration.registerReadOnlyAttribute(OPERATION_NAME, SecureOperationReadHandler.INSTANCE);
+        resourceRegistration.registerReadOnlyAttribute(ADDRESS, SecureOperationReadHandler.INSTANCE);
+        resourceRegistration.registerReadOnlyAttribute(CALLER_THREAD, null);
+        resourceRegistration.registerReadOnlyAttribute(ACCESS_MECHANISM, null);
+        resourceRegistration.registerReadOnlyAttribute(EXECUTION_STATUS, null);
+        resourceRegistration.registerReadOnlyAttribute(CANCELLED, null);
+
+        // HACK -- workaround WFLY-3057
+        resourceRegistration.setRuntimeOnly(true);
+    }
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
@@ -25,6 +25,7 @@ package org.jboss.as.domain.management.controller;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.util.EnumSet;
 
@@ -62,6 +63,7 @@ public class CancelActiveOperationHandler implements OperationStepHandler {
     @Override
     public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
 
+        DomainManagementLogger.ROOT_LOGGER.debugf("Cancel of %s requested", PathAddress.pathAddress(operation.get(OP_ADDR)).getLastElement().getValue());
         context.authorize(operation, EnumSet.of(Action.ActionEffect.WRITE_RUNTIME));
 
         context.addStep(new OperationStepHandler() {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelActiveOperationHandler.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+
+import java.util.EnumSet;
+
+import org.jboss.as.controller.Cancellable;
+import org.jboss.as.controller.NoSuchResourceException;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.access.Action;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.domain.management.logging.DomainManagementLogger;
+import org.jboss.as.domain.management._private.DomainManagementResolver;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * {@link org.jboss.as.controller.OperationStepHandler} to cancel an
+ * {@link org.jboss.as.domain.management.controller.ActiveOperationResourceDefinition active operation}.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class CancelActiveOperationHandler implements OperationStepHandler {
+
+    static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("cancel",
+            DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS, ACTIVE_OPERATION))
+            .setReplyType(ModelType.BOOLEAN)
+            .withFlag(OperationEntry.Flag.HOST_CONTROLLER_ONLY)
+            .build();
+
+    static final OperationStepHandler INSTANCE = new CancelActiveOperationHandler();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        context.authorize(operation, EnumSet.of(Action.ActionEffect.WRITE_RUNTIME));
+
+        context.addStep(new OperationStepHandler() {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                boolean cancelled = false;
+                try {
+                    Cancellable cancellable = Cancellable.class.cast(context.readResource(PathAddress.EMPTY_ADDRESS));
+                    DomainManagementLogger.ROOT_LOGGER.debugf("Cancelling %s", cancellable);
+                    cancelled = cancellable.cancel();
+                } catch (NoSuchResourceException nsre) {
+                    // resource is gone; return 'false'
+                }
+                context.getResult().set(cancelled);
+
+                context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
+            }
+        }, OperationContext.Stage.RUNTIME);
+
+        context.stepCompleted();
+    }
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/CancelNonProgressingOperationHandler.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXCLUSIVE_RUNNING_TIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.domain.management.logging.DomainManagementLogger;
+import org.jboss.as.domain.management._private.DomainManagementResolver;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * {@link org.jboss.as.controller.OperationStepHandler} that looks for and cancels a single operation that is in
+ * execution status {@link org.jboss.as.controller.OperationContext.ExecutionStatus#AWAITING_STABILITY}
+ * and has been executing in that status for longer than a specified {@code timeout} seconds.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class CancelNonProgressingOperationHandler implements OperationStepHandler {
+
+    private static final AttributeDefinition STABILITY_TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.INT, false)
+            .setDefaultValue(new ModelNode(15))
+            .setValidator(new IntRangeValidator(0, true))
+            .setMeasurementUnit(MeasurementUnit.SECONDS)
+            .build();
+
+    static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("cancel-non-progressing-operation",
+            DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS))
+            .setReplyType(ModelType.STRING)
+            .withFlag(OperationEntry.Flag.HOST_CONTROLLER_ONLY)
+            .build();
+
+    static final OperationStepHandler INSTANCE = new CancelNonProgressingOperationHandler();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        final long timeout = TimeUnit.SECONDS.toNanos(STABILITY_TIMEOUT.resolveModelAttribute(context, operation).asLong());
+
+        DomainManagementLogger.ROOT_LOGGER.debugf("Cancel of operation not progressing after [%d] ns requested", timeout);
+
+        final Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+        String blockingId = null;
+        for (Resource.ResourceEntry child : resource.getChildren(ModelDescriptionConstants.ACTIVE_OPERATION)) {
+            ModelNode model = child.getModel();
+            if (model.get(EXCLUSIVE_RUNNING_TIME).asLong() > timeout) {
+                blockingId = child.getName();
+                break;
+            }
+        }
+
+        if (blockingId != null) {
+
+            final String toCancel = blockingId;
+            PathAddress pa = PathAddress.pathAddress(operation.get(OP_ADDR));
+            ModelNode op = Util.createEmptyOperation(CancelActiveOperationHandler.DEFINITION.getName(),
+                    pa.append(PathElement.pathElement(ACTIVE_OPERATION, toCancel)));
+            final ModelNode response = new ModelNode();
+            context.addStep(response, op, CancelActiveOperationHandler.INSTANCE, OperationContext.Stage.MODEL, true);
+            context.completeStep(new OperationContext.ResultHandler() {
+                @Override
+                public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                    if (response.hasDefined(RESULT) && response.get(RESULT).asBoolean()) {
+                        context.getResult().set(toCancel);
+                    }
+                }
+            });
+        } else {
+            context.getFailureDescription().set(DomainManagementLogger.ROOT_LOGGER.noNonProgressingOperationFound(TimeUnit.NANOSECONDS.toSeconds(timeout)));
+            context.stepCompleted();
+        }
+    }
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/FindNonProgressingOperationHandler.java
@@ -1,0 +1,90 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXCLUSIVE_RUNNING_TIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.domain.management.logging.DomainManagementLogger;
+import org.jboss.as.domain.management._private.DomainManagementResolver;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+
+/**
+ * {@link org.jboss.as.controller.OperationStepHandler} that looks for and returns the id of single operation that is in
+ * execution status {@link org.jboss.as.controller.OperationContext.ExecutionStatus#AWAITING_STABILITY}
+ * and has been executing in that status for longer than a specified {@code timeout} seconds.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class FindNonProgressingOperationHandler implements OperationStepHandler {
+
+    private static final AttributeDefinition STABILITY_TIMEOUT = SimpleAttributeDefinitionBuilder.create("timeout", ModelType.INT, false)
+            .setDefaultValue(new ModelNode(15))
+            .setValidator(new IntRangeValidator(0, true))
+            .setMeasurementUnit(MeasurementUnit.SECONDS)
+            .build();
+
+    static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("find-non-progressing-operation",
+            DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS))
+            .setReplyType(ModelType.STRING)
+            .withFlag(OperationEntry.Flag.HOST_CONTROLLER_ONLY)
+            .build();
+
+    static final OperationStepHandler INSTANCE = new FindNonProgressingOperationHandler();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        final long timeout = TimeUnit.SECONDS.toNanos(STABILITY_TIMEOUT.resolveModelAttribute(context, operation).asLong());
+
+        DomainManagementLogger.ROOT_LOGGER.debugf("Identification of operation not progressing after [%d] ns has been requested", timeout);
+
+        Resource resource = context.readResource(PathAddress.EMPTY_ADDRESS);
+        ModelNode result = context.getResult();
+        for (Resource.ResourceEntry child : resource.getChildren(ModelDescriptionConstants.ACTIVE_OPERATION)) {
+            ModelNode model = child.getModel();
+            if (model.get(EXCLUSIVE_RUNNING_TIME).asLong() > timeout) {
+                result.set(child.getName());
+                break;
+            }
+        }
+        context.stepCompleted();
+    }
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/ManagementControllerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/ManagementControllerResourceDefinition.java
@@ -48,6 +48,13 @@ public class ManagementControllerResourceDefinition extends SimpleResourceDefini
     }
 
     @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(FindNonProgressingOperationHandler.DEFINITION, FindNonProgressingOperationHandler.INSTANCE);
+        resourceRegistration.registerOperationHandler(CancelNonProgressingOperationHandler.DEFINITION, CancelNonProgressingOperationHandler.INSTANCE);
+    }
+
+    @Override
     public void registerChildren(ManagementResourceRegistration resourceRegistration) {
         super.registerChildren(resourceRegistration);
         resourceRegistration.registerSubModel(ActiveOperationResourceDefinition.INSTANCE);

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/ManagementControllerResourceDefinition.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/ManagementControllerResourceDefinition.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ResourceDefinition;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.domain.management._private.DomainManagementResolver;
+
+/**
+ * {@code ResourceDefinition} for the management of operation execution.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class ManagementControllerResourceDefinition extends SimpleResourceDefinition {
+
+    public static final PathElement PATH_ELEMENT = PathElement.pathElement(SERVICE, MANAGEMENT_OPERATIONS);
+
+    public static final ResourceDefinition INSTANCE = new ManagementControllerResourceDefinition();
+
+    private ManagementControllerResourceDefinition() {
+        super(PATH_ELEMENT, DomainManagementResolver.getResolver(CORE, MANAGEMENT_OPERATIONS));
+    }
+
+    @Override
+    public void registerChildren(ManagementResourceRegistration resourceRegistration) {
+        super.registerChildren(resourceRegistration);
+        resourceRegistration.registerSubModel(ActiveOperationResourceDefinition.INSTANCE);
+
+        // HACK -- workaround WFLY-3057
+        resourceRegistration.setRuntimeOnly(true);
+    }
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/controller/SecureOperationReadHandler.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/controller/SecureOperationReadHandler.java
@@ -1,0 +1,120 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.domain.management.controller;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.access.Action;
+import org.jboss.as.controller.access.AuthorizationResult;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * Handler for reading the 'operation' and 'address' fields of an active operation that
+ * ensures that responses are elided if the caller does not have rights to address the
+ * operation's target.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class SecureOperationReadHandler implements OperationStepHandler {
+
+    private static final String HIDDEN = "<hidden>";
+    private static final Set<Action.ActionEffect> ADDRESS_EFFECT = EnumSet.of(Action.ActionEffect.ADDRESS);
+
+    static final OperationStepHandler INSTANCE = new SecureOperationReadHandler();
+
+    @Override
+    public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+
+        ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+        AuthorizedAddress authorizedAddress = authorizeAddress(context, operation);
+
+        String attribute = operation.require(ModelDescriptionConstants.NAME).asString();
+        if (ActiveOperationResourceDefinition.OPERATION_NAME.getName().equals(attribute)) {
+            if (authorizedAddress.elided) {
+                context.getResult().set(HIDDEN);
+            } else {
+                context.getResult().set(model.get(attribute));
+            }
+        } else if (ActiveOperationResourceDefinition.ADDRESS.getName().equals(attribute)) {
+            if (authorizedAddress.elided) {
+                context.getResult().set(authorizedAddress.address);
+            } else {
+                context.getResult().set(model.get(attribute));
+            }
+        } else {
+            // Programming error
+            throw new IllegalStateException();
+        }
+
+        context.stepCompleted();
+    }
+
+    private AuthorizedAddress authorizeAddress(OperationContext context, ModelNode operation) {
+        ModelNode address = operation.get(ModelDescriptionConstants.OP_ADDR);
+        ModelNode testOp = new ModelNode();
+        testOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.READ_RESOURCE_OPERATION);
+        testOp.get(ModelDescriptionConstants.OP_ADDR).set(address);
+
+        AuthorizationResult authResult = context.authorize(testOp, ADDRESS_EFFECT);
+        if (authResult.getDecision() == AuthorizationResult.Decision.PERMIT) {
+            return new AuthorizedAddress(address, false);
+        }
+
+        // Failed. Now we need to see how far we can go
+        ModelNode partialAddress = new ModelNode().setEmptyList();
+        ModelNode elidedAddress = new ModelNode().setEmptyList();
+        for (Property prop : address.asPropertyList()) {
+            partialAddress.add(prop);
+            testOp.get(ModelDescriptionConstants.OP_ADDR).set(address);
+            authResult = context.authorize(testOp, ADDRESS_EFFECT);
+            if (authResult.getDecision() == AuthorizationResult.Decision.DENY) {
+                elidedAddress.add(prop.getName(), HIDDEN);
+                return new AuthorizedAddress(elidedAddress, false);
+            } else {
+                elidedAddress.add(prop);
+            }
+        }
+
+        // Should not be reachable, but in case of a bug, be conservative and hide data
+        ModelNode strange = new ModelNode();
+        strange.add(HIDDEN, HIDDEN);
+        return new AuthorizedAddress(strange, true);
+    }
+
+    private static class AuthorizedAddress {
+        private final ModelNode address;
+        private final boolean elided;
+
+        private AuthorizedAddress(ModelNode address, boolean elided) {
+            this.address = address;
+            this.elided = elided;
+        }
+    }
+}

--- a/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/logging/DomainManagementLogger.java
@@ -985,6 +985,9 @@ public interface DomainManagementLogger extends BasicLogger {
     @Message(id = 88, value = "Unable to load username for supplied username '%s'")
     NamingException usernameNotLoaded(String name);
 
+    @Message(id = 89, value = "No operation was found that has been holding the operation execution write lock for long than [%d] seconds")
+    String noNonProgressingOperationFound(long timeout);
+
     /**
      * Information message saying the username and password must be different.
      *

--- a/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
+++ b/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
@@ -179,3 +179,14 @@ core.management.syslog-tls.host=The host of the syslog server for the tls over t
 core.management.syslog-tls.message-transfer=The message transfer setting as described in section 3.4 of RFC-6587. This can either be OCTET_COUNTING as described in section 3.4.1 of RFC-6587, or NON_TRANSPARENT_FRAMING as described in section 3.4.1 of RFC-6587. See your syslog provider's documentation for what is supported.
 core.management.syslog-tls.port=The port of the syslog server for the tls over tcp requests.
 core.management.syslog-tls.authentication=Configuration for the truststore for the server certificate if not signed by an authority, and the keystore containing the client certificate if the syslog server is set up to require client authentication.
+
+core.management.service=Management services.
+core.management-operations=Execution of management operations.
+core.management-operations.active-operation=A currently executing operation.
+core.management-operations.active-operation.operation=The name of the operation, or '<hidden>' if the caller is not authorized to address the operation's target resource.
+core.management-operations.active-operation.address=The address of the resource targeted by the operation. The value in the final element of the address will be '<hidden>' if the caller is not authorized to address the operation's target resource.
+core.management-operations.active-operation.caller-thread=The name of the thread that is executing the operation.
+core.management-operations.active-operation.access-mechanism=The mechanism used to submit a request to the server.
+core.management-operations.active-operation.execution-status=The current activity of the operation.
+core.management-operations.active-operation.cancelled=Whether the operation has been cancelled.
+core.management-operations.active-operation.cancel=Attempt to cancel the operation.

--- a/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
+++ b/domain-management/src/main/resources/org/jboss/as/domain/management/_private/LocalDescriptions.properties
@@ -182,6 +182,10 @@ core.management.syslog-tls.authentication=Configuration for the truststore for t
 
 core.management.service=Management services.
 core.management-operations=Execution of management operations.
+core.management-operations.cancel-non-progressing-operation=Check for an operation that has been holding the exclusive operation execution lock for greater than the provided timeout period, and if found cancel it.
+core.management-operations.cancel-non-progressing-operation.timeout=Mimumum period, in seconds, that an operation must have held the exclusive execution lock before it can be considered eligible for cancellation.
+core.management-operations.find-non-progressing-operation=Check for an operation that has been holding the exclusive operation execution lock for greater than the provided timeout period, and if found return its id.
+core.management-operations.find-non-progressing-operation.timeout=Mimumum period, in seconds, that an operation must have held the exclusive execution lock before its id should be returned.
 core.management-operations.active-operation=A currently executing operation.
 core.management-operations.active-operation.operation=The name of the operation, or '<hidden>' if the caller is not authorized to address the operation's target resource.
 core.management-operations.active-operation.address=The address of the resource targeted by the operation. The value in the final element of the address will be '<hidden>' if the caller is not authorized to address the operation's target resource.
@@ -189,4 +193,6 @@ core.management-operations.active-operation.caller-thread=The name of the thread
 core.management-operations.active-operation.access-mechanism=The mechanism used to submit a request to the server.
 core.management-operations.active-operation.execution-status=The current activity of the operation.
 core.management-operations.active-operation.cancelled=Whether the operation has been cancelled.
+core.management-operations.active-operation.running-time=Amount of time the operation has been executing.
+core.management-operations.active-operation.exclusive-running-time=Amount of time the operation has been executing with the exclusive operation execution lock held, or -1 if the operation does not hold the exclusive execution lock.
 core.management-operations.active-operation.cancel=Attempt to cancel the operation.

--- a/domain-management/src/test/java/org/jboss/as/domain/management/security/util/AbstractControllerTestBase.java
+++ b/domain-management/src/test/java/org/jboss/as/domain/management/security/util/AbstractControllerTestBase.java
@@ -180,7 +180,7 @@ public abstract class AbstractControllerTestBase {
             return super.boot(bootOperations, rollbackOnRuntimeFailure);
         }
 
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             try {
                 AbstractControllerTestBase.this.initModel(rootResource, rootRegistration);
             } catch (Exception e) {

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/logging/DomainControllerLogger.java
@@ -93,8 +93,8 @@ public interface DomainControllerLogger extends BasicLogger {
      * @param serverName the name of the server.
      * @param hostName   the name of the host.
      */
-    @LogMessage(level = Level.WARN)
-    @Message(id = 3, value = "Interrupted awaiting final response from server %s on host %s")
+    @LogMessage(level = Level.INFO)
+    @Message(id = 3, value = "Interrupted awaiting final response from server %s on host %s; remote process has been notified to cancel operation")
     void interruptedAwaitingFinalResponse(String serverName, String hostName);
 
     /**
@@ -115,8 +115,8 @@ public interface DomainControllerLogger extends BasicLogger {
      *
      * @param hostName the name of the host.
      */
-    @LogMessage(level = Level.WARN)
-    @Message(id = 5, value = "Interrupted awaiting final response from host %s")
+    @LogMessage(level = Level.INFO)
+    @Message(id = 5, value = "Interrupted awaiting final response from host %s; remote process has been notified to cancel operation")
     void interruptedAwaitingFinalResponse(String hostName);
 
     /**
@@ -158,7 +158,7 @@ public interface DomainControllerLogger extends BasicLogger {
      * @param task          the task.
      */
     @LogMessage(level = Level.ERROR)
-    @Message(id = 9, value = "%s caught %s waiting for task %s")
+    @Message(id = 9, value = "%s caught %s waiting for task %s. Cancelling task")
     void caughtExceptionWaitingForTask(String className, String exceptionName, String task);
 
     /**
@@ -169,9 +169,9 @@ public interface DomainControllerLogger extends BasicLogger {
      * @param exceptionName the name of the exception caught.
      * @param task          the task.
      */
-    @LogMessage(level = Level.ERROR)
-    @Message(id = 10, value = "%s caught %s waiting for task %s; returning")
-    void caughtExceptionWaitingForTaskReturning(String className, String exceptionName, String task);
+//    @LogMessage(level = Level.ERROR)
+//    @Message(id = 10, value = "%s caught %s waiting for task %s; returning")
+//    void caughtExceptionWaitingForTaskReturning(String className, String exceptionName, String task);
 
     /**
      * Logs an error message indicating the content for a configured deployment was unavailable at boot but boot
@@ -715,4 +715,11 @@ public interface DomainControllerLogger extends BasicLogger {
     @Message(id = 69, value = "Host registration task failed: %s")
     String registrationTaskFailed(String cause);
 
+    @LogMessage(level = Level.INFO)
+    @Message(id = 70, value = "%s interrupted awaiting server prepared response(s) -- cancelling updates for servers %s")
+    void interruptedAwaitingPreparedResponse(String callerClass, Set<ServerIdentity> servers);
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 71, value = "Interrupted awaiting host prepared response(s) -- cancelling updates for hosts %s")
+    void interruptedAwaitingHostPreparedResponse(Set<String> hosts);
 }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/coordination/HostControllerUpdateTask.java
@@ -211,7 +211,7 @@ class HostControllerUpdateTask {
         }
 
         public void asyncCancel() {
-            futureResult.asyncCancel(false);
+            futureResult.asyncCancel(true);
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ConcurrentUpdateTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ConcurrentUpdateTask.java
@@ -31,6 +31,8 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * A task that uses an executor service to concurrently execute other tasks
@@ -62,19 +64,36 @@ class ConcurrentUpdateTask implements Runnable {
         }
 
         // Wait until all complete before returning
+        boolean patient = true;
         for (int i = 0; i < futures.size(); i++) {
             Future<?> future = futures.get(i);
             try {
-                future.get();
+                if (patient) {
+                    future.get();
+                } else {
+                    // We've been interrupted; see if this task is already done
+                    future.get(0, TimeUnit.MILLISECONDS);
+                }
             } catch (InterruptedException e) {
-                DOMAIN_DEPLOYMENT_LOGGER.caughtExceptionWaitingForTaskReturning(ConcurrentUpdateTask.class.getSimpleName(),
+                DOMAIN_DEPLOYMENT_LOGGER.caughtExceptionWaitingForTask(ConcurrentUpdateTask.class.getSimpleName(),
                         e.getClass().getSimpleName(), concurrentTasks.get(i).toString());
-                Thread.currentThread().interrupt();
-                return;
+                patient = false;
+                future.cancel(true);
             } catch (ExecutionException e) {
                 DOMAIN_DEPLOYMENT_LOGGER.caughtExceptionWaitingForTask(ConcurrentUpdateTask.class.getSimpleName(),
                         e.getClass().getSimpleName(), concurrentTasks.get(i).toString());
+                future.cancel(true);
+            } catch (TimeoutException e) {
+                // Task wasn't already done; cancel it
+                DOMAIN_DEPLOYMENT_LOGGER.caughtExceptionWaitingForTask(ConcurrentUpdateTask.class.getSimpleName(),
+                        e.getClass().getSimpleName(), concurrentTasks.get(i).toString());
+                patient = false; // it should already be false if we got here, but just in case someone changes something
+                future.cancel(true);
             }
+        }
+
+        if (!patient) {
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/RollingServerGroupUpdateTask.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/RollingServerGroupUpdateTask.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.domain.controller.plan;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.security.auth.Subject;
@@ -57,6 +58,8 @@ class RollingServerGroupUpdateTask extends AbstractServerGroupRolloutTask implem
                     final TransactionalProtocolClient.PreparedOperation<ServerTaskExecutor.ServerOperation> prepared = listener.retrievePreparedOperation();
                     recordPreparedOperation(identity, prepared);
                 } catch (InterruptedException e) {
+                    DomainControllerLogger.DOMAIN_DEPLOYMENT_LOGGER.interruptedAwaitingPreparedResponse(getClass().getSimpleName(), Collections.singleton(identity));
+                    executor.cancelTask(identity);
                     interrupted = true;
                 }
             }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ServerTaskExecutor.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ServerTaskExecutor.java
@@ -90,6 +90,11 @@ public abstract class ServerTaskExecutor {
         return true;
     }
 
+    public boolean cancelTask(ServerIdentity toCancel) {
+        ExecutedServerRequest task = submittedTasks.get(toCancel);
+        return task != null && task.cancel();
+    }
+
     /**
      * Execute the operation.
      *
@@ -268,7 +273,7 @@ public abstract class ServerTaskExecutor {
 
         @Override
         public boolean cancel() {
-            return finalResult.cancel(false);
+            return finalResult.cancel(true);
         }
 
     }

--- a/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ServerUpdatePolicy.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/plan/ServerUpdatePolicy.java
@@ -168,6 +168,8 @@ class ServerUpdatePolicy {
      *         <code>false</code> otherwise
      */
     public synchronized boolean isFailed() {
-        return failureCount > maxFailed;
+        // Here we use successCount instead of failed count, so
+        // non-recorded servers are treated as failures
+        return (servers.size() - successCount) > maxFailed;
     }
 }

--- a/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/DomainModelControllerService.java
@@ -418,8 +418,8 @@ public class DomainModelControllerService extends AbstractControllerService impl
     }
 
     @Override
-    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
-        HostModelUtil.createRootRegistry(rootRegistration, environment, ignoredRegistry, this, processType, authorizer);
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
+        HostModelUtil.createRootRegistry(rootRegistration, environment, ignoredRegistry, this, processType, authorizer, modelControllerResource);
         VersionModelInitializer.registerRootResource(rootResource, environment != null ? environment.getProductConfig() : null);
         CoreManagementResourceDefinition.registerDomainResource(rootResource, authorizer.getWritableAuthorizerConfiguration());
         this.modelNodeRegistration = rootRegistration;

--- a/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/HostModelUtil.java
@@ -31,6 +31,7 @@ import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.operations.common.ValidateOperationHandler;
 import org.jboss.as.controller.operations.global.GlobalOperationHandlers;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManagerService;
 import org.jboss.as.domain.controller.DomainController;
 import org.jboss.as.domain.management.security.WhoAmIOperation;
@@ -74,9 +75,11 @@ public class HostModelUtil {
                                           final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
                                           final HostModelRegistrar hostModelRegistrar,
                                           final ProcessType processType,
-                                          final DelegatingConfigurableAuthorizer authorizer) {
+                                          final DelegatingConfigurableAuthorizer authorizer,
+                                          final Resource modelControllerResource) {
         // Add of the host itself
-        final HostModelRegistrationHandler hostModelRegistratorHandler = new HostModelRegistrationHandler(environment, ignoredDomainResourceRegistry, hostModelRegistrar);
+        final HostModelRegistrationHandler hostModelRegistratorHandler =
+                new HostModelRegistrationHandler(environment, ignoredDomainResourceRegistry, hostModelRegistrar, modelControllerResource);
         root.registerOperationHandler(HostModelRegistrationHandler.DEFINITION, hostModelRegistratorHandler);
 
         // Global operations

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostModelRegistrationHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostModelRegistrationHandler.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DIS
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST_ENVIRONMENT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MAJOR_VERSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MICRO_VERSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_MINOR_VERSION;
@@ -34,6 +35,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRO
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PRODUCT_VERSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_CODENAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELEASE_VERSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -70,13 +72,16 @@ public class HostModelRegistrationHandler implements OperationStepHandler {
     private final HostControllerEnvironment hostControllerEnvironment;
     private final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry;
     private final HostModelUtil.HostModelRegistrar hostModelRegistrar;
+    private final Resource modelControllerResource;
 
     public HostModelRegistrationHandler(final HostControllerEnvironment hostControllerEnvironment,
                                         final IgnoredDomainResourceRegistry ignoredDomainResourceRegistry,
-                                        final HostModelUtil.HostModelRegistrar hostModelRegistrar) {
+                                        final HostModelUtil.HostModelRegistrar hostModelRegistrar,
+                                        final Resource modelControllerResource) {
         this.hostControllerEnvironment = hostControllerEnvironment;
         this.ignoredDomainResourceRegistry = ignoredDomainResourceRegistry;
         this.hostModelRegistrar = hostModelRegistrar;
+        this.modelControllerResource = modelControllerResource;
     }
 
     /**
@@ -100,8 +105,11 @@ public class HostModelRegistrationHandler implements OperationStepHandler {
 
         initCoreModel(model, hostControllerEnvironment);
 
-        // Create the empty management security resources
+        // Create the management resources
         Resource management = context.createResource(hostAddress.append(PathElement.pathElement(CORE_SERVICE, MANAGEMENT)));
+        if (modelControllerResource != null) {
+            management.registerChild(PathElement.pathElement(SERVICE, MANAGEMENT_OPERATIONS), modelControllerResource);
+        }
 
         //Create the empty host-environment resource
         context.createResource(hostAddress.append(PathElement.pathElement(CORE_SERVICE, HOST_ENVIRONMENT)));

--- a/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostShutdownHandler.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/operations/HostShutdownHandler.java
@@ -19,6 +19,8 @@
 package org.jboss.as.host.controller.operations;
 
 
+import java.util.EnumSet;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
@@ -26,6 +28,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.access.Action;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.domain.controller.DomainController;
@@ -70,8 +73,15 @@ public class HostShutdownHandler implements OperationStepHandler {
         context.addStep(new OperationStepHandler() {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                // Even though we don't read from the service registry, we are modifying a service
-                context.getServiceRegistry(true);
+                // WFLY-2741 -- DO NOT call context.getServiceRegistry(true) as that will trigger blocking for
+                // service container stability and one use case for this op is to recover from a
+                // messed up service container from a previous op. Instead just ask for authorization.
+                // Note that we already have the exclusive lock, so we are just skipping waiting for stability.
+                // If another op that is a step in a composite step with this op needs to modify the container
+                // it will have to wait for container stability, so skipping this only matters for the case
+                // where this step is the only runtime change.
+//                context.getServiceRegistry(true);
+                context.authorize(operation, EnumSet.of(Action.ActionEffect.WRITE_RUNTIME));
                 if (restart) {
                     //Add the exit code so that we get respawned
                     domainController.stopLocalHost(ExitCodes.RESTART_PROCESS_FROM_STARTUP_SCRIPT);

--- a/jmx/src/test/java/org/jboss/as/jmx/test/util/AbstractControllerTestBase.java
+++ b/jmx/src/test/java/org/jboss/as/jmx/test/util/AbstractControllerTestBase.java
@@ -175,7 +175,7 @@ public abstract class AbstractControllerTestBase {
             return super.boot(bootOperations, rollbackOnRuntimeFailure);
         }
 
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             try {
                 AbstractControllerTestBase.this.initModel(rootResource, rootRegistration);
             } catch (Exception e) {

--- a/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
+++ b/model-test/src/main/java/org/jboss/as/model/test/ModelTestModelControllerService.java
@@ -169,13 +169,13 @@ public abstract class ModelTestModelControllerService extends AbstractController
     }
 
     @Override
-    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         this.rootRegistration = rootRegistration;
-        initCoreModel(rootResource, rootRegistration);
+        initCoreModel(rootResource, rootRegistration, modelControllerResource);
         initExtraModel(rootResource, rootRegistration);
     }
 
-    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         GlobalOperationHandlers.registerGlobalOperations(rootRegistration, ProcessType.STANDALONE_SERVER);
 
         rootRegistration.registerOperationHandler(CompositeOperationHandler.DEFINITION, CompositeOperationHandler.INSTANCE);

--- a/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
+++ b/platform-mbean/src/test/java/org/jboss/as/platform/mbean/PlatformMBeanTestModelControllerService.java
@@ -73,7 +73,7 @@ public class PlatformMBeanTestModelControllerService extends AbstractControllerS
     }
 
     @Override
-    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
 
         GlobalOperationHandlers.registerGlobalOperations(rootRegistration, processType);
         rootRegistration.registerOperationHandler(ValidateAddressOperationHandler.DEFINITION, ValidateAddressOperationHandler.INSTANCE);

--- a/protocol/src/main/java/org/jboss/as/protocol/logging/ProtocolLogger.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/logging/ProtocolLogger.java
@@ -23,6 +23,7 @@
 package org.jboss.as.protocol.logging;
 
 import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.IOException;
@@ -335,5 +336,13 @@ public interface ProtocolLogger extends BasicLogger {
      */
     @Message(id = 56, value = "No response handler for request %s")
     IOException responseHandlerNotFound(int id);
+
+    @LogMessage(level = INFO)
+    @Message(id = 57, value = "%s cancelled task by interrupting thread %s")
+    void cancelledAsyncTask(String asyncTaskRunner, Thread thread);
+
+    @LogMessage(level = INFO)
+    @Message(id = 58, value = "%s cancelled task before execution began")
+    void cancelledAsyncTaskBeforeRun(String asyncTaskRunner);
 
 }

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
@@ -125,6 +125,8 @@ class ActiveOperationSupport {
      * @param id the operation id
      * @param attachment the shared attachment
      * @return the created active operation
+     *
+     * @throws java.lang.IllegalStateException if an operation with the same id is already registered
      */
     protected <T, A> ActiveOperation<T, A> registerActiveOperation(final Integer id, A attachment) {
         final ActiveOperation.CompletedCallback<T> callback = getDefaultCallback();
@@ -138,6 +140,8 @@ class ActiveOperationSupport {
      * @param attachment the shared attachment
      * @param callback the completed callback
      * @return the created active operation
+     *
+     * @throws java.lang.IllegalStateException if an operation with the same id is already registered
      */
     protected <T, A> ActiveOperation<T, A> registerActiveOperation(final Integer id, A attachment, ActiveOperation.CompletedCallback<T> callback) {
         lock.lock(); try {

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
@@ -300,6 +300,7 @@ class ActiveOperationSupport {
 
             @Override
             public void cancel() {
+                ProtocolLogger.CONNECTION_LOGGER.debugf("Operation (%d) cancelled", operationId);
                 ActiveOperationImpl.this.cancel();
             }
         };

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementRequestContext.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementRequestContext.java
@@ -64,8 +64,7 @@ public interface ManagementRequestContext<A> {
     ManagementProtocolHeader getRequestHeader();
 
     /**
-     * Execute an async task. Basically everything waiting for a response cannot block a remoting thread and
-     * has to be executed asynchronous.
+     * Execute an async task. Equivalent to {@code executeAsync(task, true)}.
      *
      * @param task the task
      */
@@ -76,9 +75,27 @@ public interface ManagementRequestContext<A> {
      * has to be executed asynchronous.
      *
      * @param task the task
+     * @param cancellable {@code true} if the task can be cancelled as part of overall request cancellation
+     */
+    void executeAsync(final AsyncTask<A> task, boolean cancellable);
+
+    /**
+     * Execute an async task. Equivalent to {@code executeAsync(task, true, executor)}.
+     *
+     * @param task the task
      * @param executor the executor
      */
     void executeAsync(final AsyncTask<A> task, Executor executor);
+
+    /**
+     * Execute an async task. Basically everything waiting for a response cannot block a remoting thread and
+     * has to be executed asynchronous.
+     *
+     * @param task the task
+     * @param cancellable {@code true} if the task can be cancelled as part of overall request cancellation
+     * @param executor the executor
+     */
+    void executeAsync(final AsyncTask<A> task, boolean cancellable, Executor executor);
 
     /**
      * Write a new message.

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementRequestHandlerFactory.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ManagementRequestHandlerFactory.java
@@ -72,6 +72,7 @@ public interface ManagementRequestHandlerFactory {
          * @param <T> the result type
          * @param <A> the attachment type
          * @return the registered active operation
+         * @throws java.lang.IllegalStateException if an operation with the same id is already registered
          */
         <T, A> ActiveOperation<T, A> registerActiveOperation(Integer id, A attachment);
 
@@ -84,6 +85,7 @@ public interface ManagementRequestHandlerFactory {
          * @param <T> the result type
          * @param <A> the attachment type
          * @return the registered active operation
+         * @throws java.lang.IllegalStateException if an operation with the same id is already registered
          */
         <T, A> ActiveOperation<T, A> registerActiveOperation(Integer id, A attachment, ActiveOperation.CompletedCallback<T> callback);
 

--- a/server/src/main/java/org/jboss/as/server/ServerService.java
+++ b/server/src/main/java/org/jboss/as/server/ServerService.java
@@ -364,9 +364,10 @@ public final class ServerService extends AbstractControllerService {
     }
 
     @Override
-    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         // TODO maybe make creating of empty nodes part of the MNR description
         Resource managementResource = Resource.Factory.create(); // TODO - Can we get a Resource direct from CoreManagementResourceDefinition?
+        managementResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.SERVICE, ModelDescriptionConstants.MANAGEMENT_OPERATIONS), modelControllerResource);
         rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MANAGEMENT), managementResource);
         rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.SERVICE_CONTAINER), Resource.Factory.create());
         rootResource.registerChild(PathElement.pathElement(ModelDescriptionConstants.CORE_SERVICE, ModelDescriptionConstants.MODULE_LOADING), Resource.Factory.create());

--- a/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
+++ b/server/src/main/java/org/jboss/as/server/mgmt/domain/HostControllerConnection.java
@@ -279,7 +279,7 @@ class HostControllerConnection extends FutureManagementChannel {
                         resultHandler.done(Boolean.FALSE);
                     }
                 }
-            });
+            }, false);
         }
 
     }
@@ -322,6 +322,7 @@ class HostControllerConnection extends FutureManagementChannel {
 
         @Override
         public ProtocolConnectionManager.ConnectTask connectionClosed() {
+            ServerLogger.AS_ROOT_LOGGER.debugf("Connection to Host Controller closed");
             return this;
         }
 

--- a/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
+++ b/server/src/test/java/org/jboss/as/server/test/ServerControllerUnitTestCase.java
@@ -295,7 +295,7 @@ public class ServerControllerUnitTestCase {
         }
 
         @Override
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             this.rootRegistration = rootRegistration;
         }
 

--- a/subsystem-test/test-controller-7.1.2/src/main/java/org/jboss/as/subsystem/test/controller7_1_2/TestModelControllerService7_1_2.java
+++ b/subsystem-test/test-controller-7.1.2/src/main/java/org/jboss/as/subsystem/test/controller7_1_2/TestModelControllerService7_1_2.java
@@ -81,8 +81,12 @@ class TestModelControllerService7_1_2 extends ModelTestModelControllerService {
         this.mainExtension = mainExtension;
     }
 
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        initModel(rootResource, rootRegistration, null);
+    }
+
     @Override
-    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+    protected void initCoreModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
         rootResource.getModel().get(SUBSYSTEM);
         rootRegistration.registerOperationHandler(READ_RESOURCE_OPERATION, GlobalOperationHandlers.READ_RESOURCE, CommonProviders.READ_RESOURCE_PROVIDER, true);
         //rootRegistration.registerOperationHandler(READ_TRANSFORMED_RESOURCE_OPERATION, new ReadTransformedResourceOperation(), ReadTransformedResourceOperation.DESCRIPTION, true);

--- a/subsystem-test/test-controller-7.2.0/src/main/java/org/jboss/as/subsystem/test/controller7_2_0/TestModelControllerService7_2_0.java
+++ b/subsystem-test/test-controller-7.2.0/src/main/java/org/jboss/as/subsystem/test/controller7_2_0/TestModelControllerService7_2_0.java
@@ -70,6 +70,10 @@ class TestModelControllerService7_2_0 extends ModelTestModelControllerService {
         this.mainExtension = mainExtension;
     }
 
+    protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        initModel(rootResource, rootRegistration, null);
+    }
+
     @Override
     protected void initExtraModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
         rootResource.getModel().get(SUBSYSTEM);

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/ExpressionSupportSmokeTestCase.java
@@ -41,6 +41,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RELATIVE_TO;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REQUIRES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNTIME_ONLY;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STORAGE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
@@ -201,8 +202,8 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
     private void setExpressions(PathAddress address, String hostName, Map<PathAddress, Map<String, ModelNode>> expectedValues) throws IOException, MgmtOperationException {
 
         ModelNode description = readResourceDescription(address);
-        ModelNode resource = readResource(address, true);
-        ModelNode resourceNoDefaults = readResource(address, false);
+        ModelNode resource = readResource(address, true, false);
+        ModelNode resourceNoDefaults = readResource(address, false, false);
 
         Map<String, ModelNode> expressionAttrs = new HashMap<String, ModelNode>();
         Map<String, ModelNode> otherAttrs = new HashMap<String, ModelNode>();
@@ -220,7 +221,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
 
         if (expectedAttrs.size() > 0 && immediateValidation) {
             // Validate that our write-attribute calls resulted in the expected values in the model
-            ModelNode modifiedResource = readResource(address, true);
+            ModelNode modifiedResource = readResource(address, true, true);
             for (Map.Entry<String, ModelNode> entry : expectedAttrs.entrySet()) {
                 ModelNode expectedValue = entry.getValue();
                 ModelNode modVal = modifiedResource.get(entry.getKey());
@@ -619,11 +620,18 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
         return executeForResult(op, domainMasterLifecycleUtil.getDomainClient());
     }
 
-    private ModelNode readResource(PathAddress address, boolean defaults) throws IOException, MgmtOperationException {
+    private ModelNode readResource(PathAddress address, boolean defaults, boolean failIfMissing) throws IOException, MgmtOperationException {
 
-        ModelNode op = createOperation(READ_RESOURCE_OPERATION, address);
-        op.get(INCLUDE_DEFAULTS).set(defaults);
-        return executeForResult(op, domainMasterLifecycleUtil.getDomainClient());
+        try {
+            ModelNode op = createOperation(READ_RESOURCE_OPERATION, address);
+            op.get(INCLUDE_DEFAULTS).set(defaults);
+            return executeForResult(op, domainMasterLifecycleUtil.getDomainClient());
+        } catch (MgmtOperationException e) {
+            if (failIfMissing) {
+                throw e;
+            }
+            return new ModelNode();
+        }
     }
 
     private void checkForUnconvertedExpression(PathAddress address, String attrName, ModelNode attrValue) {
@@ -660,7 +668,7 @@ public class ExpressionSupportSmokeTestCase extends BuildConfigurationTestBase {
 
         Map<String, ModelNode> expectedModel = expectedValues.get(address);
         if (expectedModel != null && isValidatable(address)) {
-            ModelNode resource = readResource(address, true);
+            ModelNode resource = readResource(address, true, true);
             for (Map.Entry<String, ModelNode> entry : expectedModel.entrySet()) {
                 String attrName = entry.getKey();
                 ModelNode expectedValue = entry.getValue();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestExtension.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/extension/TestExtension.java
@@ -22,12 +22,15 @@
 
 package org.jboss.as.test.integration.domain.extension;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ATTRIBUTES;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILDREN;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NILLABLE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TYPE;
 
-import java.util.List;
 import java.util.Locale;
-
-import javax.xml.stream.XMLStreamException;
 
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
@@ -35,15 +38,10 @@ import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.DescriptionProvider;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
-import org.jboss.as.controller.parsing.ParseUtils;
-import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.staxmapper.XMLElementReader;
-import org.jboss.staxmapper.XMLElementWriter;
-import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.staxmapper.XMLExtendedStreamWriter;
 
 /**
  * Fake extension to use in testing extension management.
@@ -54,8 +52,8 @@ public class TestExtension implements Extension {
 
     public static final String MODULE_NAME = "org.jboss.as.test.extension";
 
-    private final Parser parserOne = new Parser("urn:jboss:test:extension:1:1.0");
-    private final Parser parserTwo = new Parser("urn:jboss:test:extension:2:1.0");
+    private final EmptySubsystemParser parserOne = new EmptySubsystemParser("urn:jboss:test:extension:1:1.0");
+    private final EmptySubsystemParser parserTwo = new EmptySubsystemParser("urn:jboss:test:extension:2:1.0");
 
 
     @Override
@@ -73,8 +71,8 @@ public class TestExtension implements Extension {
 
     @Override
     public void initializeParsers(ExtensionParsingContext context) {
-        context.setSubsystemXmlMapping("1", parserOne.namespace, parserOne);
-        context.setSubsystemXmlMapping("2", parserTwo.namespace, parserTwo);
+        context.setSubsystemXmlMapping("1", parserOne.getNamespace(), parserOne);
+        context.setSubsystemXmlMapping("2", parserTwo.getNamespace(), parserTwo);
     }
 
 
@@ -104,24 +102,4 @@ public class TestExtension implements Extension {
         }
     }
 
-    private static class Parser implements XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
-
-        private final String namespace;
-
-        private Parser(String namespace) {
-            this.namespace = namespace;
-        }
-
-        @Override
-        public void readElement(XMLExtendedStreamReader reader, List<ModelNode> value) throws XMLStreamException {
-            ParseUtils.requireNoAttributes(reader);
-            ParseUtils.requireNoContent(reader);
-        }
-
-        @Override
-        public void writeContent(XMLExtendedStreamWriter streamWriter, SubsystemMarshallingContext context) throws XMLStreamException {
-            context.startSubsystemElement(namespace, false);
-            streamWriter.writeEndElement();
-        }
-    }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/DomainTestSuite.java
@@ -50,6 +50,7 @@ import org.junit.runners.Suite;
         ManagementVersionTestCase.class,
         ModelPersistenceTestCase.class,
         ModuleLoadingManagementTestCase.class,
+        OperationCancellationTestCase.class,
         OperationTransformationTestCase.class,
         ReadEnvironmentVariablesTestCase.class,
         ServerRestartRequiredTestCase.class,

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/OperationCancellationTestCase.java
@@ -1,0 +1,1030 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.domain.suites;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ACTIVE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CANCELLED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXECUTION_STATUS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT_OPERATIONS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_RESOURCES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVICE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.BLOCK_POINT;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.CALLER;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.TARGET_HOST;
+import static org.jboss.as.test.integration.management.extension.blocker.BlockerExtension.TARGET_SERVER;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationMessageHandler;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.extension.ExtensionSetup;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.extension.blocker.BlockerExtension;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.dmr.Property;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Test of cancellation of running operations in a domain.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class OperationCancellationTestCase {
+
+    private static final PathAddress SUBSYSTEM_ADDRESS = PathAddress.pathAddress(
+            PathElement.pathElement(PROFILE, "default"),
+            PathElement.pathElement(SUBSYSTEM, BlockerExtension.SUBSYSTEM_NAME));
+    private static final ModelNode BLOCK_OP = Util.createEmptyOperation("block", SUBSYSTEM_ADDRESS);
+    private static final ModelNode WRITE_FOO_OP = Util.getWriteAttributeOperation(SUBSYSTEM_ADDRESS, BlockerExtension.FOO.getName(), true);
+    private static final PathAddress MGMT_CONTROLLER = PathAddress.pathAddress(
+            PathElement.pathElement(CORE_SERVICE, MANAGEMENT),
+            PathElement.pathElement(SERVICE, MANAGEMENT_OPERATIONS)
+    );
+
+    private static final long GET_TIMEOUT = TimeoutUtil.adjust(10000);
+
+    private static DomainTestSupport testSupport;
+    private static DomainClient masterClient;
+
+    @BeforeClass
+    public static void setupDomain() throws Exception {
+        testSupport = DomainTestSuite.createSupport(OperationCancellationTestCase.class.getSimpleName());
+        masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        // Initialize the test extension
+        ExtensionSetup.initializeBlockerExtension(testSupport);
+
+        ModelNode addExtension = Util.createAddOperation(PathAddress.pathAddress(PathElement.pathElement(EXTENSION, BlockerExtension.MODULE_NAME)));
+
+        executeForResult(addExtension, masterClient);
+
+        ModelNode addSubsystem = Util.createAddOperation(PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, BlockerExtension.SUBSYSTEM_NAME)));
+        executeForResult(addSubsystem, masterClient);
+    }
+
+    @AfterClass
+    public static void tearDownDomain() throws Exception {
+        ModelNode removeSubsystem = Util.createEmptyOperation(REMOVE, PathAddress.pathAddress(
+                PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, BlockerExtension.SUBSYSTEM_NAME)));
+        executeForResult(removeSubsystem, masterClient);
+
+        ModelNode removeExtension = Util.createEmptyOperation(REMOVE, PathAddress.pathAddress(PathElement.pathElement(EXTENSION, BlockerExtension.MODULE_NAME)));
+        executeForResult(removeExtension, masterClient);
+
+        testSupport = null;
+        masterClient = null;
+        DomainTestSuite.stopSupport();
+    }
+
+    @After
+    public void awaitCompletion() throws Exception {
+        // Start from the leaves of the domain process tree and work inward validating
+        // that all block ops are cleared locally. This ensures that a later test doesn't
+        // mistakenly cancel a completing op from an earlier test
+        validateNoActiveOperation(masterClient, "master", "main-one");
+        validateNoActiveOperation(masterClient, "slave", "main-three");
+        validateNoActiveOperation(masterClient, "slave", null);
+        validateNoActiveOperation(masterClient, "master", null);
+    }
+
+    @Test
+    public void testMasterBlockModel() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.MODEL);
+        String id = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.EXECUTING, start);
+        cancel(masterClient, "master", null, "block", OperationContext.ExecutionStatus.EXECUTING, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertFailedOrCancelled(response);
+        validateNoActiveOperation(masterClient, "master", null, id, false);
+    }
+
+    @Test
+    public void testMasterBlockRuntime() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.EXECUTING, start);
+        cancel(masterClient, "master", null, "block", OperationContext.ExecutionStatus.EXECUTING, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertFailedOrCancelled(response);
+        validateNoActiveOperation(masterClient, "master", null, id, false);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testMasterBlockServiceStart() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        cancel(masterClient, "master", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", null, id, false);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testMasterBlockServiceStartCancelFuture() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        blockFuture.cancel(true);
+        try {
+            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            fail("not cancelled: " + response);
+        } catch (CancellationException good) {
+            // good
+        }
+        validateNoActiveOperation(masterClient, "master", null, id, false);
+    }
+
+    @Test
+    public void testMasterBlockVerify() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.VERIFY);
+        String id = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.EXECUTING, start);
+        cancel(masterClient, "master", null, "block", OperationContext.ExecutionStatus.EXECUTING, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertFailedOrCancelled(response);
+        validateNoActiveOperation(masterClient, "master", null, id, false);
+    }
+
+    @Test
+    public void testMasterBlockCompletion() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.COMMIT);
+        String blockId = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        cancel(masterClient, "master", null, "block", OperationContext.ExecutionStatus.COMPLETING, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", null, blockId, false);
+    }
+
+    @Test
+    public void testMasterBlockRollback() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.ROLLBACK);
+        String blockId = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
+        cancel(masterClient, "master", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // master has already failed when we cancel, so it reports as failed
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", null, blockId, false);
+    }
+
+    @Test
+    public void testMasterBlockOtherOpCancelOtherOp() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", null, BlockerExtension.BlockPoint.COMMIT);
+        String blockId = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        Future<ModelNode> writeFuture = masterClient.executeAsync(WRITE_FOO_OP, OperationMessageHandler.DISCARD);
+        cancel(masterClient, "master", null, "write-attribute", OperationContext.ExecutionStatus.AWAITING_OTHER_OPERATION, start, false);
+        ModelNode response = writeFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        blockFuture.cancel(true);
+        validateNoActiveOperation(masterClient, "master", null, blockId, true);
+    }
+
+    @Test
+    public void testMasterBlockOtherOpCancelBlockOp() throws Exception {
+        long start = System.currentTimeMillis();
+        block("master", null, BlockerExtension.BlockPoint.COMMIT);
+        String blockId = findActiveOperation(masterClient, "master", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        Future<ModelNode> writeFuture = masterClient.executeAsync(WRITE_FOO_OP, OperationMessageHandler.DISCARD);
+        findActiveOperation(masterClient, "master", null, "write-attribute", OperationContext.ExecutionStatus.AWAITING_OTHER_OPERATION, start);
+        cancel(masterClient, "master", null, "block", OperationContext.ExecutionStatus.COMPLETING, start, false);
+        ModelNode response = writeFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", null, blockId, true);
+    }
+
+    @Test
+    public void testSlaveBlockModelCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.MODEL);
+        String id = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    public void testSlaveBlockRuntimeCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testSlaveBlockServiceStartCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testSlaveBlockServiceStartCancelMasterFuture() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        blockFuture.cancel(true);
+        try {
+            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            fail("not cancelled: " + response);
+        } catch (CancellationException good) {
+            // good
+        }
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    public void testSlaveBlockVerifyCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.VERIFY);
+        String id = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    public void testSlaveBlockCompletionCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // The master may or may not be done with DomainSlaveHandler.execute and DomainRolloutStepHandler.execute
+        // when cancelled. If yes, result is SUCCESS, if not result is CANCELLED
+        assertSuccessOrCancelled(response);
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    public void testSlaveBlockRollbackCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.ROLLBACK);
+        String id = findActiveOperation(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // Slave fails before Stage.DONE so no normal prepared message in DONE with the failure. The block in
+        // rollback prevents the failure coming via the final response. So the master doesn't know about
+        // the failure and just detects the local cancellation. So, CANCELLED
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, id, true);
+    }
+
+    @Test
+    public void testSlaveBlockOtherOpCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.MODEL);
+        String blockId = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        Future<ModelNode> writeFuture = masterClient.executeAsync(WRITE_FOO_OP, OperationMessageHandler.DISCARD);
+        cancel(masterClient, "master", null, "write-attribute", OperationContext.ExecutionStatus.AWAITING_OTHER_OPERATION, start, false);
+        ModelNode response = writeFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        blockFuture.cancel(true);
+        validateNoActiveOperation(masterClient, "slave", null, blockId, true);
+    }
+
+    @Test
+    public void testSlaveBlockModelCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.MODEL);
+        String blockId = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "slave", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, blockId, false);
+    }
+
+    @Test
+    public void testSlaveBlockRuntimeCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.RUNTIME);
+        String blockId = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "slave", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, blockId, false);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testSlaveBlockServiceStartCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.SERVICE_START);
+        String blockId = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, blockId, false);
+    }
+
+    @Test
+    public void testSlaveBlockVerifyCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.VERIFY);
+        String blockId = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "slave", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, blockId, false);
+    }
+
+    @Test
+    public void testSlaveBlockCompletionCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.COMMIT);
+        String blockId = findActiveOperation(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        cancel(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.COMPLETING , start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // cancellation any time in Stage.DONE on slave will not result in a prepare-phase failed response to
+        // master, so this should always be success
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, blockId, true);
+    }
+
+    @Test
+    public void testSlaveBlockRollbackCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", null, BlockerExtension.BlockPoint.ROLLBACK);
+        String blockId = findActiveOperation(masterClient, "slave", null, "block", null, start);
+        cancel(masterClient, "slave", null, "block", OperationContext.ExecutionStatus.ROLLING_BACK, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // Cancelling the rollback does not prevent the master learning that the slave failed.
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", null, blockId, true);
+    }
+
+    @Test
+    public void testMasterServerBlockModelCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.MODEL);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testMasterServerBlockRuntimeCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testMasterServerBlockServiceStartCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testMasterServerBlockServiceStartCancelMasterFuture() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        blockFuture.cancel(true);
+        try {
+            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            fail("not cancelled: " + response);
+        } catch (CancellationException good) {
+            // good
+        }
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testMasterServerBlockVerifyCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.VERIFY);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testMasterServerBlockCompletionCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // The result may be success or cancelled depending on whether the cancelled executed while
+        // DomainRolloutStepHandler.execute was running (CANCELLED) or afterwards (SUCCESS)
+        assertSuccessOrCancelled(response);
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testMasterServerBlockRollbackCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.ROLLBACK);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // The server op does not reach the prepare stage, so the master doesn't either and reports as cancelled
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testMasterServerBlockModelCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.MODEL);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        cancel(masterClient, "master", "main-one", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, false);
+    }
+
+    @Test
+    public void testMasterServerBlockRuntimeCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        cancel(masterClient, "master", "main-one", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, false);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testMasterServerBlockServiceStartCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        cancel(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, false);
+    }
+
+    @Test
+    public void testMasterServerBlockVerifyCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.VERIFY);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", null, start);
+        cancel(masterClient, "master", "main-one", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, false);
+    }
+
+    @Test
+    public void testMasterServerBlockCompletionCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        cancel(masterClient, "master", "main-one", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to master,
+        // so result should always be SUCCESS
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testMasterServerBlockRollbackCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("master", "main-one", BlockerExtension.BlockPoint.ROLLBACK);
+        String id = findActiveOperation(masterClient, "master", "main-one", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
+        cancel(masterClient, "master", "main-one", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // Server never reaches Stage.DONE before blocking, so master is waiting for initial response.
+        // Cancelling the rollback on server doesn't change that response from FAILED. So master sees and reports failure.
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "master", "main-one", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockModelCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.MODEL);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id , true);
+    }
+
+    @Test
+    public void testSlaveServerBlockRuntimeCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testSlaveServerBlockServiceStartCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testSlaveServerBlockServiceStartCancelMasterFuture() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        blockFuture.cancel(true);
+        try {
+            ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+            fail("not cancelled: " + response);
+        } catch (CancellationException good) {
+            // good
+        }
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockVerifyCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.VERIFY);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockCompletionCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // The result may be success or cancelled depending on whether the cancelled executed while
+        // DomainRolloutStepHandler.execute was running (CANCELLED) or afterwards (SUCCESS)
+        assertSuccessOrCancelled(response);
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockRollbackCancelMaster() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
+        cancel(masterClient, "master", null, "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // Server doesn't get to DONE so doesn't report there, so master is waiting for initial report, which is blocking
+        // on server. So master detects local cancellation and reports it
+        assertEquals(response.asString(), CANCELLED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+
+    // Tests of cancelling an op blocking on a slave server via an op on the slave
+
+    // NOTE: Not the way a user should cancel a server op -- either cancel it on the coordinating HC
+    // (i.e. master for a domain-wide op) on on the server itself. Otherwise it's easy to mistakenly
+    // cancel the master's call to the slave HC and not its proxied call to the server.
+    // But we test this for completeness.
+
+    @Test
+    public void testSlaveServerBlockModelCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.MODEL);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
+        cancel(masterClient, "slave", null, "block", null, start, true);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockRuntimeCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
+        cancel(masterClient, "slave", null, "block", null, start, true);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testSlaveServerBlockServiceStartCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start);
+        // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
+        cancel(masterClient, "slave", null, "block", null, start, true);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockVerifyCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.VERIFY);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
+        cancel(masterClient, "slave", null, "block", null, start, true);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockCompletionCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start);
+        // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
+        cancel(masterClient, "slave", null, "block", null, start, true);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // The slave will already have sent its prepare phase response to master before the slave op even gets started.
+        // So the subsequent cancellation will not affect the overall result, so it's SUCCESS
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+    @Test
+    public void testSlaveServerBlockRollbackCancelSlave() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
+        // Here we must pass 'true' to the 'serverOpOnly' param to ensure we cancel the server op, and not the non-blocking HC op
+        cancel(masterClient, "slave", null, "block", null, start, true);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // Server can't report it's failure as a prepared message in DONE because it doesn't get there. So master is
+        // waiting for the initial report. The slave then cancelling releases the initial report but doesn't change
+        // its outcome from FAILED. So master sees failure
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, true);
+    }
+
+    @Test
+    public void testSlaveServerBlockModelCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.MODEL);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "slave", "main-three", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, false);
+    }
+
+    @Test
+    public void testSlaveServerBlockRuntimeCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.RUNTIME);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "slave", "main-three", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, false);
+    }
+
+    @Test
+    @Ignore("MSC-143")
+    public void testSlaveServerBlockServiceStartCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.SERVICE_START);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.AWAITING_STABILITY, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, false);
+    }
+
+    @Test
+    public void testSlaveServerBlockVerifyCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.VERIFY);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "slave", "main-three", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, false);
+    }
+
+    @Test
+    public void testSlaveServerBlockCompletionCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.COMMIT);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", null, start);
+        cancel(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.COMPLETING, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // cancelling on the server during Stage.DONE should not result in a prepare-phase failure sent to master,
+        // so result should always be SUCCESS
+        assertEquals(response.asString(), SUCCESS, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, false);
+    }
+
+    @Test
+    public void testSlaveServerBlockRollbackCancelServer() throws Exception {
+        long start = System.currentTimeMillis();
+        Future<ModelNode> blockFuture = block("slave", "main-three", BlockerExtension.BlockPoint.ROLLBACK);
+        String id = findActiveOperation(masterClient, "slave", "main-three", "block", OperationContext.ExecutionStatus.ROLLING_BACK, start);
+        cancel(masterClient, "slave", "main-three", "block", null, start, false);
+        ModelNode response = blockFuture.get(GET_TIMEOUT, TimeUnit.MILLISECONDS);
+        // Cancelling in rollback doesn't change the server's FAILED outcome, so master sees it and reports it.
+        assertEquals(response.asString(), FAILED, response.get(OUTCOME).asString());
+        validateNoActiveOperation(masterClient, "slave", "main-three", id, false);
+    }
+
+    private Future<ModelNode> block(String host, String server, BlockerExtension.BlockPoint blockPoint) {
+        ModelNode op = BLOCK_OP.clone();
+        op.get(TARGET_HOST.getName()).set(host);
+        if (server != null) {
+            op.get(TARGET_SERVER.getName()).set(server);
+        }
+        op.get(BLOCK_POINT.getName()).set(blockPoint.toString());
+        op.get(CALLER.getName()).set(getTestMethod());
+        return masterClient.executeAsync(op, OperationMessageHandler.DISCARD);
+    }
+
+    private void cancel(DomainClient client, String host, String server, String opName,
+                           OperationContext.ExecutionStatus targetStatus, long executionStart, boolean serverOpOnly) throws Exception {
+        PathAddress address = PathAddress.pathAddress(PathElement.pathElement(HOST, host));
+        if (server != null) {
+            address = address.append(PathElement.pathElement(SERVER, server));
+        }
+        address = address.append(MGMT_CONTROLLER);
+
+        final String opToCancel = findActiveOperation(client, address, opName, targetStatus, executionStart, serverOpOnly);
+        address = address.append(PathElement.pathElement(ACTIVE_OPERATION, opToCancel));
+
+        ModelNode result = executeForResult(Util.createEmptyOperation("cancel", address), client);
+
+        boolean retVal = result.asBoolean();
+        assertTrue(result.asString(), retVal);
+    }
+
+    private String findActiveOperation(DomainClient client, String host, String server, String opName,
+                                       OperationContext.ExecutionStatus targetStatus, long executionStart) throws Exception {
+        PathAddress address = getManagementControllerAddress(host, server);
+        return findActiveOperation(client, address, opName, targetStatus, executionStart, false);
+    }
+
+    private String findActiveOperation(DomainClient client, PathAddress address, String opName, OperationContext.ExecutionStatus targetStatus, long executionStart, boolean serverOpOnly) throws Exception {
+        ModelNode op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
+        op.get(CHILD_TYPE).set(ACTIVE_OPERATION);
+        long maxTime = TimeoutUtil.adjust(5000);
+        long timeout = executionStart + maxTime;
+        List<Property> activeOps = new ArrayList<Property>();
+        String opToCancel = null;
+        do {
+            ModelNode result = executeForResult(op, client);
+            if (result.isDefined()) {
+                assertEquals(result.asString(), ModelType.OBJECT, result.getType());
+                for (Property prop : result.asPropertyList()) {
+                    if (prop.getValue().get(OP).asString().equals(opName)) {
+                        PathAddress pa = PathAddress.pathAddress(prop.getValue().get(OP_ADDR));
+                        if (!serverOpOnly || pa.size() > 2 && pa.getElement(1).getKey().equals(SERVER)) {
+                            activeOps.add(prop);
+                            if (targetStatus == null || prop.getValue().get(EXECUTION_STATUS).asString().equals(targetStatus.toString())) {
+                                opToCancel = prop.getName();
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if (opToCancel == null) {
+                activeOps.clear();
+                Thread.sleep(50);
+            }
+
+        } while ((opToCancel == null || activeOps.size() > 1) && System.currentTimeMillis() <= timeout);
+
+        assertTrue(opName + " not present after " + maxTime + " ms", activeOps.size() > 0);
+        assertEquals("Multiple instances of " + opName + " present: " + activeOps, 1, activeOps.size());
+        assertNotNull(opName + " not in status " + targetStatus + " after " + maxTime + " ms", opToCancel);
+
+        return opToCancel;
+    }
+
+    private String findActiveOperation(DomainClient client, PathAddress address, String opName) throws Exception {
+        ModelNode op = Util.createEmptyOperation(READ_CHILDREN_RESOURCES_OPERATION, address);
+        op.get(CHILD_TYPE).set(ACTIVE_OPERATION);
+        ModelNode result = executeForResult(op, client);
+        if (result.isDefined()) {
+            assertEquals(result.asString(), ModelType.OBJECT, result.getType());
+            for (Property prop : result.asPropertyList()) {
+                if (prop.getValue().get(OP).asString().equals(opName)) {
+                    return prop.getName();
+                }
+            }
+        }
+        return null;
+    }
+
+    private void validateNoActiveOperation(DomainClient client, String host, String server) throws Exception {
+
+        PathAddress baseAddress = getManagementControllerAddress(host, server);
+
+        // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
+        // something strange is happening on the machine is overloaded
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(5000);
+        MgmtOperationException failure;
+        do {
+            String id = findActiveOperation(client, baseAddress, "block");
+            if (id == null) {
+                return;
+            }
+            failure = null;
+            PathAddress address = baseAddress.append(PathElement.pathElement(ACTIVE_OPERATION, id));
+            ModelNode op = Util.createEmptyOperation(READ_ATTRIBUTE_OPERATION, address);
+            op.get(NAME).set(OP);
+            try {
+                executeForFailure(op, client);
+            } catch (MgmtOperationException moe) {
+                failure = moe;
+            }
+            Thread.sleep(50);
+        } while (System.currentTimeMillis() < timeout);
+
+        throw failure;
+    }
+
+    private void validateNoActiveOperation(DomainClient client, String host, String server, String id,
+                                           boolean patient) throws Exception {
+        PathAddress address = getManagementControllerAddress(host, server);
+        address = address.append(PathElement.pathElement(ACTIVE_OPERATION, id));
+        ModelNode op = Util.createEmptyOperation(READ_ATTRIBUTE_OPERATION, address);
+        op.get(NAME).set(OP);
+
+        // The op should clear w/in a few ms but we'll wait up to 5 secs just in case
+        // something strange is happening on the machine is overloaded
+        long timeout = patient ? System.currentTimeMillis() + TimeoutUtil.adjust(5000) : 0;
+        MgmtOperationException failure;
+        do {
+            try {
+                executeForFailure(op, client);
+                return;
+            } catch (MgmtOperationException moe) {
+                if (!patient) {
+                    throw moe;
+                }
+                failure = moe;
+            }
+            Thread.sleep(50);
+        } while (System.currentTimeMillis() < timeout);
+
+        throw failure;
+    }
+
+    private static PathAddress getManagementControllerAddress(String host, String server) {
+        PathAddress address = PathAddress.pathAddress(PathElement.pathElement(HOST, host));
+        if (server != null) {
+            address = address.append(PathElement.pathElement(SERVER, server));
+        }
+        address = address.append(MGMT_CONTROLLER);
+        return address;
+    }
+
+    private static ModelNode executeForResult(final ModelNode op, final ModelControllerClient modelControllerClient) throws IOException, MgmtOperationException {
+        try {
+            return DomainTestUtils.executeForResult(op, modelControllerClient);
+        } catch (MgmtOperationException e) {
+            System.out.println(" Op failed:");
+            System.out.println(e.getOperation());
+            System.out.println("with result");
+            System.out.println(e.getResult());
+            throw e;
+        }
+    }
+
+    private static ModelNode executeForFailure(final ModelNode op, final ModelControllerClient modelControllerClient) throws IOException, MgmtOperationException {
+        try {
+            return DomainTestUtils.executeForFailure(op, modelControllerClient);
+        } catch (MgmtOperationException e) {
+            System.out.println(" Op that incorrectly succeeded:");
+            System.out.println(e.getOperation());
+            throw e;
+        }
+    }
+
+    private static String getTestMethod() {
+        final StackTraceElement[] stack = Thread.currentThread().getStackTrace();
+        for (StackTraceElement ste : stack) {
+            String method = ste.getMethodName();
+            if (method.startsWith("test")) {
+                return method;
+            }
+        }
+        return "unknown";
+    }
+
+    private static void assertFailedOrCancelled(ModelNode response) {
+        assertXorCancelled(response, FAILED);
+    }
+
+    private static void assertSuccessOrCancelled(ModelNode response) {
+        assertXorCancelled(response, SUCCESS);
+    }
+
+    private static void assertXorCancelled(ModelNode response, String x) {
+        String outcome = response.get(OUTCOME).asString();
+        if (!CANCELLED.equals(outcome)) {
+            assertEquals(response.asString(), x, response.get(OUTCOME).asString());
+        }
+
+    }
+}

--- a/testsuite/domain/src/test/resources/extension/blocker-module.xml
+++ b/testsuite/domain/src/test/resources/extension/blocker-module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.blocker-test">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="blocker-extension.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.msc"/>
+    </dependencies>
+</module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/extension/remove/module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/extension/remove/module.xml
@@ -25,7 +25,7 @@
 <module xmlns="urn:jboss:module:1.1" name="extensionremovemodule">
 
     <resources>
-        <resource-root path="extension-remove-module.jar"/>
+        <resource-root path="test-extension.jar"/>
     </resources>
 
     <dependencies>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ManagementOpTimeoutTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/management/cli/ManagementOpTimeoutTestCase.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.management.cli;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.logging.ControllerLogger;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.as.test.integration.management.extension.ExtensionUtils;
+import org.jboss.as.test.integration.management.extension.blocker.BlockerExtension;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.dmr.ModelNode;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Integration test of management op timeout handling. This test focuses on the CLI handling
+ * of the 'blocking-timeout' operation header and on the ability to restart the server with
+ * a MSC thread hanging in start.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ManagementOpTimeoutTestCase extends AbstractCliTestBase {
+
+    public static final String DEFAULT_JBOSSAS = "default-jbossas";
+    public static final String DEPLOYMENT_NAME = "DUMMY";
+
+    @ArquillianResource
+    private static ContainerController container;
+
+    //NOTE: BeforeClass is not subject to ARQ injection.
+    @Before
+    public void initServer() throws Exception {
+        container.start(DEFAULT_JBOSSAS);
+        initCLI();
+        ExtensionUtils.createExtensionModule("org.wildfly.extension.blocker-test", BlockerExtension.class,
+                EmptySubsystemParser.class.getPackage());
+    }
+
+    @After
+    public void closeServer() throws Exception {
+        cli.sendLine("/subsystem=blocker-test:remove", true);
+        cli.sendLine("/extension=org.wildfly.extension.blocker-test:remove");
+        closeCLI();
+        container.stop(DEFAULT_JBOSSAS);
+        ExtensionUtils.deleteExtensionModule("org.wildfly.extension.blocker-test");
+    }
+
+    @Test
+    public void testTimeoutCausesRestartRequired() throws Exception {
+        // Add the extension and subsystem
+        cli.sendLine("/extension=org.wildfly.extension.blocker-test:add");
+        CLIOpResult result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+        cli.sendLine("/subsystem=blocker-test:add");
+        result = cli.readAllAsOpResult();
+        assertTrue(result.isIsOutcomeSuccess());
+
+        // Trigger a hang, but with a short timeout
+        final CountDownLatch latch = new CountDownLatch(1);
+        final Throwable[] holder = new Throwable[1];
+        Runnable r = new Runnable() {
+            @Override
+            public void run() {
+                block(latch, holder);
+            }
+        };
+        Thread t = new Thread(r);
+        t.setDaemon(true);
+        t.start();
+
+        assertTrue(latch.await(20, TimeUnit.SECONDS));
+        assertNull(holder[0]);
+    }
+
+    private void block(CountDownLatch latch, Throwable[] holder) {
+
+        try {
+            cli.sendLine("/subsystem=blocker-test:block(block-point=SERVICE_START,block-time=10000){blocking-timeout=1}", true);
+            CLIOpResult result = cli.readAllAsOpResult();
+            assertFalse(result.isIsOutcomeSuccess());
+            checkResponseHeadersForProcessState(result, "restart-required");
+            ModelNode response = result.getResponseNode();
+            assertTrue(response.toString(), response.get(FAILURE_DESCRIPTION).asString().contains(ControllerLogger.ROOT_LOGGER.timeoutExecutingOperation()));
+        } catch (Throwable t) {
+            holder[0] = t;
+        }
+        latch.countDown();
+    }
+
+    protected void checkResponseHeadersForProcessState(CLIOpResult result, String requiredState) {
+        assertNotNull("No response headers!", result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS));
+        Map responseHeaders = (Map) result.getFromResponse(ModelDescriptionConstants.RESPONSE_HEADERS);
+        Object processState = responseHeaders.get("process-state");
+        assertNotNull("No process state in response-headers!", processState);
+        assertTrue("Process state is of wrong type!", processState instanceof String);
+        assertEquals("Wrong content of process-state header", requiredState, (String) processState);
+
+    }
+}

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -963,7 +963,7 @@ public class ParseAndMarshalModelsTestCase {
             latch.countDown();
         }
 
-        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration) {
+        protected void initModel(Resource rootResource, ManagementResourceRegistration rootRegistration, Resource modelControllerResource) {
             registration.setup(rootResource, rootRegistration, authorizer);
 
             rootRegistration.registerOperationHandler(new SimpleOperationDefinitionBuilder("capture-model", new NonResolvingResourceDescriptionResolver()).build()

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/EmptySubsystemParser.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/EmptySubsystemParser.java
@@ -1,0 +1,65 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension;
+
+import java.util.List;
+
+import javax.xml.stream.XMLStreamException;
+
+import org.jboss.as.controller.parsing.ParseUtils;
+import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
+import org.jboss.dmr.ModelNode;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.jboss.staxmapper.XMLExtendedStreamReader;
+import org.jboss.staxmapper.XMLExtendedStreamWriter;
+
+/**
+* Handles xml parsing/marshalling for a subsystem with no child elements or attributes.
+*
+* @author Brian Stansberry (c) 2014 Red Hat Inc.
+*/
+public class EmptySubsystemParser implements XMLElementReader<List<ModelNode>>, XMLElementWriter<SubsystemMarshallingContext> {
+
+    private final String namespace;
+
+    public EmptySubsystemParser(String namespace) {
+        this.namespace = namespace;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    @Override
+    public void readElement(XMLExtendedStreamReader reader, List<ModelNode> value) throws XMLStreamException {
+        ParseUtils.requireNoAttributes(reader);
+        ParseUtils.requireNoContent(reader);
+    }
+
+    @Override
+    public void writeContent(XMLExtendedStreamWriter streamWriter, SubsystemMarshallingContext context) throws XMLStreamException {
+        context.startSubsystemElement(namespace, false);
+        streamWriter.writeEndElement();
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/ExtensionUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/ExtensionUtils.java
@@ -1,0 +1,157 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.jboss.as.controller.Extension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.StreamExporter;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.xnio.IoUtils;
+
+/**
+ * Utilities for manipulating extensions in integration tests.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class ExtensionUtils {
+
+    public static final String JAR_NAME = "test-extension.jar";
+
+    public static void createExtensionModule(String extensionName, Class<? extends Extension> extension) throws IOException {
+        createExtensionModule(getExtensionModuleRoot(extensionName), extension);
+    }
+
+    public static void createExtensionModule(String extensionName, Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
+        createExtensionModule(getExtensionModuleRoot(extensionName), extension, additionalPackages);
+    }
+
+    public static void createExtensionModule(File extensionModuleRoot, Class<? extends Extension> extension) throws IOException {
+        createExtensionModule(extensionModuleRoot, extension, new Package[0]);
+    }
+
+    public static void createExtensionModule(File extensionModuleRoot, Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
+
+        deleteRecursively(extensionModuleRoot);
+
+        if (extensionModuleRoot.exists()) {
+            throw new IllegalArgumentException(extensionModuleRoot + " already exists");
+        }
+        File file = new File(extensionModuleRoot, "main");
+        if (!file.mkdirs()) {
+            throw new IllegalArgumentException("Could not create " + file);
+        }
+        final InputStream is = createResourceRoot(extension, additionalPackages).exportAsInputStream();
+        try {
+            copyFile(new File(file, JAR_NAME), is);
+        } finally {
+            IoUtils.safeClose(is);
+        }
+
+        URL url = extension.getResource("module.xml");
+        if (url == null) {
+            throw new IllegalStateException("Could not find module.xml");
+        }
+        copyFile(new File(file, "module.xml"), url.openStream());
+    }
+
+    public static void deleteExtensionModule(String moduleName) {
+        deleteRecursively(getExtensionModuleRoot(moduleName));
+    }
+
+    public static void deleteExtensionModule(File extensionModuleRoot) {
+        deleteRecursively(extensionModuleRoot);
+    }
+
+    private static void copyFile(File target, InputStream src) throws IOException {
+        final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(target));
+        try {
+            int i = src.read();
+            while (i != -1) {
+                out.write(i);
+                i = src.read();
+            }
+        } finally {
+            IoUtils.safeClose(out);
+        }
+    }
+
+    public static File getModulePath() {
+        String modulePath = System.getProperty("module.path", null);
+        if (modulePath == null) {
+            String jbossHome = System.getProperty("jboss.home", null);
+            if (jbossHome == null) {
+                throw new IllegalStateException("Neither -Dmodule.path nor -Djboss.home were set");
+            }
+            modulePath = jbossHome + File.separatorChar + "modules";
+        }else{
+            modulePath = modulePath.split(File.pathSeparator)[0];
+        }
+        File moduleDir = new File(modulePath);
+        if (!moduleDir.exists()) {
+            throw new IllegalStateException("Determined module path does not exist");
+        }
+        if (!moduleDir.isDirectory()) {
+            throw new IllegalStateException("Determined module path is not a dir");
+        }
+        return moduleDir;
+    }
+
+    private static File getExtensionModuleRoot(String extensionName) {
+        File file = getModulePath();
+        for (String element : extensionName.split("\\.")) {
+            file = new File(file, element);
+        }
+        return file;
+    }
+
+    private static StreamExporter createResourceRoot(Class<? extends Extension> extension, Package... additionalPackages) throws IOException {
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class);
+        archive.addPackage(extension.getPackage());
+        if (additionalPackages != null) {
+            for (Package pkg : additionalPackages) {
+                archive.addPackage(pkg);
+            }
+        }
+        archive.addAsServiceProvider(Extension.class, extension);
+        return archive.as(ZipExporter.class);
+    }
+
+    private static void deleteRecursively(File file) {
+        if (file.exists()) {
+            if (file.isDirectory()) {
+                for (String name : file.list()) {
+                    deleteRecursively(new File(file, name));
+                }
+            }
+            assert file.delete();
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -1,0 +1,328 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.management.extension.blocker;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.HOST;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import java.util.Set;
+import java.util.logging.Logger;
+
+import org.jboss.as.controller.AbstractAddStepHandler;
+import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.Extension;
+import org.jboss.as.controller.ExtensionContext;
+import org.jboss.as.controller.ModelOnlyWriteAttributeHandler;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationDefinition;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ProcessType;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.client.helpers.MeasurementUnit;
+import org.jboss.as.controller.descriptions.NonResolvingResourceDescriptionResolver;
+import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
+import org.jboss.as.controller.operations.validation.EnumValidator;
+import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.ServerEnvironment;
+import org.jboss.as.test.integration.management.extension.EmptySubsystemParser;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * Extension that can block threads.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class BlockerExtension implements Extension {
+
+    public static final String MODULE_NAME = "org.wildfly.extension.blocker-test";
+    public static final String SUBSYSTEM_NAME = "blocker-test";
+    public static final AttributeDefinition TARGET_HOST = SimpleAttributeDefinitionBuilder.create(HOST, ModelType.STRING, true).build();
+    public static final AttributeDefinition TARGET_SERVER = SimpleAttributeDefinitionBuilder.create(SERVER, ModelType.STRING, true).build();
+    public static final AttributeDefinition BLOCK_POINT = SimpleAttributeDefinitionBuilder.create("block-point", ModelType.STRING)
+            .setValidator(EnumValidator.create(BlockPoint.class, false, false))
+            .build();
+    public static final AttributeDefinition BLOCK_TIME = SimpleAttributeDefinitionBuilder.create("block-time", ModelType.LONG, true)
+            .setDefaultValue(new ModelNode(20000))
+            .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
+            .build();
+
+    public static final AttributeDefinition FOO = SimpleAttributeDefinitionBuilder.create("foo", ModelType.BOOLEAN, true).build();
+
+
+    private static final EmptySubsystemParser PARSER = new EmptySubsystemParser("urn:wildfly:extension:blocker-test:1.0");
+    private static final Logger log = Logger.getLogger(BlockerExtension.class.getCanonicalName());
+
+    @Override
+    public void initialize(ExtensionContext context) {
+        SubsystemRegistration subsystem = context.registerSubsystem(SUBSYSTEM_NAME, 1, 0, 0);
+        subsystem.registerSubsystemModel(new BlockerSubsystemResourceDefinition(context.getProcessType() == ProcessType.HOST_CONTROLLER));
+        subsystem.registerXMLElementWriter(PARSER);
+    }
+
+    @Override
+    public void initializeParsers(ExtensionParsingContext context) {
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, PARSER.getNamespace(), PARSER);
+    }
+
+    private static class BlockerSubsystemResourceDefinition extends SimpleResourceDefinition {
+
+        private final boolean forHost;
+        private BlockerSubsystemResourceDefinition(boolean forHost) {
+            super(PathElement.pathElement(SUBSYSTEM, SUBSYSTEM_NAME), new NonResolvingResourceDescriptionResolver(),
+                    new AbstractAddStepHandler(),
+                    ReloadRequiredRemoveStepHandler.INSTANCE);
+            this.forHost = forHost;
+        }
+
+        @Override
+        public void registerOperations(ManagementResourceRegistration resourceRegistration) {
+            super.registerOperations(resourceRegistration);
+            resourceRegistration.registerOperationHandler(BlockHandler.DEFINITION, new BlockHandler());
+            if (forHost) {
+                resourceRegistration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+            }
+            log.info("Registered blocker-test operations");
+        }
+
+        @Override
+        public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+            super.registerAttributes(resourceRegistration);
+            resourceRegistration.registerReadWriteAttribute(FOO, null, new ModelOnlyWriteAttributeHandler(FOO));
+        }
+    }
+
+    public static enum BlockPoint {
+        MODEL,
+        RUNTIME,
+        SERVICE_START,
+        SERVICE_STOP,
+        VERIFY,
+        COMMIT,
+        ROLLBACK
+    }
+
+    private static class BlockHandler implements OperationStepHandler {
+
+        private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", new NonResolvingResourceDescriptionResolver())
+                .setParameters(TARGET_HOST, TARGET_SERVER, BLOCK_POINT, BLOCK_TIME)
+                .build();
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            log.info("block requested");
+            boolean forMe = false;
+            if (context.getProcessType() == ProcessType.STANDALONE_SERVER) {
+                forMe = true;
+            } else {
+                Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
+                ModelNode targetServer = TARGET_SERVER.resolveModelAttribute(context, operation);
+                if (targetServer.isDefined()) {
+                    if (context.getProcessType().isServer()) {
+                        String name = System.getProperty(ServerEnvironment.SERVER_NAME);
+                        log.info("name is " + name);
+                        forMe = targetServer.asString().equals(name);
+                    }
+                } else if (context.getProcessType() == ProcessType.HOST_CONTROLLER) {
+                    Set<String> hosts = rootResource.getChildrenNames(HOST);
+                    String name;
+                    if (hosts.size() > 1) {
+                        name = "master";
+                    } else {
+                        name = hosts.iterator().next();
+                    }
+                    log.info("name is " + name);
+                    ModelNode targetHost = TARGET_HOST.resolveModelAttribute(context, operation);
+                    if (!targetHost.isDefined()) {
+                        throw new OperationFailedException("target-host required");
+                    }
+                    forMe = targetHost.asString().equals(name);
+                }
+            }
+            if (forMe) {
+                final long blockTime = BLOCK_TIME.resolveModelAttribute(context, operation).asLong();
+                final BlockPoint blockPoint = BlockPoint.valueOf(BLOCK_POINT.resolveModelAttribute(context, operation).asString());
+                log.info("will block at " + blockPoint + " for " + blockTime);
+                switch (blockPoint) {
+                    case MODEL: {
+                        block(blockTime);
+                        break;
+                    }
+                    case RUNTIME: {
+                        context.addStep(new BlockStep(blockTime), OperationContext.Stage.RUNTIME);
+                        break;
+                    }
+                    case SERVICE_START:
+                    case SERVICE_STOP: {
+                        context.addStep(new OperationStepHandler() {
+                            @Override
+                            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                BlockingService service = new BlockingService(blockTime, blockPoint == BlockPoint.SERVICE_START);
+
+                                context.getServiceTarget().addService(BlockingService.SERVICE_NAME, service).install();
+
+                                context.completeStep(new OperationContext.ResultHandler() {
+                                    @Override
+                                    public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                                        log.info("BlockingService step completed: result = " + resultAction);
+                                        context.removeService(BlockingService.SERVICE_NAME);
+                                    }
+                                });
+                            }
+                        }, OperationContext.Stage.RUNTIME);
+                        break;
+                    }
+                    case VERIFY: {
+                        context.addStep(new BlockStep(blockTime), OperationContext.Stage.VERIFY);
+                        break;
+                    }
+                    case ROLLBACK:
+                        context.addStep(new OperationStepHandler() {
+                            @Override
+                            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                                context.getFailureDescription().set("rollback");
+                                context.setRollbackOnly();
+                                context.stepCompleted();
+                            }
+                        }, OperationContext.Stage.MODEL);
+                        break;
+                    case COMMIT:
+                        break;
+                    default:
+                        throw new IllegalStateException(blockPoint.toString());
+                }
+                context.completeStep(new OperationContext.ResultHandler() {
+                    @Override
+                    public void handleResult(OperationContext.ResultAction resultAction, OperationContext context, ModelNode operation) {
+                        if ((blockPoint == BlockPoint.COMMIT && resultAction == OperationContext.ResultAction.KEEP)
+                            || (blockPoint == BlockPoint.ROLLBACK && resultAction == OperationContext.ResultAction.ROLLBACK)) {
+                            block(blockTime);
+                        }
+                    }
+                });
+            } else {
+
+                context.stepCompleted();
+            }
+        }
+
+        private static void block(long time) {
+            try {
+                log.info("blocking");
+                Thread.sleep(time);
+            } catch (InterruptedException e) {
+                log.info("interrupted");
+                throw new RuntimeException(e);
+            }
+        }
+
+        private static class BlockStep implements OperationStepHandler {
+            private final long blockTime;
+
+            private BlockStep(long blockTime) {
+                this.blockTime = blockTime;
+            }
+
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                block(blockTime);
+                context.stepCompleted();
+            }
+        }
+    }
+
+    private static class BlockingService implements Service<BlockingService> {
+
+        private static final ServiceName SERVICE_NAME = ServiceName.of("jboss", "test", "blocking-service");
+        private final long blockTime;
+        private final boolean blockStart;
+
+        private final Object waitObject = new Object();
+
+        private BlockingService(long blockTime, boolean blockStart) {
+            this.blockTime = blockTime;
+            this.blockStart = blockStart;
+        }
+
+        @Override
+        public void start(final StartContext context) throws StartException {
+            if (blockStart) {
+//                Runnable r = new Runnable() {
+//                    @Override
+//                    public void run() {
+                        try {
+                            synchronized (waitObject) {
+                                log.info("BlockService blocking in start");
+                                waitObject.wait(blockTime);
+                            }
+                            context.complete();
+                        } catch (InterruptedException e) {
+                            log.info("BlockService interrupted");
+//                            context.failed(new StartException(e));
+                            throw new StartException(e);
+                        }
+//                    }
+//                };
+//                Thread thread = new Thread(r);
+//                thread.start();
+//                context.asynchronous();
+            } else {
+                // Not yet used
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        @Override
+        public void stop(final StopContext context) {
+            if (!blockStart) {
+                // Not yet used
+                throw new UnsupportedOperationException();
+            } else {
+                synchronized (waitObject) {
+                    log.info("BlockService Stopping");
+                    waitObject.notifyAll();
+                }
+            }
+        }
+
+        @Override
+        public BlockingService getValue() throws IllegalStateException, IllegalArgumentException {
+            return this;
+        }
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/management/extension/blocker/BlockerExtension.java
@@ -72,6 +72,8 @@ public class BlockerExtension implements Extension {
 
     public static final String MODULE_NAME = "org.wildfly.extension.blocker-test";
     public static final String SUBSYSTEM_NAME = "blocker-test";
+    public static final AttributeDefinition CALLER = SimpleAttributeDefinitionBuilder.create("caller", ModelType.STRING, true)
+            .setDefaultValue(new ModelNode("unknown")).build();
     public static final AttributeDefinition TARGET_HOST = SimpleAttributeDefinitionBuilder.create(HOST, ModelType.STRING, true).build();
     public static final AttributeDefinition TARGET_SERVER = SimpleAttributeDefinitionBuilder.create(SERVER, ModelType.STRING, true).build();
     public static final AttributeDefinition BLOCK_POINT = SimpleAttributeDefinitionBuilder.create("block-point", ModelType.STRING)
@@ -140,22 +142,24 @@ public class BlockerExtension implements Extension {
     private static class BlockHandler implements OperationStepHandler {
 
         private static final OperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder("block", new NonResolvingResourceDescriptionResolver())
-                .setParameters(TARGET_HOST, TARGET_SERVER, BLOCK_POINT, BLOCK_TIME)
+                .setParameters(CALLER, TARGET_HOST, TARGET_SERVER, BLOCK_POINT, BLOCK_TIME)
                 .build();
 
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-            log.info("block requested");
+            ModelNode targetServer = TARGET_SERVER.resolveModelAttribute(context, operation);
+            ModelNode targetHost = TARGET_HOST.resolveModelAttribute(context, operation);
+            final BlockPoint blockPoint = BlockPoint.valueOf(BLOCK_POINT.resolveModelAttribute(context, operation).asString());
+            log.info("block requested by " + CALLER.resolveModelAttribute(context, operation).asString() + " for " +
+                targetHost.asString() + "/" + targetServer.asString() + "(" + blockPoint + ")");
             boolean forMe = false;
             if (context.getProcessType() == ProcessType.STANDALONE_SERVER) {
                 forMe = true;
             } else {
                 Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
-                ModelNode targetServer = TARGET_SERVER.resolveModelAttribute(context, operation);
                 if (targetServer.isDefined()) {
                     if (context.getProcessType().isServer()) {
                         String name = System.getProperty(ServerEnvironment.SERVER_NAME);
-                        log.info("name is " + name);
                         forMe = targetServer.asString().equals(name);
                     }
                 } else if (context.getProcessType() == ProcessType.HOST_CONTROLLER) {
@@ -166,8 +170,6 @@ public class BlockerExtension implements Extension {
                     } else {
                         name = hosts.iterator().next();
                     }
-                    log.info("name is " + name);
-                    ModelNode targetHost = TARGET_HOST.resolveModelAttribute(context, operation);
                     if (!targetHost.isDefined()) {
                         throw new OperationFailedException("target-host required");
                     }
@@ -176,7 +178,6 @@ public class BlockerExtension implements Extension {
             }
             if (forMe) {
                 final long blockTime = BLOCK_TIME.resolveModelAttribute(context, operation).asLong();
-                final BlockPoint blockPoint = BlockPoint.valueOf(BLOCK_POINT.resolveModelAttribute(context, operation).asString());
                 log.info("will block at " + blockPoint + " for " + blockTime);
                 switch (blockPoint) {
                     case MODEL: {

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/blocker/module.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/management/extension/blocker/module.xml
@@ -1,0 +1,16 @@
+<module xmlns="urn:jboss:module:1.1" name="org.wildfly.extension.blocker-test">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <resource-root path="test-extension.jar"/>
+        <!-- Insert resources here -->
+    </resources>
+
+    <dependencies>
+        <module name="org.jboss.staxmapper"/>
+        <module name="org.jboss.as.controller"/>
+        <module name="org.jboss.msc"/>
+    </dependencies>
+</module>


### PR DESCRIPTION
Supersedes https://github.com/wildfly/wildfly/pull/6206 by continuing on with further work related to operation cancellation.

See description of #6206 for discussion of the operation timeout piece (the 1st two commits).

This PR adds commits related to administratively canceling problematic ops.

Caveat: it is still not possible to force MSC stability if some service will not properly return from start/stop. See https://issues.jboss.org/browse/MSC-143. But the cancellation fixes included here will allow the HC processes to no longer block waiting for servers to stabilize, making it possible for an admin to take corrective action (e.g. kill the hung server.)

The last 3 commits do the following:

1) Expose a resource for each currently executing management operation:

[domain@localhost:9990 /] /host=master/core-service=management/service=management-operations:read-children-resources(child-type=active-operation)
{
    "outcome" => "success",
    "result" => {"-63170310" => {
        "access-mechanism" => "undefined",
        "address" => [
            ("host" => "master"),
            ("core-service" => "management"),
            ("service" => "management-operations")
        ],
        "caller-thread" => "management-handler-thread - 3",
        "cancelled" => false,
        "exclusive-running-time" => -1L,
        "execution-status" => "executing",
        "operation" => "read-children-resources",
        "running-time" => 3534000L
    }}
}

Strip /host=master off the address for the standalone server address; include server=<?> for the domain server address.

2) Include a "cancel" op in those resources, which if invoked interrupts the thread executing the op. Canceling an op is done via thread interruption, as has been the case since 7.0.

3) Implement a number of fixes related to ensuring that canceling an op via interruption is properly propagated throughout a managed domain, while also ensuring that the thread interruption that is the basic mechanism for cancellation does not result in inadvertently closing the communication channels between the processes in the domain.

4) The ModelControllerClient async API has always supported canceling op from the client side by canceling the Future returned from executeAsync. This is now more reliable in a domain due to 3) above.

5) The parent resource for the active-operation resources includes two convenience operations:

a) find-non-progressing-operation: Checks for an operation that has been holding the exclusive operation execution lock for greater than the provided number of seconds, and if found return its id.

b) cancel-non-progressing-operation: Like find-non-progressing-operation, but instead of returning an operation's id, it cancels that operation.

The intent of these two ops is to simplify identifying/canceling the problem operation that is hanging with the exclusive lock while a number of other ops are blocking waiting for that lock.
