### PR TITLE
WFLY-3319 Upgrade to Hibernate Validator 5.1.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <version.jboss.jaxbintros>1.0.2.GA</version.jboss.jaxbintros>
         <version.joda-time>1.6.2</version.joda-time>
         <version.junit>4.11</version.junit>
-        <version.jsoup>1.6.1</version.jsoup>
+        <version.jsoup>1.7.1</version.jsoup>
         <version.log4j>1.2.16</version.log4j>
         <version.net.jcip>1.0</version.net.jcip>
         <version.org.apache.ant>1.8.2</version.org.apache.ant>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>
         <version.org.hibernate>4.3.5.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.4.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.validator>5.1.0.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>5.1.1.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.0.0.Alpha6</version.org.hibernate.hql>
         <version.org.hibernate.search>4.5.1.Final</version.org.hibernate.search>


### PR DESCRIPTION
Based on top of https://github.com/wildfly/wildfly/pull/6236.

I've added https://github.com/gunnarmorling/wildfly/commit/57a15e117af777f870aa601408d462a88749df02 to update the JSoup version from 1.6.1 to 1.7.1. HV itelf has been depending on 1.7.1 for quite a while already, but for a bug fix in HV 5.1.1 we're now using an API which had been introduced in JSoup 1.7.x.
