### PR TITLE
[WFLY-2994] Improve messaging connector param resources

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/AbstractTransportDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AbstractTransportDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.messaging;
 
 import java.util.Locale;
 import java.util.ResourceBundle;
+import java.util.Set;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
@@ -43,7 +44,15 @@ public abstract class AbstractTransportDefinition extends SimpleResourceDefiniti
 
     private final boolean registerRuntimeOnly;
     private final AttributeDefinition[] attrs;
-    private final boolean isAcceptor;
+    protected final boolean isAcceptor;
+
+    /**
+     * If the keys are not known at compile time (e.g. for generic transport), the method
+     * must return an empty set.
+     *
+     * @return the set of keys that are allowed by the transport.
+     */
+    protected abstract Set<String> getAllowedKeys();
 
     protected AbstractTransportDefinition(final boolean registerRuntimeOnly, final boolean isAcceptor, final String specificType, AttributeDefinition... attrs) {
         super(PathElement.pathElement(specificType),
@@ -54,7 +63,7 @@ public abstract class AbstractTransportDefinition extends SimpleResourceDefiniti
                         return bundle.getString(specificType);
                     }
                 },
-                new TransportConfigOperationHandlers.BasicTransportConfigAdd(attrs),
+                new HornetQReloadRequiredHandlers.AddStepHandler(attrs),
                 new HornetQReloadRequiredHandlers.RemoveStepHandler());
         this.registerRuntimeOnly = registerRuntimeOnly;
         this.isAcceptor = isAcceptor;
