### PR TITLE
Fix Vault logging messages

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
@@ -466,7 +466,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 52, value = "Enter Keystore password")
+    @Message(id = 52, value = "Enter Keystore password:")
     String enterKeyStorePassword();
 
     /**
@@ -530,14 +530,17 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 60, value = "Enter your password")
+    @Message(id = 60, value = "Enter your password:")
     String enterYourPassword();
 
     /**
      * i18n version of string from Vault Tool utility
      *
+     * @deprecated do not use this message to build confirmation message
+     *
      * @return
      */
+    @Deprecated
     @Message(id = 61, value = " again: ")
     String passwordAgain();
 
@@ -700,4 +703,21 @@ public interface SecurityLogger extends BasicLogger {
      */
     @Message(id = 81, value = "Secured attribute (password) doesn't exist.")
     String cmdLineSecuredAttributeDoesNotExist();
+
+    /**
+     * Password confirmation
+     *
+     * @return
+     */
+    @Message(id = 82, value = "Enter your password again:")
+    String enterYourPasswordAgain();
+
+    /**
+     * Keystore password confirmation
+     *
+     * @return
+     */
+    @Message(id = 83, value = "Enter Keystore password again:")
+    String enterKeyStorePasswordAgain();
+
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.security.logging;
 
+import static org.jboss.logging.annotations.Message.NONE;
+
 import java.lang.reflect.Method;
 import javax.naming.InvalidNameException;
 import javax.naming.OperationNotSupportedException;
@@ -450,7 +452,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 50, value = "Enter directory to store encrypted files:")
+    @Message(id = NONE, value = "Enter directory to store encrypted files:")
     String enterEncryptionDirectory();
 
     /**
@@ -458,7 +460,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 51, value = "Enter Keystore URL:")
+    @Message(id = NONE, value = "Enter Keystore URL:")
     String enterKeyStoreURL();
 
     /**
@@ -466,7 +468,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 52, value = "Enter Keystore password:")
+    @Message(id = NONE, value = "Enter Keystore password:")
     String enterKeyStorePassword();
 
     /**
@@ -474,7 +476,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 53, value = "Enter 8 character salt:")
+    @Message(id = NONE, value = "Enter 8 character salt:")
     String enterSalt();
 
     /**
@@ -482,7 +484,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 54, value = "Enter iteration count as a number (e.g.: 44):")
+    @Message(id = NONE, value = "Enter iteration count as a number (e.g.: 44):")
     String enterIterationCount();
 
     /**
@@ -490,7 +492,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 55, value = "Enter Keystore Alias:")
+    @Message(id = NONE, value = "Enter Keystore Alias:")
     String enterKeyStoreAlias();
 
     /**
@@ -530,7 +532,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 60, value = "Enter your password:")
+    @Message(id = NONE, value = "Enter your password:")
     String enterYourPassword();
 
     /**
@@ -549,7 +551,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 62, value = "Values entered don't match")
+    @Message(id = NONE, value = "Values entered don't match")
     String passwordsDoNotMatch();
 
     /**
@@ -557,7 +559,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 63, value = "Values match")
+    @Message(id = NONE, value = "Values match")
     String passwordsMatch();
 
     /**
@@ -565,7 +567,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 64, value = "Problem occurred:")
+    @Message(id = NONE, value = "Problem occurred:")
     String problemOcurred();
 
     /**
@@ -573,7 +575,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 65, value = "Please enter a Digit::   0: Start Interactive Session   1: Remove Interactive Session  2: Exit")
+    @Message(id = NONE, value = "Please enter a Digit::   0: Start Interactive Session   1: Remove Interactive Session  2: Exit")
     String interactiveCommandString();
 
     /**
@@ -581,7 +583,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 66, value = "Starting an interactive session")
+    @Message(id = NONE, value = "Starting an interactive session")
     String startingInteractiveSession();
 
     /**
@@ -589,7 +591,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 67, value = "Removing the current interactive session")
+    @Message(id = NONE, value = "Removing the current interactive session")
     String removingInteractiveSession();
 
     /**
@@ -605,7 +607,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 69, value = "Keystore URL")
+    @Message(id = NONE, value = "Keystore URL")
     String cmdLineKeyStoreURL();
 
     /**
@@ -613,7 +615,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 70, value = "Keystore password")
+    @Message(id = NONE, value = "Keystore password")
     String cmdLineKeyStorePassword();
 
     /**
@@ -621,7 +623,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 71, value = "Directory containing encrypted files")
+    @Message(id = NONE, value = "Directory containing encrypted files")
     String cmdLineEncryptionDirectory();
 
     /**
@@ -629,7 +631,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 72, value = "8 character salt")
+    @Message(id = NONE, value = "8 character salt")
     String cmdLineSalt();
 
     /**
@@ -637,7 +639,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 73, value = "Iteration count")
+    @Message(id = NONE, value = "Iteration count")
     String cmdLineIterationCount();
 
     /**
@@ -645,7 +647,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 74, value = "Vault keystore alias")
+    @Message(id = NONE, value = "Vault keystore alias")
     String cmdLineVaultKeyStoreAlias();
 
     /**
@@ -653,7 +655,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 75, value = "Vault block")
+    @Message(id = NONE, value = "Vault block")
     String cmdLineVaultBlock();
 
     /**
@@ -661,7 +663,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 76, value = "Attribute name")
+    @Message(id = NONE, value = "Attribute name")
     String cmdLineAttributeName();
 
     /**
@@ -669,7 +671,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 77, value = "Secured attribute value (such as password) to store")
+    @Message(id = NONE, value = "Secured attribute value (such as password) to store")
     String cmdLineSecuredAttribute();
 
     /**
@@ -677,7 +679,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 78, value = "Check whether the secured attribute already exists in the Vault")
+    @Message(id = NONE, value = "Check whether the secured attribute already exists in the Vault")
     String cmdLineCheckAttribute();
 
     /**
@@ -685,7 +687,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 79, value = "Help")
+    @Message(id = NONE, value = "Help")
     String cmdLineHelp();
 
     /**
@@ -709,7 +711,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 82, value = "Enter your password again:")
+    @Message(id = NONE, value = "Enter your password again:")
     String enterYourPasswordAgain();
 
     /**
@@ -717,7 +719,7 @@ public interface SecurityLogger extends BasicLogger {
      *
      * @return
      */
