### PR TITLE
WFLY-794: adds missing package in sun.jdk module, adds simple test to en...

### DIFF
--- a/core-build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/core-build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -50,6 +50,7 @@
                 <path name="com/sun/jndi/url/iiopname"/>
                 <path name="com/sun/jndi/url/ldap"/>
                 <path name="com/sun/jndi/url/ldaps"/>
+                <path name="com/sun/jndi/url/rmi"/>
                 <path name="com/sun/media/sound"/>
                 <path name="com/sun/crypto/provider"/>
                 <path name="com/sun/org/apache/xml/internal/security/transforms/implementations"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupBean.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,21 +20,21 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.test.integration.naming.connector;
+package org.jboss.as.test.integration.naming.rmi;
 
-import javax.ejb.Remote;
-import javax.management.remote.JMXServiceURL;
-
+import javax.ejb.Stateless;
+import javax.naming.Context;
+import javax.naming.InitialContext;
 
 /**
- * @author baranowb
- * @author Eduardo Martins
  *
+ * @author Eduardo Martins
  */
-@Remote
-public interface ConnectedBeanInterface {
+@Stateless
+public class RmiContextLookupBean {
 
-    public int getMBeanCountFromConnector(JMXServiceURL jmxServiceURL) throws Exception;
-
-    public int getMBeanCountFromJNDI(String rmiServerJndiName) throws Exception;
+    public void testRmiContextLookup(String serverAddress, int serverPort) throws Exception {
+        final Context rmiContext = InitialContext.doLookup("rmi://" + serverAddress + ":" + serverPort);
+        rmiContext.close();
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/rmi/RmiContextLookupTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.naming.rmi;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.InitialContext;
+
+/**
+ *
+ * Test which ensures RMI Context is available in JNDI.
+ * @author Eduardo Martins
+ *
+ */
+@RunWith(Arquillian.class)
+public class RmiContextLookupTestCase {
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @Deployment
+    public static WebArchive getDeployment() {
+        return ShrinkWrap.create(WebArchive.class, RmiContextLookupTestCase.class.getSimpleName() + ".war")
+                .addClasses(RmiContextLookupTestCase.class, RmiContextLookupBean.class);
+    }
+
+    @Test
+    public void testTaskSubmit() throws Exception {
+        final RmiContextLookupBean bean =  InitialContext.doLookup("java:module/" + RmiContextLookupBean.class.getSimpleName());
+        bean.testRmiContextLookup(managementClient.getMgmtAddress(), 11090);
+    }
+
+}


### PR DESCRIPTION
...sure rmi context is in jndi, and enhances the existent jmx connector test to run remotely (which fails without the missing package in sun.jdk module)

Related PR for 8.x: #6429
