### PR TITLE
ServletContext.getVirtualServerName always returns "localhost"

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -491,6 +491,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
                 d.setDisplayName(mergedMetaData.getDescriptionGroup().getDisplayName());
             }
             d.setDeploymentName(deploymentName);
+            d.setHostName(host.getValue().getName());
             final ServletContainerService servletContainer = container.getValue();
             try {
                 //TODO: make the caching limits configurable


### PR DESCRIPTION
I experimented with the new getVirtualServerName method introduced for interface ServletContext in servlet spec 3.1. The JavaDoc states: 

> Returns the primary name of the virtual host on which this context is deployed. The name may or may not be a valid host name.

However Wildfly always seems to return "localhost" instead of the virtual host name specified in XML configuration files. My host config in standalone.xml looks like this: `<host name="default-host" alias="www.sample.com">`. I expected that getVirtualServerName returns "default-host" in this case. 

getVirtualServerName is implemented like this: `return deployment.getDeploymentInfo().getHostName();`. However DeploymentInfo.setHostName is never called during startup. 

If I did not misunderstand what getVirtualServerName is supposed to deliver, something similar to my proposed patch should fix the problem. Sorry, I only looked at Wildfly source code for the first time today in a debugger and was unable to verify if my proposed patch compiles :( Hope a more experienced developer can have a quick look and verify if this fix is valid. 
