### PR TITLE
Update JSF based on Mojarra 2.2.7 and add a missing dependency to the jsf-injection module to fix some JSF TCK failures

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/jsf-injection/main/module.xml
@@ -36,6 +36,7 @@
         <module name="com.sun.jsf-impl"/>
         <module name="javax.api"/>
         <module name="org.jboss.as.ee"/>
+        <module name="org.jboss.as.jsf"/>
         <module name="org.jboss.as.web-common"/>
         <module name="javax.servlet.api"/>
         <module name="javax.enterprise.api"/>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <version.com.google.guava>16.0.1</version.com.google.guava>
         <version.com.h2database>1.3.173</version.com.h2database>
         <version.com.sun.codemodel>2.6</version.com.sun.codemodel>
-        <version.com.sun.faces>2.2.6-jbossorg-4</version.com.sun.faces>
+        <version.com.sun.faces>2.2.7-jbossorg-1</version.com.sun.faces>
         <version.com.sun.istack>2.6.1</version.com.sun.istack>
         <version.com.sun.xml.fastinfoset>1.2.12</version.com.sun.xml.fastinfoset>
         <version.com.sun.xml.txw2>20110809</version.com.sun.xml.txw2>
@@ -211,7 +211,7 @@
         <version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>1.0.0.Final</version.org.jboss.spec.javax.ejb.jboss-ejb-api_3.2_spec>
         <version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>1.0.3.Final</version.org.jboss.spec.javax.el.jboss-el-api_3.0_spec>
         <version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>1.0.0.Final</version.org.jboss.spec.javax.enterprise.concurrent.jboss-concurrency-api_1.0_spec>
-        <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>2.2.6</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>
+        <version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>2.2.7</version.org.jboss.spec.javax.faces.jboss-jsf-api_2.2_spec>
         <version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.interceptor.jboss-interceptors-api_1.2_spec>
         <version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec>
         <version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.management.j2ee.jboss-j2eemgmt-api_1.1_spec>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/scopes/FlowScopedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/deployment/scopes/FlowScopedBean.java
@@ -21,8 +21,9 @@
  */
 package org.jboss.as.test.integration.weld.deployment.scopes;
 
+import java.io.Serializable;
 import javax.faces.flow.FlowScoped;
 
 @FlowScoped("myFlow")
-public class FlowScopedBean {
+public class FlowScopedBean implements Serializable {
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3484
