### PR TITLE
[8.x] [WFLY-3256] IronJacamar 1.1.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <version.org.jboss.genericjms>1.0.5.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.1.Final</version.org.jboss.invocation>
-        <version.org.jboss.ironjacamar>1.1.5.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.ironjacamar>1.1.6.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jandex>1.2.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.2.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-transaction-spi>7.1.0.Final</version.org.jboss.jboss-transaction-spi>


### PR DESCRIPTION
Ready for 8.2.

master is using IronJacamar 1.2, so no master PR for this release.
