### PR TITLE
WFLY-3478 subnet-match is completely broken

### DIFF
--- a/controller/src/test/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteriaTestCase.java
+++ b/controller/src/test/java/org/jboss/as/controller/interfaces/ParsedInterfaceCriteriaTestCase.java
@@ -115,4 +115,39 @@ public class ParsedInterfaceCriteriaTestCase {
         Assert.assertFalse(criteria.getCriteria().isEmpty());
     }
 
+    @Test
+    public void testSubnetMatchInterfaceCriteria() throws Exception {
+        SubnetMatchInterfaceCriteria criteria;
+
+        // ipv4
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {10, 0, 0, 0}, 24);
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {10, 0, 0, 1}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {10, 0, 1, 1}));
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {10, 0, 2, 0}, 23);
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {10, 0, 2, 1}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {10, 0, 1, 1}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {10, 0, 0, 1}));
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {(byte)192, (byte)168, 20, 32}, 31);
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {(byte)192, (byte)168, 20, 31}));
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {(byte)192, (byte)168, 20, 32}));
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {(byte)192, (byte)168, 20, 33}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {(byte)192, (byte)168, 20, 34}));
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {0, 0, 0, 0}, 0);
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {10, 0, 0, 1}));
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {(byte)192, (byte)168, 20, 32}, 32);
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {(byte)192, (byte)168, 20, 32}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {(byte)192, (byte)168, 20, 31}));
+
+        // ipv6
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {0x20, 0x01, (byte)0xdb, 0x08, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 64);
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {0x20, 0x01, (byte)0xdb, 0x08, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x23}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {0x20, 0x01, (byte)0xdb, 0x08, 0x0b, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x23}));
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte)0xff, (byte)0xff, 0x00, 0x00, 0x00, 0x00}, 96);
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte)0xff, (byte)0xff, 0x0a, 0x00, 0x00, 0x01}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte)0xff, (byte)0xfe, 0x0a, 0x00, 0x00, 0x01}));
+        criteria = new SubnetMatchInterfaceCriteria(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte)0xff, (byte)0xff, 0x0a, 0x00, 0x02, 0x00}, 119);
+        Assert.assertTrue(criteria.verifyAddressByMask(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte)0xff, (byte)0xff, 0x0a, 0x00, 0x02, 0x01}));
+        Assert.assertFalse(criteria.verifyAddressByMask(new byte[] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte)0xff, (byte)0xff, 0x0a, 0x00, 0x01, 0x01}));
+    }
+
 }


### PR DESCRIPTION
A fix for subnet mask evaluation.

https://issues.jboss.org/browse/WFLY-3478
