### PR TITLE
[WFLY-2551] Defer reading DS's override registration until Stage.RUNTIME...

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
@@ -75,7 +75,6 @@ public class DataSourceEnable implements OperationStepHandler {
 
     public void execute(OperationContext context, ModelNode operation) {
 
-        final ManagementResourceRegistration registration = context.getResourceRegistrationForUpdate();
         final Resource resource = context.readResourceForUpdate(PathAddress.EMPTY_ADDRESS);
         final ModelNode model = resource.getModel();
 
@@ -85,6 +84,7 @@ public class DataSourceEnable implements OperationStepHandler {
 
             context.addStep(new OperationStepHandler() {
                 public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                    final ManagementResourceRegistration registration = context.getResourceRegistrationForUpdate();
                     ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
                     final List<ServiceController<?>> controllers = new ArrayList<ServiceController<?>>();
                     addServices(context, operation, verificationHandler, registration, model, isXa(), controllers);


### PR DESCRIPTION
... as it's not added by the add handler until then.

Really the add handler should be adding it in MODEL, but trying that leads to test failures and I don't feel like spending the time to sort them now.

This fixes a bug I added in #6544.
