### PR TITLE
[WFLY-3338] Injected JMSContext is not thread-safe

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.context.transactionscoped;
+
+import static org.junit.Assert.assertEquals;
+
+import javax.annotation.Resource;
+import javax.ejb.EJB;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSConsumer;
+import javax.jms.JMSContext;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.messaging.jms.context.transactionscoped.auxiliary.AppScopedBean;
+import org.jboss.as.test.integration.messaging.jms.context.transactionscoped.auxiliary.ThreadLauncher;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@RunWith(Arquillian.class)
+public class TransactionScopedJMSContextTestCase {
+
+    public static final String QUEUE_NAME = "java:app/TransactionScopedJMSContextTestCase";
+
+    @Resource(mappedName = "/JmsXA")
+    private ConnectionFactory factory;
+
+    @Resource(mappedName = QUEUE_NAME)
+    private Queue queue;
+
+    @EJB
+    ThreadLauncher launcher;
+
+    @Deployment
+    public static JavaArchive createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class, "TransactionScopedJMSContextTestCase.jar")
+                .addClass(TimeoutUtil.class)
+                .addPackage(AppScopedBean.class.getPackage())
+                .addAsManifestResource(EmptyAsset.INSTANCE,
+                        "beans.xml");
+    }
+
+    @Test
+    public void sendAndReceiveWithContext() throws JMSException, InterruptedException {
+        int numThreads = 5;
+        int numMessages = 10;
+        launcher.start(numThreads, numMessages);
+
+        int receivedMessages = 0;
+        try(JMSContext context = factory.createContext()) {
+            JMSConsumer consumer = context.createConsumer(queue);
+            Message m;
+            do {
+                m = consumer.receive(1000);
+                if (m != null) {
+                    receivedMessages++;
+                }
+            }
+            while (m != null);
+        }
+
+        assertEquals(numThreads * numMessages, receivedMessages);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/auxiliary/AppScopedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/auxiliary/AppScopedBean.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.context.transactionscoped.auxiliary;
+
+
+import static org.jboss.as.test.integration.messaging.jms.context.transactionscoped.TransactionScopedJMSContextTestCase.QUEUE_NAME;
+
+import javax.annotation.Resource;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.jms.JMSContext;
+import javax.jms.JMSProducer;
+import javax.jms.Queue;
+import javax.transaction.Transactional;
+
+
+@ApplicationScoped
+@Transactional
+public class AppScopedBean {
+
+    @Inject
+    private JMSContext context;
+
+    @Resource(lookup = QUEUE_NAME)
+    private Queue queue;
+
+    public void sendMessage() {
+        JMSProducer producer = context.createProducer();
+        producer.send(queue, "a message");
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/auxiliary/ThreadLauncher.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/auxiliary/ThreadLauncher.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.messaging.jms.context.transactionscoped.auxiliary;
+
+import static org.jboss.as.test.integration.messaging.jms.context.transactionscoped.TransactionScopedJMSContextTestCase.QUEUE_NAME;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import javax.annotation.Resource;
+import javax.ejb.Stateful;
+import javax.enterprise.concurrent.ManagedThreadFactory;
+import javax.inject.Inject;
+import javax.jms.JMSDestinationDefinition;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc.
+ */
+@JMSDestinationDefinition(
+        name = QUEUE_NAME,
+        interfaceName = "javax.jms.Queue",
+        destinationName = "InjectedJMSContextTestCaseQueue"
+)
+@Stateful(passivationCapable = false)
+public class ThreadLauncher {
+
+    @Resource
+    private ManagedThreadFactory threadFactory;
+    @Inject
+    private AppScopedBean bean;
+
+    public void start(int numThreads, int numMessages) throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(numThreads);
+        System.out.println("starting threads");
+        for (int i = 0; i < numThreads; i++) {
+            threadFactory.newThread(new SendRunnable(latch, numMessages)).start();
+        }
+        System.out.println("start finished");
+
+        latch.await(30, TimeUnit.SECONDS);
+        System.out.println("DONE");
+    }
+
+    private class SendRunnable implements Runnable {
+
+        private final CountDownLatch latch;
+        private final int numMessages;
+
+        public SendRunnable(CountDownLatch latch, int numMessages) {
+
+            this.latch = latch;
+            this.numMessages = numMessages;
+        }
+
+        public void run() {
+            System.out.println("starting to send");
+            for (int i = 0; i < numMessages; i++) {
+                bean.sendMessage();
+            }
+            System.out.println("done sending");
+
+            latch.countDown();
+        }
+
+    }
+
+}


### PR DESCRIPTION
If there is an active transaction, create a new delegate JMSContext and
store it in the TransactionSynchronizationRegistry to ensure it is
scoped with the transaction

JIRA: https://issues.jboss.org/browse/WFLY-3338
