### PR TITLE
Add EAP 6.2.0 to the list of release we test in core-model-test

### DIFF
--- a/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
+++ b/core-model-test/tests/src/test/java/org/jboss/as/core/model/test/util/TransformersTestParameter.java
@@ -69,6 +69,7 @@ public class TransformersTestParameter extends ClassloaderParameter {
             data.add(new TransformersTestParameter(ModelVersion.create(1, 3, 0), ModelTestControllerVersion.EAP_6_0_1));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_0));
             data.add(new TransformersTestParameter(ModelVersion.create(1, 4, 0), ModelTestControllerVersion.EAP_6_1_1));
+            data.add(new TransformersTestParameter(ModelVersion.create(1, 5, 0), ModelTestControllerVersion.EAP_6_2_0));
         }
 
 


### PR DESCRIPTION
We'll see if this passes.
