### PR TITLE
[WFLY-3344] Port WF 8 updates to WF 9 schemas.

### DIFF
--- a/build/src/main/resources/docs/schema/wildfly-config_3_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-config_3_0.xsd
@@ -281,7 +281,47 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="referrals" default="IGNORE" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    Defines how referrals should be handled if encountered when using this connection, by default they are
+                    ignored.
+
+                    If set to FOLLOW then if referrals are encountered using this connection they will automatically be followed. Apart from the alternative
+                    location if set to FOLLOW it is assumed the remainder of settings for this connection can be applied to the connection
+                    for the referral.
+
+                    Finally if this option is set to THROW an exception is thrown by the connection when referrals are encountered, the security realm will then
+                    use information from the Exception to identify an alternative connection to use.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="IGNORE" />
+                    <xs:enumeration value="FOLLOW" />
+                    <xs:enumeration value="THROW" />
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="handles-referrals-for" type="urlListType" use="optional">
+            <xs:annotation>
+                <xs:documentation>
+                    A space seaparated list of URLs that this connection will handle referrals for.
+
+                    Note: Only the prototocol, host and port should be specified in the URLs.  The LDAP connections are not ordered so a single URL should only
+                    be listed against a single connection, if multpile connections are defined as handling the same URL which connection will be selected is undefined
+                    and subject to change.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
+
+    <xs:simpleType name="urlListType">
+        <xs:annotation>
+            <xs:documentation>A list of URLs.</xs:documentation>
+        </xs:annotation>
+        <xs:list itemType="xs:anyURI"/>
+    </xs:simpleType>
 
     <xs:complexType name="security-realmType">
         <xs:annotation>
@@ -423,7 +463,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="keystore" type="extendedKeyStoreType" />
+            <xs:element name="keystore" type="realmExtendedKeyStoreType" />
         </xs:sequence>
         <xs:attribute name="protocol" type="xs:string" default="TLS">
             <xs:annotation>
@@ -440,23 +480,6 @@
                 The keystore configuration for the server.
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="path" type="xs:string" use="required">
-            <xs:annotation>
-                <xs:documentation>
-                    The path of the keystore.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
-        <xs:attribute name="relative-to" use="optional" type="xs:string">
-            <xs:annotation>
-                <xs:documentation>
-                    The name of another previously named path, or of one of the
-                    standard paths provided by the system. If 'relative-to' is
-                    provided, the value of the 'path' attribute is treated as
-                    relative to the path specified by this attribute.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="keystore-password" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
@@ -480,6 +503,8 @@
                         <xs:documentation>
                             The alias of the entry to use from the keystore, if specified all remaining
                             entries in the keystore will be ignored.
+
+                            Note: The use of aliases is only available for JKS based stores, for other store types this will be ignored.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -487,6 +512,139 @@
                     <xs:annotation>
                         <xs:documentation>
                             The password to use when loading keys from the keystore.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="realmKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An extension of keyStoreType used by realms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="keyStoreType">
+                <xs:attribute name="provider" type="xs:string" default="JKS">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The provider for the store, the default is a file based JKS store.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="path" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="realmExtendedKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An extension of keyStoreType used by realms.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="extendedKeyStoreType">
+                <xs:attribute name="provider" type="xs:string" default="JKS">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The provider for the store, the default is a file based JKS store.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="path" type="xs:string" use="optional">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this
+                            attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="auditKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An extension of keyStoreType used for audit logging configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="keyStoreType">
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this
+                            attribute.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="auditExtendedKeyStoreType">
+        <xs:annotation>
+            <xs:documentation>
+                An audit specific extension of the extended key store type.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="extendedKeyStoreType">
+                <xs:attribute name="path" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The path of the keystore, this is required if the provider is JKS otherwise it will be ignored.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="relative-to" use="optional" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            The name of another previously named path, or of one of the
+                            standard paths provided by the system. If 'relative-to' is
+                            provided, the value of the 'path' attribute is treated as
+                            relative to the path specified by this
+                            attribute.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -516,8 +674,8 @@
                     using the local authentication mechanism.
 
                     If a default user has been specified then that user is automatically added to the
-                    allowed list.  If both default-user and allowed-users are ommitted despite the mechanism
-                    being enabled no incomming connection attemps using the mechanism will succeed.
+                    allowed list.  If both default-user and allowed-users are omitted despite the mechanism
+                    being enabled no incoming connection attemps using the mechanism will succeed.
 
                     If any user name should be accepted the value should be set to "*".
                 </xs:documentation>
@@ -554,7 +712,7 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
-            <xs:element name="truststore" type="keyStoreType" minOccurs="0">
+            <xs:element name="truststore" type="realmKeyStoreType" minOccurs="0">
                 <xs:annotation>
                     <xs:documentation>
                         Configuration of a keystore to use to create a trust manager to verify clients.
@@ -565,7 +723,7 @@
                 <xs:annotation>
                     <xs:documentation>
                         Configuration to enable the local authentication mechanism, if this element
