### PR TITLE
[WFLY-3534] - Transaction is not being shared by different operations within the same thread.

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/picketlink/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/picketlink/main/module.xml
@@ -36,6 +36,7 @@
         <module name="org.wildfly.extension.undertow"/>
         <module name="org.jboss.as.jpa"/>
         <module name="org.jboss.as.transactions"/>
+        <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.as.web-common"/>

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/jpa/transaction/TransactionalEntityManagerHelper.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/jpa/transaction/TransactionalEntityManagerHelper.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.picketlink.idm.jpa.transaction;
+
+import org.wildfly.extension.picketlink.logging.PicketLinkLogger;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+import javax.transaction.TransactionSynchronizationRegistry;
+
+/**
+ * <p>A helper that knows how to associate {@link javax.persistence.EntityManager} instances with active transactions.</p>
+ *
+ * @author Pedro Igor (reusing code from JPA subsystem)
+ */
+public class TransactionalEntityManagerHelper {
+
+    private final TransactionSynchronizationRegistry transactionSynchronizationRegistry;
+    private final TransactionManager transactionManager;
+
+    public TransactionalEntityManagerHelper(TransactionSynchronizationRegistry transactionSynchronizationRegistry,
+        TransactionManager transactionManager) {
+        this.transactionSynchronizationRegistry = transactionSynchronizationRegistry;
+        this.transactionManager = transactionManager;
+    }
+
+    /**
+     * Get current persistence context.  Only call while a transaction is active in the current thread.
+     *
+     * @param puScopedName
+     * @return
+     */
+    public EntityManager getTransactionScopedEntityManager(String puScopedName) {
+        return (EntityManager) this.transactionSynchronizationRegistry.getResource(puScopedName);
+    }
+
+    /**
+     * Save the specified EntityManager in the local threads active transaction.  The TransactionSynchronizationRegistry
+     * will clear the reference to the EntityManager when the transaction completes.
+     *
+     * @param scopedPuName
+     * @param entityManager
+     */
+    public  void putEntityManagerInTransactionRegistry(String scopedPuName, EntityManager entityManager) {
+        try {
+            Transaction transaction = this.transactionManager.getTransaction();
+
+            transaction.registerSynchronization(new TransactionalEntityManagerSynchronization(entityManager));
+
+            this.transactionSynchronizationRegistry.putResource(scopedPuName, entityManager);
+        } catch (Exception e) {
+            throw PicketLinkLogger.ROOT_LOGGER.idmJpaFailedCreateTransactionEntityManager(e);
+        }
+    }
+}

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/jpa/transaction/TransactionalEntityManagerSynchronization.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/jpa/transaction/TransactionalEntityManagerSynchronization.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.wildfly.extension.picketlink.idm.jpa.transaction;
+
+import org.jboss.tm.TxUtils;
+
+import javax.persistence.EntityManager;
+import javax.transaction.Synchronization;
+
+/**
+ * <p>{@link javax.transaction.Synchronization} that knows how to close a transactional {@link javax.persistence.EntityManager}
+ * once the transaction finishes.</p>
+ *
+ * @author Pedro Igor
+ */
+public class TransactionalEntityManagerSynchronization implements Synchronization {
+
+    private final EntityManager entityManager;
+
+    TransactionalEntityManagerSynchronization(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Override
+    public void beforeCompletion() {
+
+    }
+
+    @Override
+    public void afterCompletion(int status) {
+        if (safeToClose()) {
+            this.entityManager.close();
+        }
+    }
+
+    /**
+     * AS7-6586 requires that the container avoid closing the EntityManager while the application
+     * may be using the EntityManager in a different thread.  If the transaction has been rolled
+     * back, will check if the current thread is the Arjuna transaction manager Reaper thread.  It is not
+     * safe to call EntityManager.close from the Reaper thread, so false is returned.
+     *
+     * TODO: switch to depend on JBTM-1556 instead of checking the current thread name.
+     *
+     * @return
+     */
+    private boolean safeToClose() {
+        if (this.entityManager.isOpen()) {
+            return !TxUtils.isTransactionManagerTimeoutThread();
+        }
+
+        return true;
+    }
+
+}

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/PartitionManagerAddHandler.java
@@ -61,11 +61,9 @@ import org.wildfly.extension.picketlink.idm.config.JPAStoreSubsystemConfiguratio
 import org.wildfly.extension.picketlink.idm.service.FileIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.JPAIdentityStoreService;
 import org.wildfly.extension.picketlink.idm.service.PartitionManagerService;
-
-import javax.transaction.TransactionManager;
-
 import org.wildfly.extension.picketlink.logging.PicketLinkLogger;
 
+import javax.transaction.TransactionManager;
 import java.util.List;
 
 import static org.jboss.as.controller.PathAddress.EMPTY_ADDRESS;
@@ -424,8 +422,7 @@ public class PartitionManagerAddHandler extends AbstractAddStepHandler {
                     throw PicketLinkLogger.ROOT_LOGGER.typeNotProvided(IDENTITY_STORE_CREDENTIAL_HANDLER.getName());
                 }
 
-                Class<? extends AttributedType> attributedTypeClass = loadClass(moduleNode, typeName);
-                storeConfig.addCredentialHandler((Class<? extends CredentialHandler>) attributedTypeClass);
+                storeConfig.addCredentialHandler(this.<CredentialHandler>loadClass(moduleNode, typeName));
             }
         }
     }

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/logging/PicketLinkLogger.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/logging/PicketLinkLogger.java
@@ -22,7 +22,6 @@
 
 package org.wildfly.extension.picketlink.logging;
 
