### PR TITLE
Remove PersistentResourceDefinitionBuilder.addAttributes(Collection)

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
+++ b/controller/src/main/java/org/jboss/as/controller/PersistentResourceXMLDescription.java
@@ -1,7 +1,6 @@
 package org.jboss.as.controller;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -270,13 +269,6 @@ public class PersistentResourceXMLDescription {
         }
 
         public PersistentResourceXMLBuilder addAttributes(AttributeDefinition... attributes) {
-            for (final AttributeDefinition at : attributes) {
-                this.attributes.put(at.getXmlName(), at);
-            }
-            return this;
-        }
-
-        public PersistentResourceXMLBuilder addAttributes(Collection<? extends AttributeDefinition> attributes) {
             for (final AttributeDefinition at : attributes) {
                 this.attributes.put(at.getXmlName(), at);
             }

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser2_0.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser2_0.java
@@ -50,26 +50,26 @@ public class MailSubsystemParser2_0 implements XMLStreamConstants, XMLElementRea
         xmlDescription = builder(MailSubsystemResource.INSTANCE)
                 .addChild(
                         builder(MailSessionDefinition.INSTANCE)
-                                .addAttributes(MailSessionDefinition.INSTANCE.getAttributes())
+                                .addAttributes(MailSessionDefinition.DEBUG, MailSessionDefinition.JNDI_NAME, MailSessionDefinition.FROM)
                                 .addChild(
                                         builder(MailServerDefinition.INSTANCE_SMTP)
-                                                .addAttributes(MailServerDefinition.INSTANCE_SMTP.getAttributes())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD)
                                                 .setXmlElementName(MailSubsystemModel.SMTP_SERVER)
 
                                 )
                                 .addChild(
                                         builder(MailServerDefinition.INSTANCE_POP3)
-                                                .addAttributes(MailServerDefinition.INSTANCE_SMTP.getAttributes())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD)
                                                 .setXmlElementName(MailSubsystemModel.POP3_SERVER)
                                 )
                                 .addChild(
                                         builder(MailServerDefinition.INSTANCE_IMAP)
-                                                .addAttributes(MailServerDefinition.INSTANCE_SMTP.getAttributes())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD)
                                                 .setXmlElementName(MailSubsystemModel.IMAP_SERVER)
                                 )
                                 .addChild(
                                         builder(MailServerDefinition.INSTANCE_CUSTOM)
-                                                .addAttributes(MailServerDefinition.INSTANCE_CUSTOM.getAttributes())
+                                                .addAttributes(MailServerDefinition.OUTBOUND_SOCKET_BINDING_REF_OPTIONAL, MailServerDefinition.SSL, MailServerDefinition.TLS, MailServerDefinition.USERNAME, MailServerDefinition.PASSWORD, MailServerDefinition.PROPERTIES)
                                                 .setXmlElementName(MailSubsystemModel.CUSTOM_SERVER)
                                 )
                 )

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointResource.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingEndpointResource.java
@@ -24,7 +24,6 @@ package org.jboss.as.remoting;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
-import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
@@ -40,7 +39,6 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.remoting3.RemotingOptions;
 import org.wildfly.extension.io.OptionAttributeDefinition;
