### PR TITLE
[WFLY-3462]  fixed missing break in HostXml:parseDomainController

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
+++ b/host-controller/src/main/java/org/jboss/as/host/controller/parsing/HostXml.java
@@ -927,6 +927,7 @@ public class HostXml extends CommonXml {
                         }
                         case DOMAIN_1_5: {
                             parseRemoteDomainController2_0(reader, address, expectedNs, list, false);
+                            break;
                         }
                         default: {
                             parseRemoteDomainController2_0(reader, address, expectedNs, list, true);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3462
