### PR TITLE
Fix for connector and timer TCK regressions

### DIFF
--- a/core-security/implementation/src/main/java/org/jboss/as/core/security/ServerSecurityManager.java
+++ b/core-security/implementation/src/main/java/org/jboss/as/core/security/ServerSecurityManager.java
@@ -50,7 +50,12 @@ public interface ServerSecurityManager {
 
     Subject getSubject();
 
+    //TODO: we have no internal users of this, find out if it is used downstream
+    @Deprecated
     boolean isCallerInRole(final String ejbName, final Object mappedRoles, final Map<String, Collection<String>> roleLinks,
+            final String... roleNames);
+
+    boolean isCallerInRole(final String ejbName, String policyContextId, final Object mappedRoles, final Map<String, Collection<String>> roleLinks,
             final String... roleNames);
 
     boolean authorize(String ejbName, CodeSource ejbCodeSource, String ejbMethodIntf, Method ejbMethod, Set<Principal> methodRoles, String contextID);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -97,6 +97,7 @@ public abstract class EJBComponent extends BasicComponent {
     private final String earApplicationName;
     private final String moduleName;
     private final String distinctName;
+    private final String policyContextID;
     private final EJBRemoteTransactionsRepository ejbRemoteTransactionsRepository;
 
     private final InvocationMetrics invocationMetrics = new InvocationMetrics();
@@ -149,6 +150,7 @@ public abstract class EJBComponent extends BasicComponent {
         this.applicationName = ejbComponentCreateService.getApplicationName();
         this.earApplicationName = ejbComponentCreateService.getEarApplicationName();
         this.distinctName = ejbComponentCreateService.getDistinctName();
+        this.policyContextID = ejbComponentCreateService.getPolicyContextID();
         this.moduleName = ejbComponentCreateService.getModuleName();
         this.ejbObjectViewServiceName = ejbComponentCreateService.getEjbObject();
         this.ejbLocalObjectViewServiceName = ejbComponentCreateService.getEjbLocalObject();
@@ -396,11 +398,11 @@ public abstract class EJBComponent extends BasicComponent {
         if (WildFlySecurityManager.isChecking()) {
             return WildFlySecurityManager.doUnchecked(new PrivilegedAction<Boolean>() {
                 public Boolean run() {
-                    return serverSecurityManager.isCallerInRole(getComponentName(), securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
+                    return serverSecurityManager.isCallerInRole(getComponentName(), policyContextID, securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
                 }
             });
         } else {
-            return this.serverSecurityManager.isCallerInRole(getComponentName(), securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
+            return this.serverSecurityManager.isCallerInRole(getComponentName(), policyContextID, securityMetaData.getSecurityRoles(), securityMetaData.getSecurityRoleLinks(), roleName);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -87,6 +87,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final String earApplicationName;
     private final String moduleName;
     private final String distinctName;
+    private final String policyContextID;
 
     private final ShutDownInterceptorFactory shutDownInterceptorFactory;
 
@@ -110,6 +111,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
         this.transactionManagementType = ejbComponentDescription.getTransactionManagementType();
 
         this.timerService = ejbComponentDescription.getTimerService();
+        this.policyContextID = ejbComponentDescription.getPolicyContextID();
 
         // CMTTx
         if (transactionManagementType.equals(TransactionManagementType.CONTAINER)) {
@@ -346,4 +348,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
         return this.serverSecurityManagerInjectedValue;
     }
 
+    public String getPolicyContextID() {
+        return this.policyContextID;
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponentDescription.java
@@ -111,7 +111,8 @@ public class SingletonComponentDescription extends SessionBeanComponentDescripti
             getConfigurators().add(new ComponentConfigurator() {
                     @Override
                     public void configure(final DeploymentPhaseContext context, final ComponentDescription description, final ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
-                        configuration.addPostConstructInterceptor(new SecurityContextInterceptorFactory(isExplicitSecurityDomainConfigured(), false), InterceptorOrder.View.SECURITY_CONTEXT);
+                        configuration.addPostConstructInterceptor(new SecurityContextInterceptorFactory(isExplicitSecurityDomainConfigured(), false,
+                                SecurityContextInterceptorFactory.contextIdForDeployment(context.getDeploymentUnit())), InterceptorOrder.View.SECURITY_CONTEXT);
                     }
                 });
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
@@ -43,7 +43,6 @@ import org.jboss.as.ejb3.component.session.SessionBeanComponentDescription;
 import org.jboss.as.ejb3.deployment.ApplicableMethodInformation;
 import org.jboss.as.ejb3.security.service.EJBViewMethodSecurityAttributesService;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
-import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndexUtil;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
@@ -80,11 +79,7 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
         final EJBViewDescription ejbViewDescription = (EJBViewDescription) viewDescription;
 
         // setup the JACC contextID.
-        DeploymentUnit deploymentUnit = context.getDeploymentUnit();
-        String contextID = deploymentUnit.getName();
-        if (deploymentUnit.getParent() != null) {
-            contextID = deploymentUnit.getParent().getName() + "!" + contextID;
-        }
+        String contextID = SecurityContextInterceptorFactory.contextIdForDeployment(context.getDeploymentUnit());
 
         final EJBViewMethodSecurityAttributesService.Builder viewMethodSecurityAttributesServiceBuilder;
         final ServiceName viewMethodSecurityAttributesServiceName;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/SecurityContextInterceptorFactory.java
@@ -32,6 +32,7 @@ import org.jboss.as.ee.component.ComponentInterceptorFactory;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.security.service.SimpleSecurityManager;
+import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.invocation.Interceptor;
 import org.jboss.invocation.InterceptorFactoryContext;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
@@ -47,8 +48,16 @@ public class SecurityContextInterceptorFactory extends ComponentInterceptorFacto
     private final boolean propagateSecurity;
     private final String policyContextID;
 
-    public SecurityContextInterceptorFactory(final boolean securityRequired) {
-        this(securityRequired, true);
+    public static String contextIdForDeployment(final DeploymentUnit du) {
+        String contextID = du.getName();
+        if (du.getParent() != null) {
+            contextID = du.getParent().getName() + "!" + contextID;
+        }
+        return contextID;
+    }
+
+    public SecurityContextInterceptorFactory(final boolean securityRequired, final String policyContextID) {
+        this(securityRequired, true, policyContextID);
     }
 
     public SecurityContextInterceptorFactory(final boolean securityRequired, final boolean propagateSecurity) {

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -45,6 +45,7 @@ import org.jboss.as.domain.management.security.PasswordCredential;
 import org.jboss.as.security.logging.SecurityLogger;
 import org.jboss.as.security.remoting.RemotingConnectionCredential;
 import org.jboss.as.security.remoting.RemotingConnectionPrincipal;
+import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.security.UserInfo;
 import org.jboss.security.AuthenticationManager;
@@ -56,6 +57,7 @@ import org.jboss.security.SecurityContext;
 import org.jboss.security.SecurityContextAssociation;
 import org.jboss.security.SecurityContextFactory;
 import org.jboss.security.SecurityContextUtil;
+import org.jboss.security.SecurityRolesAssociation;
 import org.jboss.security.SimplePrincipal;
 import org.jboss.security.SubjectInfo;
 import org.jboss.security.audit.AuditEvent;
@@ -176,6 +178,11 @@ public class SimpleSecurityManager implements ServerSecurityManager {
         return callerPrincipal == null ? principal : callerPrincipal;
     }
 
+    @Override
+    public boolean isCallerInRole(String ejbName, Object mappedRoles, Map<String, Collection<String>> roleLinks, String... roleNames) {
+        return isCallerInRole(ejbName, PolicyContext.getContextID(), mappedRoles, roleLinks, roleNames);
+    }
+
     /**
      * @param ejbName              The name of the EJB component where isCallerInRole was invoked.
      * @param incommingMappedRoles The principal vs roles mapping (if any). Can be null.
@@ -184,7 +191,7 @@ public class SimpleSecurityManager implements ServerSecurityManager {
      * @param roleNames            The role names for which the caller is being checked for
      * @return true if the user is in <b>any</b> one of the <code>roleNames</code>. Else returns false
      */
-    public boolean isCallerInRole(final String ejbName, final Object incommingMappedRoles,
+    public boolean isCallerInRole(final String ejbName, final String policyContextID, final Object incommingMappedRoles,
                                   final Map<String, Collection<String>> roleLinks, final String... roleNames) {
 
         final SecurityContext securityContext = doPrivileged(securityContext());
@@ -194,7 +201,7 @@ public class SimpleSecurityManager implements ServerSecurityManager {
 
         final EJBResource resource = new EJBResource(new HashMap<String, Object>());
         resource.setEjbName(ejbName);
-        resource.setPolicyContextID(PolicyContext.getContextID());
+        resource.setPolicyContextID(policyContextID);
         resource.setCallerRunAsIdentity(securityContext.getIncomingRunAs());
         resource.setCallerSubject(securityContext.getUtil().getSubject());
         Principal userPrincipal = securityContext.getUtil().getUserPrincipal();
@@ -211,7 +218,14 @@ public class SimpleSecurityManager implements ServerSecurityManager {
             resource.setSecurityRoleReferences(roleRefs);
         }
 
+        Map<String, Set<String>> previousRolesAssociationMap = null;
         try {
+            // ensure the security roles association contains the incoming principal x roles map.
+            if (incommingMappedRoles != null) {
+                SecurityRolesMetaData rolesMetaData = (SecurityRolesMetaData) incommingMappedRoles;
+                previousRolesAssociationMap = this.setSecurityRolesAssociation(rolesMetaData.getPrincipalVersusRolesMap());
+            }
+
             AbstractEJBAuthorizationHelper helper = SecurityHelperFactory.getEJBAuthorizationHelper(securityContext);
             for (String roleName : roleNames) {
                 if (helper.isCallerInRole(resource, roleName)) {
@@ -222,6 +236,12 @@ public class SimpleSecurityManager implements ServerSecurityManager {
         }
         catch (Exception e) {
             throw new RuntimeException(e);
+        }
+        finally {
+            // reset the security roles association state.
+            if (incommingMappedRoles != null) {
+                this.setSecurityRolesAssociation(previousRolesAssociationMap);
+            }
         }
     }
 
@@ -447,5 +467,33 @@ public class SimpleSecurityManager implements ServerSecurityManager {
                 return am.getSubjectRoles(authenticatedSubject, scb);
             }
         });
+    }
+
+    private Map<String, Set<String>> setSecurityRolesAssociation(Map<String, Set<String>> mappedRoles) {
+        if (System.getSecurityManager() == null) {
+            Map<String, Set<String>> previousMappedRoles = SecurityRolesAssociation.getSecurityRoles();
+            SecurityRolesAssociation.setSecurityRoles(mappedRoles);
+            return previousMappedRoles;
+        }
+        else {
+            SetSecurityRolesAssociationAction action = new SetSecurityRolesAssociationAction(mappedRoles);
+            return AccessController.doPrivileged(action);
+        }
+    }
+
+    private static class SetSecurityRolesAssociationAction implements PrivilegedAction<Map<String, Set<String>>> {
+
+        private final Map<String, Set<String>> mappedRoles;
+
+        SetSecurityRolesAssociationAction(Map<String, Set<String>> mappedRoles) {
+            this.mappedRoles = mappedRoles;
+        }
+
+        @Override
+        public Map<String, Set<String>> run() {
+            Map<String, Set<String>> previousMappedRoles = SecurityRolesAssociation.getSecurityRoles();
+            SecurityRolesAssociation.setSecurityRoles(this.mappedRoles);
+            return previousMappedRoles;
+        }
     }
 }


### PR DESCRIPTION
Related Jira: https://issues.jboss.org/browse/WFLY-3380

Original fix introduced a couple of regressions in the connector and timer TCK modules. This patch fixes the regressions by ensuring that a JACC policy context ID is always present.
