### PR TITLE
org.jboss.arquillian.junit twice in testsuite/pom.xml

### DIFF
--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -213,11 +213,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.wildfly.arquillian</groupId>
             <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
A lot of messages like 
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.wildfly:wildfly-ts-integ-smoke:jar:9.0.0.Alpha1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.jboss.arquillian.junit:arquillian-junit-container:jar -> duplicate declaration of version (?) @ org.wildfly:wildfly-testsuite:9.0.0.Alpha1-SNAPSHOT, /home/jboss/WildFly-9.0/wildfly/testsuite/pom.xml, line 215, column 21
shown right at the beginning of the build process.
