### PR TITLE
[WFLY-3464] Fixed an issue where a nonexistent ldap group causes an auth...

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapGroupSearcherFactory.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/LdapGroupSearcherFactory.java
@@ -33,6 +33,7 @@ import java.util.Set;
 
 import javax.naming.NamingEnumeration;
 import javax.naming.NamingException;
+import javax.naming.NameNotFoundException;
 import javax.naming.directory.Attribute;
 import javax.naming.directory.Attributes;
 import javax.naming.directory.DirContext;
@@ -193,6 +194,8 @@ public class LdapGroupSearcherFactory {
         private final String groupAttribute; // The attribute on the principal that references the group it is a member of.
         private final String groupNameAttribute; // The attribute on the group that is it's simple name.
         private final boolean preferOriginalConnection; // After a referral should we still prefer the original connection?
+        private static final boolean IGNORE_NONEXISTENT_ROLE =
+              Boolean.valueOf(System.getProperty("org.jboss.as.domain.management.security.LdapGroupSearcherService.IGNORE_NONEXISTENT_ROLE", "false")).booleanValue();
 
         private PrincipalToGroupSearcher(final String groupAttribute, final String groupNameAttribute, final boolean preferOriginalConnection) {
             this.groupAttribute = groupAttribute;
@@ -265,6 +268,10 @@ public class LdapGroupSearcherFactory {
                                 SECURITY_LOGGER.trace("No groupNameAttribute to load simpleName");
                             }
                             foundEntries.add(new LdapEntry(simpleName, distingushedName, groupReferralAddress));
+                        } catch (NameNotFoundException e) {
+                            SECURITY_LOGGER.tracef("Failed to query roleNameAttrName: %s", e.getMessage());
+                            if( !this.IGNORE_NONEXISTENT_ROLE )
+                                throw e;
                         } catch (LdapReferralException e) {
                             Object info = e.getReferralInfo();
                             try {


### PR DESCRIPTION
[WFLY-3464] Fixed an issue where a nonexistent ldap group causes an authentication attempt to fail in a security-realm
