### PR TITLE
[WFLY-3556] Timer persistence and restore

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlParser_1_0.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlParser_1_0.java
@@ -126,7 +126,7 @@ public class EjbTimerXmlParser_1_0 implements XMLElementReader<List<TimerImpl>> 
     private void parseTimer(XMLExtendedStreamReader reader, List<TimerImpl> timers) throws XMLStreamException {
         LoadableElements loadableElements = new LoadableElements();
         TimerImpl.Builder builder = TimerImpl.builder();
-        final Set<String> required = new HashSet<>(Arrays.asList(new String[]{TIMED_OBJECT_ID, TIMER_ID, INITIAL_DATE, REPEAT_INTERVAL, NEXT_DATE, TIMER_STATE}));
+        final Set<String> required = new HashSet<>(Arrays.asList(new String[]{TIMED_OBJECT_ID, TIMER_ID, INITIAL_DATE, REPEAT_INTERVAL, TIMER_STATE}));
         for (int i = 0; i < reader.getAttributeCount(); ++i) {
             String attr = reader.getAttributeValue(i);
             String attrName = reader.getAttributeLocalName(i);

--- a/ejb3/src/main/resources/schema/wildfly-ejb-timer_1_0.xsd
+++ b/ejb3/src/main/resources/schema/wildfly-ejb-timer_1_0.xsd
@@ -67,8 +67,8 @@
         </xs:sequence>
         <xs:attribute name="timed-object-id" type="xs:string" use="required"/>
         <xs:attribute name="timer-id" type="xs:string" use="required"/>
-        <xs:attribute name="initial-date" use="required"/>
-        <xs:attribute name="next-date" use="required"/>
+        <xs:attribute name="initial-date" use="optional"/>
+        <xs:attribute name="next-date" use="optional"/>
         <xs:attribute name="previous-run" use="optional"/>
         <xs:attribute name="timer-state" use="required"/>
         <xs:attribute name="schedule-expr-second" use="required"/>
@@ -78,9 +78,9 @@
         <xs:attribute name="schedule-expr-day-of-month" use="required"/>
         <xs:attribute name="schedule-expr-month" use="required"/>
         <xs:attribute name="schedule-expr-year" use="required"/>
-        <xs:attribute name="schedule-expr-start-date" use="required"/>
-        <xs:attribute name="schedule-expr-end-date" use="required"/>
-        <xs:attribute name="schedule-expr-timezone" use="required"/>
+        <xs:attribute name="schedule-expr-start-date" use="optional"/>
+        <xs:attribute name="schedule-expr-end-date" use="optional"/>
+        <xs:attribute name="schedule-expr-timezone" use="optional"/>
 
     </xs:complexType>
 


### PR DESCRIPTION
As next-date is persisted only if <> null, make next-date optional for parser (for both kinds of timers).
Rename wildfly-ejb-timer_1_0.xml to wildfly-ejb-timer_1_0.xsd as it is a schema definition.
