### PR TITLE
WFLY-3361 - IBM JDK's XSL transformer behavior causes invalid config XMLs in some cases

### DIFF
--- a/testsuite/integration/src/test/xslt/addCacheContainer.xsl
+++ b/testsuite/integration/src/test/xslt/addCacheContainer.xsl
@@ -20,54 +20,96 @@
         <xsl:attribute name="batching">true</xsl:attribute>
     </xsl:attribute-set>
 
-    <xsl:variable name="newCacheDefinition">
-        <cache-container name="testDbPersistence" default-cache="jdbc-cache" module="org.wildfly.clustering.web.infinispan">
-            <transport lock-timeout="60000" />
-            <xsl:element name="{$cacheType}-cache" use-attribute-sets="cacheAttributes">
-                <xsl:element name="{$cacheLoader}-jdbc-store" use-attribute-sets="cacheLoaderAttributes">
-                    <xsl:choose>
-                        
-                        <xsl:when test="$cacheLoader = 'string-keyed'">
-                            <string-keyed-table prefix="stringbased">
-                                <id-column name="id" type="VARCHAR(255)" />
-                                <data-column name="datum" type="VARBINARY(10000)" />
-                                <timestamp-column name="version" type="BIGINT" />
-                            </string-keyed-table>
-                        </xsl:when>
-                        
-                        <xsl:when test="$cacheLoader = 'binary-keyed'">
-                            <binary-keyed-table prefix="binarybased">
-                                <id-column name="id" type="VARCHAR(255)" />
-                                <data-column name="datum" type="VARBINARY(10000)" />
-                                <timestamp-column name="version" type="BIGINT" />
-                            </binary-keyed-table>
-                        </xsl:when>
-
-                        <xsl:when test="$cacheLoader = 'mixed-keyed'">
-                            <string-keyed-table prefix="stringbased">
-                                <id-column name="id" type="VARCHAR(255)" />
-                                <data-column name="datum" type="VARBINARY(10000)" />
-                                <timestamp-column name="version" type="BIGINT" />
-                            </string-keyed-table>
-                            <binary-keyed-table prefix="binarybased">
-                                <id-column name="id" type="VARCHAR(255)" />
-                                <data-column name="datum" type="VARBINARY(10000)" />
-                                <timestamp-column name="version" type="BIGINT" />
-                            </binary-keyed-table>
-                        </xsl:when>
-
-                    </xsl:choose>
-                </xsl:element>
-            </xsl:element>
-        </cache-container>
-    </xsl:variable>
     <!-- replace the old definition with the new -->
