### PR TITLE
Proactively validate that distributable session attributes are Serializable

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
@@ -91,13 +91,13 @@ public class InfinispanBeanFactory<G, I, T> implements BeanFactory<G, I, T> {
     @Override
     public BeanEntry<G> createValue(I id, G groupId) {
         BeanEntry<G> entry = new InfinispanBeanEntry<>(groupId);
-        BeanEntry<G> existing = this.invoker.invoke(this.cache, new Creator.CreateOperation<>(this.createKey(id), entry));
+        BeanEntry<G> existing = this.invoker.invoke(this.cache, new Creator.CreateOperation<>(this.createKey(id), entry), Flag.FORCE_SYNCHRONOUS);
         return (existing != null) ? existing : entry;
     }
 
     @Override
     public void remove(I id, RemoveListener<T> listener) {
-        BeanEntry<G> entry = this.invoker.invoke(this.cache, new RemoveOperation<BeanKey<I>, BeanEntry<G>>(this.createKey(id)));
+        BeanEntry<G> entry = this.invoker.invoke(this.cache, new RemoveOperation<BeanKey<I>, BeanEntry<G>>(this.createKey(id)), Flag.FORCE_SYNCHRONOUS);
         if (entry != null) {
             G groupId = entry.getGroupId();
             try (BeanGroup<G, I, T> group = this.groupFactory.createGroup(groupId, this.groupFactory.findValue(groupId))) {

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroupFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroupFactory.java
@@ -62,7 +62,7 @@ public class InfinispanBeanGroupFactory<G, I, T> implements BeanGroupFactory<G, 
     public BeanGroupEntry<I, T> createValue(G id) {
         Map<I, T> beans = new HashMap<>();
         BeanGroupEntry<I, T> entry = new InfinispanBeanGroupEntry<>(this.factory.createMarshalledValue(beans));
-        BeanGroupEntry<I, T> existing = this.invoker.invoke(this.cache, new CreateOperation<>(id, entry));
+        BeanGroupEntry<I, T> existing = this.invoker.invoke(this.cache, new CreateOperation<>(id, entry), Flag.FORCE_SYNCHRONOUS);
         return (existing != null) ? existing : entry;
     }
 

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
@@ -165,7 +165,7 @@ public class CacheRegistry<K, V> implements Registry<K, V> {
                 return removed;
             }
         };
-        Map<K, V> removed = this.invoker.invoke(this.cache, operation);
+        Map<K, V> removed = this.invoker.invoke(this.cache, operation, Flag.FORCE_SYNCHRONOUS);
         if (!removed.isEmpty()) {
             for (Listener<K, V> listener: this.listeners) {
                 listener.removedEntries(removed);

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
@@ -93,14 +93,14 @@ public class CoarseSessionFactory<L> implements SessionFactory<CoarseSessionEntr
     @Override
     public CoarseSessionEntry<L> createValue(String id) {
         CoarseSessionCacheEntry<L> cacheEntry = new CoarseSessionCacheEntry<>(new SimpleSessionMetaData());
-        CoarseSessionCacheEntry<L> existingCacheEntry = this.invoker.invoke(this.sessionCache, new CreateOperation<>(id, cacheEntry));
+        CoarseSessionCacheEntry<L> existingCacheEntry = this.invoker.invoke(this.sessionCache, new CreateOperation<>(id, cacheEntry), Flag.FORCE_SYNCHRONOUS);
         if (existingCacheEntry != null) {
             MarshalledValue<Map<String, Object>, MarshallingContext> value = this.invoker.invoke(this.attributesCache, new FindOperation<SessionAttributesCacheKey, MarshalledValue<Map<String, Object>, MarshallingContext>>(new SessionAttributesCacheKey(id)));
             return new CoarseSessionEntry<>(existingCacheEntry, value);
         }
         Map<String, Object> map = new HashMap<>();
         MarshalledValue<Map<String, Object>, MarshallingContext> value = this.marshaller.write(map);
-        MarshalledValue<Map<String, Object>, MarshallingContext> existingValue = this.invoker.invoke(this.attributesCache, new CreateOperation<>(new SessionAttributesCacheKey(id), value));
+        MarshalledValue<Map<String, Object>, MarshallingContext> existingValue = this.invoker.invoke(this.attributesCache, new CreateOperation<>(new SessionAttributesCacheKey(id), value), Flag.FORCE_SYNCHRONOUS);
         return new CoarseSessionEntry<>(cacheEntry, (existingValue != null) ? existingValue : value);
     }
 

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionAttributes.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionAttributes.java
@@ -53,7 +53,7 @@ public class FineSessionAttributes<V> extends FineImmutableSessionAttributes<V> 
 
     @Override
     public Object removeAttribute(String name) {
-        return this.attributes.remove(name) ? this.marshaller.read(this.invoker.invoke(this.cache, new Remover.RemoveOperation<SessionAttributeCacheKey, V>(this.createKey(name)))) : null;
+        return this.attributes.remove(name) ? this.marshaller.read(this.invoker.invoke(this.cache, new Remover.RemoveOperation<SessionAttributeCacheKey, V>(this.createKey(name)), Flag.FORCE_SYNCHRONOUS)) : null;
     }
 
     @Override
@@ -69,7 +69,7 @@ public class FineSessionAttributes<V> extends FineImmutableSessionAttributes<V> 
                 return cache.put(key, value);
             }
         };
-        return this.marshaller.read(this.invoker.invoke(this.cache, operation, this.attributes.add(name) ? new Flag[] { Flag.IGNORE_RETURN_VALUES } : new Flag[0]));
+        return this.marshaller.read(this.invoker.invoke(this.cache, operation, this.attributes.add(name) ? Flag.IGNORE_RETURN_VALUES : Flag.FORCE_SYNCHRONOUS));
     }
 
     @Override

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionFactory.java
@@ -90,13 +90,13 @@ public class FineSessionFactory<L> implements SessionFactory<FineSessionCacheEnt
     @Override
     public FineSessionCacheEntry<L> createValue(String id) {
         FineSessionCacheEntry<L> entry = new FineSessionCacheEntry<>(new SimpleSessionMetaData());
-        FineSessionCacheEntry<L> existing = this.invoker.invoke(this.sessionCache, new CreateOperation<>(id, entry));
+        FineSessionCacheEntry<L> existing = this.invoker.invoke(this.sessionCache, new CreateOperation<>(id, entry), Flag.FORCE_SYNCHRONOUS);
         return (existing != null) ? existing : entry;
     }
 
     @Override
     public void remove(final String id) {
-        final FineSessionCacheEntry<L> entry = this.invoker.invoke(this.sessionCache, new RemoveOperation<String, FineSessionCacheEntry<L>>(id));
+        final FineSessionCacheEntry<L> entry = this.invoker.invoke(this.sessionCache, new RemoveOperation<String, FineSessionCacheEntry<L>>(id), Flag.FORCE_SYNCHRONOUS);
         Operation<SessionAttributeCacheKey, MarshalledValue<Object, MarshallingContext>, Void> attributeOperation = new Operation<SessionAttributeCacheKey, MarshalledValue<Object,MarshallingContext>, Void>() {
             @Override
             public Void invoke(Cache<SessionAttributeCacheKey, MarshalledValue<Object, MarshallingContext>> cache) {

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseAuthenticationEntryExternalizer.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseAuthenticationEntryExternalizer.java
@@ -50,6 +50,7 @@ public class CoarseAuthenticationEntryExternalizer<A, D> extends AbstractSimpleE
         output.writeObject(entry.getAuthentication());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public CoarseAuthenticationEntry<A, D, ?> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
         CoarseAuthenticationEntry<A, D, ?> entry = new CoarseAuthenticationEntry<>();

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseSSOFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/sso/coarse/CoarseSSOFactory.java
@@ -62,13 +62,13 @@ public class CoarseSSOFactory<I, D, L> implements SSOFactory<CoarseSSOEntry<I, D
     @Override
     public CoarseSSOEntry<I, D, L> createValue(String id) {
         CoarseAuthenticationEntry<I, D, L> entry = new CoarseAuthenticationEntry<>();
-        CoarseAuthenticationEntry<I, D, L> existingEntry = this.invoker.invoke(this.authenticationCache, new CreateOperation<>(id, entry));
+        CoarseAuthenticationEntry<I, D, L> existingEntry = this.invoker.invoke(this.authenticationCache, new CreateOperation<>(id, entry), Flag.FORCE_SYNCHRONOUS);
         if (existingEntry != null) {
             Map<D, String> value = this.invoker.invoke(this.sessionsCache, new FindOperation<CoarseSessionsKey, Map<D, String>>(new CoarseSessionsKey(id)));
             return new CoarseSSOEntry<>(existingEntry, value);
         }
         Map<D, String> map = new HashMap<>();
-        Map<D, String> existingMap = this.invoker.invoke(this.sessionsCache, new CreateOperation<>(new CoarseSessionsKey(id), map));
+        Map<D, String> existingMap = this.invoker.invoke(this.sessionsCache, new CreateOperation<>(new CoarseSessionsKey(id), map), Flag.FORCE_SYNCHRONOUS);
         return new CoarseSSOEntry<>(entry, (existingMap != null) ? existingMap : map);
     }
 

--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSession.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/session/DistributableSession.java
@@ -21,6 +21,8 @@
  */
 package org.wildfly.clustering.web.undertow.session;
 
+import java.io.NotSerializableException;
+import java.io.Serializable;
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -103,6 +105,9 @@ public class DistributableSession extends AbstractDistributableSession<Session<L
             AuthenticatedSession old = context.getAuthenticatedSession();
             context.setAuthenticatedSession(session);
             return old;
+        }
+        if (!(value instanceof Serializable)) {
+            throw new IllegalArgumentException(new NotSerializableException(value.getClass().getName()));
         }
         Object old = this.getSession().getAttributes().setAttribute(name, value);
         if (old == null) {

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/session/DistributableSessionTestCase.java
@@ -179,7 +179,7 @@ public class DistributableSessionTestCase {
         listeners.addSessionListener(listener);
         
         String name = "name";
-        Object value = new Object();
+        Integer value = Integer.valueOf(1);
         Object expected = new Object();
 
         when(this.session.getAttributes()).thenReturn(attributes);
@@ -202,7 +202,7 @@ public class DistributableSessionTestCase {
         SessionListeners listeners = new SessionListeners();
         listeners.addSessionListener(listener);
         String name = "name";
-        Object value = new Object();
+        Integer value = Integer.valueOf(1);
         Object expected = null;
 
         when(this.session.getAttributes()).thenReturn(attributes);
@@ -248,7 +248,7 @@ public class DistributableSessionTestCase {
         SessionListeners listeners = new SessionListeners();
         listeners.addSessionListener(listener);
         String name = "name";
-        Object value = new Object();
+        Integer value = Integer.valueOf(1);
         Object expected = value;
 
         when(this.session.getAttributes()).thenReturn(attributes);


### PR DESCRIPTION
From SRV-7.7.2:
"The distributed servlet container must throw an IllegalArgumentException for objects where the container cannot support the mechanism necessary for migration of the session storing them."

Also, improve DIST_ASYNC compatibility by using FORCE_SYNCHRONOUS flag where cache write result is required.
