### PR TITLE
WFLY-3674 add extension for non-transactional entity manager invocations to defer entity detachment until persistence context is closed.

### DIFF
--- a/jpa/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -167,6 +167,11 @@ public class Configuration {
     private static final String JPA_ALLOW_DEFAULT_DATA_SOURCE_USE = "wildfly.jpa.allowdefaultdatasourceuse";
 
     /**
+     * set to true to defer detaching entities until persistence context is closed (WFLY-3674)
+     */
+    private static final String JPA_DEFER_DETACH = "jboss.as.jpa.deferdetach";
+
+    /**
      * name of the persistence provider adapter class
      */
     public static final String ADAPTER_CLASS = "jboss.as.jpa.adapterClass";
@@ -273,4 +278,19 @@ public class Configuration {
         }
         return result;
     }
+
+    /**
+     * Return true if detaching of managed entities should be deferred until the entity manager is closed.
+     * Note:  only applies to transaction scoped entity managers used without an active JTA transaction.
+     *
+     * @param properties
+     * @return
+     */
+    public static boolean deferEntityDetachUntilClose(final Map properties) {
+        boolean result = false;
+        if ( properties.containsKey(JPA_DEFER_DETACH))
+            result = Boolean.parseBoolean((String)properties.get(JPA_DEFER_DETACH));
+        return result;
+    }
+
 }

--- a/jpa/src/main/java/org/jboss/as/jpa/container/AbstractEntityManager.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/container/AbstractEntityManager.java
@@ -82,6 +82,8 @@ public abstract class AbstractEntityManager implements EntityManager {
 
     public abstract SynchronizationType getSynchronizationType();
 
+    protected abstract boolean deferEntityDetachUntilClose();
+
     public <T> T unwrap(Class<T> cls) {
         return getEntityManager().unwrap(cls);
     }
@@ -836,7 +838,7 @@ public abstract class AbstractEntityManager implements EntityManager {
     // used by TransactionScopedEntityManager to auto detach loaded entities
     // after each non-jta invocation
     protected void detachNonTxInvocation(EntityManager underlyingEntityManager) {
-        if (!this.isExtendedPersistenceContext() && !this.isInTx()) {
+        if (!this.isExtendedPersistenceContext() && !this.isInTx() && !deferEntityDetachUntilClose()) {
             underlyingEntityManager.clear();
         }
     }

--- a/jpa/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/container/ExtendedEntityManager.java
@@ -251,4 +251,9 @@ public class ExtendedEntityManager extends AbstractEntityManager implements Seri
     public SynchronizationType getSynchronizationType() {
         return SynchronizationType.SYNCHRONIZED;
     }
+
+    @Override
+    protected boolean deferEntityDetachUntilClose() {
+        return false;
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/Company.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/Company.java
@@ -1,0 +1,42 @@
+package org.jboss.as.test.integration.jpa.transaction;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+
+/**
+ * Company
+ *
+ * @author Scott Marlow
+ */
+@Entity
+public class Company {
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public Set<Employee> getEmployees() {
+        return employees;
+    }
+
+    public void setEmployees(Set<Employee> employees) {
+        this.employees = employees;
+    }
+
+    @Id
+    private int id;
+
+    @OneToMany(fetch = FetchType.LAZY)
+    public Set<Employee> employees = new HashSet<Employee>();
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/TransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/TransactionTestCase.java
@@ -57,6 +57,7 @@ public class TransactionTestCase {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
         jar.addClasses(TransactionTestCase.class,
             Employee.class,
+            Company.class,
             SFSB1.class,
             SFSBXPC.class,
             SFSBCMT.class,
@@ -254,5 +255,14 @@ public class TransactionTestCase {
         assertNull("entity created in SynchronizationType.UNSYNCHRONIZED XPC should not of been saved to database", employee);       // same extended persistence context
 
     }
+
+    @Test
+    @InSequence(10)
+    public void testQueryNonTXTransactionalDetachIsDeferred() throws Exception {
+        SFSB1 sfsb1 = lookup("SFSB1", SFSB1.class);
+        sfsb1.createEmployee("Mad", "368 Mad Country Lane", 204);
+        assertTrue("expecting that lazily fetched association is still attached, so that we can verify its lazy fetched collection size of one", sfsb1.isLazyAssociationAccessibleWithDeferredDetach(204));
+    }
+
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/transaction/persistence.xml
@@ -22,6 +22,15 @@
   -->
 
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"	version="1.0">
+    <persistence-unit name="deferdetachpc">
+   		<description>Persistence Unit.</description>
+   		<jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
+   		<properties>
+   			<property name="hibernate.hbm2ddl.auto" value="create-drop" />
+   			<property name="hibernate.show_sql" value="true" />
+            <property name="jboss.as.jpa.deferdetach" value="true" />
+   		</properties>
+   	</persistence-unit>
 	<persistence-unit name="mypc">
 		<description>Persistence Unit.</description>
 		<jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>


### PR DESCRIPTION
This should also help users migrating from older versions of JBoss application server (AS 5.x/6.x)
