### PR TITLE
WFLY-3691 Use correct AuditLevel string in SimpleSecurityManager

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -434,7 +434,7 @@ public class SimpleSecurityManager implements ServerSecurityManager {
      * @param userPrincipal
      */
     private void audit(String level, AuditManager auditManager, Principal userPrincipal) {
-        AuditEvent auditEvent = new AuditEvent(AuditLevel.SUCCESS);
+        AuditEvent auditEvent = new AuditEvent(level);
         Map<String, Object> ctxMap = new HashMap<String, Object>();
         ctxMap.put("principal", userPrincipal != null ? userPrincipal.getName() : "null");
         ctxMap.put("Source", getClass().getCanonicalName());


### PR DESCRIPTION
Wrong AuditLevel string was used in `SimpleSecurityManager.audit()` method. This caused adding misleading entries to a log file when authentication failed.
