### PR TITLE
WFLY-3380 Change isCallerInRole implementation to use the EJBAuthorizati...

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
@@ -128,7 +128,7 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
 
         final boolean securityRequired = beanHasMethodLevelSecurityMetadata || ejbComponentDescription.hasBeanLevelSecurityMetadata();
         // setup the security context interceptor
-        viewConfiguration.addViewInterceptor(new SecurityContextInterceptorFactory(securityRequired), InterceptorOrder.View.SECURITY_CONTEXT);
+        viewConfiguration.addViewInterceptor(new SecurityContextInterceptorFactory(securityRequired, true, contextID), InterceptorOrder.View.SECURITY_CONTEXT);
         // now add the security interceptor if the bean has *any* security metadata applicable
         if (securityRequired) {
             // also check the missing-method-permissions-deny-access configuration and add the authorization interceptor

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptor.java
@@ -21,9 +21,11 @@
  */
 package org.jboss.as.ejb3.security;
 
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 import javax.ejb.EJBAccessException;
+import javax.security.jacc.PolicyContext;
 
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorContext;
@@ -41,6 +43,7 @@ import static java.security.AccessController.doPrivileged;
 public class SecurityContextInterceptor implements Interceptor {
     private final PrivilegedAction<Void> pushAction;
     private final PrivilegedAction<Void> popAction;
+    private final String policyContextID;
 
     public SecurityContextInterceptor(final SecurityContextInterceptorHolder holder) {
         this.pushAction = new PrivilegedAction<Void>() {
@@ -81,11 +84,13 @@ public class SecurityContextInterceptor implements Interceptor {
                 return null;
             }
         };
+        this.policyContextID = holder.policyContextID;
     }
 
     @Override
     public Object processInvocation(final InterceptorContext context) throws Exception {
         // TODO - special cases need to be handled where SecurityContext not established or minimal unauthenticated principal context instead.
+        String previousContextID = this.setContextID(this.policyContextID);
         if (WildFlySecurityManager.isChecking()) {
             doPrivileged(pushAction);
         } else {
@@ -94,11 +99,50 @@ public class SecurityContextInterceptor implements Interceptor {
         try {
             return context.proceed();
         } finally {
+            this.setContextID(previousContextID);
             if (WildFlySecurityManager.isChecking()) {
                 doPrivileged(popAction);
             } else {
                 popAction.run();
             }
+        }
+    }
+
+    /**
+     * <p>
+     * Sets the JACC contextID using a privileged action and returns the previousID from the {@code PolicyContext}.
+     * </p>
+     *
+     * @param contextID the JACC contextID to be set.
+     * @return the previous contextID as retrieved from the {@code PolicyContext}.
+     */
+    protected String setContextID(final String contextID) {
+        if (! WildFlySecurityManager.isChecking()) {
+            final String previousID = PolicyContext.getContextID();
+            PolicyContext.setContextID(contextID);
+            return previousID;
+        } else {
+            final PrivilegedAction<String> action = new SetContextIDAction(contextID);
+            return AccessController.doPrivileged(action);
+        }
+    }
+
+    /**
+     * PrivilegedAction that sets the {@code PolicyContext} id.
+     */
+    private static class SetContextIDAction implements PrivilegedAction<String> {
+
+        private String contextID;
+
+        SetContextIDAction(final String contextID) {
+            this.contextID = contextID;
+        }
+
+        @Override
+        public String run() {
+            final String previousID = PolicyContext.getContextID();
+            PolicyContext.setContextID(this.contextID);
+            return previousID;
         }
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
@@ -45,14 +45,20 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
 
     private final boolean securityRequired;
     private final boolean propagateSecurity;
+    private final String policyContextID;
 
     public SecurityContextInterceptorFactory(final boolean securityRequired) {
         this(securityRequired, true);
     }
 
     public SecurityContextInterceptorFactory(final boolean securityRequired, final boolean propagateSecurity) {
+        this(securityRequired, propagateSecurity, null);
+    }
+
+    public SecurityContextInterceptorFactory(final boolean securityRequired, final boolean propagateSecurity, final String policyContextID) {
         this.securityRequired = securityRequired;
         this.propagateSecurity = propagateSecurity;
+        this.policyContextID = policyContextID;
     }
 
     @Override
@@ -88,7 +94,7 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
         }
         SecurityContextInterceptorHolder holder = new SecurityContextInterceptorHolder();
         holder.setSecurityManager(securityManager).setSecurityDomain(securityDomain)
-        .setRunAs(runAs).setRunAsPrincipal(runAsPrincipal)
+        .setRunAs(runAs).setRunAsPrincipal(runAsPrincipal).setPolicyContextID(this.policyContextID)
         .setExtraRoles(extraRoles).setPrincipalVsRolesMap(principalVsRolesMap)
         .setSkipAuthentication(securityRequired == false);
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorHolder.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorHolder.java
@@ -34,6 +34,7 @@ import org.jboss.as.core.security.ServerSecurityManager;
 class SecurityContextInterceptorHolder {
     ServerSecurityManager securityManager;
     String securityDomain, runAs, runAsPrincipal;
+    String policyContextID;
     Set<String> extraRoles;
     Map<String, Set<String>> principalVsRolesMap;
     boolean skipAuthentication;
@@ -58,6 +59,11 @@ class SecurityContextInterceptorHolder {
 
     public SecurityContextInterceptorHolder setRunAsPrincipal(String ras) {
         this.runAsPrincipal = ras;
+        return this;
+    }
+
+    public SecurityContextInterceptorHolder setPolicyContextID(String policyContextID) {
+        this.policyContextID = policyContextID;
         return this;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/roles.properties
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/roles.properties
@@ -20,4 +20,6 @@
 # 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 #
 foo=bar
+#TODO add a mapping module of type 'role' to the test security domain so it can use the mapping specified in jboss-ejb3.xml
+phantom=RealRole
 


### PR DESCRIPTION
...onHelper
- This change fixes an issue in which the configured authorization modules were not invoked when isCallerInRole was called. Now both isCallerInRole and authorize methods use the EJBAuthorizationHelper to ensure the proper modules get involved in authorization decisions.
- The SecurityContextInterceptor is now responsible for setting the JACC context ID in the PolicyContext. This guarantees a valid context ID is available when the EJBAuthorizationHelper is called.
