### PR TITLE
Remove non-core deps from managed and embedded arquillian containers

### DIFF
--- a/arquillian/container-embedded/pom.xml
+++ b/arquillian/container-embedded/pom.xml
@@ -43,10 +43,6 @@
 
 	<packaging>jar</packaging>
 
-	<properties>
-		<jboss.home>${project.basedir}/../../${wildfly.build.output.dir}</jboss.home>
-	</properties>
-
 	<dependencies>
         <dependency>
             <groupId>javax.enterprise</groupId>
@@ -64,41 +60,49 @@
 			<groupId>org.jboss.logging</groupId>
 			<artifactId>jboss-logging</artifactId>
 		</dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-protocol</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-core-build</artifactId>
+            <type>zip</type>
+            <scope>test</scope>
+        </dependency>
 		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>org.jboss.arquillian.junit</groupId>
 			<artifactId>arquillian-junit-container</artifactId>
 			<scope>test</scope>
 		</dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+            <scope>test</scope>
+        </dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-resources-plugin</artifactId>
-				<executions>
-					<execution>
-						<id>copy-resources</id>
-						<phase>process-test-classes</phase>
-						<goals>
-							<goal>copy-resources</goal>
-						</goals>
-						<configuration>
-							<outputDirectory>${basedir}/target/jbossas</outputDirectory>
-							<overwrite>true</overwrite>
-							<resources>
-								<resource>
-									<directory>${jboss.home}</directory>
-									<excludes>
-										<exclude>modules/</exclude>
-									</excludes>
-								</resource>
-							</resources>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>unpack-wildfly</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <includeGroupIds>org.wildfly</includeGroupIds>
+                            <includeArtifactIds>wildfly-core-build</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -107,8 +111,7 @@
                     <forkMode>always</forkMode>
                     <systemPropertyVariables>
                         <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
-                        <jboss.home>${jboss.home}</jboss.home>
-                        <module.path>${jboss.home}/modules</module.path>
+                        <jboss.home>${basedir}/target/wildfly-core-${project.version}</jboss.home>
                     </systemPropertyVariables>
                     <redirectTestOutputToFile>false</redirectTestOutputToFile>
                 </configuration>

--- a/arquillian/container-embedded/src/test/java/org/jboss/as/arquillian/container/embedded/DeploymentTestCase.java
+++ b/arquillian/container-embedded/src/test/java/org/jboss/as/arquillian/container/embedded/DeploymentTestCase.java
@@ -17,11 +17,10 @@
  */
 package org.jboss.as.arquillian.container.embedded;
 
-import javax.inject.Inject;
-
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.container.embedded.archive.GreetingService;
+import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -30,29 +29,24 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import javax.inject.Inject;
+
 /**
- * Tests CDI and injection
- *
- * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ * Tests basic deployment
  */
 @RunWith(Arquillian.class)
-@Ignore("We don't have a dependency on the full server, just the core, to avoid nasty circular dep")
-public class CdiTestCase {
+public class DeploymentTestCase {
 
     @Deployment
     public static JavaArchive create() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class).addClass(GreetingService.class);
-        archive.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+                .addClass(SystemPropertyServiceActivator.class)
+                .addAsServiceProvider(ServiceActivator.class, SystemPropertyServiceActivator.class);
         return archive;
     }
 
-    @Inject
-    private GreetingService service;
-
     @Test
-    public void shouldBeAbleToInject() throws Exception {
-        Assert.assertNotNull(service);
-        final String name = "ALR";
-        Assert.assertEquals(GreetingService.GREETING_PREPENDED + name, service.greet(name));
+    public void testSystemPropSet() throws Exception {
+        Assert.assertEquals(SystemPropertyServiceActivator.VALUE, System.getProperty(SystemPropertyServiceActivator.TEST_PROPERTY));
     }
 }

--- a/arquillian/container-embedded/src/test/java/org/jboss/as/arquillian/container/embedded/SystemPropertyServiceActivator.java
+++ b/arquillian/container-embedded/src/test/java/org/jboss/as/arquillian/container/embedded/SystemPropertyServiceActivator.java
@@ -1,0 +1,39 @@
+package org.jboss.as.arquillian.container.embedded;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author Stuart Douglas
+ */
+public class SystemPropertyServiceActivator implements ServiceActivator {
+
+    public static final String TEST_PROPERTY = "test-property";
+    public static final String VALUE = "set";
+
+    @Override
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        serviceActivatorContext.getServiceTarget().addService(ServiceName.of("test-service"), new Service<Object>() {
+            @Override
+            public void start(StartContext context) throws StartException {
+                System.setProperty(TEST_PROPERTY, VALUE);
+            }
+
+            @Override
+            public void stop(StopContext context) {
+                System.clearProperty(TEST_PROPERTY);
+            }
+
+            @Override
+            public Object getValue() throws IllegalStateException, IllegalArgumentException {
+                return this;
+            }
+        }).install();
+    }
+}

