### PR TITLE
Security manager related tests which checks PropertyPermissions granted to deployments

### DIFF
--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/PermissionUtil.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/PermissionUtil.java
@@ -20,10 +20,22 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-/**
- * This package contains a part of the AS integration testsuite, which checks permissions granted when running
- * the AS with Java Security Manager (JSM) enabled.<br>
- * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
- */
 package org.jboss.as.testsuite.integration.secman;
 
+/**
+ * Helper class for permissions testing. This class is usually packaged to a library-like archive in a test deployment.
+ *
+ * @author Josef Cacek
+ */
+public class PermissionUtil {
+
+    /**
+     * Simply calls {@link System#getProperty(String)} method.
+     *
+     * @param property
+     * @return system property
+     */
+    public static String getSystemProperty(String property) {
+        return System.getProperty(property);
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyBean.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyBean.java
@@ -19,11 +19,22 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.as.testsuite.integration.secman.ejbs;
+
+import javax.ejb.Local;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
 
 /**
- * This package contains a part of the AS integration testsuite, which checks permissions granted when running
- * the AS with Java Security Manager (JSM) enabled.<br>
- * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
+ * A SLSB bean which reads the given system property and returns its value.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
  */
-package org.jboss.as.testsuite.integration.secman;
-
+@Stateless
+@Remote(ReadSystemPropertyRemote.class)
+@Local(ReadSystemPropertyLocal.class)
+public class ReadSystemPropertyBean {
+    public String readSystemProperty(final String propertyName) {
+        return System.getProperty(propertyName, "");
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyLocal.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyLocal.java
@@ -19,11 +19,13 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.as.testsuite.integration.secman.ejbs;
 
 /**
- * This package contains a part of the AS integration testsuite, which checks permissions granted when running
- * the AS with Java Security Manager (JSM) enabled.<br>
- * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
+ * Local interface dedicated for ReadSystemPropertyBean.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
  */
-package org.jboss.as.testsuite.integration.secman;
-
+public interface ReadSystemPropertyLocal {
+    String readSystemProperty(final String propertyName);
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyRemote.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyRemote.java
@@ -19,11 +19,13 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.as.testsuite.integration.secman.ejbs;
 
 /**
- * This package contains a part of the AS integration testsuite, which checks permissions granted when running
- * the AS with Java Security Manager (JSM) enabled.<br>
- * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
+ * Remote interface dedicated for ReadSystemPropertyBean.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
  */
-package org.jboss.as.testsuite.integration.secman;
-
+public interface ReadSystemPropertyRemote {
+    String readSystemProperty(final String propertyName);
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithJSP.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithJSP.java
@@ -1,0 +1,143 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.jboss.as.testsuite.integration.secman.propertypermission.SystemPropertiesSetup.PROPERTY_NAME;
+
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Abstract parent for PropertyPermission testcases, which have also readproperty.jsp page included.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractPPTestsWithJSP extends AbstractPropertyPermissionTests {
+
+    /**
+     * Check standard java property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    @Ignore("WFLY-3651")
+    public void testJavaHomePropertyInJSPGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application, where JSP don't get PropertyPermissions (servlets get them).
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    @Ignore("WFLY-3651")
+    public void testJavaHomePropertyInJSPLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testJavaHomePropertyInJSPDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    @Ignore("WFLY-3651")
+    public void testASLevelPropertyInJSPGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testASLevelPropertyInJSPLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testASLevelPropertyInJSPDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    private void checkJavaHomePropertyInJSP(URL webAppURL, int expectedStatus) throws Exception {
+        checkPropertyInJSP(webAppURL, "java.home", expectedStatus, "java.home=");
+    }
+
+    /**
+     * Check access to {@value #WEBAPP_BASE_NAME} property.
+     */
+    private void checkTestPropertyInJSP(URL webAppURL, final int expectedStatus) throws Exception {
+        checkPropertyInJSP(webAppURL, PROPERTY_NAME, expectedStatus, PROPERTY_NAME);
+    }
+
+    /**
+     * Checks access to a system property on the server using <code>readproperty.jsp</code>.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBodyStart expected beginning of response value; if null then response body is not checked
+     * @throws Exception
+     */
+    protected abstract void checkPropertyInJSP(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBodyStart) throws Exception;
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithLibrary.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithLibrary.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.PermissionUtil;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * Abstract parent for tests which creates deployments with library JAR including {@link PermissionUtil}.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractPPTestsWithLibrary extends AbstractPropertyPermissionTests {
+
+    private static Logger LOGGER = Logger.getLogger(AbstractPPTestsWithLibrary.class);
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    @Override
+    protected void checkJavaHomeProperty(URL webAppURL, int expectedStatus) throws Exception {
+        checkProperty(webAppURL, "java.home", expectedStatus);
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link CallPermissionUtilServlet}.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @throws Exception
+     */
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode) throws Exception {
+        checkProperty(webAppURL, propertyName, expectedCode, null);
+    }
+
+    /**
+     * Checks access to a system property on the server.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + CallPermissionUtilServlet.SERVLET_PATH.substring(1) + "?"
+                + Utils.encodeQueryParam(CallPermissionUtilServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBody != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertEquals("System property value doesn't match the expected one.", expectedBody, respBody);
+        }
+    }
+
+    /**
+     * Create java archive with PropertyReadStaticMethodClass class
+     *
+     * @return created java archive
+     */
+    protected static JavaArchive createLibrary() {
+        final JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "library.jar");
+        lib.addClasses(PermissionUtil.class);
+        return lib;
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPropertyPermissionTests.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPropertyPermissionTests.java
@@ -1,0 +1,211 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.jboss.as.testsuite.integration.secman.propertypermission.SystemPropertiesSetup.PROPERTY_NAME;
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URL;
+import java.security.AllPermission;
+import java.util.PropertyPermission;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.servlets.JSMCheckServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.container.ClassContainer;
+import org.jboss.shrinkwrap.api.container.ManifestContainer;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Abstract parent for testcases aimed on PropertyPermission.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public abstract class AbstractPropertyPermissionTests {
+
+    public static final Asset ALL_PERMISSIONS_XML = Utils.getPermissionsXml(new AllPermission());
+    public static final Asset EMPTY_PERMISSIONS_XML = Utils.getPermissionsXml();
+
+    public static final Asset GRANT_PERMISSIONS_XML = Utils.getPermissionsXml(new PropertyPermission("*", "read,write"));
+    public static final Asset LIMITED_PERMISSIONS_XML = Utils.getPermissionsXml(new PropertyPermission("java.home", "read"));
+
+    protected static final String APP_GRANT = "read-props-grant";
+    protected static final String APP_LIMITED = "read-props-limited";
+    protected static final String APP_DENY = "read-props-deny";
+
+    private static Logger LOGGER = Logger.getLogger(AbstractPropertyPermissionTests.class);
+
+    /**
+     * Checks if the AS runs with security manager enabled.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testJSMEnabled(@ArquillianResource URL webAppURL) throws Exception {
+        final URI checkJSMuri = new URI(webAppURL.toExternalForm() + JSMCheckServlet.SERVLET_PATH.substring(1));
+        LOGGER.debug("Checking if JSM is enabled: " + checkJSMuri);
+        assertEquals("JSM should be enabled.", Boolean.toString(true), Utils.makeCall(checkJSMuri, 200));
+    }
+
+    /**
+     * Check standard java property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    @Ignore("WFLY-3651")
+    public void testJavaHomePropertyGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomeProperty(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    @Ignore("WFLY-3651")
+    public void testJavaHomePropertyLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomeProperty(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testJavaHomePropertyDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomeProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    @Ignore("WFLY-3651")
+    public void testASLevelPropertyGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testASLevelPropertyLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testASLevelPropertyDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    protected void checkJavaHomeProperty(URL webAppURL, int expectedStatus) throws Exception {
+        checkProperty(webAppURL, "java.home", expectedStatus, null);
+    }
+
+    /**
+     * Check access to {@value #APP_BASE_NAME} property.
+     */
+    protected void checkTestProperty(URL webAppURL, final int expectedStatus) throws Exception {
+        checkProperty(webAppURL, PROPERTY_NAME, expectedStatus, PROPERTY_NAME);
+    }
+
+    /**
+     * Adds {@link JSMCheckServlet} to the given archive.
+     *
+     * @param archive
+     */
+    protected static void addJSMCheckServlet(final ClassContainer<?> archive) {
+        archive.addClass(JSMCheckServlet.class);
+    }
+
+    /**
+     * Adds {@link JSMCheckServlet} to the given archive.
+     *
+     * @param archive
+     */
+    protected static void addPermissionsXml(final ManifestContainer<?> archive, final Asset permissionsAsset,
+            final Asset jbossPermissionsAsset) {
+        if (permissionsAsset != null) {
+            archive.addAsManifestResource(permissionsAsset, "permissions.xml");
+        }
+        if (jbossPermissionsAsset != null) {
+            archive.addAsManifestResource(jbossPermissionsAsset, "jboss-permissions.xml");
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    protected abstract void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception;
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarLibInWarPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarLibInWarPPTestCase.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to lib in war of deployed ear applications. The applications try to do a
+ * protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class EarLibInWarPPTestCase extends AbstractPPTestsWithLibrary {
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static EnterpriseArchive createDeployment1() {
+        return earDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static EnterpriseArchive createDeployment2() {
+        return earDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static EnterpriseArchive createDeployment3() {
+        return earDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static EnterpriseArchive earDeployment(final String app, Asset permissionsXml) {
+
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, app + ".war");
+        addJSMCheckServlet(war);
+        war.addClasses(CallPermissionUtilServlet.class);
+        war.addAsLibraries(createLibrary());
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, app + ".ear");
+        // override grant-all in permissions.xml by customized jboss-permissions.xm
+        addPermissionsXml(ear, ALL_PERMISSIONS_XML, permissionsXml);
+        ear.addAsModule(war);
+
+        return ear;
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarModulesPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarModulesPPTestCase.java
@@ -1,0 +1,313 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.jboss.as.testsuite.integration.secman.propertypermission.SystemPropertiesSetup.PROPERTY_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessControlException;
+
+import javax.ejb.EJBException;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.ejbs.ReadSystemPropertyBean;
+import org.jboss.as.testsuite.integration.secman.ejbs.ReadSystemPropertyRemote;
+import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to sub-deployment of deployed ear applications. The applications try to
+ * do a protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
+
+    private static final String EJBAPP_BASE_NAME = "ejb-module";
+    private static final String WEBAPP_BASE_NAME = "web-module";
+
+    private static Logger LOGGER = Logger.getLogger(EarModulesPPTestCase.class);
+
+    @ArquillianResource
+    private InitialContext iniCtx;
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static EnterpriseArchive createDeployment1() {
+        return earDeployment(APP_GRANT, AbstractPropertyPermissionTests.GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static EnterpriseArchive createDeployment2() {
+        return earDeployment(APP_LIMITED, AbstractPropertyPermissionTests.LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static EnterpriseArchive createDeployment3() {
+        return earDeployment(APP_DENY, AbstractPropertyPermissionTests.EMPTY_PERMISSIONS_XML);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testJavaHomePropertyEjbInJarGrant() throws Exception {
+        checkJavaHomePropertyEjb(APP_GRANT, false);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testJavaHomePropertyEjbInJarLimited() throws Exception {
+        checkJavaHomePropertyEjb(APP_LIMITED, false);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    @Ignore("WFLY-3667")
+    public void testJavaHomePropertyEjbInJarDeny() throws Exception {
+        checkJavaHomePropertyEjb(APP_DENY, true);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testASLevelPropertyEjbInJarGrant() throws Exception {
+        checkTestPropertyEjb(APP_GRANT, false);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    @Ignore("WFLY-3667")
+    public void testASLevelPropertyEjbInJarLimited() throws Exception {
+        checkTestPropertyEjb(APP_LIMITED, true);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    @Ignore("WFLY-3667")
+    public void testASLevelPropertyEjbInJarDeny() throws Exception {
+        checkTestPropertyEjb(APP_DENY, true);
+    }
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    private void checkJavaHomePropertyEjb(final String moduleNameSuffix, final boolean exceptionExpected) throws Exception {
+        checkPropertyEjb(moduleNameSuffix, "java.home", exceptionExpected, null);
+    }
+
+    /**
+     * Check access to {@value #EARAPP_BASE_NAME} property.
+     */
+    private void checkTestPropertyEjb(final String moduleNameSuffix, final boolean exceptionExpected) throws Exception {
+        checkPropertyEjb(moduleNameSuffix, PROPERTY_NAME, exceptionExpected, PROPERTY_NAME);
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link PrintSystemPropertyServlet}.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + PrintSystemPropertyServlet.SERVLET_PATH.substring(1) + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBody != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertThat("System property value doesn't match the expected one.", respBody,
+                    CoreMatchers.containsString(expectedBody));
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server using <code>readproperty.jsp</code>.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBodyStart expected beginning of response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkPropertyInJSP(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBodyStart) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + "readproperty.jsp" + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBodyStart != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertNotNull("Response from JSP should not be null.", respBody);
+            assertTrue("The readproperty.jsp response doesn't start with the expected value.",
+                    respBody.startsWith(expectedBodyStart));
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server using EJB.
+     *
+     * @param moduleName
+     * @param propertyName
+     * @param exceptionExpected
+     * @param expectedValue
+     * @throws Exception
+     */
+    private void checkPropertyEjb(final String moduleName, final String propertyName, final boolean exceptionExpected,
+            final String expectedValue) throws Exception {
+        LOGGER.debug("Checking if '" + propertyName + "' property is available");
+        ReadSystemPropertyRemote bean = lookupEjb(moduleName, EJBAPP_BASE_NAME + moduleName,
+                ReadSystemPropertyBean.class.getSimpleName(), ReadSystemPropertyRemote.class);
+        assertNotNull(bean);
+
+        Exception ex = null;
+        String propertyValue = null;
+        try {
+            propertyValue = bean.readSystemProperty(propertyName);
+        } catch (Exception e) {
+            ex = e;
+        }
+
+        if (ex instanceof EJBException && ex.getCause() instanceof AccessControlException) {
+            assertTrue("AccessControlException came, but it was not expected", exceptionExpected);
+        } else if (ex != null) {
+            throw ex;
+        } else if (exceptionExpected) {
+            fail("AccessControlException was expected");
+        }
+
+        if (ex == null && expectedValue != null) {
+            assertEquals("System property value doesn't match the expected one.", expectedValue, propertyValue);
+        }
+    }
+
+    private <T> T lookupEjb(final String appName, final String moduleName, final String beanName, final Class<T> interfaceType)
+            throws NamingException {
+        return interfaceType.cast(iniCtx.lookup("ejb:" + appName + "/" + moduleName + "//" + beanName + "!"
+                + interfaceType.getName()));
+    }
+
+    private static EnterpriseArchive earDeployment(final String suffix, final Asset permissionsXml) {
+        JavaArchive jar = ejbDeployment(suffix);
+        WebArchive war = warDeployment(suffix);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, suffix + ".ear");
+        ear.addAsModule(jar);
+        ear.addAsModule(war);
+        addPermissionsXml(ear, permissionsXml, null);
+        return ear;
+    }
+
+    private static JavaArchive ejbDeployment(final String suffix) {
+        final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, EJBAPP_BASE_NAME + suffix + ".jar");
+        ejb.addPackage(ReadSystemPropertyBean.class.getPackage());
+        return ejb;
+    }
+
+    private static WebArchive warDeployment(final String suffix) {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, WEBAPP_BASE_NAME + suffix + ".war");
+        war.addClasses(PrintSystemPropertyServlet.class);
+        war.addAsWebResource(PrintSystemPropertyServlet.class.getPackage(), "readproperty.jsp", "readproperty.jsp");
+        addJSMCheckServlet(war);
+        return war;
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarWithLibPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarWithLibPPTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to lib of deployed ear applications. The applications try to do a
+ * protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class EarWithLibPPTestCase extends AbstractPPTestsWithLibrary {
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static EnterpriseArchive createDeployment1() {
+        return earDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static EnterpriseArchive createDeployment2() {
+        return earDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static EnterpriseArchive createDeployment3() {
+        return earDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static EnterpriseArchive earDeployment(final String appName, final Asset permissionsXml) {
+
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, appName + ".war");
+        addJSMCheckServlet(war);
+        war.addClasses(CallPermissionUtilServlet.class);
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, appName + ".ear");
+        ear.addAsModule(war);
+        // use just jboss-permissions.xml (and no permissions.xml)
+        addPermissionsXml(ear, null, permissionsXml);
+        ear.addAsLibraries(createLibrary());
+
+        return ear;
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/SystemPropertiesSetup.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/SystemPropertiesSetup.java
@@ -19,11 +19,21 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
 
 /**
- * This package contains a part of the AS integration testsuite, which checks permissions granted when running
- * the AS with Java Security Manager (JSM) enabled.<br>
- * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
+ * Server setup task, which adds a custom system property to AS configuration.
+ *
+ * @author Josef Cacek
  */
-package org.jboss.as.testsuite.integration.secman;
+public class SystemPropertiesSetup extends AbstractSystemPropertiesServerSetupTask {
 
+    public static final String PROPERTY_NAME = "custom-test-property";
+
+    @Override
+    protected SystemProperty[] getSystemProperties() {
+        return new SystemProperty[] { new DefaultSystemProperty(PROPERTY_NAME, PROPERTY_NAME) };
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarPPTestCase.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to deployed web applications. The applications try to do a protected
+ * action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class WarPPTestCase extends AbstractPPTestsWithJSP {
+
+    private static Logger LOGGER = Logger.getLogger(WarPPTestCase.class);
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static WebArchive grantDeployment() {
+        return warDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static WebArchive limitedDeployment() {
+        return warDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static WebArchive denyDeployment() {
+        return warDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static WebArchive warDeployment(final String appName, Asset permissionsXmlAsset) {
+        LOGGER.info("Start WAR deployment");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, appName + ".war");
+        addJSMCheckServlet(war);
+        addPermissionsXml(war, permissionsXmlAsset, null);
+        war.addClasses(PrintSystemPropertyServlet.class);
+        war.addAsWebResource(PrintSystemPropertyServlet.class.getPackage(), "readproperty.jsp", "readproperty.jsp");
+        LOGGER.info(war.toString(true));
+        return war;
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link PrintSystemPropertyServlet}.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + PrintSystemPropertyServlet.SERVLET_PATH.substring(1) + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBody != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertEquals("System property value doesn't match the expected one.", expectedBody, respBody);
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server using <code>readproperty.jsp</code>.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBodyStart expected beginning of response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkPropertyInJSP(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBodyStart) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + "readproperty.jsp" + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBodyStart != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertNotNull("Response from JSP should not be null.", respBody);
+            assertTrue("The readproperty.jsp response doesn't start with the expected value.",
+                    respBody.startsWith(expectedBodyStart));
+        }
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarWithLibPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarWithLibPPTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to lib of deployed war applications. The applications try to do a
+ * protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class WarWithLibPPTestCase extends AbstractPPTestsWithLibrary {
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static WebArchive createDeployment1() {
+        return warDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static WebArchive createDeployment2() {
+        return warDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static WebArchive createDeployment3() {
+        return warDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static WebArchive warDeployment(final String suffix, final Asset permissionsXml) {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, suffix + ".war");
+        war.addClasses(CallPermissionUtilServlet.class);
+        addJSMCheckServlet(war);
+        addPermissionsXml(war, EMPTY_PERMISSIONS_XML, permissionsXml);
+        war.addAsLibraries(createLibrary());
+        return war;
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/package-info.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/package-info.java
@@ -21,9 +21,8 @@
  */
 
 /**
- * This package contains a part of the AS integration testsuite, which checks permissions granted when running
- * the AS with Java Security Manager (JSM) enabled.<br>
- * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
+ * This package contains tests related to granting java.util.PropertyPermission in AS deployments.
+ * <i>Permissions for the deployments are defined in permissions.xml and/or jboss-permissions.xml</i>
  */
-package org.jboss.as.testsuite.integration.secman;
+package org.jboss.as.testsuite.integration.secman.propertypermission;
 

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/CallPermissionUtilServlet.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/CallPermissionUtilServlet.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.testsuite.integration.secman.PermissionUtil;
+
+/**
+ * Servlet which calls method(s) from {@link PermissionUtil} class usually packaged in a library (i.e. another archive).
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(CallPermissionUtilServlet.SERVLET_PATH)
+public class CallPermissionUtilServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/CallPermissionUtilServlet";
+    public static final String PARAM_PROPERTY_NAME = "property";
+    public static final String DEFAULT_PROPERTY_NAME = "java.home";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        String property = req.getParameter(PARAM_PROPERTY_NAME);
+        if (property == null || property.length() == 0) {
+            property = DEFAULT_PROPERTY_NAME;
+        }
+        final PrintWriter writer = resp.getWriter();
+        writer.write(PermissionUtil.getSystemProperty(property));
+        writer.close();
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/JSMCheckServlet.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/JSMCheckServlet.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet, which checks if the Java Security Manager (JSM) is enabled. Response is a plain text "true" when JSM is enabled or
+ * "false" otherwise.
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(JSMCheckServlet.SERVLET_PATH)
+public class JSMCheckServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/JSMCheckServlet";
+
+    /**
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        final PrintWriter writer = resp.getWriter();
+        writer.write(Boolean.toString(System.getSecurityManager() != null));
+        writer.close();
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/PrintSystemPropertyServlet.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/PrintSystemPropertyServlet.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet, which prints value of system property. By default it prints value of property {@value #DEFAULT_PROPERTY_NAME}, but
+ * you can specify another property name by using request parameter {@value #PARAM_PROPERTY_NAME}.
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(PrintSystemPropertyServlet.SERVLET_PATH)
+public class PrintSystemPropertyServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/SysPropServlet";
+    public static final String PARAM_PROPERTY_NAME = "property";
+    public static final String DEFAULT_PROPERTY_NAME = "java.home";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        String property = req.getParameter(PARAM_PROPERTY_NAME);
+        if (property == null || property.length() == 0) {
+            property = DEFAULT_PROPERTY_NAME;
+        }
+        final PrintWriter writer = resp.getWriter();
+        writer.write(System.getProperty(property, ""));
+        writer.close();
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/package-info.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/package-info.java
@@ -21,9 +21,6 @@
  */
 
 /**
- * This package contains a part of the AS integration testsuite, which checks permissions granted when running
- * the AS with Java Security Manager (JSM) enabled.<br>
- * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
+ * Package in which servlets checking JSM permissions are located.
  */
-package org.jboss.as.testsuite.integration.secman;
-
+package org.jboss.as.testsuite.integration.secman.servlets;

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/readproperty.jsp
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/readproperty.jsp
@@ -1,0 +1,6 @@
+<%@ page language="java" pageEncoding="UTF-8" contentType="text/plain; charset=UTF-8" session="false"
+%><%!
+private String defaultString(String str, String defVal) {
+    return (str != null && str.length() > 0)?str:defVal;
+}
+%>${(empty param.property)?"java.home":param.property}=<%= System.getProperty(defaultString(request.getParameter("property"),"java.home")) %>

--- a/testsuite/integration/secman/src/test/resources/jboss-ejb-client.properties
+++ b/testsuite/integration/secman/src/test/resources/jboss-ejb-client.properties
@@ -1,0 +1,32 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=${node0:localhost}
+remote.connection.default.port=8080
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
+remote.connection.default.connect.options.org.xnio.Options.WORKER_TASK_MAX_THREADS=4
+callback.handler.class=org.jboss.as.test.shared.integration.ejb.security.CallbackHandler
+

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.security.MessageDigest;
+import java.security.Permission;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -392,7 +393,6 @@ public class Utils extends CoreUtils{
      * @param DefaultHttpClient httpClient to test multiple access
      * @param expectedStatusCode expected status code returned from the requested server
      * @return HTTP response body
-     * @throws ClientProtocolException
      * @throws IOException
      * @throws URISyntaxException
      */
@@ -752,6 +752,35 @@ public class Utils extends CoreUtils{
             }
         }
         sb.append("\n</dependencies></deployment></jboss-deployment-structure>");
+        return new StringAsset(sb.toString());
+    }
+
+    /**
+     * Creates content of permissions.xml (or jboss-permissions.xml) which placed in META-INF of the deployment specifies
+     * security permissions granted to the deployment.
+     *
+     * @param permissions instances from which are &lt;permission&gt; elements generated
+     * @return not-<code>null</code> content of permissions.xml (version=7)
+     */
+    public static Asset getPermissionsXml(final Permission... permissions) {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("<permissions xmlns='http://xmlns.jcp.org/xml/ns/javaee' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd' version='7'>");
+        if (permissions != null) {
+            for (Permission permission : permissions) {
+                if (permission != null) {
+                    sb.append("\n\t<permission>");
+                    sb.append("\n\t\t<class-name>").append(permission.getClass().getName()).append("</class-name>");
+                    if (permission.getName() != null) {
+                        sb.append("\n\t\t<name>").append(permission.getName()).append("</name>");
+                    }
+                    if (permission.getActions() != null) {
+                        sb.append("\n\t\t<actions>").append(permission.getActions()).append("</actions>");
+                    }
+                    sb.append("\n\t</permission>");
+                }
+            }
+        }
+        sb.append("\n</permissions>");
         return new StringAsset(sb.toString());
     }
 


### PR DESCRIPTION
Added tests for checking permissions granted to deployments using `META-INF/permissions.xml` or `META-INF/jboss-permissions.xml`. Tests are added to the `secman` TS module.

Some of the new tests are ignored because of following bugs:
- https://issues.jboss.org/browse/WFLY-3651
- https://issues.jboss.org/browse/WFLY-3667
