### PR TITLE
WFLY-3380 Add JACC support to SimpleSecurityManager.isCallerInRole

### DIFF
--- a/core-security/implementation/src/main/java/org/jboss/as/core/security/ServerSecurityManager.java
+++ b/core-security/implementation/src/main/java/org/jboss/as/core/security/ServerSecurityManager.java
@@ -50,7 +50,7 @@ public interface ServerSecurityManager {
 
     Subject getSubject();
 
-    boolean isCallerInRole(final Object mappedRoles, final Map<String, Collection<String>> roleLinks,
+    boolean isCallerInRole(final String ejbName, final Object mappedRoles, final Map<String, Collection<String>> roleLinks,
             final String... roleNames);
 
     boolean authorize(String ejbName, CodeSource ejbCodeSource, String ejbMethodIntf, Method ejbMethod, Set<Principal> methodRoles, String contextID);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -396,11 +396,11 @@ public abstract class EJBComponent extends BasicComponent {
         if (WildFlySecurityManager.isChecking()) {
             return WildFlySecurityManager.doUnchecked(new PrivilegedAction<Boolean>() {
                 public Boolean run() {
-                    return serverSecurityManager.isCallerInRole(securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
+                    return serverSecurityManager.isCallerInRole(getComponentName(), securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
                 }
             });
         } else {
-            return this.serverSecurityManager.isCallerInRole(securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
+            return this.serverSecurityManager.isCallerInRole(getComponentName(), securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/AuthorizationInterceptor.java
@@ -134,14 +134,13 @@ public class AuthorizationInterceptor implements Interceptor {
                     throw EjbLogger.ROOT_LOGGER.invocationOfMethodNotAllowed(invokedMethod,ejbComponent.getComponentName());
                 }
             }
+            // successful authorization, let the invocation proceed
+            return context.proceed();
         }
         finally {
             // reset the previous JACC contextID.
             setContextID(previousContextID);
         }
-
-        // successful authorization, let the invocation proceed
-        return context.proceed();
     }
 
     /**

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -24,11 +24,15 @@ package org.jboss.as.security.service;
 import static java.security.AccessController.doPrivileged;
 
 import javax.security.auth.Subject;
+import javax.security.jacc.EJBRoleRefPermission;
+
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.CodeSource;
+import java.security.Policy;
 import java.security.Principal;
 import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
 import java.security.acl.Group;
 import java.util.Collection;
 import java.util.Collections;
@@ -62,8 +66,13 @@ import org.jboss.security.SubjectInfo;
 import org.jboss.security.audit.AuditEvent;
 import org.jboss.security.audit.AuditLevel;
 import org.jboss.security.audit.AuditManager;
+import org.jboss.security.authorization.config.AuthorizationModuleEntry;
+import org.jboss.security.authorization.modules.JACCAuthorizationModule;
 import org.jboss.security.authorization.resources.EJBResource;
 import org.jboss.security.callbacks.SecurityContextCallbackHandler;
+import org.jboss.security.config.ApplicationPolicy;
+import org.jboss.security.config.AuthorizationInfo;
+import org.jboss.security.config.SecurityConfiguration;
 import org.jboss.security.identity.Identity;
 import org.jboss.security.identity.Role;
 import org.jboss.security.identity.RoleGroup;
@@ -178,14 +187,15 @@ public class SimpleSecurityManager implements ServerSecurityManager {
     }
 
     /**
+     * @param ejbName              The name of the EJB component where isCallerInRole was invoked.
      * @param incommingMappedRoles The principal vs roles mapping (if any). Can be null.
      * @param roleLinks            The role link map where the key is an alias role name and the value is the collection of
      *                             role names, that alias represents. Can be null.
      * @param roleNames            The role names for which the caller is being checked for
      * @return true if the user is in <b>any</b> one of the <code>roleNames</code>. Else returns false
      */
-    public boolean isCallerInRole(final Object incommingMappedRoles, final Map<String, Collection<String>> roleLinks,
-                                  final String... roleNames) {
+    public boolean isCallerInRole(final String ejbName, final Object incommingMappedRoles,
+                                  final Map<String, Collection<String>> roleLinks, final String... roleNames) {
         final SecurityRolesMetaData mappedRoles = (SecurityRolesMetaData) incommingMappedRoles;
         final SecurityContext securityContext = doPrivileged(securityContext());
         if (securityContext == null) {
@@ -228,24 +238,43 @@ public class SimpleSecurityManager implements ServerSecurityManager {
                 actualRoles.addAll(mapped);
             }
         }
-        // if the actual roles matches any of the required roles, then return true
-        if (!Collections.disjoint(requiredRoles, actualRoles)) {
-            return true;
-        }
-        // we did not have a match between the required roles and the actual roles.
-        // let's now get the alias role names (if any) for each of the actual role
-        // and see if any of those aliases of the actual roles matches the required roles
-        if (roleLinks != null) {
-            for (final String actualRole : actualRoles) {
-                // get aliases (if any) for actual role
-                final Set<String> aliases = this.getRoleAliases(actualRole, roleLinks);
-                // if there's a match between the required role and an alias of an actual role, then
-                // return true indicating that the caller is in one of the required roles
-                if (!Collections.disjoint(requiredRoles, aliases)) {
+
+        // use JACC permissions to check for role matches, including role links.
+        if (isJaccEnabled(securityContext.getSecurityDomain())) {
+            Set<Principal> rolesPrincipals = new HashSet<Principal>();
+            for (String role : actualRoles)
+                rolesPrincipals.add(new SimplePrincipal(role));
+            for (String roleName : requiredRoles) {
+                EJBRoleRefPermission permission = new EJBRoleRefPermission(ejbName, roleName);
+                ProtectionDomain pd = new ProtectionDomain (null, null, null, rolesPrincipals.toArray(new Principal[rolesPrincipals.size()]));
+                if (Policy.getPolicy().implies(pd, permission))
                     return true;
+            }
+            return false;
+        }
+
+        // if the actual roles matches any of the required roles, then return true
+        else {
+            if (!Collections.disjoint(requiredRoles, actualRoles)) {
+                return true;
+            }
+
+            // we did not have a match between the required roles and the actual roles.
+            // let's now get the alias role names (if any) for each of the actual role
+            // and see if any of those aliases of the actual roles matches the required roles
+            if (roleLinks != null) {
+                for (final String actualRole : actualRoles) {
+                    // get aliases (if any) for actual role
+                    final Set<String> aliases = this.getRoleAliases(actualRole, roleLinks);
+                    // if there's a match between the required role and an alias of an actual role, then
+                    // return true indicating that the caller is in one of the required roles
+                    if (!Collections.disjoint(requiredRoles, aliases)) {
+                        return true;
+                    }
                 }
             }
         }
+
         // caller is not in any of the required roles
         return false;
     }
@@ -496,5 +525,26 @@ public class SimpleSecurityManager implements ServerSecurityManager {
                 return am.getSubjectRoles(authenticatedSubject, scb);
             }
         });
+    }
+
+    /**
+     * Determines whether JACC was enabled for the specified security domain or not.
+     *
+     * @param securityDomain the security domain being checked.
+     * @return {@code true} if JACC was enabled for the domain; {@code false} otherwise.
+     */
+    private boolean isJaccEnabled(String securityDomain) {
+        ApplicationPolicy applicationPolicy = SecurityConfiguration.getApplicationPolicy(securityDomain);
+        if (applicationPolicy != null) {
+            AuthorizationInfo authorizationInfo = applicationPolicy.getAuthorizationInfo();
+            if (authorizationInfo != null) {
+                for (AuthorizationModuleEntry entry : authorizationInfo.getModuleEntries()) {
+                    if (JACCAuthorizationModule.class.getName().equals(entry.getPolicyModuleName())) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
SimpleSecurityManager.isCallerInRole now uses the appropriate EJBRoleRefPermission when JACC is enabled.