--- a/arquillian/container-embedded/src/test/resources/arquillian.xml
+++ b/arquillian/container-embedded/src/test/resources/arquillian.xml
@@ -3,9 +3,11 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+    <defaultProtocol type="jmx-as7" />
+
     <container qualifier="jboss" default="true">
         <configuration>
-            <property name="jbossHome">target/jbossas</property>
+            <property name="jbossHome">${jboss.home}</property>
         </configuration>
     </container>
 </arquillian>

--- a/arquillian/container-managed-domain/pom.xml
+++ b/arquillian/container-managed-domain/pom.xml
@@ -37,7 +37,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <jboss.home>${project.basedir}/../../${wildfly.build.output.dir}</jboss.home>
+        <jboss.home>${project.basedir}/../../${wildfly.core.build.output.dir}</jboss.home>
     </properties>
 
     <dependencies>

--- a/arquillian/container-managed/pom.xml
+++ b/arquillian/container-managed/pom.xml
@@ -36,10 +36,6 @@
 
     <packaging>jar</packaging>
 
-    <properties>
-        <jboss.home>${project.basedir}/../../${wildfly.build.output.dir}</jboss.home>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>org.wildfly</groupId>
@@ -111,31 +107,30 @@
             <artifactId>jboss-servlet-api_3.1_spec</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-resources-plugin</artifactId>
+                <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>copy-resources</id>
-                        <phase>process-test-classes</phase>
+                        <id>unpack-wildfly</id>
+                        <phase>generate-test-resources</phase>
                         <goals>
-                            <goal>copy-resources</goal>
+                            <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
-                            <outputDirectory>${basedir}/target/jbossas</outputDirectory>
-                            <overwrite>true</overwrite>
-                            <resources>
-                                <resource>
-                                    <directory>${jboss.home}</directory>
-                                    <excludes>
-                                        <exclude>modules/</exclude>
-                                    </excludes>
-                                </resource>
-                            </resources>
+                            <includeGroupIds>org.wildfly</includeGroupIds>
+                            <includeArtifactIds>wildfly-core-build</includeArtifactIds>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -149,15 +144,10 @@
                           <name>java.util.logging.manager</name>
                           <value>org.jboss.logmanager.LogManager</value>
                         </property>
-                        <property>
-                          <name>jboss.home</name>
-                          <value>${basedir}/target/jbossas</value>
-                        </property>
-                        <property>
-                          <name>module.path</name>
-                          <value>${jboss.home}/modules</value>
-                        </property>
                     </systemProperties>
+                    <systemPropertyVariables>
+                        <jboss.home>${basedir}/target/wildfly-core-${project.version}</jboss.home>
+                    </systemPropertyVariables>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                 </configuration>
             </plugin>

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/DeploymentTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/DeploymentTestCase.java
@@ -15,44 +15,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.jboss.as.arquillian.container.embedded;
-
-import javax.inject.Inject;
+package org.jboss.as.arquillian.container.managed;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.arquillian.container.embedded.archive.GreetingService;
+import org.jboss.msc.service.ServiceActivator;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Tests CDI and injection
- *
- * @author <a href="mailto:alr@jboss.org">Andrew Lee Rubinger</a>
+ * Tests basic deployment
  */
 @RunWith(Arquillian.class)
