### PR TITLE
WFLY-3394 remove IBM exclude profile from secman testsuite module

### DIFF
--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -100,33 +100,6 @@
 				</plugins>
 			</build>
 		</profile>
-
-		<!-- When Java vendor is IBM, then skip the module. IBM with Security Manager
-			is only supported, when the "policy.provider" property value is changed to
-			"sun.security.provider.PolicyFile" in ${JAVA_HOME}/jre/lib/security/java.security -->
-		<profile>
-			<id>skipIBMJDK.secman.profile</id>
-			<activation>
-				<property>
-					<name>java.vendor</name>
-					<value>IBM Corporation</value>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.apache.maven.plugins</groupId>
-						<artifactId>maven-surefire-plugin</artifactId>
-						<executions>
-							<execution>
-								<id>secman-integration.surefire</id>
-								<phase>none</phase>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
 	</profiles>
 
 </project>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-3394

IBM JDK exclude is not needed in WFLY, because only version 1.6 of IBM JDK had unsupported `policy.provider` value configured in `${JAVA_HOME}/jre/lib/security/java.security`.

IBM Java 7 and newer have the correct (supported) default value of `policy.provider`.
