### PR TITLE
WFLY-3587: removes the need for infinispan module when creating security...

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainAdd.java
@@ -70,7 +70,6 @@ import javax.security.auth.login.AppConfigurationEntry.LoginModuleControlFlag;
 import javax.security.auth.login.Configuration;
 import javax.transaction.TransactionManager;
 
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.as.clustering.infinispan.subsystem.EmbeddedCacheManagerService;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -84,13 +83,13 @@ import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.as.security.service.JaasConfigurationService;
 import org.jboss.as.security.service.SecurityDomainService;
 import org.jboss.as.security.service.SecurityManagementService;
-import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.msc.inject.InjectionException;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.security.ISecurityManagement;
 import org.jboss.security.JBossJSSESecurityDomain;
@@ -180,12 +179,12 @@ class SecurityDomainAdd extends AbstractAddStepHandler {
                         securityDomainService.getSecurityManagementInjector())
                 .addDependency(JaasConfigurationService.SERVICE_NAME, Configuration.class,
                         securityDomainService.getConfigurationInjector())
-                .addDependency(ServiceBuilder.DependencyType.OPTIONAL, TransactionManagerService.SERVICE_NAME, TransactionManager.class,
+                .addDependency(ServiceBuilder.DependencyType.OPTIONAL, ServiceName.JBOSS.append("txn", "TransactionManager"), TransactionManager.class,
                         transactionManagerInjector);
 
         if ("infinispan".equals(cacheType)) {
             builder.addDependency(EmbeddedCacheManagerService.getServiceName(CACHE_CONTAINER_NAME),
-                    EmbeddedCacheManager.class, securityDomainService.getCacheManagerInjector());
+                    Object.class, securityDomainService.getCacheManagerInjector());
         }
 
         if (verificationHandler != null) {

--- a/security/subsystem/src/main/java/org/jboss/as/security/plugins/AuthenticationCacheFactory.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/plugins/AuthenticationCacheFactory.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -22,34 +22,22 @@
 
 package org.jboss.as.security.plugins;
 
+import org.jboss.security.authentication.JBossCachedAuthenticationManager.DomainInfo;
+
 import java.security.Principal;
 import java.util.concurrent.ConcurrentMap;
-
-import org.jboss.as.security.org.jboss.as.security.lru.LRUCache;
-import org.jboss.as.security.org.jboss.as.security.lru.RemoveCallback;
-import org.jboss.security.authentication.JBossCachedAuthenticationManager.DomainInfo;
 
 /**
  * Factory that creates default {@code ConcurrentMap}s for authentication cache.
  *
- * @author <a href="mailto:mmoyses@redhat.com">Marcus Moyses</a>
+ * @author Eduardo Martins
  */
-public class DefaultAuthenticationCacheFactory implements AuthenticationCacheFactory {
+public interface AuthenticationCacheFactory {
 
     /**
-     * Returns a default cache implementation
+     * Returns a cache implementation
      *
      * @return cache implementation
      */
-    public ConcurrentMap<Principal, DomainInfo> getCache() {
-        ConcurrentMap<Principal, DomainInfo> map = new LRUCache<>(1000,  new RemoveCallback<Principal, DomainInfo>() {
-            @Override
-            public void afterRemove(Principal key, DomainInfo value) {
-                if (value != null) {
-                    value.logout();
-                }
-            }
-        });
-        return map;
-    }
+    ConcurrentMap<Principal, DomainInfo> getCache();
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/plugins/InfinispanAuthenticationCacheFactory.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/plugins/InfinispanAuthenticationCacheFactory.java
@@ -1,0 +1,68 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.security.plugins;
+
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.jboss.security.authentication.JBossCachedAuthenticationManager.DomainInfo;
+
+import java.security.Principal;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Factory that creates ISPN {@code ConcurrentMap}s for authentication cache.
+ *
+ * @author Eduardo Martins
+ */
+public class InfinispanAuthenticationCacheFactory implements AuthenticationCacheFactory {
+
+    private final EmbeddedCacheManager cacheManager;
+    private final String securityDomain;
+
+    /**
+     *
+     * @param cacheManager
+     * @param securityDomain
+     */
+    public InfinispanAuthenticationCacheFactory(Object cacheManager, String securityDomain) {
+        this.cacheManager = (EmbeddedCacheManager) cacheManager;
+        this.securityDomain = securityDomain;
+    }
+
+    /**
+     * Returns a default cache implementation
+     *
+     * @return cache implementation
+     */
+    public ConcurrentMap<Principal, DomainInfo> getCache() {
+        // TODO override global settings with security domain specific
+        ConfigurationBuilder builder = new ConfigurationBuilder();
+        Configuration baseCfg = cacheManager.getCacheConfiguration("auth-cache");
+        if (baseCfg != null) {
+            builder.read(baseCfg);
+        }
+        cacheManager.defineConfiguration(securityDomain, builder.build());
+        return cacheManager.getCache(securityDomain);
+    }
+}

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityDomainService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityDomainService.java
@@ -24,10 +24,11 @@ package org.jboss.as.security.service;
 
 import javax.security.auth.login.Configuration;
 
-import org.infinispan.manager.EmbeddedCacheManager;
 import org.jboss.as.security.SecurityExtension;
 import org.jboss.as.security.logging.SecurityLogger;
+import org.jboss.as.security.plugins.AuthenticationCacheFactory;
 import org.jboss.as.security.plugins.DefaultAuthenticationCacheFactory;
+import org.jboss.as.security.plugins.InfinispanAuthenticationCacheFactory;
 import org.jboss.as.security.plugins.JNDIBasedSecurityManagement;
 import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.msc.inject.Injector;
@@ -57,7 +58,7 @@ public class SecurityDomainService implements Service<SecurityDomainContext> {
 
     private final InjectedValue<Configuration> configurationValue = new InjectedValue<Configuration>();
 
-    private final InjectedValue<EmbeddedCacheManager> cacheManagerValue = new InjectedValue<EmbeddedCacheManager>();
+    private final InjectedValue<Object> cacheManagerValue = new InjectedValue<>();
 
     private final String name;
 
@@ -87,9 +88,9 @@ public class SecurityDomainService implements Service<SecurityDomainContext> {
             applicationPolicyRegistration.addApplicationPolicy(applicationPolicy.getName(), applicationPolicy);
         }
         final JNDIBasedSecurityManagement securityManagement = (JNDIBasedSecurityManagement) securityManagementValue.getValue();
-        Object cacheFactory = null;
+        AuthenticationCacheFactory cacheFactory = null;
         if ("infinispan".equals(cacheType)) {
-            cacheFactory = cacheManagerValue.getValue();
+            cacheFactory = new InfinispanAuthenticationCacheFactory(cacheManagerValue.getValue(), name);
         } else if ("default".equals(cacheType)) {
             cacheFactory = new DefaultAuthenticationCacheFactory();
         }
@@ -150,7 +151,7 @@ public class SecurityDomainService implements Service<SecurityDomainContext> {
      *
      * @return target
      */
-    public Injector<EmbeddedCacheManager> getCacheManagerInjector() {
+    public Injector<Object> getCacheManagerInjector() {
         return cacheManagerValue;
     }
 


### PR DESCRIPTION
... domains without a cache of type infinispan.

Also removing dependency on Transaction subsystem class.

These changes are needed to have security subsystem working on web-build, without Infinispan and Transactions subsystems.
