### PR TITLE
[WFLY-3658] Upgrade to HornetQ 2.4.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.0.0.Alpha6</version.org.hibernate.hql>
         <version.org.hibernate.search>4.5.1.Final</version.org.hibernate.search>
-        <version.org.hornetq>2.4.1.Final</version.org.hornetq>
+        <version.org.hornetq>2.4.3.Final</version.org.hornetq>
         <version.org.infinispan>6.0.2.Final</version.org.infinispan>
         <version.org.jacorb>2.3.2-jbossorg-5</version.org.jacorb>
         <version.org.javassist>3.18.1-GA</version.org.javassist>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/ReplyingMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/containerstart/ReplyingMDB.java
@@ -62,8 +62,8 @@ public class ReplyingMDB implements MessageListener {
     private Connection connection;
     private Session session;
     private MessageProducer sender;
-    
-    private static final int WAIT_S = TimeoutUtil.adjust(10);
+
+    private static final int WAIT_S = TimeoutUtil.adjust(15);
 
     public void onMessage(Message m) {
         try {
@@ -76,7 +76,9 @@ public class ReplyingMDB implements MessageListener {
                     // we have received the first message
                     HelperSingletonImpl.barrier.await(WAIT_S, SECONDS);
                     HelperSingletonImpl.barrier.reset();
-                    // wait for undeploy, the MDB will be interrupted when it is undeployed
+                    // wait for undeploy to start and wake up after the transaction
+                    // timeout is hit.
+                    // Since HornetQ 2.4.3.Final, the MDB is *not* interrupted when it is undeployed
                     Thread.sleep(SECONDS.toMillis(WAIT_S));
                 }
                 replyMessage = session.createTextMessage("Reply: " + text);


### PR DESCRIPTION
- upgrade HornetQ to 2.4.3.Final
- modifiy SendMessagesTestCase since HornetQ RA will no longer interrupt
  the MDB when an undeployment is triggered

JIRA: https://issues.jboss.org/browse/WFLY-3658