-    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $ispn)]
-    /*[local-name()='cache-container' and starts-with(namespace-uri(), $ispn) and @name='web']">
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $ispn)]">
         <xsl:copy>
             <xsl:apply-templates select="@*|node()" />
+            <xsl:element name="cache-container" namespace="{namespace-uri()}">
+                <xsl:attribute name="name">testDbPersistence</xsl:attribute>
+                <xsl:attribute name="default-cache">jdbc-cache</xsl:attribute>
+                <xsl:attribute name="module">org.wildfly.clustering.web.infinispan</xsl:attribute>            
+
+                <xsl:element name="transport" namespace="{namespace-uri()}">
+                    <xsl:attribute name="lock-timeout">6000</xsl:attribute>
+                </xsl:element>
+                <xsl:element name="{$cacheType}-cache" use-attribute-sets="cacheAttributes" namespace="{namespace-uri()}">
+                    <xsl:element name="{$cacheLoader}-jdbc-store" use-attribute-sets="cacheLoaderAttributes" namespace="{namespace-uri()}">
+                        <xsl:choose>
+
+                            <xsl:when test="$cacheLoader = 'string-keyed'">
+                                <xsl:element name="string-keyed-table" namespace="{namespace-uri()}">
+                                    <xsl:attribute name="prefix">stringbased</xsl:attribute>
+                                    <xsl:element name="id-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">id</xsl:attribute>
+                                        <xsl:attribute name="type">VARCHAR(255)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="data-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">datum</xsl:attribute>
+                                        <xsl:attribute name="type">VARBINARY(10000)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="timestamp-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">version</xsl:attribute>
+                                        <xsl:attribute name="type">BIGINT</xsl:attribute>
+                                    </xsl:element>
+                                </xsl:element>
+                            </xsl:when>
+
+                            <xsl:when test="$cacheLoader = 'binary-keyed'">
+                                <xsl:element name="binary-keyed-table" namespace="{namespace-uri()}">
+                                    <xsl:attribute name="prefix">binarybased</xsl:attribute>
+                                    <xsl:element name="id-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">id</xsl:attribute>
+                                        <xsl:attribute name="type">VARCHAR(255)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="data-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">datum</xsl:attribute>
+                                        <xsl:attribute name="type">VARBINARY(10000)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="timestamp-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">version</xsl:attribute>
+                                        <xsl:attribute name="type">BIGINT</xsl:attribute>
+                                    </xsl:element>
+                                </xsl:element>                                
+                            </xsl:when>
+
+                            <xsl:when test="$cacheLoader = 'mixed-keyed'">
+                                <xsl:element name="string-keyed-table" namespace="{namespace-uri()}">
+                                    <xsl:attribute name="prefix">stringbased</xsl:attribute>
+                                    <xsl:element name="id-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">id</xsl:attribute>
+                                        <xsl:attribute name="type">VARCHAR(255)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="data-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">datum</xsl:attribute>
+                                        <xsl:attribute name="type">VARBINARY(10000)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="timestamp-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">version</xsl:attribute>
+                                        <xsl:attribute name="type">BIGINT</xsl:attribute>
+                                    </xsl:element>
+                                </xsl:element>
+                                <xsl:element name="binary-keyed-table" namespace="{namespace-uri()}">
+                                    <xsl:attribute name="prefix">binarybased</xsl:attribute>
+                                    <xsl:element name="id-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">id</xsl:attribute>
+                                        <xsl:attribute name="type">VARCHAR(255)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="data-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">datum</xsl:attribute>
+                                        <xsl:attribute name="type">VARBINARY(10000)</xsl:attribute>
+                                    </xsl:element>
+                                    <xsl:element name="timestamp-column" namespace="{namespace-uri()}">                                        
+                                        <xsl:attribute name="name">version</xsl:attribute>
+                                        <xsl:attribute name="type">BIGINT</xsl:attribute>
+                                    </xsl:element>
+                                </xsl:element>                                   
+                            </xsl:when>
+
+                        </xsl:choose>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>            
         </xsl:copy>
-        <xsl:copy-of select="$newCacheDefinition" />
     </xsl:template>
 
     <!-- Copy everything else. -->

--- a/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
+++ b/testsuite/integration/src/test/xslt/addIdentityRealm.xsl
@@ -7,17 +7,6 @@
     
     <xsl:variable name="jboss" select="'urn:jboss:domain:'"/>
 
-    <xsl:variable name="newIdentityRealm">
-        <security-realm>
-            <xsl:attribute name="name"><xsl:value-of select="$realmName"/></xsl:attribute>
-            <server-identities>
-                <secret>
-                    <xsl:attribute name="value"><xsl:value-of select="$secret"/></xsl:attribute>
-                </secret>
-            </server-identities>
-        </security-realm>
-    </xsl:variable>
-
     <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
     <xsl:template match="node()|@*">
         <xsl:copy>
@@ -33,8 +22,15 @@
     <xsl:template match="//*[local-name()='management' and starts-with(namespace-uri(), $jboss)]
    						  /*[local-name()='security-realms']">
         <xsl:copy>
-            <xsl:apply-templates select="node()|@*"/>
-            <xsl:copy-of select="$newIdentityRealm"/>
+            <xsl:apply-templates select="node()|@*"/>            
+            <xsl:element name="security-realm" namespace="{namespace-uri()}">
+                <xsl:attribute name="name"><xsl:value-of select="$realmName"/></xsl:attribute>
+                <xsl:element name="server-identities"  namespace="{namespace-uri()}">
+                    <xsl:element name="secret" namespace="{namespace-uri()}">
+                        <xsl:attribute name="value"><xsl:value-of select="$secret"/></xsl:attribute>
+                    </xsl:element>
+                </xsl:element>
+            </xsl:element>
         </xsl:copy>
     </xsl:template>
 </xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
+++ b/testsuite/integration/src/test/xslt/addMessagingFailoverOnShutdown.xsl
@@ -8,7 +8,7 @@
     <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $messaging)]
    						  /*[local-name()='hornetq-server']">
         <xsl:copy>
-            <xsl:element name="failover-on-shutdown">true</xsl:element>
+            <xsl:element name="failover-on-shutdown" namespace="{namespace-uri()}">true</xsl:element>
             <xsl:apply-templates select="node()"/>
         </xsl:copy>
     </xsl:template>

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -19,23 +19,37 @@
     <xsl:param name="userName" select="NOT_DEFINED"/>
     <xsl:param name="protocol" select="http-remoting"/>
 
-    <xsl:variable name="newRemoteOutboundConnection">
-        <remote-outbound-connection>
-            <xsl:attribute name="name"><xsl:value-of select="$connectionName"/></xsl:attribute>
+    <xsl:template name="newRemoteOutboundConnection">        
+        <xsl:element name="remote-outbound-connection" namespace="{namespace-uri()}">
+            <xsl:attribute name="name">
+                <xsl:value-of select="$connectionName"/>
+            </xsl:attribute>
             <xsl:attribute name="outbound-socket-binding-ref">binding-<xsl:value-of select="$connectionName"/></xsl:attribute>
-            <xsl:attribute name="protocol"><xsl:value-of select="$protocol"/></xsl:attribute>
+            <xsl:attribute name="protocol">
+                <xsl:value-of select="$protocol"/>
+            </xsl:attribute>
             <xsl:if test="$securityRealm != 'NOT_DEFINED'">
-                <xsl:attribute name="security-realm"><xsl:value-of select="$securityRealm"/></xsl:attribute>
+                <xsl:attribute name="security-realm">
+                    <xsl:value-of select="$securityRealm"/>
+                </xsl:attribute>
             </xsl:if>
             <xsl:if test="$userName != 'NOT_DEFINED'">
-                <xsl:attribute name="username"><xsl:value-of select="$userName"/></xsl:attribute>
+                <xsl:attribute name="username">
+                    <xsl:value-of select="$userName"/>
+                </xsl:attribute>
             </xsl:if>
-            <properties>
-                <property name="SASL_POLICY_NOANONYMOUS" value="false"/>
-                <property name="SSL_ENABLED" value="false"/>
-            </properties>
-        </remote-outbound-connection>
-    </xsl:variable>
+            <xsl:element name="properties" namespace="{namespace-uri()}">
+                <xsl:element name="property" namespace="{namespace-uri()}">
+                    <xsl:attribute name="name">SASL_POLICY_NOANONYMOUS</xsl:attribute>
+                    <xsl:attribute name="value">false</xsl:attribute>
+                </xsl:element>
+                <xsl:element name="property" namespace="{namespace-uri()}">
+                  <xsl:attribute name="name">SSL_ENABLED</xsl:attribute>
+                    <xsl:attribute name="value">false</xsl:attribute>
+                </xsl:element>
+            </xsl:element>
+        </xsl:element>                                       
+    </xsl:template>
 
     <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
     <xsl:template match="node()|@*">
@@ -51,9 +65,9 @@
             					 /*[local-name()='outbound-connections'])">
                 <xsl:copy>
                     <xsl:apply-templates select="node()|@*"/>
-                    <outbound-connections>
-                        <xsl:copy-of select="$newRemoteOutboundConnection"/>
-                    </outbound-connections>
+                    <xsl:element name="outbound-connections" namespace="{namespace-uri()}">
+                        <xsl:call-template name="newRemoteOutboundConnection"/>
+                    </xsl:element>                    
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>
@@ -68,7 +82,7 @@
             			  /*[local-name()='outbound-connections']">
         <xsl:copy>
             <xsl:apply-templates select="node()|@*"/>
-            <xsl:copy-of select="$newRemoteOutboundConnection"/>
+            <xsl:call-template name="newRemoteOutboundConnection"/>
         </xsl:copy>
     </xsl:template>
 
@@ -84,13 +98,13 @@
                 <xsl:value-of select="@port-offset"/>
             </xsl:attribute>
             <xsl:apply-templates select="node()"/>
-            <outbound-socket-binding>
+            <xsl:element name="outbound-socket-binding" namespace="{namespace-uri()}">
                 <xsl:attribute name="name">binding-<xsl:value-of select="$connectionName"/></xsl:attribute>
-                <remote-destination>
+                <xsl:element name="remote-destination" namespace="{namespace-uri()}">
                     <xsl:attribute name="host"><xsl:value-of select="$node"/></xsl:attribute>
                     <xsl:attribute name="port"><xsl:value-of select="$remotePort"/></xsl:attribute>
-                </remote-destination>
-            </outbound-socket-binding>
+                </xsl:element>
+            </xsl:element>
         </xsl:copy>
     </xsl:template>
 

--- a/testsuite/integration/src/test/xslt/addXsiteBackupFor.xsl
+++ b/testsuite/integration/src/test/xslt/addXsiteBackupFor.xsl
@@ -16,12 +16,7 @@
     <xsl:output method="xml" indent="yes"/>
 
     <xsl:variable name="ispnns">urn:jboss:domain:infinispan:2.0</xsl:variable>
-
-    <!-- populate the <backup/> element by input parameters -->
-    <xsl:variable name="new-backup-element">
-        <backup-for remote-site="{$remote-site}" remote-cache="{$remote-cache}"/>
-    </xsl:variable>
-
+   
     <xsl:template name="copy-attributes">
         <xsl:for-each select="@*">
             <xsl:copy/>
@@ -29,7 +24,10 @@
     </xsl:template>
 
     <xsl:template name="add-backup-for-element">
-        <xsl:copy-of select="$new-backup-element"/>
+        <xsl:element name="backup-for" namespace="{namespace-uri()}">
+            <xsl:attribute name="remote-site"><xsl:value-of select="$remote-site"/></xsl:attribute>
+            <xsl:attribute name="remote-cache"><xsl:value-of select="$remote-cache"/></xsl:attribute>
+        </xsl:element>
     </xsl:template>
 
     <!-- copy the cache over and add the backup element -->

--- a/testsuite/integration/src/test/xslt/enableJTS.xsl
+++ b/testsuite/integration/src/test/xslt/enableJTS.xsl
@@ -22,7 +22,10 @@
         <xsl:copy>
             <xsl:attribute name="socket-binding"><xsl:value-of select="@socket-binding"/></xsl:attribute>
             <xsl:attribute name="ssl-socket-binding"><xsl:value-of select="@ssl-socket-binding"/></xsl:attribute>
-            <initializers transactions="on" security="client"/>
+            <xsl:element name="initializers" namespace="{namespace-uri()}">
+                <xsl:attribute name="transactions">on</xsl:attribute>
+                <xsl:attribute name="security">client</xsl:attribute>
+            </xsl:element>
         </xsl:copy>
     </xsl:template>
 
@@ -32,7 +35,7 @@
             				     /*[local-name()='jts'])">
                 <xsl:copy>
                     <xsl:apply-templates select="node()|@*"/>
-                    <jts/>
+                    <xsl:element name="jts" namespace="{namespace-uri()}"/>
                 </xsl:copy>
             </xsl:when>
             <xsl:otherwise>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -1322,40 +1322,5 @@
             </build>
         </profile>
 
-	<!-- WFLY-3361 Remove empty xmlns attributes from server configs which XSLT transformation on IBM JDK could produce. -->
-	<profile>
-	    <id>ibmjdk.cleanBlankNs.profile</id>
-            <activation>
-                <property>
-                    <name>java.vendor</name>
-                    <value>IBM Corporation</value>
-               </property>
-            </activation>
-	    <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.google.code.maven-replacer-plugin</groupId>
-                        <artifactId>replacer</artifactId>
-                        <version>1.5.2</version>
-                        <executions>
-                            <execution>
-                                <id>ibmjdk.clean.blank.namespaces</id>
-                                <phase>test-compile</phase>
-                                <goals><goal>replace</goal></goals>
-                                <inherited>true</inherited>
-                                <configuration>
-                                    <includes>
-                                        <include>**/standalone/configuration/standalone*.xml</include>
-                                        <include>**/domain/configuration/domain.xml</include>
-                                    </includes>
-                                    <token>xmlns=\"\"</token>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-	    </build>
-	</profile>
-
     </profiles>
 </project>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -342,15 +342,19 @@
                            </configuration>
                        </execution>
                    </executions>
