### PR TITLE
[PLINK-405] regression tests

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/KerberosKeyTabSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/KerberosKeyTabSetup.java
@@ -1,0 +1,88 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.picketlink;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.directory.server.kerberos.shared.crypto.encryption.KerberosKeyFactory;
+import org.apache.directory.server.kerberos.shared.keytab.Keytab;
+import org.apache.directory.server.kerberos.shared.keytab.KeytabEntry;
+import org.apache.directory.shared.kerberos.KerberosTime;
+import org.apache.directory.shared.kerberos.codec.types.EncryptionType;
+import org.apache.directory.shared.kerberos.components.EncryptionKey;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+
+/**
+ * Class which sets up the Kerberos keytab file for HTTP service principal. It also sets system properties
+ */
+public class KerberosKeyTabSetup implements ServerSetupTask {
+
+    private static final String KEYTAB_FILENAME = "keytab.krb";
+    private static final File KEYTAB_FILE = new File(KEYTAB_FILENAME);
+
+    public static final String HTTP_SERVICE_PASSWORD = "httppwd";
+
+    /**
+     * Creates a keytab file for given principal.
+     *
+     * @param principalName
+     * @param passPhrase
+     * @param keytabFile
+     * @throws IOException
+     *
+     * @author Josef Cacek
+     */
+    public static void createKeytab(final String principalName, final String passPhrase, final File keytabFile)
+            throws IOException {
+        final KerberosTime timeStamp = new KerberosTime();
+        final long principalType = 1L; // KRB5_NT_PRINCIPAL
+
+        final Keytab keytab = Keytab.getInstance();
+        final List<KeytabEntry> entries = new ArrayList<KeytabEntry>();
+        for (Map.Entry<EncryptionType, EncryptionKey> keyEntry : KerberosKeyFactory.getKerberosKeys(principalName, passPhrase)
+                .entrySet()) {
+            final EncryptionKey key = keyEntry.getValue();
+            final byte keyVersion = (byte) key.getKeyVersion();
+            entries.add(new KeytabEntry(principalName, principalType, timeStamp, keyVersion, key));
+        }
+        keytab.setEntries(entries);
+        keytab.write(keytabFile);
+    }
+
+    public static File getKeyTab() {
+        return KEYTAB_FILE;
+    }
+
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        createKeytab(KerberosServerSetupTask.getHttpServicePrincipal(managementClient), HTTP_SERVICE_PASSWORD, KEYTAB_FILE);
+    }
+
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        KEYTAB_FILE.delete();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/PicketLinkTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/PicketLinkTestBase.java
@@ -1,27 +1,42 @@
 package org.jboss.as.test.integration.security.picketlink;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+
+import javax.security.auth.Subject;
+import javax.security.auth.login.Configuration;
+import javax.security.auth.login.LoginContext;
+import javax.security.auth.login.LoginException;
+import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.NameValuePair;
+import org.apache.http.auth.AuthScope;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.params.AuthPolicy;
 import org.apache.http.client.params.ClientPNames;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.message.BasicNameValuePair;
@@ -31,9 +46,14 @@ import org.apache.http.util.EntityUtils;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
+import org.jboss.as.test.integration.security.common.Krb5LoginConfiguration;
+import org.jboss.as.test.integration.security.common.NullHCCredentials;
+import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.integration.security.common.negotiation.JBossNegotiateSchemeFactory;
 import org.jboss.logging.Logger;