-import org.wildfly.extension.io.OptionList;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -54,30 +52,33 @@ public class RemotingEndpointResource extends PersistentResourceDefinition {
             .build();
 
 
-    static final List<OptionAttributeDefinition> OPTIONS = OptionList.builder()
-            .addOption(RemotingOptions.SEND_BUFFER_SIZE, "send-buffer-size", new ModelNode(RemotingOptions.DEFAULT_SEND_BUFFER_SIZE))
-            .addOption(RemotingOptions.RECEIVE_BUFFER_SIZE, "receive-buffer-size", new ModelNode(RemotingOptions.DEFAULT_RECEIVE_BUFFER_SIZE))
-            .addOption(RemotingOptions.BUFFER_REGION_SIZE, "buffer-region-size")
-            .addOption(RemotingOptions.TRANSMIT_WINDOW_SIZE, "transmit-window-size", new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE))
-            .addOption(RemotingOptions.RECEIVE_WINDOW_SIZE, "receive-window-size", new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_RECEIVE_WINDOW_SIZE))
-            .addOption(RemotingOptions.MAX_OUTBOUND_CHANNELS, "max-outbound-channels", new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_CHANNELS))
-            .addOption(RemotingOptions.MAX_INBOUND_CHANNELS, "max-inbound-channels", new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_CHANNELS))
-            .addOption(RemotingOptions.AUTHORIZE_ID, "authorize-id")
-            .addOption(RemotingOptions.AUTH_REALM, "auth-realm")
-            .addOption(RemotingOptions.AUTHENTICATION_RETRIES, "authentication-retries", new ModelNode(RemotingOptions.DEFAULT_AUTHENTICATION_RETRIES))
-            .addOption(RemotingOptions.MAX_OUTBOUND_MESSAGES, "max-outbound-messages", new ModelNode(RemotingOptions.OUTGOING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES))
-            .addOption(RemotingOptions.MAX_INBOUND_MESSAGES, "max-inbound-messages", new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES))
-            .addOption(RemotingOptions.HEARTBEAT_INTERVAL, "heartbeat-interval", new ModelNode(RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL))
-            .addOption(RemotingOptions.MAX_INBOUND_MESSAGE_SIZE, "max-inbound-message-size", new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_MESSAGE_SIZE))
-            .addOption(RemotingOptions.MAX_OUTBOUND_MESSAGE_SIZE, "max-outbound-message-size", new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_MESSAGE_SIZE))
-            .addOption(RemotingOptions.SERVER_NAME, "server-name")
-            .addOption(RemotingOptions.SASL_PROTOCOL, "sasl-protocol", new ModelNode(RemotingOptions.DEFAULT_SASL_PROTOCOL))
-            .build();
+    public static final OptionAttributeDefinition SEND_BUFFER_SIZE = OptionAttributeDefinition.builder("send-buffer-size", RemotingOptions.SEND_BUFFER_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_SEND_BUFFER_SIZE)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition RECEIVE_BUFFER_SIZE = OptionAttributeDefinition.builder("receive-buffer-size", RemotingOptions.RECEIVE_BUFFER_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_RECEIVE_BUFFER_SIZE)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition BUFFER_REGION_SIZE = OptionAttributeDefinition.builder("buffer-region-size", RemotingOptions.BUFFER_REGION_SIZE).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition TRANSMIT_WINDOW_SIZE = OptionAttributeDefinition.builder("transmit-window-size", RemotingOptions.TRANSMIT_WINDOW_SIZE).setDefaultValue(new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_TRANSMIT_WINDOW_SIZE)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition RECEIVE_WINDOW_SIZE = OptionAttributeDefinition.builder("receive-window-size", RemotingOptions.RECEIVE_WINDOW_SIZE).setDefaultValue(new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_RECEIVE_WINDOW_SIZE)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_OUTBOUND_CHANNELS = OptionAttributeDefinition.builder("max-outbound-channels", RemotingOptions.MAX_OUTBOUND_CHANNELS).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_CHANNELS)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_INBOUND_CHANNELS = OptionAttributeDefinition.builder("max-inbound-channels", RemotingOptions.MAX_INBOUND_CHANNELS).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_CHANNELS)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition AUTHORIZE_ID = OptionAttributeDefinition.builder("authorize-id", RemotingOptions.AUTHORIZE_ID).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition AUTH_REALM = OptionAttributeDefinition.builder("auth-realm", RemotingOptions.AUTH_REALM).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition AUTHENTICATION_RETRIES = OptionAttributeDefinition.builder("authentication-retries", RemotingOptions.AUTHENTICATION_RETRIES).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_AUTHENTICATION_RETRIES)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_OUTBOUND_MESSAGES = OptionAttributeDefinition.builder("max-outbound-messages", RemotingOptions.MAX_OUTBOUND_MESSAGES).setDefaultValue(new ModelNode(RemotingOptions.OUTGOING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_INBOUND_MESSAGES = OptionAttributeDefinition.builder("max-inbound-messages", RemotingOptions.MAX_INBOUND_MESSAGES).setDefaultValue(new ModelNode(RemotingOptions.INCOMING_CHANNEL_DEFAULT_MAX_OUTBOUND_MESSAGES)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition HEARTBEAT_INTERVAL = OptionAttributeDefinition.builder("heartbeat-interval", RemotingOptions.HEARTBEAT_INTERVAL).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_HEARTBEAT_INTERVAL)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_INBOUND_MESSAGE_SIZE = OptionAttributeDefinition.builder("max-inbound-message-size", RemotingOptions.MAX_INBOUND_MESSAGE_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_INBOUND_MESSAGE_SIZE)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_OUTBOUND_MESSAGE_SIZE = OptionAttributeDefinition.builder("max-outbound-message-size", RemotingOptions.MAX_OUTBOUND_MESSAGE_SIZE).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_MAX_OUTBOUND_MESSAGE_SIZE)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition SERVER_NAME = OptionAttributeDefinition.builder("server-name", RemotingOptions.SERVER_NAME).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition SASL_PROTOCOL = OptionAttributeDefinition.builder("sasl-protocol", RemotingOptions.SASL_PROTOCOL).setDefaultValue(new ModelNode(RemotingOptions.DEFAULT_SASL_PROTOCOL)).setAllowExpression(true).build();
+
 
     protected static final PathElement ENDPOINT_PATH = PathElement.pathElement("configuration", "endpoint");
     protected static final Collection<AttributeDefinition> ATTRIBUTES;
 
     static final RemotingEndpointResource INSTANCE = new RemotingEndpointResource();
+
+    public static final java.util.List<OptionAttributeDefinition> OPTIONS = Arrays.asList(SEND_BUFFER_SIZE, RECEIVE_BUFFER_SIZE, BUFFER_REGION_SIZE, TRANSMIT_WINDOW_SIZE, RECEIVE_WINDOW_SIZE,
+            MAX_OUTBOUND_CHANNELS, MAX_INBOUND_CHANNELS, AUTHORIZE_ID, AUTHORIZE_ID, AUTH_REALM, AUTHENTICATION_RETRIES, MAX_OUTBOUND_MESSAGES,
+            MAX_INBOUND_MESSAGES, HEARTBEAT_INTERVAL, MAX_INBOUND_MESSAGE_SIZE, MAX_OUTBOUND_MESSAGE_SIZE, SERVER_NAME, SASL_PROTOCOL);
 
     static {
         ATTRIBUTES = new LinkedHashSet<AttributeDefinition>(Arrays.asList(WORKER));

--- a/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem20Parser.java
+++ b/remoting/subsystem/src/main/java/org/jboss/as/remoting/RemotingSubsystem20Parser.java
@@ -64,7 +64,9 @@ class RemotingSubsystem20Parser extends RemotingSubsystem11Parser implements XML
 
     static final RemotingSubsystem20Parser INSTANCE = new RemotingSubsystem20Parser();
     static final PersistentResourceXMLDescription ENDPOINT_PARSER = PersistentResourceXMLDescription.builder(RemotingEndpointResource.INSTANCE)
-            .addAttributes(RemotingEndpointResource.INSTANCE.getAttributes())
+            .addAttributes(RemotingEndpointResource.WORKER, RemotingEndpointResource.SEND_BUFFER_SIZE, RemotingEndpointResource.RECEIVE_BUFFER_SIZE, RemotingEndpointResource.BUFFER_REGION_SIZE, RemotingEndpointResource.TRANSMIT_WINDOW_SIZE, RemotingEndpointResource.RECEIVE_WINDOW_SIZE,
+                    RemotingEndpointResource.MAX_OUTBOUND_CHANNELS, RemotingEndpointResource.MAX_INBOUND_CHANNELS, RemotingEndpointResource.AUTHORIZE_ID, RemotingEndpointResource.AUTHORIZE_ID, RemotingEndpointResource.AUTH_REALM, RemotingEndpointResource.AUTHENTICATION_RETRIES, RemotingEndpointResource.MAX_OUTBOUND_MESSAGES,
+                    RemotingEndpointResource.MAX_INBOUND_MESSAGES, RemotingEndpointResource.HEARTBEAT_INTERVAL, RemotingEndpointResource.MAX_INBOUND_MESSAGE_SIZE, RemotingEndpointResource.MAX_OUTBOUND_MESSAGE_SIZE, RemotingEndpointResource.SERVER_NAME, RemotingEndpointResource.SASL_PROTOCOL)
             .build();
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -42,7 +42,6 @@ import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.io.OptionAttributeDefinition;
-import org.wildfly.extension.io.OptionList;
 import org.xnio.Options;
 
 /**
@@ -82,37 +81,46 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
             .setAllowExpression(false)
             .build();
 
-    static final List<OptionAttributeDefinition> SOCKET_OPTIONS = OptionList.builder()
-            .addOption(Options.BACKLOG, "tcp-backlog")
-            .addOption(Options.RECEIVE_BUFFER, "receive-buffer")
-            .addOption(Options.SEND_BUFFER, "send-buffer")
-            .addOption(Options.KEEP_ALIVE, "tcp-keep-alive")
-            .build();
+
+    public static final OptionAttributeDefinition BACKLOG = OptionAttributeDefinition.builder("tcp-backlog", Options.BACKLOG).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition RECEIVE_BUFFER = OptionAttributeDefinition.builder("receive-buffer", Options.RECEIVE_BUFFER).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition SEND_BUFFER = OptionAttributeDefinition.builder("send-buffer", Options.SEND_BUFFER).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition KEEP_ALIVE = OptionAttributeDefinition.builder("tcp-keep-alive", Options.KEEP_ALIVE).setAllowExpression(true).build();
 
 
-    static final List<OptionAttributeDefinition> LISTENER_OPTIONS = OptionList.builder()
-            .addOption(UndertowOptions.MAX_HEADER_SIZE, "max-header-size", new ModelNode(UndertowOptions.DEFAULT_MAX_HEADER_SIZE))
-            .addOption(UndertowOptions.MAX_ENTITY_SIZE, Constants.MAX_POST_SIZE, new ModelNode(10485760L))
-            .addOption(UndertowOptions.BUFFER_PIPELINED_DATA, "buffer-pipelined-data", new ModelNode(true))
-            .addOption(UndertowOptions.MAX_PARAMETERS, "max-parameters", new ModelNode(1000))
-            .addOption(UndertowOptions.MAX_HEADERS, "max-headers", new ModelNode(200))
-            .addOption(UndertowOptions.MAX_COOKIES, "max-cookies", new ModelNode(200))
-            .addOption(UndertowOptions.ALLOW_ENCODED_SLASH, "allow-encoded-slash", new ModelNode(false))
-            .addOption(UndertowOptions.DECODE_URL, "decode-url", new ModelNode(true))
-            .addOption(UndertowOptions.URL_CHARSET, "url-charset", new ModelNode("UTF-8"))
-            .addOption(UndertowOptions.ALWAYS_SET_KEEP_ALIVE, "always-set-keep-alive", new ModelNode(true))
-            .addOption(UndertowOptions.MAX_BUFFERED_REQUEST_SIZE, "max-buffered-request-size", new ModelNode(16384))
-            .addOption(UndertowOptions.RECORD_REQUEST_START_TIME, "record-request-start-time", new ModelNode(false))
-            .addOption(UndertowOptions.ALLOW_EQUALS_IN_COOKIE_VALUE, "allow-equals-in-cookie-value", new ModelNode(false))
-            .build();
+    public static final OptionAttributeDefinition MAX_HEADER_SIZE = OptionAttributeDefinition.builder("max-header-size", UndertowOptions.MAX_HEADER_SIZE).setDefaultValue(new ModelNode(UndertowOptions.DEFAULT_MAX_HEADER_SIZE)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_ENTITY_SIZE = OptionAttributeDefinition.builder(Constants.MAX_POST_SIZE, UndertowOptions.MAX_ENTITY_SIZE).setDefaultValue(new ModelNode(10485760L)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition BUFFER_PIPELINED_DATA = OptionAttributeDefinition.builder("buffer-pipelined-data", UndertowOptions.BUFFER_PIPELINED_DATA).setDefaultValue(new ModelNode(true)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_PARAMETERS = OptionAttributeDefinition.builder("max-parameters", UndertowOptions.MAX_PARAMETERS).setDefaultValue(new ModelNode(1000)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_HEADERS = OptionAttributeDefinition.builder("max-headers", UndertowOptions.MAX_HEADERS).setDefaultValue(new ModelNode(200)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_COOKIES = OptionAttributeDefinition.builder("max-cookies", UndertowOptions.MAX_COOKIES).setDefaultValue(new ModelNode(200)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition ALLOW_ENCODED_SLASH = OptionAttributeDefinition.builder("allow-encoded-slash", UndertowOptions.ALLOW_ENCODED_SLASH).setDefaultValue(new ModelNode(false)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition DECODE_URL = OptionAttributeDefinition.builder("decode-url", UndertowOptions.DECODE_URL).setDefaultValue(new ModelNode(true)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition URL_CHARSET = OptionAttributeDefinition.builder("url-charset", UndertowOptions.URL_CHARSET).setDefaultValue(new ModelNode("UTF-8")).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition ALWAYS_SET_KEEP_ALIVE = OptionAttributeDefinition.builder("always-set-keep-alive", UndertowOptions.ALWAYS_SET_KEEP_ALIVE).setDefaultValue(new ModelNode(true)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition MAX_BUFFERED_REQUEST_SIZE = OptionAttributeDefinition.builder("max-buffered-request-size", UndertowOptions.MAX_BUFFERED_REQUEST_SIZE).setDefaultValue(new ModelNode(16384)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition RECORD_REQUEST_START_TIME = OptionAttributeDefinition.builder("record-request-start-time", UndertowOptions.RECORD_REQUEST_START_TIME).setDefaultValue(new ModelNode(false)).setAllowExpression(true).build();
+    public static final OptionAttributeDefinition ALLOW_EQUALS_IN_COOKIE_VALUE = OptionAttributeDefinition.builder("allow-equals-in-cookie-value", UndertowOptions.ALLOW_EQUALS_IN_COOKIE_VALUE).setDefaultValue(new ModelNode(false)).setAllowExpression(true).build();
+
 
     protected static final Collection ATTRIBUTES;
     protected static final List<AccessConstraintDefinition> CONSTRAINTS = Arrays.asList(UndertowExtension.LISTENER_CONSTRAINT);
 
+    public static final List<OptionAttributeDefinition> LISTENER_OPTIONS = Arrays.asList(MAX_HEADER_SIZE, MAX_ENTITY_SIZE,
+            BUFFER_PIPELINED_DATA, MAX_PARAMETERS, MAX_HEADERS, MAX_COOKIES, ALLOW_ENCODED_SLASH, DECODE_URL,
+            URL_CHARSET, ALWAYS_SET_KEEP_ALIVE, MAX_BUFFERED_REQUEST_SIZE, RECORD_REQUEST_START_TIME,
+            ALLOW_EQUALS_IN_COOKIE_VALUE);
+
+    public static final List<OptionAttributeDefinition> SOCKET_OPTIONS = Arrays.asList(BACKLOG, RECEIVE_BUFFER, SEND_BUFFER, KEEP_ALIVE);
+
     static {
         ATTRIBUTES = new LinkedHashSet<AttributeDefinition>(Arrays.asList(SOCKET_BINDING, WORKER, BUFFER_POOL, ENABLED));
+
         ATTRIBUTES.addAll(LISTENER_OPTIONS);
+
+
         ATTRIBUTES.addAll(SOCKET_OPTIONS);
+
     }
 
     public ListenerResourceDefinition(PathElement pathElement) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_0.java
@@ -72,15 +72,26 @@ public class UndertowSubsystemParser_1_0 implements XMLStreamConstants, XMLEleme
                         .addChild(
                                 builder(AjpListenerResourceDefinition.INSTANCE)
                                         .addAttributes(AjpListenerResourceDefinition.SCHEME, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED, AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_SOCKET)
-                                        .addAttributes(ListenerResourceDefinition.LISTENER_OPTIONS)
+                                        .addAttributes(ListenerResourceDefinition.MAX_HEADER_SIZE, ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                                                ListenerResourceDefinition.BUFFER_PIPELINED_DATA, ListenerResourceDefinition.MAX_PARAMETERS, ListenerResourceDefinition.MAX_HEADERS, ListenerResourceDefinition.MAX_COOKIES,ListenerResourceDefinition.ALLOW_ENCODED_SLASH, ListenerResourceDefinition.DECODE_URL,
+                                                ListenerResourceDefinition.URL_CHARSET, ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE, ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE, ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                                                ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE)
                         )
                         .addChild(
                                 builder(HttpListenerResourceDefinition.INSTANCE)
                                         .addAttributes(HttpListenerResourceDefinition.BUFFER_POOL, HttpListenerResourceDefinition.CERTIFICATE_FORWARDING, HttpListenerResourceDefinition.ENABLED, HttpListenerResourceDefinition.SOCKET_BINDING, HttpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_SOCKET, HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING)
-                                        .addAttributes(ListenerResourceDefinition.LISTENER_OPTIONS)
+                                        .addAttributes(ListenerResourceDefinition.MAX_HEADER_SIZE, ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                                                ListenerResourceDefinition.BUFFER_PIPELINED_DATA, ListenerResourceDefinition.MAX_PARAMETERS, ListenerResourceDefinition.MAX_HEADERS, ListenerResourceDefinition.MAX_COOKIES,ListenerResourceDefinition.ALLOW_ENCODED_SLASH, ListenerResourceDefinition.DECODE_URL,
+                                                ListenerResourceDefinition.URL_CHARSET, ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE, ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE, ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                                                ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE)
                         ).addChild(
                                 builder(HttpsListenerResourceDefinition.INSTANCE)
-                                        .addAttributes(HttpsListenerResourceDefinition.INSTANCE.getAttributes())
+                                        .addAttributes(AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED)
+                                        .addAttributes(HttpsListenerResourceDefinition.SECURITY_REALM, HttpsListenerResourceDefinition.VERIFY_CLIENT, HttpsListenerResourceDefinition.ENABLED_CIPHER_SUITES,HttpsListenerResourceDefinition.ENABLED_PROTOCOLS)
+                                        .addAttributes(ListenerResourceDefinition.MAX_HEADER_SIZE, ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                                                ListenerResourceDefinition.BUFFER_PIPELINED_DATA, ListenerResourceDefinition.MAX_PARAMETERS, ListenerResourceDefinition.MAX_HEADERS, ListenerResourceDefinition.MAX_COOKIES,ListenerResourceDefinition.ALLOW_ENCODED_SLASH, ListenerResourceDefinition.DECODE_URL,
+                                                ListenerResourceDefinition.URL_CHARSET, ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE, ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE, ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                                                ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE)
                         ).addChild(
                                 builder(HostDefinition.INSTANCE)
                                         .addAttributes(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE)
@@ -89,17 +100,17 @@ public class UndertowSubsystemParser_1_0 implements XMLStreamConstants, XMLEleme
                                                         .addAttributes(LocationDefinition.HANDLER)
                                                         .addChild(
                                                                 builder(FilterRefDefinition.INSTANCE)
-                                                                        .addAttributes(FilterRefDefinition.INSTANCE.getAttributes())
+                                                                        .addAttributes(FilterRefDefinition.PREDICATE)
                                                         )
                                         ).addChild(
                                         builder(AccessLogDefinition.INSTANCE)
                                                 .addAttributes(AccessLogDefinition.PATTERN, AccessLogDefinition.DIRECTORY, AccessLogDefinition.PREFIX, AccessLogDefinition.WORKER, AccessLogDefinition.ROTATE)
                                 ).addChild(
                                         builder(FilterRefDefinition.INSTANCE)
-                                                .addAttributes(FilterRefDefinition.INSTANCE.getAttributes())
+                                                .addAttributes(FilterRefDefinition.PREDICATE)
                                 ).addChild(
                                         builder(SingleSignOnDefinition.INSTANCE)
-                                                .addAttributes(SingleSignOnDefinition.INSTANCE.getAttributes())
+                                                .addAttributes(SingleSignOnDefinition.DOMAIN, SingleSignOnDefinition.PATH, SingleSignOnDefinition.HTTP_ONLY, SingleSignOnDefinition.SECURE)
                                 )
                         )
                 )
@@ -198,10 +209,9 @@ public class UndertowSubsystemParser_1_0 implements XMLStreamConstants, XMLEleme
                                                 .addAttributes(ConnectionLimitHandler.MAX_CONCURRENT_REQUESTS, ConnectionLimitHandler.QUEUE_SIZE)
                                 ).addChild(
                                 builder(ResponseHeaderFilter.INSTANCE)
-                                        .addAttributes(ResponseHeaderFilter.INSTANCE.getAttributes())
+                                        .addAttributes(ResponseHeaderFilter.NAME, ResponseHeaderFilter.VALUE)
                         ).addChild(
                                 builder(GzipFilter.INSTANCE)
-                                        .addAttributes(GzipFilter.INSTANCE.getAttributes())
                         )
 
                 )

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_1.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_1_1.java
@@ -70,18 +70,31 @@ public class UndertowSubsystemParser_1_1 implements XMLStreamConstants, XMLEleme
                         .addAttributes(ServerDefinition.DEFAULT_HOST, ServerDefinition.SERVLET_CONTAINER)
                         .addChild(
                                 builder(AjpListenerResourceDefinition.INSTANCE)
+
                                         .addAttributes(AjpListenerResourceDefinition.SCHEME, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED, AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_SOCKET)
-                                        .addAttributes(ListenerResourceDefinition.LISTENER_OPTIONS)
-                                        .addAttributes(ListenerResourceDefinition.SOCKET_OPTIONS)
+                                        .addAttributes(ListenerResourceDefinition.MAX_HEADER_SIZE, ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                                                ListenerResourceDefinition.BUFFER_PIPELINED_DATA, ListenerResourceDefinition.MAX_PARAMETERS, ListenerResourceDefinition.MAX_HEADERS, ListenerResourceDefinition.MAX_COOKIES,ListenerResourceDefinition.ALLOW_ENCODED_SLASH, ListenerResourceDefinition.DECODE_URL,
+                                                ListenerResourceDefinition.URL_CHARSET, ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE, ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE, ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                                                ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE)
+                                        .addAttributes(ListenerResourceDefinition.BACKLOG, ListenerResourceDefinition.RECEIVE_BUFFER, ListenerResourceDefinition.SEND_BUFFER, ListenerResourceDefinition.KEEP_ALIVE)
                         )
                         .addChild(
                                 builder(HttpListenerResourceDefinition.INSTANCE)
                                         .addAttributes(HttpListenerResourceDefinition.BUFFER_POOL, HttpListenerResourceDefinition.CERTIFICATE_FORWARDING, HttpListenerResourceDefinition.ENABLED, HttpListenerResourceDefinition.SOCKET_BINDING, HttpListenerResourceDefinition.WORKER, ListenerResourceDefinition.REDIRECT_SOCKET, HttpListenerResourceDefinition.PROXY_ADDRESS_FORWARDING)
-                                        .addAttributes(ListenerResourceDefinition.LISTENER_OPTIONS)
-                                        .addAttributes(ListenerResourceDefinition.SOCKET_OPTIONS)
+                                        .addAttributes(ListenerResourceDefinition.MAX_HEADER_SIZE, ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                                                ListenerResourceDefinition.BUFFER_PIPELINED_DATA, ListenerResourceDefinition.MAX_PARAMETERS, ListenerResourceDefinition.MAX_HEADERS, ListenerResourceDefinition.MAX_COOKIES,ListenerResourceDefinition.ALLOW_ENCODED_SLASH, ListenerResourceDefinition.DECODE_URL,
+                                                ListenerResourceDefinition.URL_CHARSET, ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE, ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE, ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                                                ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE)
+                                        .addAttributes(ListenerResourceDefinition.BACKLOG, ListenerResourceDefinition.RECEIVE_BUFFER, ListenerResourceDefinition.SEND_BUFFER, ListenerResourceDefinition.KEEP_ALIVE)
                         ).addChild(
                                 builder(HttpsListenerResourceDefinition.INSTANCE)
-                                        .addAttributes(HttpsListenerResourceDefinition.INSTANCE.getAttributes())
+                                        .addAttributes(AjpListenerResourceDefinition.SOCKET_BINDING, AjpListenerResourceDefinition.WORKER, AjpListenerResourceDefinition.BUFFER_POOL, AjpListenerResourceDefinition.ENABLED)
+                                        .addAttributes(HttpsListenerResourceDefinition.SECURITY_REALM, HttpsListenerResourceDefinition.VERIFY_CLIENT, HttpsListenerResourceDefinition.ENABLED_CIPHER_SUITES,HttpsListenerResourceDefinition.ENABLED_PROTOCOLS)
+                                        .addAttributes(ListenerResourceDefinition.MAX_HEADER_SIZE, ListenerResourceDefinition.MAX_ENTITY_SIZE,
+                                                ListenerResourceDefinition.BUFFER_PIPELINED_DATA, ListenerResourceDefinition.MAX_PARAMETERS, ListenerResourceDefinition.MAX_HEADERS, ListenerResourceDefinition.MAX_COOKIES,ListenerResourceDefinition.ALLOW_ENCODED_SLASH, ListenerResourceDefinition.DECODE_URL,
+                                                ListenerResourceDefinition.URL_CHARSET, ListenerResourceDefinition.ALWAYS_SET_KEEP_ALIVE, ListenerResourceDefinition.MAX_BUFFERED_REQUEST_SIZE, ListenerResourceDefinition.RECORD_REQUEST_START_TIME,
+                                                ListenerResourceDefinition.ALLOW_EQUALS_IN_COOKIE_VALUE)
+                                        .addAttributes(ListenerResourceDefinition.BACKLOG, ListenerResourceDefinition.RECEIVE_BUFFER, ListenerResourceDefinition.SEND_BUFFER, ListenerResourceDefinition.KEEP_ALIVE)
                         ).addChild(
                                 builder(HostDefinition.INSTANCE)
                                         .addAttributes(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE)
@@ -90,17 +103,17 @@ public class UndertowSubsystemParser_1_1 implements XMLStreamConstants, XMLEleme
                                                         .addAttributes(LocationDefinition.HANDLER)
                                                         .addChild(
                                                                 builder(FilterRefDefinition.INSTANCE)
-                                                                        .addAttributes(FilterRefDefinition.INSTANCE.getAttributes())
+                                                                        .addAttributes(FilterRefDefinition.PREDICATE)
                                                         )
                                         ).addChild(
                                                 builder(AccessLogDefinition.INSTANCE)
                                                     .addAttributes(AccessLogDefinition.PATTERN, AccessLogDefinition.DIRECTORY, AccessLogDefinition.PREFIX, AccessLogDefinition.SUFFIX, AccessLogDefinition.WORKER, AccessLogDefinition.ROTATE)
                                         ).addChild(
                                                 builder(FilterRefDefinition.INSTANCE)
-                                                    .addAttributes(FilterRefDefinition.INSTANCE.getAttributes())
+                                                    .addAttributes(FilterRefDefinition.PREDICATE)
                                         ).addChild(
                                                 builder(SingleSignOnDefinition.INSTANCE)
-                                                    .addAttributes(SingleSignOnDefinition.INSTANCE.getAttributes())
+                                                    .addAttributes(SingleSignOnDefinition.DOMAIN, SingleSignOnDefinition.PATH, SingleSignOnDefinition.HTTP_ONLY, SingleSignOnDefinition.SECURE)
                                         )
                         )
                 )
@@ -199,10 +212,9 @@ public class UndertowSubsystemParser_1_1 implements XMLStreamConstants, XMLEleme
                                                 .addAttributes(ConnectionLimitHandler.MAX_CONCURRENT_REQUESTS, ConnectionLimitHandler.QUEUE_SIZE)
                                 ).addChild(
                                         builder(ResponseHeaderFilter.INSTANCE)
-                                                .addAttributes(ResponseHeaderFilter.INSTANCE.getAttributes())
+                                                .addAttributes(ResponseHeaderFilter.NAME, ResponseHeaderFilter.VALUE)
                                 ).addChild(
                                         builder(GzipFilter.INSTANCE)
-                                                .addAttributes(GzipFilter.INSTANCE.getAttributes())
                                 )
 
                 )

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/FilterRefDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/FilterRefDefinition.java
@@ -38,7 +38,7 @@ import org.wildfly.extension.undertow.UndertowExtension;
  */
 public class FilterRefDefinition extends PersistentResourceDefinition {
 
-    static final AttributeDefinition PREDICATE = new SimpleAttributeDefinitionBuilder("predicate", ModelType.STRING)
+    public static final AttributeDefinition PREDICATE = new SimpleAttributeDefinitionBuilder("predicate", ModelType.STRING)
                 .setAllowNull(true)
                 .setAllowExpression(true)
                 .build();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ResponseHeaderFilter.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ResponseHeaderFilter.java
@@ -36,11 +36,11 @@ import org.jboss.dmr.ModelType;
  */
 public class ResponseHeaderFilter extends Filter {
 
-    private static final AttributeDefinition NAME = new SimpleAttributeDefinitionBuilder("header-name", ModelType.STRING)
+    public static final AttributeDefinition NAME = new SimpleAttributeDefinitionBuilder("header-name", ModelType.STRING)
             .setAllowNull(false)
             .setAllowExpression(true)
             .build();
-    private static final AttributeDefinition VALUE = new SimpleAttributeDefinitionBuilder("header-value", ModelType.STRING)
+    public static final AttributeDefinition VALUE = new SimpleAttributeDefinitionBuilder("header-value", ModelType.STRING)
             .setAllowNull(false)
             .setAllowExpression(true)
             .build();


### PR DESCRIPTION
This version of the method is problematic because any changes to the underling
list will cause existing parsers to change. In particular if an attribute is added
or removed this change will affect old versions of the parser.
