### PR TITLE
Ultimately fix WFLY-3401 EJB StatefulTimeoutTestCase transient failures.

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
@@ -80,7 +80,7 @@ public class InfinispanBean<G, I, T> implements Bean<G, I, T> {
         if (this.timeout == null) return false;
         Date lastAccessedTime = this.entry.getLastAccessedTime();
         long timeout = this.timeout.convert(TimeUnit.MILLISECONDS);
-        return (lastAccessedTime != null) && (timeout > 0) ? ((System.currentTimeMillis() - lastAccessedTime.getTime()) > timeout) : false;
+        return (lastAccessedTime != null) && (timeout > 0) ? ((System.currentTimeMillis() - lastAccessedTime.getTime()) >= timeout) : false;
     }
 
     @Override

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionMetaData.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionMetaData.java
@@ -52,7 +52,7 @@ public class SimpleSessionMetaData implements SessionMetaData {
     @Override
     public boolean isExpired() {
         long maxInactiveInterval = this.getMaxInactiveInterval(TimeUnit.MILLISECONDS);
-        return (maxInactiveInterval > 0) ? (System.currentTimeMillis() - this.lastAccessedTime.getTime()) > maxInactiveInterval : false;
+        return (maxInactiveInterval > 0) ? (System.currentTimeMillis() - this.lastAccessedTime.getTime()) >= maxInactiveInterval : false;
     }
 
     @Override


### PR DESCRIPTION
If expiration task fires promptly, then now - lastAccessedTime == timeout
So make sure expiration check is inclusive.