-@Ignore("We don't have a dependency on the full server, just the core, to avoid nasty circular dep")
-public class CdiTestCase {
+public class DeploymentTestCase {
 
     @Deployment
     public static JavaArchive create() {
-        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class).addClass(GreetingService.class);
-        archive.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        final JavaArchive archive = ShrinkWrap.create(JavaArchive.class)
+                .addClass(SystemPropertyServiceActivator.class)
+                .addAsServiceProvider(ServiceActivator.class, SystemPropertyServiceActivator.class);
         return archive;
     }
 
-    @Inject
-    private GreetingService service;
-
     @Test
-    public void shouldBeAbleToInject() throws Exception {
-        Assert.assertNotNull(service);
-        final String name = "ALR";
-        Assert.assertEquals(GreetingService.GREETING_PREPENDED + name, service.greet(name));
+    public void testSystemPropSet() throws Exception {
+        Assert.assertEquals(SystemPropertyServiceActivator.VALUE, System.getProperty(SystemPropertyServiceActivator.TEST_PROPERTY));
     }
 }

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/IntegrationTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/IntegrationTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -35,6 +36,7 @@ import org.junit.runner.RunWith;
  * @author <a href="mailto:aslak@redhat.com">Aslak Knutsen</a>
  */
 @RunWith(Arquillian.class)
+@Ignore("We don't have a dependency on the full server, just the core, to avoid nasty circular dep")
 public class IntegrationTestCase {
 
     @Deployment

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientEnterpriseArchiveServletTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Ignore("We don't have a dependency on the full server, just the core, to avoid nasty circular dep")
 public class ManagedAsClientEnterpriseArchiveServletTestCase {
 
     @Deployment(testable = false)

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedAsClientWebArchiveServletTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Ignore("We don't have a dependency on the full server, just the core, to avoid nasty circular dep")
 public class ManagedAsClientWebArchiveServletTestCase {
 
     private static final String CONTEXT_NAME = "foo-v1.2";

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedInContainerTestCase.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/ManagedInContainerTestCase.java
@@ -28,6 +28,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.container.managed.archive.ConfigService;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 
 /**
@@ -37,6 +38,7 @@ import org.junit.runner.RunWith;
  * @author Thomas.Diesler@jboss.com
  */
 @RunWith(Arquillian.class)
+@Ignore("We don't have a dependency on the full server, just the core, to avoid nasty circular dep")
 public class ManagedInContainerTestCase extends AbstractContainerTestCase {
 
     @Deployment

--- a/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/SystemPropertyServiceActivator.java
+++ b/arquillian/container-managed/src/test/java/org/jboss/as/arquillian/container/managed/SystemPropertyServiceActivator.java
@@ -1,0 +1,39 @@
+package org.jboss.as.arquillian.container.managed;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceActivator;
+import org.jboss.msc.service.ServiceActivatorContext;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistryException;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+
+/**
+ * @author Stuart Douglas
+ */
+public class SystemPropertyServiceActivator implements ServiceActivator {
+
+    public static final String TEST_PROPERTY = "test-property";
+    public static final String VALUE = "set";
+
+    @Override
+    public void activate(ServiceActivatorContext serviceActivatorContext) throws ServiceRegistryException {
+        serviceActivatorContext.getServiceTarget().addService(ServiceName.of("test-service"), new Service<Object>() {
+            @Override
+            public void start(StartContext context) throws StartException {
+                System.setProperty(TEST_PROPERTY, VALUE);
+            }
+
+            @Override
+            public void stop(StopContext context) {
+                System.clearProperty(TEST_PROPERTY);
+            }
+
+            @Override
+            public Object getValue() throws IllegalStateException, IllegalArgumentException {
+                return this;
+            }
+        }).install();
+    }
+}

--- a/arquillian/container-managed/src/test/resources/arquillian.xml
+++ b/arquillian/container-managed/src/test/resources/arquillian.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-    <defaultProtocol type="jmx-as7" />
+    <defaultProtocol type="jmx-as7"/>
 
-	<container qualifier="jboss" default="true">
-		<configuration>
-                        <property name="jbossHome">target/jbossas</property>
-                        <property name="jbossArguments">-P=src/test/resources/testfile.properties</property>
-			<!-- 
-			     Please leave this as false. It is a good, early catch for the reviewers to make
-			     sure that they have not left a stale server running when merging pull requests
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="jbossArguments">-P=src/test/resources/testfile.properties</property>
+            <!--
+                 Please leave this as false. It is a good, early catch for the reviewers to make
+                 sure that they have not left a stale server running when merging pull requests
                         -->
-                        <property name="allowConnectingToRunningServer">false</property>
+            <property name="allowConnectingToRunningServer">false</property>
 
-			<!--
+            <!--
             Time to wait for shutdown to complete
             <property name="stopTimeoutInSeconds">60</property>
 
-			Space-delimited list of ports on which to wait 
-			<property name="waitForPorts">2222</property>
-			
-			Time, in seconds, to wait on the above ports
-			<property name="waitForPortsTimeoutInSeconds">20</property>
-			 -->
-		</configuration>
-	</container>
+            Space-delimited list of ports on which to wait
+            <property name="waitForPorts">2222</property>
+
+            Time, in seconds, to wait on the above ports
+            <property name="waitForPortsTimeoutInSeconds">20</property>
+             -->
+        </configuration>
+    </container>
 </arquillian>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -57,6 +57,10 @@
            <artifactId>arquillian-core-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.jboss.remotingjmx</groupId>
+            <artifactId>remoting-jmx</artifactId>
+        </dependency>
+        <dependency>
            <groupId>junit</groupId>
            <artifactId>junit</artifactId>
            <scope>test</scope>
@@ -64,20 +68,13 @@
         <!-- Super Hack to get things to run in the correct order-->
         <dependency>
             <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-dist</artifactId>
+            <artifactId>wildfly-core-build</artifactId>
             <version>${project.version}</version>
+            <type>zip</type>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
                     <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-build</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-build</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/core-build/src/main/resources/configuration/standalone/subsystems.xml
+++ b/core-build/src/main/resources/configuration/standalone/subsystems.xml
@@ -3,5 +3,6 @@
 <config>
    <subsystems>
       <subsystem>logging.xml</subsystem>
+      <subsystem>jmx.xml</subsystem>
    </subsystems>
 </config>


### PR DESCRIPTION
Initial work that is required to split out Arquillian. The domain container still needs to be done.
