### PR TITLE
[WFLY-3508][BZ1104730], add parameter StateValues for new ErrorState.

### DIFF
--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ErrorState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ErrorState.java
@@ -41,6 +41,10 @@ public class ErrorState implements State {
         this(theConsole, errorMessage, null, null);
     }
 
+    public ErrorState(ConsoleWrapper theConsole, String errorMessage, StateValues stateValues) {
+        this(theConsole, errorMessage, null, stateValues);
+    }
+
     public ErrorState(ConsoleWrapper theConsole, String errorMessage, State nextState) {
         this(theConsole, errorMessage, nextState, null);
     }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptNewUserState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptNewUserState.java
@@ -56,7 +56,7 @@ public class PromptNewUserState implements State {
             }
             // The user could have pressed Ctrl-D, in which case we do not use the default value.
             if (temp == null || existingUsername == null || existingUsername.length() == 0) {
-                return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.noUsernameExiting());
+                return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.noUsernameExiting(), stateValues);
             }
             stateValues.setUserName(existingUsername);
         }

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptPasswordState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PromptPasswordState.java
@@ -78,7 +78,7 @@ public class PromptPasswordState implements State {
                 theConsole.printf(DomainManagementLogger.ROOT_LOGGER.passwordPrompt());
                 char[] tempChar = theConsole.readPassword(" : ");
                 if (tempChar == null || tempChar.length == 0) {
-                    return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.noPasswordExiting());
+                    return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.noPasswordExiting(), stateValues);
                 }
                 stateValues.setPassword(new String(tempChar));
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFilePrompt.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/PropertyFilePrompt.java
@@ -78,7 +78,7 @@ public class PropertyFilePrompt implements State {
                 }
                 return new PropertyFileFinder(theConsole, stateValues);
             default:
-                return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.invalidChoiceResponse(), this);
+                return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.invalidChoiceResponse(), this, stateValues);
         }
     }
 

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidatePasswordState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidatePasswordState.java
@@ -82,7 +82,7 @@ public class ValidatePasswordState extends AbstractValidationState {
                             return confirmWeakPassword(result);
                         }
                         if (rejectResult) {
-                            return new ErrorState(theConsole, result.getMessage(), getRetryState());
+                            return new ErrorState(theConsole, result.getMessage(), getRetryState(), stateValues);
                         }
                         break;
                     default:

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidateRealmState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidateRealmState.java
@@ -51,7 +51,7 @@ public class ValidateRealmState implements State {
     public State execute() {
         String enteredRealm = stateValues.getRealm();
         if (enteredRealm.length() == 0) {
-            return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.realmMustBeSpecified(), new PromptRealmState(theConsole, stateValues));
+            return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.realmMustBeSpecified(), new PromptRealmState(theConsole, stateValues), stateValues);
         }
 
         if (stateValues.getFileMode() != FileMode.UNDEFINED) {

--- a/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidateUserState.java
+++ b/domain-management/src/main/java/org/jboss/as/domain/management/security/adduser/ValidateUserState.java
@@ -151,7 +151,7 @@ public class ValidateUserState extends AbstractValidationState {
                                 stateValues.getOptions().setDisable(true);
                                 return new PreModificationState(theConsole, stateValues);
                             default:
-                                return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.invalidChoiceUpdateUserResponse(), this);
+                                return new ErrorState(theConsole, DomainManagementLogger.ROOT_LOGGER.invalidChoiceUpdateUserResponse(), this, stateValues);
                         }
                         return ValidateUserState.this;
                     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3508
add parameter StateValues for new ErrorState in order to throw proper exception from ErrorState.java:
// Throw an exception if the mode is non-interactive and there's no next state.
if ((stateValues != null && !stateValues.isInteractive()) && nextState == null) {
    throw new AddUserFailedException(errorMessage);
}
Thus, we can obtain expected exit code 1, otherwise stateValues is null by default
