### PR TITLE
WFLY-3530 Upgrade Weld to 2.2.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -230,8 +230,8 @@
         <version.org.jboss.staxmapper>1.1.0.Final</version.org.jboss.staxmapper>
         <version.org.jboss.stdio>1.0.2.GA</version.org.jboss.stdio>
         <version.org.jboss.threads>2.1.1.Final</version.org.jboss.threads>
-        <version.org.jboss.weld.weld>2.2.1.Final</version.org.jboss.weld.weld>
-        <version.org.jboss.weld.weld-api>2.2.SP1</version.org.jboss.weld.weld-api>
+        <version.org.jboss.weld.weld>2.2.2.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld-api>2.2.SP2</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.2.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.spi>2.3.0.Final</version.org.jboss.ws.spi>
         <version.org.jboss.ws.common>2.3.0.Final</version.org.jboss.ws.common>


### PR DESCRIPTION
This should be backported to 8.x (WildFly 8.2.0.CR1) branch as well.
