### PR TITLE
Add topology stabilization logic to clustering tests that are timing sensitive to topology changes.

### DIFF
--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
@@ -21,6 +21,14 @@
  */
 package org.jboss.as.test.clustering;
 
+import javax.naming.NamingException;
+
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.container.ClassContainer;
+import org.jboss.shrinkwrap.api.container.ManifestContainer;
+
 /**
  * Utility class for cluster test.
  *
@@ -41,7 +49,17 @@ public class ClusterTestUtil {
         }
     }
 
-    private ClusterTestUtil() {
+    public static <A extends Archive<A> & ClassContainer<A> & ManifestContainer<A>> A addTopologyListenerDependencies(A archive) {
+        archive.addClasses(TopologyChangeListener.class, TopologyChangeListenerBean.class, TopologyChangeListenerServlet.class);
+        archive.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.jboss.as.server, org.infinispan\n"));
+        return archive;
     }
 
+    public static void establishTopology(EJBDirectory directory, String container, String cache, String... nodes) throws NamingException, InterruptedException {
+        TopologyChangeListener listener = directory.lookupStateless(TopologyChangeListenerBean.class, TopologyChangeListener.class);
+        listener.establishTopology(container, cache, nodes);
+    }
+
+    private ClusterTestUtil() {
+    }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListener.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListener.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface TopologyChangeListener {
+    /**
+     * Waits until the specified topology is established on the specified cache.
+     * @param containerName the cache container name
+     * @param cacheName the cache name
+     * @param nodes the anticipated topology
+     * @throws InterruptedException if topology to stabilize did not stabilize within a reasonable amount of time - or the process was interrupted.
+     */
+    void establishTopology(String containerName, String cacheName, String... nodes) throws InterruptedException;
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerBean.java
@@ -1,0 +1,102 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import org.infinispan.Cache;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.TopologyChanged;
+import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
+import org.infinispan.remoting.transport.Address;
+import org.jboss.as.clustering.msc.ServiceContainerHelper;
+import org.jboss.as.server.CurrentServiceContainer;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * EJB that establishes a stable topology.
+ * @author Paul Ferraro
+ */
+@Stateless
+@Remote(TopologyChangeListener.class)
+@Listener(sync = false)
+public class TopologyChangeListenerBean implements TopologyChangeListener {
+    public static final long TIMEOUT = 15000;
+
+    @Override
+    public void establishTopology(String containerName, String cacheName, String... nodes) throws InterruptedException {
+        Set<String> expectedMembers = new TreeSet<>();
+        if (nodes != null) {
+            for (String name: nodes) {
+                expectedMembers.add(name + "/" + containerName);
+            }
+        }
+        ServiceRegistry registry = CurrentServiceContainer.getServiceContainer();
+        ServiceName name = ServiceName.JBOSS.append("infinispan", containerName, cacheName);
+        Cache<?, ?> cache = ServiceContainerHelper.findValue(registry, name);
+        if (cache == null) {
+            throw new IllegalStateException(String.format("Failed to locate %s", name));
+        }
+        cache.addListener(this);
+        try
+        {
+            long start = System.currentTimeMillis();
+            long now = start;
+            long timeout = start + TIMEOUT;
+            synchronized (this) {
+                Set<String> members = getMembers(cache);
+                while (!expectedMembers.equals(members)) {
+                    System.out.println(String.format("%s != %s, waiting for a topology change event...", expectedMembers, members));
+                    this.wait(timeout - now);
+                    now = System.currentTimeMillis();
+                    if (now >= timeout) {
+                        throw new InterruptedException(String.format("Cache %s/%s failed to establish view %s within %d ms.  Current view is: %s", containerName, cacheName, expectedMembers, TIMEOUT, members));
+                    }
+                    members = getMembers(cache);
+                }
+                System.out.println(String.format("Cache %s/%s successfully established view %s within %d ms.", containerName, cacheName, expectedMembers, now - start));
+            }
+        } finally {
+            cache.removeListener(this);
+        }
+    }
+
+    private static Set<String> getMembers(Cache<?, ?> cache) {
+        Set<String> members = new TreeSet<>();
+        for (Address address: cache.getAdvancedCache().getComponentRegistry().getStateTransferManager().getCacheTopology().getMembers()) {
+            members.add(address.toString());
+        }
+        return members;
+    }
+
+    @TopologyChanged
+    public void topologyChanged(TopologyChangedEvent<?, ?> event) {
+        synchronized (this) {
+            this.notify();
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerServlet.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.ejb.EJB;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Utility servlet that delegates to an EJB to perform topology stabilization.
+ * @author Paul Ferraro
+ */
+@WebServlet(urlPatterns = { TopologyChangeListenerServlet.SERVLET_PATH })
+public class TopologyChangeListenerServlet extends HttpServlet {
+    private static final long serialVersionUID = -4382952409558738642L;
+    private static final String SERVLET_NAME = "membership";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    private static final String CONTAINER = "container";
+    private static final String CACHE = "cache";
+    private static final String NODES = "nodes";
+
+    public static URI createURI(URL baseURL, String container, String cache, String... nodes) throws URISyntaxException {
+        StringBuilder builder = new StringBuilder(baseURL.toURI().resolve(SERVLET_NAME).toString());
+        builder.append('?').append(CONTAINER).append('=').append(container);
+        builder.append('&').append(CACHE).append('=').append(cache);
+        for (String node: nodes) {
+            builder.append('&').append(NODES).append('=').append(node);
+        }
+        return URI.create(builder.toString());
+    }
+
+    @EJB
+    private TopologyChangeListener listener;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        String container = getRequiredParameter(request, CONTAINER);
+        String cache = getRequiredParameter(request, CACHE);
+        String[] nodes = request.getParameterValues(NODES);
+        try {
+            this.listener.establishTopology(container, cache, nodes);
+        } catch (InterruptedException e) {
+            throw new ServletException(e);
+        }
+    }
+
+    private static String getRequiredParameter(HttpServletRequest request, String name) throws ServletException {
+        String value = request.getParameter(name);
+        if (value == null) {
+            throw new ServletException(String.format("No '%s' parameter specified", name));
+        }
+        return value;
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -23,7 +23,6 @@ package org.jboss.as.test.clustering.cluster;
 
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -33,7 +32,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusteringTestConstants;
 import org.jboss.as.test.clustering.NodeUtil;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.web.session.RoutingSupport;
 import org.jboss.as.web.session.SimpleRoutingSupport;
 import org.jboss.logging.Logger;
@@ -91,7 +89,6 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
     public void beforeTestMethod() {
         NodeUtil.start(this.controller, CONTAINERS);
         NodeUtil.deploy(this.deployer, DEPLOYMENTS);
-        this.waitForTopologyChange();
     }
 
     /**
@@ -104,40 +101,22 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
         NodeUtil.undeploy(this.deployer, DEPLOYMENTS);
     }
 
-    protected void waitForTopologyChange() {
-        // For now, just sleep a moment
-        // TODO replace this with a server side check for rehash completion
-        this.sleep(TimeoutUtil.adjust(500), TimeUnit.MILLISECONDS);
-    }
-
-    protected void sleep(long value, TimeUnit unit) {
-        try {
-            unit.sleep(value);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
     // Node and deployment lifecycle management convenience methods
 
     protected void start(String... containers) {
         NodeUtil.start(this.controller, containers);
-        this.waitForTopologyChange();
     }
 
     protected void stop(String... containers) {
         NodeUtil.stop(this.controller, containers);
-        this.waitForTopologyChange();
     }
 
     protected void deploy(String... deployments) {
         NodeUtil.deploy(this.deployer, deployments);
-        this.waitForTopologyChange();
     }
 
     protected void undeploy(String... deployments) {
         NodeUtil.undeploy(this.deployer, deployments);
-        this.waitForTopologyChange();
     }
 
     protected String findDeployment(String node) {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/session/persistence/SessionClusterDbPersistenceTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/session/persistence/SessionClusterDbPersistenceTestCase.java
@@ -4,12 +4,12 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.cluster.web.ClusteredWebFailoverAbstractCase;
 import org.jboss.as.test.clustering.single.web.Mutable;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
@@ -17,6 +17,7 @@ import org.junit.runner.RunWith;
 @RunAsClient
 @org.junit.Ignore("WFLY-2409")
 public class SessionClusterDbPersistenceTestCase extends ClusteredWebFailoverAbstractCase {
+    private static final String DEPLOYMENT_NAME = "session-db-cluster.war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -31,13 +32,17 @@ public class SessionClusterDbPersistenceTestCase extends ClusteredWebFailoverAbs
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "session-db-cluster.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
         war.addClasses(SimpleServlet.class, Mutable.class);
+        ClusterTestUtil.addTopologyListenerDependencies(war);
         war.setWebXML(SessionClusterDbPersistenceTestCase.class.getPackage(), "web.xml");
-        war.setManifest(new StringAsset(
-                "Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         war.addAsWebInfResource("WEB-INF/jboss-web.xml","jboss-web.xml");
         log.info(war.toString(true));
         return war;
+    }
+
+    @Override
+    protected String getDeploymentName() {
+        return DEPLOYMENT_NAME;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.clustering.cluster.web;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.single.web.Mutable;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
@@ -30,6 +31,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class CoarseWebFailoverTestCase extends ClusteredWebFailoverAbstractCase {
+    private static final String DEPLOYMENT_NAME = "coarse-distributable.war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -44,12 +46,17 @@ public class CoarseWebFailoverTestCase extends ClusteredWebFailoverAbstractCase 
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
         war.addClasses(SimpleServlet.class, Mutable.class);
+        ClusterTestUtil.addTopologyListenerDependencies(war);
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         log.info(war.toString(true));
         return war;
     }
 
+    @Override
+    protected String getDeploymentName() {
+        return DEPLOYMENT_NAME;
+    }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.clustering.cluster.web;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.single.web.Mutable;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
@@ -34,6 +35,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  * @version April 2012
  */
 public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCase {
+    private static final String DEPLOYMENT_NAME = "granular-distributable.war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -48,12 +50,18 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "granular-distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME);
         war.addClasses(SimpleServlet.class, Mutable.class);
+        ClusterTestUtil.addTopologyListenerDependencies(war);
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
         log.info(war.toString(true));
         return war;
+    }
+
+    @Override
+    protected String getDeploymentName() {
+        return DEPLOYMENT_NAME;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
@@ -22,6 +22,8 @@
 package org.jboss.as.test.clustering.cluster.web;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import javax.servlet.http.HttpServletResponse;
@@ -34,6 +36,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.single.web.Mutable;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.as.test.integration.security.common.Utils;
@@ -44,6 +47,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class ReplicationForNegotiationAuthenticatorTestCase extends ClusteredWebFailoverAbstractCase {
+    private static final String DEPLOYMENT_NAME = "negotiationAuthenticator.war";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -60,29 +64,30 @@ public class ReplicationForNegotiationAuthenticatorTestCase extends ClusteredWeb
     private static Archive<?> getDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "negotiationAuthenticator.war");
         war.addClasses(SimpleServlet.class, Mutable.class);
+        ClusterTestUtil.addTopologyListenerDependencies(war);
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");    
         war.addAsManifestResource(Utils.getJBossDeploymentStructure("org.jboss.security.negotiation"),"jboss-deployment-structure.xml");
         war.addAsWebInfResource(Utils.getJBossWebXmlAsset("other", "org.jboss.security.negotiation.NegotiationAuthenticator"), "jboss-web.xml");
         return war;
     }
-    
-    @Test      
+
+    @Test
     public void testOneRequestSimpleFailover(
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
             @ArquillianResource(SimpleServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
-            throws IOException {
+            throws IOException, URISyntaxException {
 
         DefaultHttpClient client = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
 
-        String url1 = baseURL1.toString() + "simple";
-        String url2 = baseURL2.toString() + "simple";
+        URI uri1 = SimpleServlet.createURI(baseURL1);
+        URI uri2 = SimpleServlet.createURI(baseURL2);
 
         try {
             
-            HttpResponse response = client.execute(new HttpGet(url1));
+            HttpResponse response = client.execute(new HttpGet(uri1));
             try {
-                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + uri1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -91,9 +96,9 @@ public class ReplicationForNegotiationAuthenticatorTestCase extends ClusteredWeb
             
             // Now check on the 2nd server
             
-            response = client.execute(new HttpGet(url2));
+            response = client.execute(new HttpGet(uri2));
             try {
-                log.info("Requested " + url2 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + uri2 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals("Session failed to replicate after container 1 was shutdown.", 2, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -101,9 +106,9 @@ public class ReplicationForNegotiationAuthenticatorTestCase extends ClusteredWeb
             }
            
             //and back on the 1st server
-            response = client.execute(new HttpGet(url1));
+            response = client.execute(new HttpGet(uri1));
             try {
-                log.info("Requested " + url1 + ", got " + response.getFirstHeader("value").getValue() + ".");
+                log.info("Requested " + uri1 + ", got " + response.getFirstHeader("value").getValue() + ".");
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
                 Assert.assertEquals("Session failed to replicate after container 1 was brough up.", 3, Integer.parseInt(response.getFirstHeader("value").getValue()));
             } finally {
@@ -116,4 +121,8 @@ public class ReplicationForNegotiationAuthenticatorTestCase extends ClusteredWeb
 
     }
 
+    @Override
+    protected String getDeploymentName() {
+        return DEPLOYMENT_NAME;
+    }
 }


### PR DESCRIPTION
This should more thoroughly stabilize the web failover tests.
