### PR TITLE
[WFLY-3492], Addtionally check jsse keystore paramter type and length.

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/ComplexAttributes.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/ComplexAttributes.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.security.logging.SecurityLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
@@ -129,6 +130,8 @@ public class ComplexAttributes {
         public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
             if (name.equals(parameterName)) {
                 ModelNode parameters = value.clone();
+                if (!(parameters.getType() == ModelType.OBJECT && !parameters.asList().isEmpty()))
+                    throw SecurityLogger.ROOT_LOGGER.incorrectKeystoreParameters(name);
                 if (isConfigured(parameters)) {
                     for (SimpleAttributeDefinition attribute : KEY_STORE_FIELDS) {
                         attribute.getValidator().validateParameter(attribute.getName(), parameters.get(attribute.getName()));

--- a/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
@@ -722,4 +722,12 @@ public interface SecurityLogger extends BasicLogger {
     @Message(id = NONE, value = "Enter Keystore password again:")
     String enterKeyStorePasswordAgain();
 
+    /**
+     * Keystore parameter type checking
+     *
+     * @return
+     */
+    @Message(id = NONE, value = "'%s' parameter type or length is incorrect")
+    IllegalArgumentException incorrectKeystoreParameters(final String keystoreName);
+
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3492
check parameter type and length to avoid a empty jsse element like: 
<security-domain name="trust-domain">
    <jsse/>
</security-domain>
