### PR TITLE
Refactor the way we register transformers for jgroups and infinispan sub...

### DIFF
--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
@@ -150,10 +150,10 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition {
                     .addRejectCheck(RejectAttributeChecker.UNDEFINED, STATISTICS_ENABLED)
                     .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, STATISTICS_ENABLED)
                     .addRejectCheck(new RejectAttributeChecker.SimpleRejectAttributeChecker(new ModelNode(false)), STATISTICS_ENABLED);
+        }
 
-            if (InfinispanModel.VERSION_1_4_0.requiresTransformation(version)) {
-                builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, ALIASES, JNDI_NAME, START, LISTENER_EXECUTOR, EVICTION_EXECUTOR, REPLICATION_QUEUE_EXECUTOR, MODULE);
-            }
+        if (InfinispanModel.VERSION_1_4_0.requiresTransformation(version)) {
+            builder.getAttributeBuilder().addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, ALIASES, JNDI_NAME, START, LISTENER_EXECUTOR, EVICTION_EXECUTOR, REPLICATION_QUEUE_EXECUTOR, MODULE);
         }
 
         TransportResourceDefinition.buildTransformation(version, builder);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResourceDefinition.java
@@ -117,14 +117,14 @@ public class CacheResourceDefinition extends SimpleResourceDefinition {
                     .addRejectCheck(RejectAttributeChecker.UNDEFINED, STATISTICS_ENABLED)
                     .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, STATISTICS_ENABLED)
                     .addRejectCheck(new RejectAttributeChecker.SimpleRejectAttributeChecker(new ModelNode(false)), STATISTICS_ENABLED);
+        }
 
-            if (InfinispanModel.VERSION_1_4_0.requiresTransformation(version)) {
-                // The following attributes now support expressions
-                builder.getAttributeBuilder()
-                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, BATCHING, INDEXING, JNDI_NAME, MODULE, START)
-                        .setDiscard(DiscardAttributeChecker.UNDEFINED, INDEXING_PROPERTIES)
-                        .addRejectCheck(RejectAttributeChecker.DEFINED, INDEXING_PROPERTIES);
-            }
+        if (InfinispanModel.VERSION_1_4_0.requiresTransformation(version)) {
+            // The following attributes now support expressions
+            builder.getAttributeBuilder()
+                    .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, BATCHING, INDEXING, JNDI_NAME, MODULE, START)
+                    .setDiscard(DiscardAttributeChecker.UNDEFINED, INDEXING_PROPERTIES)
+                    .addRejectCheck(RejectAttributeChecker.DEFINED, INDEXING_PROPERTIES);
         }
 
         LockingResourceDefinition.buildTransformation(version, builder);

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
@@ -149,26 +149,26 @@ public class JDBCStoreResourceDefinition extends StoreResourceDefinition {
             builder.getAttributeBuilder()
                     .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(), DIALECT)
                     .addRejectCheck(RejectAttributeChecker.DEFINED, DIALECT);
+        }
 
-            if (InfinispanModel.VERSION_1_4_0.requiresTransformation(version)) {
-                Map<String, RejectAttributeChecker> columnCheckers = new HashMap<>();
-                columnCheckers.put(COLUMN_NAME.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
-                columnCheckers.put(COLUMN_TYPE.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
-                RejectAttributeChecker columnChecker = new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(columnCheckers);
+        if (InfinispanModel.VERSION_1_4_0.requiresTransformation(version)) {
+            Map<String, RejectAttributeChecker> columnCheckers = new HashMap<>();
+            columnCheckers.put(COLUMN_NAME.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
+            columnCheckers.put(COLUMN_TYPE.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
+            RejectAttributeChecker columnChecker = new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(columnCheckers);
 
-                Map<String, RejectAttributeChecker> tableCheckers = new HashMap<>();
-                tableCheckers.put(PREFIX.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
-                tableCheckers.put(BATCH_SIZE.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
-                tableCheckers.put(FETCH_SIZE.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
-                tableCheckers.put(ID_COLUMN.getName(), columnChecker);
-                tableCheckers.put(DATA_COLUMN.getName(), columnChecker);
-                tableCheckers.put(TIMESTAMP_COLUMN.getName(), columnChecker);
-                RejectAttributeChecker tableChecker = new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(tableCheckers);
+            Map<String, RejectAttributeChecker> tableCheckers = new HashMap<>();
+            tableCheckers.put(PREFIX.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
+            tableCheckers.put(BATCH_SIZE.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
+            tableCheckers.put(FETCH_SIZE.getName(), RejectAttributeChecker.SIMPLE_EXPRESSIONS);
+            tableCheckers.put(ID_COLUMN.getName(), columnChecker);
+            tableCheckers.put(DATA_COLUMN.getName(), columnChecker);
+            tableCheckers.put(TIMESTAMP_COLUMN.getName(), columnChecker);
+            RejectAttributeChecker tableChecker = new RejectAttributeChecker.ObjectFieldsRejectAttributeChecker(tableCheckers);
 
-                builder.getAttributeBuilder()
-                        .addRejectCheck(tableChecker, BINARY_KEYED_TABLE, STRING_KEYED_TABLE)
-                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, DATA_SOURCE);
-            }
+            builder.getAttributeBuilder()
+                    .addRejectCheck(tableChecker, BINARY_KEYED_TABLE, STRING_KEYED_TABLE)
+                    .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, DATA_SOURCE);
         }
 
         StoreResourceDefinition.buildTransformation(version, builder);


### PR DESCRIPTION
...systems - enclosing if-s is not necessary

@pferraro, here it is as promised, it was only 3 occurences (continuation of https://github.com/wildfly/wildfly/pull/6372)

We agreed it's worth having to evaluate several more if statements when registering transformers rather than with every new model version having to indent entire transformation block which makes the change log significantly larger, make git blaming complicated and making rebasing painful.
