### PR TITLE
Remove override of unused method we're going to delete from wildfly-core

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/ApplicationClientConfigurationPersister.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/ApplicationClientConfigurationPersister.java
@@ -130,9 +130,4 @@ public class ApplicationClientConfigurationPersister extends XmlConfigurationPer
     public void registerSubsystemWriter(final String name, final XMLElementWriter<SubsystemMarshallingContext> writer) {
 
     }
-
-    @Override
-    public void registerSubsystemDeploymentWriter(final String name, final XMLElementWriter<SubsystemMarshallingContext> writer) {
-
-    }
 }


### PR DESCRIPTION
This will allow me to delete the method in core without introducing a compilation problem in wildfly.

No code calls this method so removing the override has no impact.
