### PR TITLE
[WFLY-3641] Upgrade httpcomponents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,8 +124,8 @@
         <version.org.apache.cxf>2.7.11</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>2.6.1</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
-        <version.org.apache.httpcomponents.httpclient>4.2.1</version.org.apache.httpcomponents.httpclient>
-        <version.org.apache.httpcomponents.httpcore>4.2.1</version.org.apache.httpcomponents.httpcore>
+        <version.org.apache.httpcomponents.httpclient>4.2.6</version.org.apache.httpcomponents.httpclient>
+        <version.org.apache.httpcomponents.httpcore>4.2.5</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>
         <version.org.apache.maven>3.2.1</version.org.apache.maven>
         <version.org.apache.lucene>3.6.2</version.org.apache.lucene>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSManagementInterfaceTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSManagementInterfaceTestCase.java
@@ -43,6 +43,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 
 import org.apache.commons.io.FileUtils;
@@ -160,7 +161,7 @@ public class HTTPSManagementInterfaceTestCase {
             String responseBody = makeCallWithHttpClient(mgmtURL, httpClient, 401);
             assertThat("Management index page was reached", responseBody, not(containsString("management-major-version")));
             fail("Untrusted client should not be authenticated.");
-        } catch (SSLPeerUnverifiedException e) {
+        } catch (SSLHandshakeException e) {
             // OK
         }
 
@@ -193,7 +194,7 @@ public class HTTPSManagementInterfaceTestCase {
         try {
             String responseBody = makeCallWithHttpClient(mgmtURL, httpClientUntrusted, 401);
             assertThat("Management index page was reached", responseBody, not(containsString("management-major-version")));
-        } catch (SSLPeerUnverifiedException e) {
+        } catch (SSLHandshakeException e) {
             // OK
         }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
@@ -338,21 +338,21 @@ public class HTTPSWebConnectorTestCase {
             try {
                 makeCallWithHttpClient(unsecuredUrl, httpClientUntrusted, HttpServletResponse.SC_FORBIDDEN);
                 fail("Untrusted client should not be authenticated.");
-            } catch (SSLPeerUnverifiedException e) {
+            } catch (SSLHandshakeException e) {
                 // OK
             }
 
             try {
                 makeCallWithHttpClient(printPrincipalUrl, httpClientUntrusted, HttpServletResponse.SC_FORBIDDEN);
                 fail("Untrusted client should not be authenticated.");
-            } catch (SSLPeerUnverifiedException e) {
+            } catch (SSLHandshakeException e) {
                 // OK
             }
 
             try {
                 makeCallWithHttpClient(securedUrl, httpClientUntrusted, HttpServletResponse.SC_FORBIDDEN);
                 fail("Untrusted client should not be authenticated.");
-            } catch (SSLPeerUnverifiedException e) {
+            } catch (SSLHandshakeException e) {
                 // OK
             }
 


### PR DESCRIPTION
httpcomponents-core to 4.2.5
httpcomponents-httpclient to 4.2.6

Relative BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1078186

According from httpcomponent release notes upgrading to 4.2.6 won’t break backward compatibility:

```
https://www.apache.org/dist/httpcomponents/httpcore/RELEASE_NOTES-4.3.x.txt
http://www.apache.org/dist/httpcomponents/httpclient/RELEASE_NOTES-4.2.x.txt
```