+import org.jboss.security.auth.callback.UsernamePasswordHandler;
 
 /**
  * Base class with common utilities for PicketLink integration tests
@@ -42,212 +62,268 @@ import org.jboss.logging.Logger;
  */
 public class PicketLinkTestBase {
 
-	public static final String ANIL = "anil";
-	public static final String MARCUS = "marcus";
+    public static final String ANIL = "anil";
+    public static final String MARCUS = "marcus";
 
-	public static final String USERS = ANIL + "=" + ANIL + "\n" + MARCUS + "=" + MARCUS;
-	public static final String ROLES = ANIL + "=" + "gooduser" + "\n" + MARCUS	+ "=baduser";
-	
-	private static final Logger LOGGER = Logger.getLogger(PicketLinkTestBase.class);
-	
-	/**
-	 * Requests given URL and checks if the returned HTTP status code is the
-	 * expected one. Returns HTTP response body
-	 * 
-	 * @param URL url to which the request should be made
-	 * @param DefaultHttpClient httpClient to test multiple access            
-	 * @param expectedStatusCode expected status code returned from the requested server
-	 * @return HTTP response body
-	 * @throws ClientProtocolException
-	 * @throws IOException
-	 * @throws URISyntaxException
-	 */
-	public static String makeCall(URL url, DefaultHttpClient httpClient, int expectedStatusCode) 
-			throws ClientProtocolException,	IOException, URISyntaxException {
+    public static final String USERS = ANIL + "=" + ANIL + "\n" + MARCUS + "=" + MARCUS;
+    public static final String ROLES = ANIL + "=" + "gooduser" + "\n" + MARCUS + "=baduser";
 
-		String httpResponseBody = null;
-		HttpGet httpGet = new HttpGet(url.toURI());
-		HttpResponse response = httpClient.execute(httpGet);
-		int statusCode = response.getStatusLine().getStatusCode();
-		LOGGER.info("Request to: " + url + " responds: " + statusCode);
+    private static final Logger LOGGER = Logger.getLogger(PicketLinkTestBase.class);
 
-		assertEquals("Unexpected status code", expectedStatusCode, statusCode);
+    /**
+     * Requests given URL and checks if the returned HTTP status code is the expected one. Returns HTTP response body
+     * 
+     * @param URL url to which the request should be made
+     * @param DefaultHttpClient httpClient to test multiple access
+     * @param expectedStatusCode expected status code returned from the requested server
+     * @return HTTP response body
+     * @throws ClientProtocolException
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public static String makeCall(URL url, DefaultHttpClient httpClient, int expectedStatusCode)
+            throws ClientProtocolException, IOException, URISyntaxException {
 
-		HttpEntity entity = response.getEntity();
-		if (entity != null) {
-			httpResponseBody = EntityUtils.toString(response.getEntity());
-			EntityUtils.consume(entity);
-		}
-		return httpResponseBody;
-	}
+        String httpResponseBody = null;
+        HttpGet httpGet = new HttpGet(url.toURI());
+        HttpResponse response = httpClient.execute(httpGet);
+        int statusCode = response.getStatusLine().getStatusCode();
+        LOGGER.info("Request to: " + url + " responds: " + statusCode);
 
-	
-	/**
-	 * Requests given URL and returns redirect location URL from response header.
-	 * If response is not redirected then returns the same URL which was
-	 * requested
-	 * 
-	 * @param URL url to which the request should be made
-	 * @param DefaultHttpClient httpClient to test multiple access
-	 * @return URL redirect location
-	 * @throws ClientProtocolException
-	 * @throws IOException
-	 * @throws URISyntaxException
-	 */
-	public static URL makeCallWithoutRedirect(URL url, DefaultHttpClient httpClient)
-			throws ClientProtocolException, IOException, URISyntaxException {
+        assertEquals("Unexpected status code", expectedStatusCode, statusCode);
 
-		HttpParams params = new BasicHttpParams();
-		params.setParameter(ClientPNames.HANDLE_REDIRECTS, false);
-		String redirectLocation = url.toExternalForm();
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            httpResponseBody = EntityUtils.toString(response.getEntity());
+            EntityUtils.consume(entity);
+        }
+        return httpResponseBody;
+    }
 
-		HttpGet httpGet = new HttpGet(url.toURI());
-		httpGet.setParams(params);
-		HttpResponse response = httpClient.execute(httpGet);
-		int statusCode = response.getStatusLine().getStatusCode();
-		LOGGER.info("Request to: " + url + " responds: " + statusCode);
+    /**
+     * Requests given URL and returns redirect location URL from response header. If response is not redirected then returns the
+     * same URL which was requested
+     * 
+     * @param URL url to which the request should be made
+     * @param DefaultHttpClient httpClient to test multiple access
+     * @return URL redirect location
+     * @throws ClientProtocolException
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public static URL makeCallWithoutRedirect(URL url, DefaultHttpClient httpClient) throws ClientProtocolException,
+            IOException, URISyntaxException {
 
-		Header locationHeader = response.getFirstHeader("location");
-		if (locationHeader != null) {
-			redirectLocation = locationHeader.getValue();
-		}
+        HttpParams params = new BasicHttpParams();
+        params.setParameter(ClientPNames.HANDLE_REDIRECTS, false);
+        String redirectLocation = url.toExternalForm();
 
-		HttpEntity entity = response.getEntity();
-		if (entity != null) {
-			EntityUtils.consume(entity);
-		}
-		return new URL(redirectLocation);
-	}
-	
-	/**
-	 * Requests given SP and post SAMLRequest to IdP, then post back SAMLResponse. 
-	 * Returns HTTP response body
-	 * 
-	 * @param URL spURL of requested Service Provider
-	 * @param URL idpURL of Identity Provider
-	 * @param DefaultHttpClient httpClient to test multiple access  
-	 * @return HTTP response body
-	 * @throws ClientProtocolException
-	 * @throws IOException
-	 * @throws URISyntaxException
-	 */
-	public static String postSAML2Assertions(URL spURL, URL idpURL, DefaultHttpClient httpClient)
-			throws ClientProtocolException, IOException, URISyntaxException{
-		
-		String httpResponseBody = makeCall(spURL, httpClient, 200);
-		
-		//parse SAMLRequest and post it to IdP
-		String[] splitted = httpResponseBody.split("NAME=\"SAMLRequest\" VALUE=\"");
-		String samlRequest = splitted[1].substring(0,	splitted[1].indexOf("\""));
-		List<NameValuePair> pairs = new ArrayList<NameValuePair>();
-		pairs.add(new BasicNameValuePair("SAMLRequest", samlRequest));
+        HttpGet httpGet = new HttpGet(url.toURI());
+        httpGet.setParams(params);
+        HttpResponse response = httpClient.execute(httpGet);
+        int statusCode = response.getStatusLine().getStatusCode();
+        LOGGER.info("Request to: " + url + " responds: " + statusCode);
 
-		HttpPost httpPost = new HttpPost(idpURL.toURI());
-		httpPost.setEntity(new UrlEncodedFormEntity(pairs));
-		HttpResponse httpResponse = httpClient.execute(httpPost);
+        Header locationHeader = response.getFirstHeader("location");
+        if (locationHeader != null) {
+            redirectLocation = locationHeader.getValue();
+        }
 
-		HttpEntity entity = httpResponse.getEntity();
-		if (entity != null) {
-			httpResponseBody = EntityUtils.toString(httpResponse.getEntity());
-			EntityUtils.consume(entity);
-		}
-		
-		//parse SAMLResponse and post it back to SP
-		splitted = httpResponseBody.split("NAME=\"SAMLResponse\" VALUE=\"");
-		String samlResponse = splitted[1].substring(0, splitted[1].indexOf("\""));
-		pairs = new ArrayList<NameValuePair>();
-		pairs.add(new BasicNameValuePair("SAMLResponse", samlResponse));
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            EntityUtils.consume(entity);
+        }
+        return new URL(redirectLocation);
+    }
 
