### PR TITLE
Revert "[WFLY-3362] make sure operations get cancelled on channel close"

### DIFF
--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/AbstractMessageHandler.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/AbstractMessageHandler.java
@@ -34,8 +34,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.jboss.as.protocol.StreamUtils;
 import org.jboss.as.protocol.logging.ProtocolLogger;
+import org.jboss.as.protocol.StreamUtils;
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.CloseHandler;
 import org.jboss.remoting3.MessageOutputStream;
@@ -138,7 +138,6 @@ public abstract class AbstractMessageHandler extends ActiveOperationSupport impl
      */
     protected <T, A> AsyncFuture<T> executeRequest(final ManagementRequest<T, A> request, final Channel channel, final ActiveOperation<T, A> support) {
         assert support != null;
-        updateChannelRef(support, channel);
         final Integer requestId = this.requestID.incrementAndGet();
         final ActiveRequest<T, A> ar = new ActiveRequest<T, A>(support, request, channel);
         requests.put(requestId, ar);
@@ -249,7 +248,7 @@ public abstract class AbstractMessageHandler extends ActiveOperationSupport impl
     protected <T, A> void handleMessage(final Channel channel, final DataInput message, final ManagementProtocolHeader header,
                                  final ActiveOperation<T, A> support, final ManagementRequestHandler<T, A> handler) {
         assert support != null;
-        updateChannelRef(support, channel);
+
         final ActiveOperation.ResultHandler<T> resultHandler = support.getResultHandler();
         try {
             handler.handleRequest(message, resultHandler, new ManagementRequestContext<A>() {
@@ -350,6 +349,25 @@ public abstract class AbstractMessageHandler extends ActiveOperationSupport impl
     @Override
     public void handleClose(final Channel closed, final IOException exception) {
         handleChannelClosed(closed, exception);
+    }
+
+    /**
+     * Receive a notification that the channel was closed.
+     *
+     * This is used for the {@link ManagementClientChannelStrategy.Establishing} since it might use multiple channels.
+     *
+     * @param closed the closed resource
+     * @param e the exception which occurred during close, if any
+     */
+    public void handleChannelClosed(final Channel closed, final IOException e) {
+        for(final Map.Entry<Integer, ActiveRequest<?, ?>> requestEntry : requests.entrySet()) {
+            final ActiveRequest<?, ?> request = requestEntry.getValue();
+            if(request.channel == closed) {
+                final IOException failure = e == null ? new IOException("Channel closed") : e;
+                request.context.getResultHandler().failed(failure);
+                requests.remove(requestEntry.getKey());
+            }
+        }
     }
 
     /**

--- a/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
+++ b/protocol/src/main/java/org/jboss/as/protocol/mgmt/ActiveOperationSupport.java
@@ -22,7 +22,11 @@
 
 package org.jboss.as.protocol.mgmt;
 
-import java.io.IOException;
+import org.jboss.as.protocol.logging.ProtocolLogger;
+import org.jboss.threads.AsyncFuture;
+import org.jboss.threads.AsyncFutureTask;
+import org.xnio.Cancellable;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -32,12 +36,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
-
-import org.jboss.as.protocol.logging.ProtocolLogger;
-import org.jboss.remoting3.Channel;
-import org.jboss.threads.AsyncFuture;
-import org.jboss.threads.AsyncFutureTask;
-import org.xnio.Cancellable;
 
 /**
  * Management operation support encapsulating active operations.
@@ -211,23 +209,6 @@ class ActiveOperationSupport {
     }
 
     /**
-     * Receive a notification that the channel was closed.
-     *
-     * This is used for the {@link ManagementClientChannelStrategy.Establishing} since it might use multiple channels.
-     *
-     * @param closed the closed resource
-     * @param e the exception which occurred during close, if any
-     */
-    public void handleChannelClosed(final Channel closed, final IOException e) {
-        for(final ActiveOperationImpl<?, ?> activeOperation : activeRequests.values()) {
-            if (activeOperation.channel == closed) {
-                // Only call cancel, to also interrupt still active threads
-                activeOperation.getResultHandler().cancel();
-            }
-        }
-    }
-
-    /**
      * Cancel all currently active operations.
      *
      * @return a list of cancelled operations
@@ -293,7 +274,6 @@ class ActiveOperationSupport {
         private final A attachment;
         private final Integer operationId;
         private List<Cancellable> cancellables;
-        private volatile Channel channel;
 
         private final ResultHandler<T> completionHandler = new ResultHandler<T>() {
             @Override
@@ -422,15 +402,6 @@ class ActiveOperationSupport {
             return super.cancel(true);
         }
 
-    }
-
-    static void updateChannelRef(final ActiveOperation<?, ?> operation, Channel channel) {
-        if (operation instanceof ActiveOperationImpl) {
-            final ActiveOperationImpl<?, ?> a = (ActiveOperationImpl) operation;
-            if (a.channel == null) {
-                a.channel = channel;
-            }
-        }
     }
 
 }


### PR DESCRIPTION
This reverts commit 89d132d5376f9706aefd34f6eee2bddfb4e83ce6.

Commit introduces a race on the client side during operations like reload/shutdown that result in the channel closing.
