### PR TITLE
[WFLY-3435] jboss-as-infinispan_1_X.xsd schema has incorrect default value for flush-lock-timeout in write-behind

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanModel.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanModel.java
@@ -33,8 +33,9 @@ public enum InfinispanModel {
     VERSION_1_4_0(1, 4, 0),
     VERSION_1_4_1(1, 4, 1),
     VERSION_2_0_0(2, 0, 0),
+    VERSION_3_0_0(3, 0, 0),
     ;
-    static final InfinispanModel CURRENT = VERSION_2_0_0;
+    static final InfinispanModel CURRENT = VERSION_3_0_0;
 
     private final ModelVersion version;
 

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteBehindResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteBehindResourceDefinition.java
@@ -25,7 +25,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import org.jboss.as.clustering.controller.ReloadRequiredAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
@@ -83,11 +82,6 @@ public class StoreWriteBehindResourceDefinition extends SimpleResourceDefinition
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {
             FLUSH_LOCK_TIMEOUT, MODIFICATION_QUEUE_SIZE, THREAD_POOL_SIZE, SHUTDOWN_TIMEOUT
     };
-
-    static final ObjectTypeAttributeDefinition WRITE_BEHIND_OBJECT = ObjectTypeAttributeDefinition.Builder.of(ModelKeys.WRITE_BEHIND, ATTRIBUTES)
-            .setAllowNull(true)
-            .setSuffix("write-behind")
-            .build();
 
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder builder = parent.addChildResource(PATH);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteBehindResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteBehindResourceDefinition.java
@@ -55,7 +55,7 @@ public class StoreWriteBehindResourceDefinition extends SimpleResourceDefinition
             .setXmlName(Attribute.FLUSH_LOCK_TIMEOUT.getLocalName())
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode().set(1L))
+            .setDefaultValue(new ModelNode().set(5000L))
             .build();
 
     static final SimpleAttributeDefinition MODIFICATION_QUEUE_SIZE = new SimpleAttributeDefinitionBuilder(ModelKeys.MODIFICATION_QUEUE_SIZE, ModelType.INT, true)

--- a/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_1_2.xsd
+++ b/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_1_2.xsd
@@ -476,7 +476,7 @@
     </xs:complexType>
 
     <xs:complexType name="write-behind">
-        <xs:attribute name="flush-lock-timeout" type="xs:long" default="1">
+        <xs:attribute name="flush-lock-timeout" type="xs:long" default="5000">
             <xs:annotation>
                 <xs:documentation>
                     Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.

--- a/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_1_3.xsd
+++ b/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_1_3.xsd
@@ -456,7 +456,7 @@
     </xs:complexType>
 
     <xs:complexType name="write-behind">
-        <xs:attribute name="flush-lock-timeout" type="xs:long" default="1">
+        <xs:attribute name="flush-lock-timeout" type="xs:long" default="5000">
             <xs:annotation>
                 <xs:documentation>
                     Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.

--- a/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_1_4.xsd
+++ b/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_1_4.xsd
@@ -475,7 +475,7 @@
     </xs:complexType>
 
     <xs:complexType name="write-behind">
-        <xs:attribute name="flush-lock-timeout" type="xs:long" default="1">
+        <xs:attribute name="flush-lock-timeout" type="xs:long" default="5000">
             <xs:annotation>
                 <xs:documentation>
                     Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.

--- a/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_2_0.xsd
+++ b/clustering/infinispan/src/main/resources/schema/jboss-as-infinispan_2_0.xsd
@@ -497,7 +497,7 @@
     </xs:complexType>
 
     <xs:complexType name="write-behind">
-        <xs:attribute name="flush-lock-timeout" type="xs:long" default="1">
+        <xs:attribute name="flush-lock-timeout" type="xs:long" default="5000">
             <xs:annotation>
                 <xs:documentation>
                     Timeout to acquire the lock which guards the state to be flushed to the cache store periodically.

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
@@ -108,6 +108,16 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
+    public void testTransformer800() throws Exception {
+        testTransformer_2_0_0(
+                ModelTestControllerVersion.WILDFLY_8_0_0_FINAL,
+                "org.wildfly:wildfly-clustering-infinispan:" + ModelTestControllerVersion.WILDFLY_8_0_0_FINAL.getMavenGavVersion(),
+                "org.infinispan:infinispan-core:6.0.1.Final",
+                "org.infinispan:infinispan-cachestore-jdbc:6.0.1.Final"
+        );
+    }
+
+    @Test
     public void testTransformer600() throws Exception {
         testTransformer_1_3_0(
                 ModelTestControllerVersion.EAP_6_0_0,
@@ -251,6 +261,31 @@ public class TransformersTestCase extends OperationTestCaseBase {
         Assert.assertFalse(transformedOperation.rejectOperation(result));
         Assert.assertEquals(result, transformedOperation.transformResult(result));
     }
+
+
+    /**
+     * Tests whether:
+     * - flush-lock-timeout is converted (WFLY-3435)
+     */
+    public void testTransformer_2_0_0(ModelTestControllerVersion controllerVersion, String... mavenResourceURLs) throws Exception {
+        ModelVersion version = ModelVersion.create(2, 0, 0);
+
+        // create builder for current subsystem version
+        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT).setSubsystemXml(getSubsystemXml());
+
+        // initialise the legacy services
+        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version)
+                .addMavenResourceURL(mavenResourceURLs)
+        ;
+        KernelServices mainServices = builder.build();
+        KernelServices legacyServices = mainServices.getLegacyServices(version);
+        Assert.assertNotNull(legacyServices);
+        Assert.assertTrue(mainServices.isSuccessfulBoot());
+        Assert.assertTrue(legacyServices.isSuccessfulBoot());
+
+        checkSubsystemModelTransformation(mainServices, version);
+    }
+
 
     /*
      * Check transformation from current model version to 1.4.0 model version.
@@ -701,7 +736,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
      * - virtual nodes attribute
      *
      * This is required when comparing current model with the current controller booted with legacy operations,
-     * as the statistics attribute of ache-container and cache add operations are discarded.
+     * as the statistics attribute of cache-container and cache add operations are discarded.
      */
     private static class FixReverseControllerModel140 implements ModelFixer {
         @Override

--- a/clustering/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-2_0.xml
+++ b/clustering/infinispan/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-2_0.xml
@@ -33,7 +33,8 @@
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <!-- Leave out flush-lock-timeout here to test transformations of the default value (to 5 seconds) -->
+                <write-behind modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
             </file-store>
             <indexing index="LOCAL">
             <!--


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3435

Continuation of https://github.com/wildfly/wildfly/pull/6329
