### PR TITLE
WFLY-3322 report standard error for non-existing messaging resources

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/AbstractHornetQComponentControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AbstractHornetQComponentControlHandler.java
@@ -36,6 +36,7 @@ import static org.jboss.dmr.ModelType.BOOLEAN;
 import org.hornetq.api.core.management.HornetQComponentControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
@@ -278,7 +279,7 @@ public abstract class AbstractHornetQComponentControlHandler<T extends HornetQCo
         PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
          T control = getHornetQComponentControl(server, address);
          if (control == null) {
-             throw new OperationFailedException(MessagingMessages.MESSAGES.hqServerManagementServiceResourceNotFound(PathAddress.pathAddress(operation.require(OP_ADDR))));
+             throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
          }
          return control;
 

--- a/messaging/src/main/java/org/jboss/as/messaging/AbstractQueueControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AbstractQueueControlHandler.java
@@ -22,9 +22,9 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.CommonAttributes.FILTER;
 import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
-import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
@@ -33,6 +33,7 @@ import java.util.Locale;
 
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -293,8 +294,8 @@ public abstract class AbstractQueueControlHandler<T> extends AbstractRuntimeOnly
         final DelegatingQueueControl<T> control = getQueueControl(hqServer, queueName);
 
         if (control == null) {
-            rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         boolean reversible = false;

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressControlHandler.java
@@ -41,6 +41,7 @@ import org.hornetq.api.core.management.AddressControl;
 import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -89,8 +90,8 @@ class AddressControlHandler extends AbstractRuntimeOnlyHandler {
 
         final AddressControl addressControl = getAddressControl(context, operation);
         if (addressControl == null) {
-            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         final String name = operation.require(ModelDescriptionConstants.NAME).asString();

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
@@ -36,6 +36,7 @@ import org.hornetq.api.core.management.HornetQServerControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -137,8 +138,8 @@ public class HornetQServerControlWriteHandler extends AbstractWriteAttributeHand
     private void applyOperationToHornetQService(final OperationContext context, ModelNode operation, String attributeName, ServiceController<?> hqService) {
         HornetQServerControl serverControl = HornetQServer.class.cast(hqService.getValue()).getHornetQServerControl();
         if (serverControl == null) {
-            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
         try {
             if (attributeName.equals(CommonAttributes.FAILOVER_ON_SHUTDOWN.getName()))  {

--- a/messaging/src/main/java/org/jboss/as/messaging/ManagementUtil.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/ManagementUtil.java
@@ -22,10 +22,7 @@
 
 package org.jboss.as.messaging;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 
@@ -87,11 +84,5 @@ public class ManagementUtil {
         }
 
         return result;
-    }
-
-    public static void rollbackOperationWithResourceNotFound(OperationContext context, ModelNode operation) {
-        context.getFailureDescription().set(MessagingMessages.MESSAGES.hqServerManagementServiceResourceNotFound(PathAddress.pathAddress(operation.require(OP_ADDR))));
-        context.setRollbackOnly();
-        context.stepCompleted();
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingMessages.java
@@ -524,15 +524,6 @@ public interface MessagingMessages {
     @Message(id = 11675, value = "Resources of type %s cannot be removed")
     UnsupportedOperationException canNotRemoveResourceOfType(String childType);
 
-    /**
-     * Logs an error message indicating the given {@code address} does not match any known
-     * resource. Meant for use with runtime resources available via {@link org.hornetq.core.server.HornetQServer#getManagementService()}
-     *
-     * @param address    the address.
-     */
-    @Message(id = 11676, value = "No resource exists at address %s")
-    String hqServerManagementServiceResourceNotFound(PathAddress address);
-
     @Message(id = 11677, value = "Can not change the clustered attribute to false: The hornetq-server resource at %s has cluster-connection children resources and will remain clustered.")
     String canNotChangeClusteredAttribute(PathAddress address);
 

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueControlHandler.java
@@ -133,6 +133,9 @@ public class QueueControlHandler extends AbstractQueueControlHandler<QueueContro
     @Override
     protected DelegatingQueueControl<QueueControl> getQueueControl(HornetQServer hqServer, String queueName) {
         final QueueControl control = QueueControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.CORE_QUEUE + queueName));
+        if (control == null) {
+            return null;
+        }
         return new DelegatingQueueControl<QueueControl>() {
 
             public QueueControl getDelegate() {

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueReadAttributeHandler.java
@@ -46,6 +46,7 @@ import org.hornetq.api.core.management.QueueControl;
 import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -106,8 +107,7 @@ public class QueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
         QueueControl control = QueueControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.CORE_QUEUE + queueName));
 
         if (control == null) {
-            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         if (MESSAGE_COUNT.getName().equals(attributeName)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/SecurityRoleReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/SecurityRoleReadAttributeHandler.java
@@ -22,14 +22,15 @@
 
 package org.jboss.as.messaging;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.CommonAttributes.NAME;
-import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import org.hornetq.api.core.management.AddressControl;
 import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -66,8 +67,8 @@ public class SecurityRoleReadAttributeHandler extends AbstractRuntimeOnlyHandler
         AddressControl control = AddressControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.CORE_ADDRESS + addressName));
 
         if (control == null) {
-            rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         try {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/AbstractUpdateJndiHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/AbstractUpdateJndiHandler.java
@@ -22,10 +22,12 @@
 
 package org.jboss.as.messaging.jms;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import org.hornetq.jms.server.JMSServerManager;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -35,7 +37,6 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.messaging.CommonAttributes;
-import org.jboss.as.messaging.ManagementUtil;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -116,8 +117,8 @@ public abstract class AbstractUpdateJndiHandler implements OperationStepHandler 
                         JMSServerManager jmsServerManager = JMSServerManager.class.cast(jmsServerService.getValue());
 
                         if (jmsServerManager == null) {
-                            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
-                            return;
+                            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+                            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
                         }
 
                         try {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryReadAttributeHandler.java
@@ -22,16 +22,17 @@
 
 package org.jboss.as.messaging.jms;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.CommonAttributes.HA;
 import static org.jboss.as.messaging.CommonAttributes.NAME;
 import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
-import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.api.jms.management.ConnectionFactoryControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -81,8 +82,8 @@ public class ConnectionFactoryReadAttributeHandler extends AbstractRuntimeOnlyHa
         ConnectionFactoryControl control = ConnectionFactoryControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_CONNECTION_FACTORY + factoryName));
 
         if (control == null) {
-            rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         if (HA.getName().equals(attributeName)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueControlHandler.java
@@ -51,6 +51,9 @@ public class JMSQueueControlHandler extends AbstractQueueControlHandler<JMSQueue
 
     protected AbstractQueueControlHandler.DelegatingQueueControl<JMSQueueControl> getQueueControl(HornetQServer hqServer, String queueName){
         final JMSQueueControl control = JMSQueueControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_QUEUE + queueName));
+        if (control == null) {
+            return null;
+        }
         return new AbstractQueueControlHandler.DelegatingQueueControl<JMSQueueControl>() {
 
             @Override

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueReadAttributeHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.messaging.jms;
 
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.CommonAttributes.NAME;
 import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
@@ -31,6 +32,7 @@ import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.api.jms.management.JMSQueueControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -38,7 +40,6 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.messaging.CommonAttributes;
-import org.jboss.as.messaging.ManagementUtil;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
@@ -72,8 +73,8 @@ public class JMSQueueReadAttributeHandler extends AbstractRuntimeOnlyHandler {
 
         JMSQueueControl control = getControl(context, operation);
         if (control == null) {
-            ManagementUtil.rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         if (CommonAttributes.MESSAGE_COUNT.getName().equals(attributeName)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServerControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSServerControlHandler.java
@@ -23,8 +23,8 @@
 package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
-import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import java.util.Locale;
@@ -33,6 +33,7 @@ import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.api.jms.management.JMSServerControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -99,8 +100,8 @@ public class JMSServerControlHandler extends AbstractRuntimeOnlyHandler {
         final String operationName = operation.require(OP).asString();
         final JMSServerControl serverControl = getServerControl(context, operation);
         if (serverControl == null) {
-            rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         try {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicControlHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicControlHandler.java
@@ -22,17 +22,18 @@
 
 package org.jboss.as.messaging.jms;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.CommonAttributes.CLIENT_ID;
 import static org.jboss.as.messaging.CommonAttributes.FILTER;
 import static org.jboss.as.messaging.CommonAttributes.QUEUE_NAME;
 import static org.jboss.as.messaging.HornetQActivationService.rollbackOperationIfServerNotActive;
-import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 
 import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.api.jms.management.TopicControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -88,8 +89,8 @@ public class JMSTopicControlHandler extends AbstractRuntimeOnlyHandler {
         TopicControl control = TopicControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_TOPIC + topicName));
 
         if (control == null) {
-            rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         try {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicReadAttributeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicReadAttributeHandler.java
@@ -22,9 +22,9 @@
 
 package org.jboss.as.messaging.jms;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.messaging.CommonAttributes.NAME;
 import static org.jboss.as.messaging.HornetQActivationService.ignoreOperationIfServerNotActive;
-import static org.jboss.as.messaging.ManagementUtil.rollbackOperationWithResourceNotFound;
 import static org.jboss.as.messaging.MessagingMessages.MESSAGES;
 import static org.jboss.as.messaging.jms.JMSTopicDefinition.DURABLE_MESSAGE_COUNT;
 import static org.jboss.as.messaging.jms.JMSTopicDefinition.DURABLE_SUBSCRIPTION_COUNT;
@@ -37,6 +37,7 @@ import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.api.jms.management.TopicControl;
 import org.hornetq.core.server.HornetQServer;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -84,8 +85,8 @@ public class JMSTopicReadAttributeHandler extends AbstractRuntimeOnlyHandler {
         TopicControl control = TopicControl.class.cast(hqServer.getManagementService().getResource(ResourceNames.JMS_TOPIC + topicName));
 
         if (control == null) {
-            rollbackOperationWithResourceNotFound(context, operation);
-            return;
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         if (CommonAttributes.MESSAGE_COUNT.getName().equals(attributeName)) {

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeHandler.java
@@ -37,13 +37,13 @@ import static org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition.RESUME;
 
 import org.hornetq.jms.bridge.JMSBridge;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
+import org.jboss.as.controller.ControllerMessages;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
-import org.jboss.as.messaging.MessagingMessages;
 import org.jboss.as.messaging.MessagingServices;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
@@ -77,7 +77,8 @@ public class JMSBridgeHandler extends AbstractRuntimeOnlyHandler {
         final ServiceName bridgeServiceName = MessagingServices.getJMSBridgeServiceName(bridgeName);
         final ServiceController<?> bridgeService = context.getServiceRegistry(modify).getService(bridgeServiceName);
         if (bridgeService == null) {
-            throw new OperationFailedException(MessagingMessages.MESSAGES.hqServerManagementServiceResourceNotFound(PathAddress.pathAddress(operation.require(OP_ADDR))));
+            PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
+            throw ControllerMessages.MESSAGES.managementResourceNotFound(address);
         }
 
         final JMSBridge bridge = JMSBridge.class.cast(bridgeService.getValue());


### PR DESCRIPTION
- when the HornetQ underlying resources do not exist, report the error
  to prevent NPE when they are called
- replace messaging-specific message JBAS011676 by standard controller
  message JBAS014807 to report management resource not found

JIRA: https://issues.jboss.org/browse/WFLY-3322