-		httpPost = new HttpPost(spURL.toURI());
-		httpPost.setEntity(new UrlEncodedFormEntity(pairs));			
-		httpResponse = httpClient.execute(httpPost);
+    /**
+     * Requests given SP and post SAMLRequest to IdP, then post back SAMLResponse. Returns HTTP response body
+     * 
+     * @param URL spURL of requested Service Provider
+     * @param URL idpURL of Identity Provider
+     * @param DefaultHttpClient httpClient to test multiple access
+     * @return HTTP response body
+     * @throws ClientProtocolException
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    public static String postSAML2Assertions(URL spURL, URL idpURL, DefaultHttpClient httpClient)
+            throws ClientProtocolException, IOException, URISyntaxException {
 
-		entity = httpResponse.getEntity();
-		if (entity != null) {
-			httpResponseBody = EntityUtils.toString(httpResponse.getEntity());
-			EntityUtils.consume(entity);
-		}
-		
-		return httpResponseBody;
-	}
+        String httpResponseBody = makeCall(spURL, httpClient, 200);
 
-	
-	/**
-	 * Replace variables in PicketLink configurations files with given values
-	 * and set ${hostname} variable from system property: node0
-	 * 
-	 * @param String resourceFile 
-	 * @param String deploymentName 
-	 * @param String bindingType 
-	 * @return String content
-	 */
-	public static String propertiesReplacer(String resourceFile, String deploymentName, String bindingType, String idpContextPath) {
+        // parse SAMLRequest and post it to IdP
+        String[] splitted = httpResponseBody.split("NAME=\"SAMLRequest\" VALUE=\"");
+        String samlRequest = splitted[1].substring(0, splitted[1].indexOf("\""));
+        List<NameValuePair> pairs = new ArrayList<NameValuePair>();
+        pairs.add(new BasicNameValuePair("SAMLRequest", samlRequest));
 
-		String hostname = System.getProperty("node0");		
-		
-		//expand possible IPv6 address
-		try{
-			hostname = NetworkUtils.formatPossibleIpv6Address(InetAddress.getByName(hostname).getHostAddress());
-		}catch(UnknownHostException ex){
-			String message = "Cannot resolve host address: "+ hostname + " , error : " + ex.getMessage();
-			LOGGER.error(message);
-			throw new RuntimeException(ex);			
-		}		
-		
-		final Map<String, String> map = new HashMap<String, String>();
-		String content = "";
-		map.put("hostname", hostname);
-		map.put("deployment", deploymentName);
-		map.put("bindingType", bindingType);
-		map.put("idpContextPath", idpContextPath);
-		
-		try {
-			content = StrSubstitutor.replace(IOUtils.toString(SAML2BasicAuthenticationTestCase.class.getResourceAsStream(resourceFile), "UTF-8"), map);
-		} catch (IOException ex) {
-			String message = "Cannot find or modify configuration file "+ resourceFile + " , error : " + ex.getMessage();
-			LOGGER.error(message);
-			throw new RuntimeException(ex);
-		}
-		return content;
-	}
+        HttpPost httpPost = new HttpPost(idpURL.toURI());
+        httpPost.setEntity(new UrlEncodedFormEntity(pairs));
+        HttpResponse httpResponse = httpClient.execute(httpPost);
 
