### PR TITLE
[8.x] [WFLY-1857] Deprecate ConstrainedResourceDefinition

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/access/management/ConstrainedResourceDefinition.java
+++ b/controller/src/main/java/org/jboss/as/controller/access/management/ConstrainedResourceDefinition.java
@@ -31,7 +31,10 @@ import org.jboss.as.controller.ResourceDefinition;
  * In WildFly these methods should be moved to ResourceDefinition once porting of RBAC to EAP is complete.
  *
  * @author Brian Stansberry (c) 2013 Red Hat Inc.
+ *
+ * @deprecated methods will be moved to the parent interface and this interface will be removed in the next major release
  */
+@Deprecated
 public interface ConstrainedResourceDefinition extends ResourceDefinition {
 
     /**


### PR DESCRIPTION
In wildfly-core I filed a PR removing this interface: https://github.com/wildfly/wildfly-core/pull/30
