### PR TITLE
[[WFLY-3493] Do not remove a JMS resource with deployed dependencies

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/BinderServiceUtil.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/BinderServiceUtil.java
@@ -36,6 +36,7 @@ import org.jboss.as.naming.ValueManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.msc.service.AbstractServiceListener;
+import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.ImmediateValue;
@@ -48,6 +49,13 @@ import org.jboss.msc.value.Values;
  */
 public class BinderServiceUtil {
 
+    /**
+     * Install a binder service to bind the {@code obj} using the binding {@code name}.
+
+     * @param serviceTarget
+     * @param name the binding name
+     * @param obj the object that must be bound
+     */
     public static void installBinderService(final ServiceTarget serviceTarget,
                                                  final String name,
                                                  final Object obj) {
@@ -57,6 +65,26 @@ public class BinderServiceUtil {
         serviceTarget.addService(bindInfo.getBinderServiceName(), binderService)
                 .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
                 .addInjection(binderService.getManagedObjectInjector(), new ValueManagedReferenceFactory(Values.immediateValue(obj)))
+                .setInitialMode(ServiceController.Mode.ACTIVE)
+                .install();
+    }
+
+    /**
+     * Install a binder service to bind the value of the {@code service} using the binding {@code name}.
+
+     * @param serviceTarget
+     * @param name the binding name
+     * @param service the service whose value must be bound
+     */
+    public static void installBinderService(final ServiceTarget serviceTarget,
+                                            final String name,
+                                            final Service<?> service) {
+        final BindInfo bindInfo = ContextNames.bindInfoFor(name);
+        final BinderService binderService = new BinderService(bindInfo.getBindName());
+
+        serviceTarget.addService(bindInfo.getBinderServiceName(), binderService)
+                .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
+                .addInjection(binderService.getManagedObjectInjector(), new ValueManagedReferenceFactory(service))
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
     }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueRemove.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueRemove.java
@@ -24,6 +24,8 @@ package org.jboss.as.messaging.jms;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import java.util.ArrayList;
+
 import org.hornetq.api.core.management.ResourceNames;
 import org.hornetq.api.jms.management.JMSServerControl;
 import org.hornetq.core.server.HornetQServer;
@@ -31,8 +33,11 @@ import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.messaging.CommonAttributes;
 import org.jboss.as.messaging.MessagingServices;
+import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -46,7 +51,14 @@ import org.jboss.msc.service.ServiceName;
  */
 public class JMSQueueRemove extends AbstractRemoveStepHandler {
 
-    public static final JMSQueueRemove INSTANCE = new JMSQueueRemove();
+    static final JMSQueueRemove INSTANCE = new JMSQueueRemove(JMSQueueAdd.INSTANCE);
+
+    private final JMSQueueAdd addOperation;
+
+    private JMSQueueRemove(JMSQueueAdd addOperation) {
+
+        this.addOperation = addOperation;
+    }
 
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
 
@@ -65,11 +77,18 @@ public class JMSQueueRemove extends AbstractRemoveStepHandler {
             }
         }
 
-
         context.removeService(JMSServices.getJmsQueueBaseServiceName(hqServiceName).append(name));
+        final ModelNode entries = CommonAttributes.DESTINATION_ENTRIES.resolveModelAttribute(context, model);
+        final String[] jndiBindings = JMSServices.getJndiBindings(entries);
+
+        for (String jndiBinding : jndiBindings) {
+            final ContextNames.BindInfo bindInfo = ContextNames.bindInfoFor(jndiBinding);
+            ServiceName binderServiceName = bindInfo.getBinderServiceName();
+            context.removeService(binderServiceName);
+        }
     }
 
-    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) {
-        // TODO:  RE-ADD SERVICES
+    protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
+        addOperation.performRuntime(context, operation, model, new ServiceVerificationHandler(), new ArrayList<ServiceController<?>>());
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/DependentMessagingDeploymentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/DependentMessagingDeploymentTestCase.java
@@ -1,0 +1,164 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.deployment;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
+import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test that invoking a management operation that removes a JMS resource that is used by a deployed archive must fail:
+ * the resource must not be removed and any depending services must be recovered.
+ * The deployment must still be operating after the failing management operation.
+
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(DependentMessagingDeploymentTestCase.MessagingResourcesSetupTask.class)
+public class DependentMessagingDeploymentTestCase {
+
+    public static final String QUEUE_LOOKUP = "java:/jms/DependentMessagingDeploymentTestCase/myQueue";
+    public static final String TOPIC_LOOKUP = "java:/jms/DependentMessagingDeploymentTestCase/myTopic";
+
+    private static final String QUEUE_NAME = "myQueue";
+    private static final String TOPIC_NAME = "myTopic";
+
+    private static final ModelNode hornetQServerAddress;
+
+    static {
+        hornetQServerAddress = new ModelNode();
+        hornetQServerAddress.add("subsystem", "messaging");
+        hornetQServerAddress.add("hornetq-server", "default");
+    }
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @ArquillianResource
+    private URL url;
+
+    static class MessagingResourcesSetupTask implements ServerSetupTask {
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            addResource(managementClient, "jms-queue", QUEUE_NAME, QUEUE_LOOKUP);
+            addResource(managementClient, "jms-topic", TOPIC_NAME, TOPIC_LOOKUP);
+        }
+
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            removeResource(managementClient, "jms-queue", QUEUE_NAME);
+            removeResource(managementClient, "jms-topic", TOPIC_NAME);
+        }
+    }
+
+    @Deployment
+    public static WebArchive createArchive() {
+        return create(WebArchive.class, "DependentMessagingDeploymentTestCase.war")
+                .addClass(MessagingServlet.class)
+                .addClasses(QueueMDB.class, TopicMDB.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    public void testRemoveDependingQueue() throws Exception {
+        sendAndReceiveMessage(true);
+
+        assertFalse(removeResource(managementClient, "jms-queue", QUEUE_NAME));
+
+        sendAndReceiveMessage(true);
+    }
+
+    @Test
+    public void testRemoveDependingTopic() throws Exception {
+        sendAndReceiveMessage(false);
+
+        assertFalse(removeResource(managementClient, "jms-topic", TOPIC_NAME));
+
+        sendAndReceiveMessage(false);
+    }
+
+    private void sendAndReceiveMessage(boolean sendToQueue) throws Exception {
+        String destination = sendToQueue ? "queue" : "topic";
+        String text = UUID.randomUUID().toString();
+        URL url = new URL(this.url.toExternalForm() + "DependentMessagingDeploymentTestCase?destination=" + destination + "&text=" + text);
+        String reply = HttpRequest.get(url.toExternalForm(), 10, TimeUnit.SECONDS);
+
+        assertNotNull(reply);
+        assertEquals(text, reply);
+    }
+
+    private static void addResource(ManagementClient managementClient, String type, String name, String lookup) throws IOException {
+        ModelNode operation = new ModelNode();
+        ModelNode address = hornetQServerAddress.clone().add(type, name);
+        operation.get(OP_ADDR).set(address);
+        operation.get(OP).set(ADD);
+        operation.get("entries").add(lookup);
+        execute(managementClient, operation);
+    }
+
+    private static boolean removeResource(ManagementClient managementClient, String type, String name) throws IOException {
+        ModelNode operation = new ModelNode();
+        ModelNode address = hornetQServerAddress.clone().add(type, name);
+        operation.get(OP_ADDR).set(address);
+        operation.get(OP).set(REMOVE);
+        return execute(managementClient, operation);
+    }
+
+    private static boolean execute(ManagementClient managementClient, final ModelNode operation) throws IOException {
+        System.out.println("operation = " + operation);
+        ModelNode response = managementClient.getControllerClient().execute(operation);
+        System.out.println("response = " + response);
+        final String outcome = response.get(OUTCOME).asString();
+        return ModelDescriptionConstants.SUCCESS.equals(outcome);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/MessagingServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/MessagingServlet.java
@@ -1,0 +1,81 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.deployment;
+
+import static org.jboss.as.test.integration.messaging.jms.deployment.DependentMessagingDeploymentTestCase.QUEUE_LOOKUP;
+import static org.jboss.as.test.integration.messaging.jms.deployment.DependentMessagingDeploymentTestCase.TOPIC_LOOKUP;
+
+import java.io.IOException;
+
+import javax.annotation.Resource;
+import javax.inject.Inject;
+import javax.jms.Destination;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.Queue;
+import javax.jms.Topic;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@WebServlet("/DependentMessagingDeploymentTestCase")
+public class MessagingServlet extends HttpServlet {
+
+    @Resource(lookup = QUEUE_LOOKUP)
+    private Queue queue;
+
+    @Resource(lookup = TOPIC_LOOKUP)
+    private Topic topic;
+
+    @Inject
+    private JMSContext context;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        boolean useTopic = req.getParameterMap().keySet().contains("topic");
+        final Destination destination = useTopic ? topic : queue;
+        final String text = req.getParameter("text");
+
+        String reply = sendAndReceiveMessage(destination, text);
+
+        resp.getWriter().write(reply);
+    }
+
+    private String sendAndReceiveMessage(Destination destination, String text) {
+            Destination replyTo = context.createTemporaryQueue();
+
+            JMSConsumer consumer = context.createConsumer(replyTo);
+
+            context.createProducer()
+                    .setJMSReplyTo(replyTo)
+                    .send(destination, text);
+
+            return consumer.receiveBody(String.class, 5000);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/QueueMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/QueueMDB.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.deployment;
+
+import static org.jboss.as.test.integration.messaging.jms.deployment.DependentMessagingDeploymentTestCase.QUEUE_LOOKUP;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.inject.Inject;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@MessageDriven(
+        activationConfig = {
+                @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = QUEUE_LOOKUP)
+        }
+)
+public class QueueMDB implements MessageListener {
+
+    @Inject
+    private JMSContext context;
+
+    public void onMessage(final Message m)
+    {
+        try {
+            TextMessage message = (TextMessage)m;
+            Destination replyTo = m.getJMSReplyTo();
+
+            context.createProducer()
+                    .setJMSCorrelationID(message.getJMSMessageID())
+                    .send(replyTo, message.getText());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/TopicMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/deployment/TopicMDB.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.deployment;
+
+import static org.jboss.as.test.integration.messaging.jms.deployment.DependentMessagingDeploymentTestCase.TOPIC_LOOKUP;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.inject.Inject;
+import javax.jms.Destination;
+import javax.jms.JMSContext;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+import javax.jms.TextMessage;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+@MessageDriven(
+        activationConfig = {
+            @ActivationConfigProperty(propertyName = "destinationLookup", propertyValue = TOPIC_LOOKUP)
+        }
+)
+public class TopicMDB implements MessageListener {
+
+    @Inject
+    private JMSContext context;
+
+    public void onMessage(final Message m)
+    {
+        try {
+            TextMessage message = (TextMessage)m;
+            Destination replyTo = m.getJMSReplyTo();
+
+            context.createProducer()
+                   .setJMSCorrelationID(message.getJMSMessageID())
+                   .send(replyTo, message.getText());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
Ensure that there is a dependency between the JMS resource service
(JMSQueueService and JMSTopicService) and the BinderService for their
JNDI bindings so that if the resource is removed, the missing dependency
is detected.

Add recovering of the JMSQueue and JMSTopic services in the :remove
operations by replaying the runtime part of their corresponding :add
operations.

JIRA: https://issues.jboss.org/browse/WFLY-3493
