### PR TITLE
[8.x] [WFLY-3298] - Update PicketLink Federation Modules.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -1453,7 +1453,7 @@
         </module-def>
 
         <module-def name="org.picketlink.federation.bindings">
-            <maven-resource group="org.picketlink.distribution" artifact="picketlink-jbas7"/>
+            <maven-resource group="org.picketlink.distribution" artifact="picketlink-wildfly8"/>
         </module-def>
 
         <module-def name="org.picketlink.federation">

--- a/build/pom.xml
+++ b/build/pom.xml
@@ -1958,7 +1958,7 @@
 
                 <dependency>
                     <groupId>org.picketlink.distribution</groupId>
-                    <artifactId>picketlink-jbas7</artifactId>
+                    <artifactId>picketlink-wildfly8</artifactId>
                 </dependency>
 
                 <dependency>

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
@@ -29,11 +29,9 @@
     </resources>
 
     <dependencies>
-        <module name="javax.api" />
-        <module name="javax.xml.stream.api" />
-        <module name="javax.xml.bind.api"/>
-        <module name="javax.xml.ws.api"/>
-        <module name="org.jboss.logging" />
+        <module name="javax.api"/>
+        <module name="javax.xml.stream.api"/>
+        <module name="org.jboss.logging"/>
     </dependencies>
 
 </module>

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/bindings/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/bindings/main/module.xml
@@ -36,16 +36,22 @@
         <module name="javax.servlet.api" />
         <module name="org.jboss.common-core" />
         <module name="org.jboss.logging" />
-        <module name="org.jboss.as.web" />
+        <module name="org.wildfly.extension.undertow" />
         <module name="org.jboss.security.xacml" />
         <module name="org.picketbox" />
         <module name="javax.xml.ws.api" />
         <module name="org.apache.log4j" />
-        <module name="org.apache.santuario.xmlsec"/>
+        <module name="org.apache.santuario.xmlsec">
+            <imports>
+                <exclude path="javax/*"/>
+            </imports>
+        </module>
         <module name="javax.api" />
         <module name="org.jboss.ws.api" />
         <module name="org.jboss.ws.spi" />
         <module name="org.apache.cxf" />
+        <module name="io.undertow.core" />
+        <module name="io.undertow.servlet" />
         <module name="org.picketlink.common" />
         <module name="org.picketlink.config" />
         <module name="org.picketlink.federation" />

--- a/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/picketlink/federation/main/module.xml
@@ -41,7 +41,11 @@
         <module name="org.picketbox" />
         <module name="javax.xml.ws.api" />
         <module name="org.apache.log4j" />
-        <module name="org.apache.santuario.xmlsec"/>
+        <module name="org.apache.santuario.xmlsec">
+            <imports>
+                <exclude path="javax/*"/>
+            </imports>
+        </module>
         <module name="javax.api" />
         <module name="org.jboss.ws.api" />
         <module name="org.jboss.ws.spi" />

--- a/pom.xml
+++ b/pom.xml
@@ -250,7 +250,7 @@
         <version.org.opensaml.xmltooling>1.3.4</version.org.opensaml.xmltooling>
         <version.org.picketbox>4.0.21.Beta1</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
-        <version.org.picketlink>2.5.2.Final</version.org.picketlink>
+        <version.org.picketlink>2.6.0.CR2</version.org.picketlink>
         <version.org.powermock>1.5</version.org.powermock>
         <version.org.scannotation>1.0.3</version.org.scannotation>
         <version.org.slf4j>1.7.2.jbossorg-1</version.org.slf4j>
@@ -6321,7 +6321,7 @@
 
             <dependency>
                 <groupId>org.picketlink.distribution</groupId>
-                <artifactId>picketlink-jbas7</artifactId>
+                <artifactId>picketlink-wildfly8</artifactId>
                 <version>${version.org.picketlink}</version>
             </dependency>
 


### PR DESCRIPTION
Those changes are already in master. We need them in 8.x in order to properly support PicketLink SAML support.

This PR is a continuation of https://github.com/wildfly/wildfly/pull/6210.

Thanks.
