### PR TITLE
WFLY-838 - unnecessary exception throwing, breaks jmx tree tarversals  

### DIFF
--- a/jsr77/src/main/java/org/jboss/as/jsr77/managedobject/J2EEDeployedObjectHandlers.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/managedobject/J2EEDeployedObjectHandlers.java
@@ -242,7 +242,7 @@ public class J2EEDeployedObjectHandlers extends Handler {
 
         @Override
         Set<ObjectName> queryObjectNames(ModelReader reader, ObjectName name, QueryExp query) {
-            throw JSR77Logger.ROOT_LOGGER.shouldNotGetCalled();
+            return Collections.emptySet();
         }
 
         @Override


### PR DESCRIPTION
including Java Mission Control  and JConsole
