### PR TITLE
upgrade hibernate to 4.3.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>
-        <version.org.hibernate>4.3.5.Final</version.org.hibernate>
+        <version.org.hibernate>4.3.6.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.4.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>5.1.1.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>


### PR DESCRIPTION
Upgrade Hibernate from 4.3.5.Final to 4.3.6.Final. This is to fix HHH-8980 and pick up other fixes.