-                        is ommitted then local authentication will be disabled.
+                        is omitted then local authentication will be disabled.
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
@@ -864,6 +1022,18 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="prefer-original-connection" type="xs:boolean" default="true">
+                            <xs:annotation>
+                                <xs:documentation>
+                                    After a referral has been followed should the original LDAP connection defined for
+                                    group loading be used or should the connection from the last referral be used instead.
+
+                                    By default each attempt to load a group will revery back to the original connection as defined
+                                    in the configuration, however setting this attribute to false will cause subsequent searches to
+                                    use the connection of the last referral.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
@@ -933,7 +1103,7 @@
         <xs:attribute name="cache-failures" type="xs:boolean" default="false">
             <xs:annotation>
                 <xs:documentation>
-                    Should non IO failures be cached? e.g. should searches for a non-existant user be cached to avoid
+                    Should non IO failures be cached? e.g. should searches for a non-existent user be cached to avoid
                     repeating the same search.
                 </xs:documentation>
             </xs:annotation>
@@ -1457,16 +1627,16 @@
         <xs:complexContent>
             <xs:extension base="tcp-audit-log-protocolType">
                 <xs:sequence>
-                    <xs:element name="truststore" type="keyStoreType" minOccurs="0">
+                    <xs:element name="truststore" type="auditKeyStoreType" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>
                                 Configuration of a keystore to use to create a trust manager to verify the server
-                                certificate for encrypted comminications. If the server certificate is signed off by a
+                                certificate for encrypted communications. If the server certificate is signed off by a
                                 signing authority, tls can be used without a truststore.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:element name="client-certificate-store" type="extendedKeyStoreType" minOccurs="0">
+                    <xs:element name="client-certificate-store" type="auditExtendedKeyStoreType" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>
                                 Configuration of a keystore containing a client certificate and a private key, e.g. in
@@ -1705,13 +1875,19 @@
                         Configuration of the socket to use for the native management interface is a choice
                         between a direct configuration of the address and port, or a reference to a socket-binding
                         configuration in the server's socket-binding-group element. The latter is the recommended
-                        approach is it makes it easier to avoid port conflicts by taking advantage of the
+                        approach as it makes it easier to avoid port conflicts by taking advantage of the
                         socket-binding-group's port-offset configuration. Direct configuration of the address and
-                        ports is provided to preserve backward compatibility.
+                        ports is deprecated and is only provided to preserve backward compatibility.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:choice>
-                    <xs:element name="socket" type="native-management-socketType"/>
+                    <xs:element name="socket" type="native-management-socketType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use 'socket-binding'
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
                     <xs:element name="socket-binding" type="native-management-socket-binding-refType"/>
                 </xs:choice>
             </xs:extension>
@@ -1746,13 +1922,19 @@
                         Configuration of the socket to use for the HTTP/HTTPS management interface is a choice
                         between a direct configuration of the address and ports, or a reference to socket-binding
                         configurations in the server's socket-binding-group element. The latter is the recommended
-                        approach is it makes it easier to avoid port conflicts by taking advantage of the
+                        approach as it makes it easier to avoid port conflicts by taking advantage of the
                         socket-binding-group's port-offset configuration. Direct configuration of the address and
-                        ports is provided to preserve backward compatibility.
+                        ports is deprecated and is only provided to preserve backward compatibility.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:choice>
-                    <xs:element name="socket" type="http-management-socketType"/>
+                    <xs:element name="socket" type="http-management-socketType">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Deprecated. Use 'socket-binding'
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
                     <xs:element name="socket-binding" type="http-management-socket-binding-refType"/>
                 </xs:choice>
                 <xs:attribute name="console-enabled" type="xs:boolean" use="optional" default="true"/>
@@ -2511,7 +2693,7 @@
                 <xs:documentation>
                     The destination address that a client should connect to if the
                     source-network matches. This value can either be a hostname or
-                    an ip address.
+                    an IP address.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -2530,7 +2712,7 @@
 
     <xs:complexType name="outbound-socket-bindingType">
         <xs:annotation>
-            <xs:documentation>Configuration information for a outbound socket.</xs:documentation>
+            <xs:documentation>Configuration information for an outbound socket.</xs:documentation>
         </xs:annotation>
         <xs:choice>
             <xs:element name="remote-destination" type="remote-destinationType" maxOccurs="1"/>
@@ -2558,7 +2740,7 @@
                 <xs:documentation>
                     The port number that will be used for setting the source addresss of the outbound socket. If the
                     source-interface attribute has been specified and the source-port attribute is absent,
-                    then the system uses a ephemeral port while binding the socket to a source address.
+                    then the system uses an ephemeral port while binding the socket to a source address.
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -2577,7 +2759,7 @@
             <xs:annotation>
                 <xs:documentation>
                     The remote server address to which the outbound socket has to be connect.