@@ -90,6 +99,6 @@ public abstract class AbstractTransportDefinition extends SimpleResourceDefiniti
     public void registerChildren(ManagementResourceRegistration registry) {
         super.registerChildren(registry);
 
-        registry.registerSubModel(new TransportParamDefinition());
+        registry.registerSubModel(new TransportParamDefinition(getAllowedKeys()));
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/GenericTransportDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/GenericTransportDefinition.java
@@ -25,6 +25,9 @@ package org.jboss.as.messaging;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.dmr.ModelType.STRING;
 
+import java.util.Collections;
+import java.util.Set;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -55,5 +58,10 @@ public class GenericTransportDefinition extends AbstractTransportDefinition {
 
     private GenericTransportDefinition(final boolean registerRuntimeOnly, boolean isAcceptor, String specificType) {
         super(registerRuntimeOnly, isAcceptor, specificType, ATTRIBUTES);
+    }
+
+    @Override
+    protected Set<String> getAllowedKeys() {
+        return Collections.emptySet();
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorAdd.java
@@ -39,7 +39,7 @@ import org.jboss.msc.service.ServiceController;
  *
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
  */
-public class HTTPAcceptorAdd extends TransportConfigOperationHandlers.BasicTransportConfigAdd {
+public class HTTPAcceptorAdd extends HornetQReloadRequiredHandlers.AddStepHandler {
 
     public static final HTTPAcceptorAdd INSTANCE = new HTTPAcceptorAdd();
 

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPAcceptorDefinition.java
@@ -28,6 +28,7 @@ import static org.jboss.as.messaging.CommonAttributes.HTTP_ACCEPTOR;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
@@ -85,6 +86,6 @@ public class HTTPAcceptorDefinition extends SimpleResourceDefinition {
     public void registerChildren(ManagementResourceRegistration registry) {
         super.registerChildren(registry);
 
-        registry.registerSubModel(new TransportParamDefinition());
+        registry.registerSubModel(new TransportParamDefinition(TransportConstants.ALLOWABLE_ACCEPTOR_KEYS));
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPConnectorDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPConnectorDefinition.java
@@ -24,8 +24,11 @@ package org.jboss.as.messaging;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 
+import java.util.Set;
+
 import javax.xml.stream.XMLStreamWriter;
 
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -55,5 +58,10 @@ public class HTTPConnectorDefinition extends AbstractTransportDefinition {
 
     public HTTPConnectorDefinition(final boolean registerRuntimeOnly) {
         super(registerRuntimeOnly, false, CommonAttributes.HTTP_CONNECTOR, SOCKET_BINDING);
+    }
+
+    @Override
+    protected Set<String> getAllowedKeys() {
+        return TransportConstants.ALLOWABLE_CONNECTOR_KEYS;
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/InVMTransportDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/InVMTransportDefinition.java
@@ -25,9 +25,12 @@ package org.jboss.as.messaging;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.dmr.ModelType.INT;
 
+import java.util.Set;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
+import org.hornetq.core.remoting.impl.invm.TransportConstants;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -66,5 +69,10 @@ public class InVMTransportDefinition extends AbstractTransportDefinition {
 
     private InVMTransportDefinition(final boolean registerRuntimeOnly, boolean isAcceptor, String specificType) {
         super(registerRuntimeOnly, isAcceptor, specificType, ATTRIBUTES);
+    }
+
+    @Override
+    protected Set<String> getAllowedKeys() {
+        return isAcceptor ? TransportConstants.ALLOWABLE_ACCEPTOR_KEYS : TransportConstants.ALLOWABLE_CONNECTOR_KEYS;
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/RemoteTransportDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/RemoteTransportDefinition.java
@@ -24,8 +24,11 @@ package org.jboss.as.messaging;
 
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 
+import java.util.Set;
+
 import javax.xml.stream.XMLStreamWriter;
 
+import org.hornetq.core.remoting.impl.netty.TransportConstants;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -66,5 +69,10 @@ public class RemoteTransportDefinition extends AbstractTransportDefinition {
 
     private RemoteTransportDefinition(final boolean registerRuntimeOnly, boolean isAcceptor, String specificType) {
         super(registerRuntimeOnly, isAcceptor, specificType, ATTRIBUTES);
+    }
+
+    @Override
+    protected Set<String> getAllowedKeys() {
+        return isAcceptor ? TransportConstants.ALLOWABLE_ACCEPTOR_KEYS : TransportConstants.ALLOWABLE_CONNECTOR_KEYS;
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/TransportConfigOperationHandlers.java
@@ -45,7 +45,6 @@ import org.hornetq.core.remoting.impl.invm.InVMConnectorFactory;
 import org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory;
 import org.hornetq.core.remoting.impl.netty.NettyConnectorFactory;
 import org.hornetq.core.remoting.impl.netty.TransportConstants;
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
@@ -183,21 +182,5 @@ class TransportConfigOperationHandlers {
             }
         }
         configuration.setConnectorConfigurations(connectors);
-    }
-
-    static class BasicTransportConfigAdd extends HornetQReloadRequiredHandlers.AddStepHandler {
-
-        private final AttributeDefinition[] attributes;
-
-        BasicTransportConfigAdd(final AttributeDefinition[] attributes) {
-            this.attributes = attributes;
-        }
-
-        @Override
-        protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-            for (final AttributeDefinition attribute : attributes) {
-                attribute.validateAndSet(operation, model);
-            }
-        }
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/TransportParamDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/TransportParamDefinition.java
@@ -25,10 +25,20 @@ package org.jboss.as.messaging;
 import static org.jboss.as.controller.SimpleAttributeDefinitionBuilder.create;
 import static org.jboss.dmr.ModelType.STRING;
 
+import java.util.Set;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.messaging.logging.MessagingLogger;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Transport param resource definition.
@@ -44,10 +54,16 @@ public class TransportParamDefinition extends SimpleResourceDefinition {
             .setRestartAllServices()
             .build();
 
-    public TransportParamDefinition() {
+    public TransportParamDefinition(final Set<String> allowedKeys) {
         super(PATH,
                 MessagingExtension.getResourceDescriptionResolver("transport-config." + CommonAttributes.PARAM),
-                new HornetQReloadRequiredHandlers.AddStepHandler(VALUE),
+                new HornetQReloadRequiredHandlers.AddStepHandler(VALUE) {
+                    @Override
+                    protected void populateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+                        super.populateModel(context, operation, resource);
+                        context.addStep(new CheckParameterStep(allowedKeys), OperationContext.Stage.MODEL);
+                    }
+                },
                 new HornetQReloadRequiredHandlers.RemoveStepHandler());
     }
 
@@ -58,4 +74,23 @@ public class TransportParamDefinition extends SimpleResourceDefinition {
         registry.registerReadWriteAttribute(VALUE, null, new HornetQReloadRequiredHandlers.WriteAttributeHandler(VALUE));
     }
 
+    private static class CheckParameterStep implements OperationStepHandler {
+        private final Set<String> allowedKeys;
+
+        public CheckParameterStep(Set<String> allowedKeys) {
+            this.allowedKeys = allowedKeys;
+        }
+
+        @Override
+        public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+            String parameterName = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR)).getLastElement().getValue();
+
+            // empty allowedKeys is possible for generic transport resources where the keys are not known.
+            if (!allowedKeys.isEmpty() && !allowedKeys.contains(parameterName)) {
+                throw MessagingLogger.ROOT_LOGGER.invalidParameterName(parameterName, allowedKeys);
+            }
+
+            context.stepCompleted();
+        }
+    }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -28,6 +28,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 import static org.jboss.logging.annotations.Message.INHERIT;
 
 import java.util.Collection;
+import java.util.Set;
 
 import javax.jms.IllegalStateRuntimeException;
 import javax.xml.stream.XMLStreamException;
@@ -781,4 +782,7 @@ public interface MessagingLogger extends BasicLogger {
      */
     @Message(id = 73, value = "Can not remove JNDI name %s. The resource must have at least one JNDI name")
     String canNotRemoveLastJNDIName(String jndiName);
+
+    @Message(id = 74, value = "Invalid parameter key: %s, the allowed keys are %s.")
+    OperationFailedException invalidParameterName(String parameterName, Set<String> allowedKeys);
 }

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3.xml
@@ -79,9 +79,7 @@
                   <param key="batch-delay" value="50"/>
                   <param key="direct-deliver" value="false"/>
                </netty-acceptor>
-               <in-vm-acceptor name="in-vm" server-id="0">
-                  <param key="direct-deliver" value="true"/>
-               </in-vm-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="0" />
                <acceptor name="myacceptor">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                   <param key="batch-delay" value="50"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3_expressions.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_3_expressions.xml
@@ -77,9 +77,7 @@
                <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                   <param key="batch-delay" value="${batch.delay:50}"/>
                </netty-connector>
-               <in-vm-connector name="in-vm" server-id="${my.server-id:0}">
-                  <param key="batch-delay" value="${batch.delay:50}"/>
-               </in-vm-connector>
+               <in-vm-connector name="in-vm" server-id="${my.server-id:0}" />
                <connector name="myconnector">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
                   <param key="host" value="192.168.1.2"/>
@@ -94,9 +92,7 @@
                   <param key="batch-delay" value="50"/>
                   <param key="direct-deliver" value="false"/>
                </netty-acceptor>
-               <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}">
-                   <param key="batch-delay" value="${batch.delay:50}"/>
-               </in-vm-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}" />
                <acceptor name="myacceptor">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                   <param key="batch-delay" value="${batch.delay:50}"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_4.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_4.xml
@@ -80,9 +80,7 @@
                   <param key="batch-delay" value="50"/>
                   <param key="direct-deliver" value="false"/>
                </netty-acceptor>
-               <in-vm-acceptor name="in-vm" server-id="0">
-                  <param key="direct-deliver" value="true"/>
-               </in-vm-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="0" />
                <acceptor name="myacceptor">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                   <param key="batch-delay" value="50"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_4_expressions.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_4_expressions.xml
@@ -78,9 +78,7 @@
                <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                   <param key="batch-delay" value="${batch.delay:50}"/>
                </netty-connector>
-               <in-vm-connector name="in-vm" server-id="${my.server-id:0}">
-                  <param key="batch-delay" value="${batch.delay:50}"/>
-               </in-vm-connector>
+               <in-vm-connector name="in-vm" server-id="${my.server-id:0}" />
                <connector name="myconnector">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
                   <param key="host" value="192.168.1.2"/>
@@ -95,9 +93,7 @@
                   <param key="batch-delay" value="50"/>
                   <param key="direct-deliver" value="false"/>
                </netty-acceptor>
-               <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}">
-                   <param key="batch-delay" value="${batch.delay:50}"/>
-               </in-vm-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}" />
                <acceptor name="myacceptor">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                   <param key="batch-delay" value="${batch.delay:50}"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_2_0.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_2_0.xml
@@ -80,9 +80,7 @@
                   <param key="batch-delay" value="50"/>
                   <param key="direct-deliver" value="false"/>
                </netty-acceptor>
-               <in-vm-acceptor name="in-vm" server-id="0">
-                  <param key="direct-deliver" value="true"/>
-               </in-vm-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="0" />
                <acceptor name="myacceptor">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                   <param key="batch-delay" value="50"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_2_0_expressions.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_2_0_expressions.xml
@@ -81,9 +81,7 @@
             <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                 <param key="batch-delay" value="${batch.delay:50}"/>
             </netty-connector>
-            <in-vm-connector name="in-vm" server-id="${my.server-id:0}">
-                <param key="batch-delay" value="${batch.delay:50}"/>
-            </in-vm-connector>
+            <in-vm-connector name="in-vm" server-id="${my.server-id:0}" />
             <connector name="myconnector">
                 <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
                 <param key="host" value="192.168.1.2"/>
@@ -101,9 +99,7 @@
                 <param key="batch-delay" value="50"/>
                 <param key="direct-deliver" value="false"/>
             </netty-acceptor>
-            <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}">
-                <param key="batch-delay" value="${batch.delay:50}"/>
-            </in-vm-acceptor>
+            <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}" />
             <acceptor name="myacceptor">
                 <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                 <param key="batch-delay" value="${batch.delay:50}"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_3_0.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_3_0.xml
@@ -81,9 +81,7 @@
                   <param key="batch-delay" value="50"/>
                   <param key="direct-deliver" value="false"/>
                </netty-acceptor>
-               <in-vm-acceptor name="in-vm" server-id="0">
-                  <param key="direct-deliver" value="true"/>
-               </in-vm-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="0" />
                <acceptor name="myacceptor">
                   <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                   <param key="batch-delay" value="50"/>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_3_0_expressions.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_3_0_expressions.xml
@@ -82,9 +82,7 @@
             <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                 <param key="batch-delay" value="${batch.delay:50}"/>
             </netty-connector>
-            <in-vm-connector name="in-vm" server-id="${my.server-id:0}">
-                <param key="batch-delay" value="${batch.delay:50}"/>
-            </in-vm-connector>
+            <in-vm-connector name="in-vm" server-id="${my.server-id:0}" />
             <connector name="myconnector">
                 <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
                 <param key="host" value="192.168.1.2"/>
@@ -102,9 +100,7 @@
                 <param key="batch-delay" value="50"/>
                 <param key="direct-deliver" value="false"/>
             </netty-acceptor>
-            <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}">
-                <param key="batch-delay" value="${batch.delay:50}"/>
-            </in-vm-acceptor>
+            <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}" />
             <acceptor name="myacceptor">
                 <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
                 <param key="batch-delay" value="${batch.delay:50}"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/TransportConfigurationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/TransportConfigurationTestCase.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.mgmt;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILED;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.FAILURE_DESCRIPTION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLED_BACK;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class TransportConfigurationTestCase extends ContainerResourceMgmtTestBase {
+
+    @Test
+    public void testTransportParamWithInvalidKey() throws Exception {
+        // /subsystem=messaging/hornetq-server=default/http-connector=http-connector/param=foo:add(value=bar)
+        ModelNode address = new ModelNode();
+        address.add("subsystem", "messaging");
+        address.add("hornetq-server", "default");
+        address.add("http-connector", "http-connector");
+        address.add("param", "foo");
+
+        final ModelNode add = new ModelNode();
+        add.get(OP).set(ADD);
+        add.get(OP_ADDR).set(address);
+        add.get(VALUE).set("bar");
+
+        try {
+            executeOperation(add);
+            fail("foo is not a valid key for a http-connector parameter.");
+        } catch (MgmtOperationException e) {
+            ModelNode result = e.getResult();
+            assertEquals(FAILED, result.get(OUTCOME).asString());
+            assertTrue(result.get(FAILURE_DESCRIPTION).asString().startsWith("WFLYMSG0074"));
+            assertEquals(true, result.get(ROLLED_BACK).asBoolean());
+        }
+    }
+}


### PR DESCRIPTION
- check when a transport parameter resource is added if the parameter
  name is allowed by the parent transport configuration. If it is not
  accepted, HornetQ will log a warning, the server will be started
  but the transport itself will not be started.
  This check ensures that a misconfiguration will result in a failure at
  the MODEL stage instead of waiting for a client to use the transport at
  runtime and it is not available.
- update messaging XML configuration files used in the test that were
  not correct in that regard.

JIRA: https://issues.jboss.org/browse/WFLY-2994