-	/**
-	 * A {@link ServerSetupTask} instance which creates security domains for Identity Provider(IdP)
-	 * and Service Provider(SP)
-	 * 
-	 * @author Filip Bogyai
-	 */
-	static class SecurityDomainsSetup extends
-			AbstractSecurityDomainsServerSetupTask {
+        HttpEntity entity = httpResponse.getEntity();
+        if (entity != null) {
+            httpResponseBody = EntityUtils.toString(httpResponse.getEntity());
+            EntityUtils.consume(entity);
+        }
 
-		/**
-		 * Returns SecurityDomains configuration for this testcase.
-		 * 
-		 * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask#getSecurityDomains()
-		 */
-		@Override
-		protected SecurityDomain[] getSecurityDomains() {
+        // parse SAMLResponse and post it back to SP
+        splitted = httpResponseBody.split("NAME=\"SAMLResponse\" VALUE=\"");
+        String samlResponse = splitted[1].substring(0, splitted[1].indexOf("\""));
+        pairs = new ArrayList<NameValuePair>();
+        pairs.add(new BasicNameValuePair("SAMLResponse", samlResponse));
 
-			final SecurityDomain idp = new SecurityDomain.Builder()
-					.name("idp")
-					.cacheType("default")
-					.loginModules(
-							new SecurityModule.Builder()
-									.name("UsersRoles")
-									.flag("required")
-									.putOption("usersProperties","users.properties")
-									.putOption("rolesProperties","roles.properties").build()) //
-					.build();
-			final SecurityDomain sp = new SecurityDomain.Builder()
-					.name("sp")
-					.cacheType("default")
-					.loginModules(
-							new SecurityModule.Builder()
-									.name("org.picketlink.identity.federation.bindings.jboss.auth.SAML2LoginModule")
-									.flag("required").build()) //
-					.build();
-			return new SecurityDomain[] { idp, sp };
-		}
-	}
+        httpPost = new HttpPost(spURL.toURI());
+        httpPost.setEntity(new UrlEncodedFormEntity(pairs));
+        httpResponse = httpClient.execute(httpPost);
+
+        entity = httpResponse.getEntity();
+        if (entity != null) {
+            httpResponseBody = EntityUtils.toString(httpResponse.getEntity());
+            EntityUtils.consume(entity);
+        }
+
+        return httpResponseBody;
+    }
+
+    /**
+     * Replace variables in PicketLink configurations files with given values and set ${hostname} variable from system property:
+     * node0
+     * 
+     * @param String resourceFile
+     * @param String deploymentName
+     * @param String bindingType
+     * @return String content
+     */
+    public static String propertiesReplacer(String resourceFile, String deploymentName, String bindingType,
+            String idpContextPath) {
+
+        String hostname = System.getProperty("node0");
+
+        // expand possible IPv6 address
+        try {
+            hostname = NetworkUtils.formatPossibleIpv6Address(InetAddress.getByName(hostname).getHostAddress());
+        } catch (UnknownHostException ex) {
+            String message = "Cannot resolve host address: " + hostname + " , error : " + ex.getMessage();
+            LOGGER.error(message);
+            throw new RuntimeException(ex);
+        }
+
+        final Map<String, String> map = new HashMap<String, String>();
+        String content = "";
+        map.put("hostname", hostname);
+        map.put("deployment", deploymentName);
+        map.put("bindingType", bindingType);
+        map.put("idpContextPath", idpContextPath);
+
+        try {
+            content = StrSubstitutor.replace(
+                    IOUtils.toString(SAML2BasicAuthenticationTestCase.class.getResourceAsStream(resourceFile), "UTF-8"), map);
+        } catch (IOException ex) {
+            String message = "Cannot find or modify configuration file " + resourceFile + " , error : " + ex.getMessage();
+            LOGGER.error(message);
+            throw new RuntimeException(ex);
+        }
+        return content;
+    }
+
+    /**
+     * Returns response body for the given URL request as a String. It also checks if the returned HTTP status code is the
+     * expected one. If the server returns {@link HttpServletResponse#SC_UNAUTHORIZED} and an username is provided, then the
+     * given user is authenticated against Kerberos and a new request is executed under the new subject.
+     *
+     * @param uri URI to which the request should be made
+     * @param user Username
+     * @param pass Password
+     * @param expectedStatusCode expected status code returned from the requested server
+     * @return HTTP response body
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws PrivilegedActionException
+     * @throws LoginException
+     */
+    public static String makeCallWithKerberosAuthn(final URI uri, final DefaultHttpClient httpClient, final String user,
+            final String pass, final int expectedStatusCode) throws IOException, URISyntaxException, PrivilegedActionException,
+            LoginException {
+        LOGGER.info("Requesting URI: " + uri);
+        httpClient.getAuthSchemes().register(AuthPolicy.SPNEGO, new JBossNegotiateSchemeFactory(true));
+        httpClient.getCredentialsProvider().setCredentials(new AuthScope(null, -1, null), new NullHCCredentials());
+
+        final HttpGet httpGet = new HttpGet(uri);
+        final HttpResponse response = httpClient.execute(httpGet);
+        int statusCode = response.getStatusLine().getStatusCode();
+        if (HttpServletResponse.SC_UNAUTHORIZED != statusCode || StringUtils.isEmpty(user)) {
+            assertEquals("Unexpected HTTP response status code.", expectedStatusCode, statusCode);
+            return EntityUtils.toString(response.getEntity());
+        }
+        final HttpEntity entity = response.getEntity();
+        final Header[] authnHeaders = response.getHeaders("WWW-Authenticate");
+        assertTrue("WWW-Authenticate header is present", authnHeaders != null && authnHeaders.length > 0);
+        final Set<String> authnHeaderValues = new HashSet<String>();
+        for (final Header header : authnHeaders) {
+            authnHeaderValues.add(header.getValue());
+        }
+        assertTrue("WWW-Authenticate: Negotiate header is missing", authnHeaderValues.contains("Negotiate"));
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("HTTP response was SC_UNAUTHORIZED, let's authenticate the user " + user);
+        }
+        if (entity != null)
+            EntityUtils.consume(entity);
+
+        // Use our custom configuration to avoid reliance on external config
+        Configuration.setConfiguration(new Krb5LoginConfiguration());
+        // 1. Authenticate to Kerberos.
+        final LoginContext lc = new LoginContext(Utils.class.getName(), new UsernamePasswordHandler(user, pass));
+        lc.login();
+
+        // 2. Perform the work as authenticated Subject.
+        final String responseBody = Subject.doAs(lc.getSubject(), new PrivilegedExceptionAction<String>() {
+            public String run() throws Exception {
+                final HttpResponse response = httpClient.execute(httpGet);
+                int statusCode = response.getStatusLine().getStatusCode();
+                assertEquals("Unexpected status code returned after the authentication.", expectedStatusCode, statusCode);
+                return EntityUtils.toString(response.getEntity());
+            }
+        });
+        lc.logout();
+        return responseBody;
+    }
+
+    /**
+     * A {@link ServerSetupTask} instance which creates security domains for Identity Provider(IdP) and Service Provider(SP)
+     * 
+     * @author Filip Bogyai
+     */
+    static class SecurityDomainsSetup extends AbstractSecurityDomainsServerSetupTask {
+
+        /**
+         * Returns SecurityDomains configuration for this testcase.
+         * 
+         * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask#getSecurityDomains()
+         */
+        @Override
+        protected SecurityDomain[] getSecurityDomains() {
+
+            final SecurityDomain idp = new SecurityDomain.Builder()
+                    .name("idp")
+                    .cacheType("default")
+                    .loginModules(
+                            new SecurityModule.Builder().name("UsersRoles").flag("required")
+                                    .putOption("usersProperties", "users.properties")
+                                    .putOption("rolesProperties", "roles.properties").build()) //
+                    .build();
+            final SecurityDomain sp = new SecurityDomain.Builder()
+                    .name("sp")
+                    .cacheType("default")
+                    .loginModules(
+                            new SecurityModule.Builder()
+                                    .name("org.picketlink.identity.federation.bindings.jboss.auth.SAML2LoginModule")
+                                    .flag("required").build()) //
+                    .build();
+            return new SecurityDomain[] { idp, sp };
+        }
+    }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/SAML2AttributeMappingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/SAML2AttributeMappingTestCase.java
@@ -1,0 +1,224 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.picketlink;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URL;
+import java.util.LinkedList;
+import java.util.List;
+
+import javax.naming.Context;
+
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.security.Constants;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
+import org.jboss.as.test.integration.security.common.Krb5LoginConfiguration;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.config.SecurityDomain;
+import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.integration.security.common.servlets.PrintAttributeServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This class tests passUserPrincipalToAttributeManager attribute of Picketlink's IDPWebBrowserSSOValve. It's a regression test
+ * for attribute mapping in Identity Provider (IdP) when SPNEGO (Kerberos) authentication is used.
+ * <p>
+ * PLINK-405
+ * 
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup({ KerberosServerSetupTask.SystemPropertiesSetup.class, KerberosServerSetupTask.class, KerberosKeyTabSetup.class,
+        SAML2AttributeMappingTestCase.SecurityDomainsSetup.class })
+@Ignore("AS7-6796 - Undertow SPNEGO")
+public class SAML2AttributeMappingTestCase {
+
+    private static final String SP_RESPONSE_BODY = "Welcome to SP";
+
+    private static Logger LOGGER = Logger.getLogger(SAML2AttributeMappingTestCase.class);
+
+    protected static final String IDP = "idp";
+    protected static final String SP = "sp";
+
+    private static final String IDP_CONTEXT_PATH = "idp";
+
+    @ArquillianResource
+    @OperateOnDeployment(IDP)
+    private URL idpUrl;
+
+    @ArquillianResource
+    @OperateOnDeployment(SP)
+    private URL spUrl;
+
+    @Deployment(name = IDP)
+    public static WebArchive deploymentIdP() {
+        LOGGER.info("Start deployment " + IDP);
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, IDP + ".war");
+        war.addAsWebInfResource(SAML2AttributeMappingTestCase.class.getPackage(), "attrib-web.xml", "web.xml");
+        war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.jboss.security.negotiation", "org.picketlink"),
+                "jboss-deployment-structure.xml");
+        war.addAsWebInfResource(new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-idp.xml", IDP, "", IDP)),
+                "picketlink.xml");
+        war.add(new StringAsset("Welcome to IdP"), "index.jsp");
+        war.add(new StringAsset("Welcome to IdP hosted"), "hosted/index.jsp");
+        war.addAsWebInfResource(SAML2AttributeMappingTestCase.class.getPackage(), "attrib-jboss-web.xml", "jboss-web.xml");
+        return war;
+    }
+
+    @Deployment(name = SP)
+    public static WebArchive deploymentSP() {
+        LOGGER.info("Start deployment " + SP);
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, SP + ".war");
+        war.addAsWebInfResource(SAML2AttributeMappingTestCase.class.getPackage(), "attrib-web.xml", "web.xml");
+        war.addAsWebInfResource(Utils.getJBossWebXmlAsset("sp",
+                "org.picketlink.identity.federation.bindings.tomcat.sp.ServiceProviderAuthenticator"), "jboss-web.xml");
+        war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.picketlink"), "jboss-deployment-structure.xml");
+        war.addAsWebInfResource(
+                new StringAsset(PicketLinkTestBase.propertiesReplacer("picketlink-sp.xml", SP, "REDIRECT", IDP_CONTEXT_PATH)),
+                "picketlink.xml");
+        war.add(new StringAsset(SP_RESPONSE_BODY), "index.jsp");
+        war.addClass(PrintAttributeServlet.class);
+        return war;
+    }
+
+    /**
+     * Tests IDP attribute mapping when passUserPrincipalToAttributeManager is set to "true". Automatic handling of redirections
+     * is enabled for HTTP client used.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testPassUserPrincipalToAttributeManager() throws Exception {
+
+        final DefaultHttpClient httpClient = new DefaultHttpClient();
+        httpClient.setRedirectStrategy(Utils.REDIRECT_STRATEGY);
+
+        try {
+            String response = PicketLinkTestBase.makeCallWithKerberosAuthn(spUrl.toURI(), httpClient, "jduke", "theduke", 200);
+            assertEquals("SP index page was not reached", SP_RESPONSE_BODY, response);
+            response = PicketLinkTestBase.makeCall(new URL(spUrl.toString() + PrintAttributeServlet.SERVLET_PATH.substring(1)),
+                    httpClient, 200);
+            assertEquals("cn attribute not stored", "Java Duke", response);
+        } finally {
+            httpClient.getConnectionManager().shutdown();
+        }
+    }
+
+    /**
+     * A {@link ServerSetupTask} instance which creates security domains for this test case.
+     */
+    static class SecurityDomainsSetup extends AbstractSecurityDomainsServerSetupTask {
+
+        private static final String SERVER_SECURITY_DOMAIN = "host";
+
+        /**
+         * Returns SecurityDomains configuration for this testcase.
+         * 
+         * @see org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask#getSecurityDomains()
+         */
+        @Override
+        protected SecurityDomain[] getSecurityDomains() {
+            List<SecurityDomain> res = new LinkedList<SecurityDomain>();
+
+            // Add host security domain
+            res.add(new SecurityDomain.Builder()
+                    .name(SERVER_SECURITY_DOMAIN)
+                    .cacheType("default")
+                    .loginModules(
+                            new SecurityModule.Builder()
+                                    .name(Krb5LoginConfiguration.getLoginModule())
+                                    .flag(Constants.REQUIRED)
+                                    .options(
+                                            Krb5LoginConfiguration.getOptions(
+                                                    KerberosServerSetupTask.getHttpServicePrincipal(managementClient),
+                                                    KerberosKeyTabSetup.getKeyTab(), true)).build()).build());
+
+            // Add IdP security domain
+            res.add(new SecurityDomain.Builder()
+                    .name(IDP)
+                    .loginModules(
+                            new SecurityModule.Builder()
+                                    // Login module used for password negotiation
+                                    .name("SPNEGO").flag(Constants.REQUISITE).putOption("password-stacking", "useFirstPass")
+                                    .putOption("serverSecurityDomain", SERVER_SECURITY_DOMAIN)
+                                    .putOption("removeRealmFromPrincipal", "true").build(),
+
+                            new SecurityModule.Builder()
+                                    // Login module used for role retrieval
+                                    .name("org.jboss.security.auth.spi.LdapExtLoginModule")
+                                    .flag(Constants.REQUIRED)
+                                    .putOption("password-stacking", "useFirstPass")
+                                    .putOption(
+                                            Context.PROVIDER_URL,
+                                            "ldap://" + KerberosServerSetupTask.getCannonicalHost(managementClient) + ":"
+                                                    + KerberosServerSetupTask.LDAP_PORT)
+                                    .putOption("baseCtxDN", "ou=People,dc=jboss,dc=org").putOption("baseFilter", "(uid={0})")
+                                    .putOption("rolesCtxDN", "ou=Roles,dc=jboss,dc=org")
+                                    .putOption("roleFilter", "(|(objectClass=referral)(member={1}))")
+                                    .putOption("roleAttributeID", "cn").putOption("referralUserAttributeIDToCheck", "member")
+                                    .putOption("bindDN", KerberosServerSetupTask.SECURITY_PRINCIPAL)
+                                    .putOption("bindCredential", KerberosServerSetupTask.SECURITY_CREDENTIALS)
+                                    .putOption(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory")
+                                    .putOption(Context.SECURITY_AUTHENTICATION, "simple").putOption(Context.REFERRAL, "follow")
+                                    .putOption("throwValidateError", "true").putOption("roleRecursion", "5").build())
+                    .mappingModules(
+                            new SecurityModule.Builder()
+                                    .name("org.jboss.security.mapping.providers.attribute.LdapAttributeMappingProvider")
+                                    .flag("attribute")
+                                    .putOption(
+                                            Context.PROVIDER_URL,
+                                            "ldap://" + KerberosServerSetupTask.getCannonicalHost(managementClient) + ":"
+                                                    + KerberosServerSetupTask.LDAP_PORT)
+                                    .putOption("bindDN", KerberosServerSetupTask.SECURITY_PRINCIPAL)
+                                    .putOption("bindCredential", KerberosServerSetupTask.SECURITY_CREDENTIALS)
+                                    .putOption("baseCtxDN", "ou=People,dc=jboss,dc=org").putOption("baseFilter", "(uid={0})")
+                                    .putOption("attributeList", "cn,sn").putOption("searchTimeLimit", "10000")//
+                                    .build()) //
+                    .build());
+
+            // Add SP security domain
+            res.add(new SecurityDomain.Builder()
+                    .name(SP)
+                    .loginModules(
+                            new SecurityModule.Builder()
+                                    .name("org.picketlink.identity.federation.bindings.jboss.auth.SAML2LoginModule")
+                                    .flag(Constants.REQUIRED).build()).build());
+
+            return res.toArray(new SecurityDomain[0]);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/attrib-jboss-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/attrib-jboss-web.xml
@@ -1,0 +1,14 @@
+<jboss-web>
+	<security-domain>idp</security-domain>
+	<valve>
+		<class-name>org.jboss.security.negotiation.NegotiationAuthenticator</class-name>
+	</valve>
+
+	<valve>
+		<class-name>org.picketlink.identity.federation.bindings.tomcat.idp.IDPWebBrowserSSOValve</class-name>
+		<param>
+			<param-name>passUserPrincipalToAttributeManager</param-name>
+			<param-value>true</param-value>
+		</param>
+	</valve>
+</jboss-web>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/attrib-web.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/attrib-web.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+	version="3.0">
+
+	<!-- Define the Login Configuration for this Application -->
+	<login-config>
+		<auth-method>BASIC</auth-method>
+		<realm-name>x</realm-name>
+	</login-config>
+
+	<security-constraint>
+		<web-resource-collection>
+			<web-resource-name>secured-area</web-resource-name>
+			<url-pattern>/*</url-pattern>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>*</role-name>
+		</auth-constraint>
+	</security-constraint>
+
+	<security-role>
+		<role-name>Echo</role-name>
+	</security-role>
+
+</web-app>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-idp.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-idp.xml
@@ -1,9 +1,11 @@
 <PicketLink xmlns="urn:picketlink:identity-federation:config:2.1">
-	<PicketLinkIDP xmlns="urn:picketlink:identity-federation:config:2.1" StrictPostBinding="false">
+	<PicketLinkIDP xmlns="urn:picketlink:identity-federation:config:2.1"
+		AttributeManager="org.picketlink.identity.federation.bindings.jboss.attribute.JBossAppServerAttributeManager"
+		StrictPostBinding="false">
 		<IdentityURL>http://${hostname}:8080/${deployment}/</IdentityURL>
 		<Trust>
 			<Domains>${hostname}</Domains>
-		</Trust>		
+		</Trust>
 	</PicketLinkIDP>
 	<Handlers xmlns="urn:picketlink:identity-federation:handler:config:2.1">
 		<Handler
@@ -15,20 +17,21 @@
 		<Handler
 			class="org.picketlink.identity.federation.web.handlers.saml2.RolesGenerationHandler" />
 	</Handlers>
-	<!-- 
-		The configuration bellow defines a token timeout and a clock skew. Both configurations will be used during the SAML Assertion creation.
-		This configuration is optional. It is defined only to show you how to set the token timeout and clock skew configuration. 
-	 -->
-	<PicketLinkSTS xmlns="urn:picketlink:identity-federation:config:2.1" TokenTimeout="300000" ClockSkew="0">
+	<!-- The configuration bellow defines a token timeout and a clock skew. 
+		Both configurations will be used during the SAML Assertion creation. This 
+		configuration is optional. It is defined only to show you how to set the 
+		token timeout and clock skew configuration. -->
+	<PicketLinkSTS xmlns="urn:picketlink:identity-federation:config:2.1"
+		TokenTimeout="300000" ClockSkew="0">
 		<TokenProviders>
 			<TokenProvider
 				ProviderClass="org.picketlink.identity.federation.core.saml.v1.providers.SAML11AssertionTokenProvider"
-				TokenType="urn:oasis:names:tc:SAML:1.0:assertion"
-				TokenElement="Assertion" TokenElementNS="urn:oasis:names:tc:SAML:1.0:assertion" />
+				TokenType="urn:oasis:names:tc:SAML:1.0:assertion" TokenElement="Assertion"
+				TokenElementNS="urn:oasis:names:tc:SAML:1.0:assertion" />
 			<TokenProvider
 				ProviderClass="org.picketlink.identity.federation.core.saml.v2.providers.SAML20AssertionTokenProvider"
-				TokenType="urn:oasis:names:tc:SAML:2.0:assertion"
-				TokenElement="Assertion" TokenElementNS="urn:oasis:names:tc:SAML:2.0:assertion" />
+				TokenType="urn:oasis:names:tc:SAML:2.0:assertion" TokenElement="Assertion"
+				TokenElementNS="urn:oasis:names:tc:SAML:2.0:assertion" />
 		</TokenProviders>
 	</PicketLinkSTS>
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-sp.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/picketlink-sp.xml
@@ -5,12 +5,20 @@
 		<ServiceURL>http://${hostname}:8080/${deployment}/</ServiceURL>
 	</PicketLinkSP>
 	<Handlers xmlns="urn:picketlink:identity-federation:handler:config:2.1">
-		<Handler class="org.picketlink.identity.federation.web.handlers.saml2.SAML2LogOutHandler" />
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2LogOutHandler" />
 
-        <Handler class="org.picketlink.identity.federation.web.handlers.saml2.SAML2AuthenticationHandler">
-			<Option Key="ASSERTION_SESSION_ATTRIBUTE_NAME" Value="org.picketlink.sp.assertion"/>
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2AuthenticationHandler">
+			<Option Key="ASSERTION_SESSION_ATTRIBUTE_NAME" Value="org.picketlink.sp.assertion" />
 		</Handler>
 
-        <Handler class="org.picketlink.identity.federation.web.handlers.saml2.RolesGenerationHandler" />
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.SAML2AttributeHandler">
+			<Option Key="ATTRIBUTE_CHOOSE_FRIENDLY_NAME" Value="true" />
+		</Handler>
+		
+		<Handler
+			class="org.picketlink.identity.federation.web.handlers.saml2.RolesGenerationHandler" />
 	</Handlers>
 </PicketLink>

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/JBossNegotiateScheme.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/JBossNegotiateScheme.java
@@ -31,6 +31,7 @@ import org.apache.http.auth.Credentials;
 import org.apache.http.auth.InvalidCredentialsException;
 import org.apache.http.auth.MalformedChallengeException;
 import org.apache.http.impl.auth.AuthSchemeBase;
+import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BufferedHeader;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
@@ -126,6 +127,10 @@ public class JBossNegotiateScheme extends AuthSchemeBase {
             throws AuthenticationException {
         if (request == null) {
             throw new IllegalArgumentException("HTTP request may not be null");
+        }
+        if (state == State.TOKEN_GENERATED) {
+            // hack for auto redirects
+            return new BasicHeader("X-dummy", "Token already generated");
         }
         if (state != State.CHALLENGE_RECEIVED) {
             throw new IllegalStateException("Negotiation authentication process has not been initiated");

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/servlets/PrintAttributeServlet.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/servlets/PrintAttributeServlet.java
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.security.common.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.jboss.logging.Logger;
+
+/**
+ * This servlet prints value of an request/session attribute. It supports also nested values for {@link Map} and {@link List}
+ * instances - names in such case are delimited by {@value #DELIMITER}.
+ * <p>
+ * The servlet supports 2 parameters:
+ * <ul>
+ * <li>{@value #PARAM_ATTR_NAME} - name of attribute to retrieve. Default value is {@value #DEFAULT_PROPERTY_NAME}</li>
+ * <li>{@value #PARAM_SCOPE_NAME} - scope from which the value should be retrieved. Supported vaules are "session" and
+ * "request". Default is {@value #DEFAULT_SCOPE_NAME}</li>
+ * </ul>
+ * <p>
+ * For instance the Picketlink's handler SAML2AttributeHandler stores a map with attributes received in SAML assertion to an
+ * {@link HttpSession} as attribute named "SESSION_ATTRIBUTE_MAP". Each entry in this map is represented by a list of values. So
+ * if you want to read the first value of SAML assertion attribute named "cn" from the session, use the parameter
+ * "attrib=SESSION_ATTRIBUTE_MAP/cn/0"
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(PrintAttributeServlet.SERVLET_PATH)
+public class PrintAttributeServlet extends HttpServlet {
+
+    private static Logger LOGGER = Logger.getLogger(PrintAttributeServlet.class);
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/PrintAttrServlet";
+    public static final String PARAM_ATTR_NAME = "attr";
+    public static final String PARAM_SCOPE_NAME = "scope";
+    public static final String DELIMITER = "/";
+    public static final String DEFAULT_PROPERTY_NAME = "SESSION_ATTRIBUTE_MAP" + DELIMITER + "cn" + DELIMITER + "0";
+
+    public static final String SCOPE_REQUEST = "request";
+    public static final String SCOPE_SESSION = "session";
+    public static final String DEFAULT_SCOPE_NAME = SCOPE_SESSION;
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        String attrName = req.getParameter(PARAM_ATTR_NAME);
+        if (attrName == null || attrName.length() == 0) {
+            attrName = DEFAULT_PROPERTY_NAME;
+        }
+        StringTokenizer st = new StringTokenizer(attrName, DELIMITER);
+        String actualName = st.nextToken();
+        Object actualValue = null;
+        if (SCOPE_REQUEST.equalsIgnoreCase(req.getParameter(PARAM_SCOPE_NAME))) {
+            actualValue = req.getAttribute(actualName);
+        } else {
+            final HttpSession session = req.getSession(false);
+            if (session != null)
+                actualValue = session.getAttribute(actualName);
+        }
+
+        while (st.hasMoreTokens() && (actualValue instanceof Map || actualValue instanceof List)) {
+            actualName = st.nextToken();
+            if (actualValue instanceof List) {
+                try {
+                    actualValue = ((List) actualValue).get(Integer.parseInt(actualName));
+                } catch (Exception e) {
+                    LOGGER.warn("Unable to retrieve value from list", e);
+                    actualValue = null;
+                }
+            } else {
+                actualValue = ((Map) actualValue).get(actualName);
+            }
+        }
+
+        final PrintWriter writer = resp.getWriter();
+        writer.write(String.valueOf(actualValue));
+        writer.close();
+    }
+}


### PR DESCRIPTION
Added test to cover PLINK-405 - passUserPrincipalToAttributeManager attribute of Picketlink's IDPWebBrowserSSOValve.  It's a regression test for attribute mapping in Identity Provider (IdP) when SPNEGO (Kerberos) authentication is used.

The test itself is located in `org.jboss.as.test.integration.security.picketlink.SAML2AttributeMappingTestCase`.

The WildFly version of the test is marked with `@Ignore` because of the AS7-6796 issue (SPNEGO support in Undertow).