-    @Message(id = 83, value = "Enter Keystore password again:")
+    @Message(id = NONE, value = "Enter Keystore password again:")
     String enterKeyStorePasswordAgain();
 
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/vault/VaultInteraction.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/vault/VaultInteraction.java
@@ -56,17 +56,17 @@ public class VaultInteraction {
             switch (choice) {
                 case 0:
                     System.out.println("Task: Store a secured attribute");
-                    char[] attributeValue = VaultInteractiveSession.getSensitiveValue("Please enter secured attribute value (such as password)");
+                    char[] attributeValue = VaultInteractiveSession.getSensitiveValue("Please enter secured attribute value (such as password):", "Please enter secured attribute value (such as password) again:");
                     String vaultBlock = null;
 
                     while (vaultBlock == null || vaultBlock.length() == 0) {
-                        vaultBlock = console.readLine("Enter Vault Block:");
+                        vaultBlock = console.readLine("Enter Vault Block: ");
                     }
 
                     String attributeName = null;
 
                     while (attributeName == null || attributeName.length() == 0) {
-                        attributeName = console.readLine("Enter Attribute Name:");
+                        attributeName = console.readLine("Enter Attribute Name: ");
                     }
                     try {
                         vaultNISession.addSecuredAttributeWithDisplay(vaultBlock, attributeName, attributeValue);
@@ -80,13 +80,13 @@ public class VaultInteraction {
                         vaultBlock = null;
 
                         while (vaultBlock == null || vaultBlock.length() == 0) {
-                            vaultBlock = console.readLine("Enter Vault Block:");
+                            vaultBlock = console.readLine("Enter Vault Block: ");
                         }
 
                         attributeName = null;
 
                         while (attributeName == null || attributeName.length() == 0) {
-                            attributeName = console.readLine("Enter Attribute Name:");
+                            attributeName = console.readLine("Enter Attribute Name: ");
                         }
                         if (!vaultNISession.checkSecuredAttribute(vaultBlock, attributeName))
                             System.out.println("No value has been store for (" + vaultBlock + ", " + attributeName + ")");

--- a/security/subsystem/src/main/java/org/jboss/as/security/vault/VaultInteractiveSession.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/vault/VaultInteractiveSession.java
@@ -52,26 +52,26 @@ public class VaultInteractiveSession {
 
         while (encDir == null || encDir.length() == 0) {
             encDir = console
-                    .readLine(SecurityLogger.ROOT_LOGGER.enterEncryptionDirectory());
+                    .readLine(SecurityLogger.ROOT_LOGGER.enterEncryptionDirectory() + " ");
         }
 
         while (keystoreURL == null || keystoreURL.length() == 0) {
-            keystoreURL = console.readLine(SecurityLogger.ROOT_LOGGER.enterKeyStoreURL());
+            keystoreURL = console.readLine(SecurityLogger.ROOT_LOGGER.enterKeyStoreURL() + " ");
         }
 
-        char[] keystorePasswd = getSensitiveValue(SecurityLogger.ROOT_LOGGER.enterKeyStorePassword());
+        char[] keystorePasswd = getSensitiveValue(SecurityLogger.ROOT_LOGGER.enterKeyStorePassword(), SecurityLogger.ROOT_LOGGER.enterKeyStorePasswordAgain());
 
         try {
             while (salt == null || salt.length() != 8) {
-                salt = console.readLine(SecurityLogger.ROOT_LOGGER.enterSalt());
+                salt = console.readLine(SecurityLogger.ROOT_LOGGER.enterSalt() + " ");
             }
 
-            String ic = console.readLine(SecurityLogger.ROOT_LOGGER.enterIterationCount());
+            String ic = console.readLine(SecurityLogger.ROOT_LOGGER.enterIterationCount() + " ");
             iterationCount = Integer.parseInt(ic);
             vaultNISession = new VaultSession(keystoreURL, new String(keystorePasswd), encDir, salt, iterationCount);
 
             while (keystoreAlias == null || keystoreAlias.length() == 0) {
-                keystoreAlias = console.readLine(SecurityLogger.ROOT_LOGGER.enterKeyStoreAlias());
+                keystoreAlias = console.readLine(SecurityLogger.ROOT_LOGGER.enterKeyStoreAlias() + " ");
             }
 
             System.out.println(SecurityLogger.ROOT_LOGGER.initializingVault());
@@ -88,15 +88,18 @@ public class VaultInteractiveSession {
         }
     }
 
-    public static char[] getSensitiveValue(String passwordPrompt) {
+    public static char[] getSensitiveValue(String passwordPrompt, String confirmationPrompt) {
         while (true) {
             if (passwordPrompt == null)
                 passwordPrompt = SecurityLogger.ROOT_LOGGER.enterYourPassword();
+            if (confirmationPrompt == null) {
+                confirmationPrompt = SecurityLogger.ROOT_LOGGER.enterYourPasswordAgain();
+            }
 
             Console console = System.console();
 
-            char[] passwd = console.readPassword(passwordPrompt + ": ");
-            char[] passwd1 = console.readPassword(passwordPrompt + SecurityLogger.ROOT_LOGGER.passwordAgain());
+            char[] passwd = console.readPassword(passwordPrompt + " ");
+            char[] passwd1 = console.readPassword(confirmationPrompt + " ");
             boolean noMatch = !Arrays.equals(passwd, passwd1);
             if (noMatch)
                 System.out.println(SecurityLogger.ROOT_LOGGER.passwordsDoNotMatch());


### PR DESCRIPTION
Uses different i18n key for password prompt and password confirmation
prompt.

Current english output is incorrect as the WFLYSEC is prepended to the
again message:

WFLYSEC0052: Enter Keystore passwordWFLYSEC0061:  again:

More generally, language do not necessarily put their "again" equivalent
at the end of the sentence. E.g. in French, that would be "Saisir à
nouveau votre mot de passe" where "a nouveau" (aka again) is in the
middle of the sentence