-import javax.xml.stream.XMLStreamException;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -33,6 +32,8 @@ import org.jboss.logging.annotations.MessageLogger;
 import org.picketlink.common.exceptions.ProcessingException;
 import org.picketlink.identity.federation.core.audit.PicketLinkAuditEventType;
 import org.picketlink.idm.config.SecurityConfigurationException;
+
+import javax.xml.stream.XMLStreamException;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
@@ -45,6 +46,7 @@ public interface PicketLinkLogger extends BasicLogger {
 
     PicketLinkLogger ROOT_LOGGER = Logger.getMessageLogger(PicketLinkLogger.class, "org.wildfly.extension.picketlink");
 
+    // General Messages 1-49
     @LogMessage(level = INFO)
     @Message(id = 1, value = "Activating PicketLink %s Subsystem")
     void activatingSubsystem(String name);
@@ -65,8 +67,6 @@ public interface PicketLinkLogger extends BasicLogger {
     @Message(id = 5, value = "Error while configuring the metrics collector. Metrics will not be collected.")
     void federationErrorCollectingMetric(@Cause Throwable t);
 
-
-    // General Messages
     @Message(id = 6, value = "No writer provided for element %s. Check if a writer is registered in PicketLinkSubsystemWriter.")
     IllegalStateException noModelElementWriterProvided(String modelElement);
 
@@ -85,35 +85,38 @@ public interface PicketLinkLogger extends BasicLogger {
     @Message(id = 11, value = "Failed to get metrics %s.")
     OperationFailedException failedToGetMetrics(String reason);
 
-    // IDM Messages
-    @Message(id = 12, value = "Entities module not found [%s].")
+    // IDM Messages 50-99
+    @Message(id = 50, value = "Entities module not found [%s].")
     SecurityConfigurationException idmJpaEntityModuleNotFound(String entityModuleName);
 
-    @Message(id = 13, value = "Could not configure JPA store.")
+    @Message(id = 51, value = "Could not configure JPA store.")
     SecurityConfigurationException idmJpaStartFailed(@Cause Throwable e);
 
-    @Message(id = 14, value = "Could not lookup EntityManagerFactory [%s].")
+    @Message(id = 52, value = "Could not lookup EntityManagerFactory [%s].")
     SecurityConfigurationException idmJpaEMFLookupFailed(String entityManagerFactoryJndiName);
 
-    @Message(id = 15, value = "You must provide at least one identity configuration.")
+    @Message(id = 53, value = "Could not create transactional EntityManager.")
+    SecurityConfigurationException idmJpaFailedCreateTransactionEntityManager(@Cause Exception e);
+
+    @Message(id = 54, value = "You must provide at least one identity configuration.")
     OperationFailedException idmNoIdentityConfigurationProvided();
 
-    @Message(id = 16, value = "You must provide at least one identity store for identity configuration [%s].")
+    @Message(id = 55, value = "You must provide at least one identity store for identity configuration [%s].")
     OperationFailedException idmNoIdentityStoreProvided(String identityConfiguration);
 
-    // Federation Messages
-    @Message(id = 17, value = "No Identity Provider configuration found for federation [%s]. ")
+    // Federation Messages - 100-150
+    @Message(id = 100, value = "No Identity Provider configuration found for federation [%s]. ")
     IllegalStateException federationIdentityProviderNotConfigured(String federationAlias);
 
-    @Message(id = 18, value = "No type provided for the handler. You must specify a class-name or code.")
+    @Message(id = 101, value = "No type provided for the handler. You must specify a class-name or code.")
     OperationFailedException federationHandlerTypeNotProvided();
 
-    @Message(id = 19, value = "Could not parse default STS configuration.")
+    @Message(id = 102, value = "Could not parse default STS configuration.")
     RuntimeException federationCouldNotParseSTSConfig(@Cause Throwable t);
 
-    @Message(id = 20, value = "Required attribute [%s] for [%s].")
+    @Message(id = 103, value = "Required attribute [%s] for [%s].")
     OperationFailedException federationRequiredAttribute(String attributeName, String configuration);
 
-    @Message(id = 21, value = "Could not configure SAML Metadata to deployment [%s].")
+    @Message(id = 104, value = "Could not configure SAML Metadata to deployment [%s].")
     IllegalStateException federationSAMLMetadataConfigError(String deploymentName, @Cause ProcessingException e);
 }


### PR DESCRIPTION
This change is about using a ThreadLocal to share the same EntityManager between invocations from the same thread and transaction.

The JPAIdentityStoreService may create an embedded  EntityManagerFactory based on a data source provided by the user when configuring the IDM subsystem. In this case, is up to the subsystem to properly manage EntityManager instances in order to perform IDM operations.

The same applies to transactions, the subsystem uses JTA and it can begin or join the actual transaction. 

This change improves how EntityManager is created and also how transactions are managed by the JPAIdentityStoreService.