+                    <!-- WFLY-3361 - use external xalan for XML transformations to
+                    ensure consistent behaviour on all platrforms.-->
                    <dependencies>
                        <dependency>
                            <groupId>xalan</groupId>
                            <artifactId>xalan</artifactId>
                            <version>2.7.1</version>
                        </dependency>
-                   </dependencies>                                              
+                   </dependencies>
                </plugin>
-               
+
+               <!-- WFLY-3361 - use external xalan for XML transformations to
+               ensure consistent behaviour on all platrforms.-->
                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-antrun-plugin</artifactId>
@@ -360,7 +364,7 @@
                            <artifactId>xalan</artifactId>
                            <version>2.7.1</version>
                        </dependency>
-                   </dependencies>                                                                 
+                   </dependencies>
                </plugin>
 
                 <!--

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -342,6 +342,25 @@
                            </configuration>
                        </execution>
                    </executions>
+                   <dependencies>
+                       <dependency>
+                           <groupId>xalan</groupId>
+                           <artifactId>xalan</artifactId>
+                           <version>2.7.1</version>
+                       </dependency>
+                   </dependencies>                                              
+               </plugin>
+               
+               <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-antrun-plugin</artifactId>
+                   <dependencies>
+                       <dependency>
+                           <groupId>xalan</groupId>
+                           <artifactId>xalan</artifactId>
+                           <version>2.7.1</version>
+                       </dependency>
+                   </dependencies>                                                                 
                </plugin>
 
                 <!--


### PR DESCRIPTION
After some discussion with @zebrik I am trying another approach to WFLY-3361.

This commit:
- reverts https://github.com/wildfly/wildfly/pull/6273
- add dependency to xalan to both maven xml and antrun plugins to use the same XML processor for XSLT transforms on all platforms
- update templates