-                    The address can be either a IP address of the host server of the hostname of the server
+                    The address can be either an IP address of the host server of the hostname of the server
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
@@ -2708,7 +2890,7 @@
         <xs:attribute name="value" type="xs:string" use="required">
             <xs:annotation>
                 <xs:documentation>
-                    Either a IP address in IPv6 or IPv4 dotted decimal notation,
+                    Either an IP address in IPv6 or IPv4 dotted decimal notation,
                     or a hostname that can be resolved to an IP address.
                 </xs:documentation>
             </xs:annotation>

--- a/build/src/main/resources/docs/schema/wildfly-datasources_3_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-datasources_3_0.xsd
@@ -842,7 +842,7 @@
             <xs:annotation>
               <xs:documentation>
                 <![CDATA[[
-                   Should the XAResource instances be wrapped in a org.jboss.tm.XAResourceWrapper
+                   Should the XAResource instances be wrapped in an org.jboss.tm.XAResourceWrapper
                    instance
                    Ex: <wrap-xa-resource>true</wrap-xa-resource>
                  ]]>
@@ -1014,7 +1014,7 @@
       <xs:annotation>
         <xs:documentation>
           <![CDATA[[
-            Specifies the major version of this driver. If the major and minor version is obmitted the fist availabe
+            Specifies the major version of this driver. If the major and minor versions are omitted the first available
             Driver in module will be used.
            ]]>
         </xs:documentation>
@@ -1024,7 +1024,7 @@
     <xs:annotation>
         <xs:documentation>
           <![CDATA[[
-            Specifies the minor version of this driver. If the major and minor version is obmitted the fist availabe
+            Specifies the minor version of this driver. If the major and minor versions are omitted the first available
             Driver in module will be used.
            ]]>
         </xs:documentation>

--- a/build/src/main/resources/docs/schema/wildfly-resource-adapters_3_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-resource-adapters_3_0.xsd
@@ -599,7 +599,7 @@
             <xs:annotation>
               <xs:documentation>
                 <![CDATA[[
-                   Should the XAResource instances be wrapped in a org.jboss.tm.XAResourceWrapper
+                   Should the XAResource instances be wrapped in an org.jboss.tm.XAResourceWrapper
                    instance
                    Ex: <wrap-xa-resource>true</wrap-xa-resource>
                  ]]>

--- a/build/src/main/resources/docs/schema/wildfly-txn_3_0.xsd
+++ b/build/src/main/resources/docs/schema/wildfly-txn_3_0.xsd
@@ -27,7 +27,7 @@
             xmlns="urn:jboss:domain:transactions:3.0"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
-            version="2.0">
+            version="3.0">
 
     <!-- The transaction subsystem root element -->
     <xs:element name="subsystem" type="subsystem"/>
@@ -83,13 +83,6 @@
 
                 The process-id element specifies the process id implemention.
                 The "node-identifier" attribute is used to set the node identifier on the core environment.
-
-                The "path" attribute denotes a relative or absolute filesystem path denoting where the transaction
-                manager core should store data.
-
-                The "relative-to" attribute references a global path configuration in the domain model, defaulting
-                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
-                does not specify an absolute pathname, it will treated as relative to this path.
             ]]>
             </xs:documentation>
         </xs:annotation>
@@ -97,8 +90,24 @@
             <xs:element name="process-id" type="process-id" />
         </xs:all>
         <xs:attribute name="node-identifier" type="xs:string" default="1"/>
-        <xs:attribute name="path" type="xs:string" default="var"/>
-        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir"/>
+        <xs:attribute name="path" type="xs:string" default="var">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Deprecated. Has no meaningful effect on the behavior of the transaction manager.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[
+                    Deprecated. Has no meaningful effect on the behavior of the transaction manager.
+                ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
     </xs:complexType>
     <xs:complexType name="process-id">
         <xs:annotation>
@@ -145,13 +154,20 @@
             <xs:documentation>
             <![CDATA[
                 The coordinator environment configuration.
-                enable-statistics - if recording of transaction statistics is enabled, false otherwise.
+                statistics-enabled - if recording of transaction statistics is enabled, false otherwise.
                 enable-tsm-status - if the transaction status manager (TSM) service, needed for out of process recovery, should be provided or not.
                 default-timeout - the default transaction lifetime, in seconds.
             ]]>
             </xs:documentation>
         </xs:annotation>
-        <xs:attribute name="enable-statistics" type="xs:boolean" default="false"/>
+        <xs:attribute name="statistics-enabled" type="xs:boolean" default="false"/>
+        <xs:attribute name="enable-statistics" type="xs:boolean" default="false">
+            <xs:annotation>
+                <xs:documentation>
+                    <![CDATA[ Deprecated. Use statistics-enabled. ]]>
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
         <xs:attribute name="enable-tsm-status" type="xs:boolean" default="false"/>
         <xs:attribute name="default-timeout" type="xs:int" default="300" />
     </xs:complexType>


### PR DESCRIPTION
Picking up that some schemas were forked for WildFly 9 development whilst maintenance continued on the WildFly 8 base versions.
