### PR TITLE
WFLY-3703 "arq.container.domain.ManagementClient.readRootNode does not see servers on remote hosts"

### DIFF
--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -406,7 +406,7 @@ public class ManagementClient {
         	operation.get(RECURSIVE).set(true);
         }
         else {
-        	// Due to WFLY-3705 this is false
+            // Due to WFLY-3705 this is false
             operation.get(RECURSIVE).set(false);
             operation.get(RECURSIVE_DEPTH).set(recursiveDepth);
         }

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.INCLUDE_RUN
 import static org.jboss.as.controller.client.helpers.ClientConstants.OP;
 import static org.jboss.as.controller.client.helpers.ClientConstants.OP_ADDR;
 import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
+import static org.jboss.as.controller.client.helpers.ClientConstants.PROXIES;
 import static org.jboss.as.controller.client.helpers.ClientConstants.READ_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.READ_CHILDREN_NAMES_OPERATION;
 import static org.jboss.as.controller.client.helpers.ClientConstants.READ_RESOURCE_OPERATION;
@@ -287,7 +288,7 @@ public class ManagementClient {
     }
 
     private void readRootNode() throws Exception {
-        rootNode = readResource(new ModelNode());
+        rootNode = readResource(new ModelNode(), true, true);
     }
 
     private String getSocketBindingGroup(String serverGroup) {
@@ -392,10 +393,15 @@ public class ManagementClient {
     }
 
     private ModelNode readResource(ModelNode address, boolean includeRuntime) throws Exception {
+        return readResource(address, includeRuntime, false);
+    }
+
+    private ModelNode readResource(ModelNode address, boolean includeRuntime, boolean proxies) throws Exception {
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(READ_RESOURCE_OPERATION);
         operation.get(RECURSIVE).set("true");
         operation.get(INCLUDE_RUNTIME).set(includeRuntime);
+        operation.get(PROXIES).set(proxies);
         operation.get(OP_ADDR).set(address);
 
         return executeForResult(operation);

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -398,7 +398,7 @@ public class ManagementClient {
     private ModelNode readResource(ModelNode address, boolean includeRuntime) throws Exception {
         return readResource(address, includeRuntime, null);
     }
-    
+
     private ModelNode readResource(ModelNode address, boolean includeRuntime, Integer recursiveDepth) throws Exception {
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(READ_RESOURCE_OPERATION);

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -288,7 +288,7 @@ public class ManagementClient {
     }
 
     private void readRootNode() throws Exception {
-        rootNode = readResource(new ModelNode(), true, true);
+        rootNode = readResource(new ModelNode());
     }
 
     private String getSocketBindingGroup(String serverGroup) {
@@ -393,15 +393,11 @@ public class ManagementClient {
     }
 
     private ModelNode readResource(ModelNode address, boolean includeRuntime) throws Exception {
-        return readResource(address, includeRuntime, false);
-    }
-
-    private ModelNode readResource(ModelNode address, boolean includeRuntime, boolean proxies) throws Exception {
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(READ_RESOURCE_OPERATION);
         operation.get(RECURSIVE).set("true");
         operation.get(INCLUDE_RUNTIME).set(includeRuntime);
-        operation.get(PROXIES).set(proxies);
+        operation.get(PROXIES).set("true");
         operation.get(OP_ADDR).set(address);
 
         return executeForResult(operation);

--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -394,7 +394,7 @@ public class ManagementClient {
     private ModelNode readResource(ModelNode address) throws Exception {
         return readResource(address, true);
     }
-    
+
     private ModelNode readResource(ModelNode address, boolean includeRuntime) throws Exception {
         return readResource(address, includeRuntime, null);
     }
@@ -403,7 +403,7 @@ public class ManagementClient {
         final ModelNode operation = new ModelNode();
         operation.get(OP).set(READ_RESOURCE_OPERATION);
         if(recursiveDepth == null) {
-        	operation.get(RECURSIVE).set(true);
+            operation.get(RECURSIVE).set(true);
         }
         else {
             // Due to WFLY-3705 this is false

--- a/build/src/main/resources/docs/schema/jboss-as-logging_1_4.xsd
+++ b/build/src/main/resources/docs/schema/jboss-as-logging_1_4.xsd
@@ -1,0 +1,570 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="urn:jboss:domain:logging:1.4"
+           xmlns="urn:jboss:domain:logging:1.4"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.4">
+
+    <!-- The logging subsystem root element -->
+    <xs:element name="subsystem" type="subsystem"/>
+
+    <xs:complexType name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the logging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+            <xs:element name="add-logging-api-dependencies" type="booleanTrueValueType">
+                <xs:annotation>
+                    <xs:documentation>
+                        <![CDATA[
+                            Determines whether or not the default logging dependencies should be added to deployments during the deployment process.
+                        ]]>
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="logging-profiles" type="logging-profilesType" minOccurs="0" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profilesType">
+        <xs:annotation>
+            <xs:documentation>
+                Contains a list of profiles available for use in deployments
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="logging-profile" type="logging-profileType" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="logging-profileType">
+        <xs:annotation>
+            <xs:documentation>
+                A logging profile that can be used in a deployment for a custom logging configuration.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="logger" type="loggerType"/>
+            <xs:element name="root-logger" type="rootLoggerType"/>
+            <xs:element name="console-handler" type="consoleHandlerType"/>
+            <xs:element name="file-handler" type="fileHandlerType"/>
+            <xs:element name="periodic-rotating-file-handler" type="periodicFileHandlerType"/>
+            <xs:element name="size-rotating-file-handler" type="sizeFileHandlerType"/>
+            <xs:element name="async-handler" type="asyncHandlerType"/>
+            <xs:element name="custom-handler" type="customHandlerType"/>
+            <xs:element name="syslog-handler" type="syslogHandlerType"/>
+            <xs:element name="formatter" type="formatterType"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="propertiesType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of free-form properties.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="property">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required"/>
+                    <xs:attribute name="value" type="xs:string" use="optional"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="refType">
+        <xs:annotation>
+            <xs:documentation>
+                A named reference to another object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlersType">
+        <xs:annotation>
+            <xs:documentation>
+                A collection of handlers to apply to the enclosing object.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="handler" type="refType"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="rootLoggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines the root logger for this log context.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all minOccurs="1" maxOccurs="1">
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="handlers" type="handlersType" minOccurs="0"/>
+        </xs:all>
+    </xs:complexType>
+
+    <xs:complexType name="loggerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a logger category.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="rootLoggerType">
+                <xs:attribute name="use-parent-handlers" type="xs:boolean" use="optional" default="true"/>
+                <xs:attribute name="category" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="consoleHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the console.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="filter" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="target" minOccurs="0">
+                <xs:complexType>
+                    <xs:attribute name="name" use="required">
+                        <xs:simpleType>
+                            <xs:restriction base="xs:token">
+                                <xs:enumeration value="System.out"/>
+                                <xs:enumeration value="System.err"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="fileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType" minOccurs="1"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="periodicFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after a time period derived from the given
+                suffix string, which should be in a format understood by java.text.SimpleDateFormat.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="suffix" type="valueType"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeFileHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to a file, rotating the log after a the size of the file grows beyond a
+                certain point and keeping a fixed number of backups.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="file" type="pathType"/>
+            <xs:element name="rotate-size" type="sizeType" minOccurs="0"/>
+            <xs:element name="max-backup-index" type="positiveIntType" minOccurs="0"/>
+            <xs:element name="append" type="booleanValueType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="autoflush" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+        <xs:attribute name="rotate-on-boot" type="xs:boolean" use="optional" default="false"/>
+    </xs:complexType>
+
+    <xs:complexType name="asyncHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a handler which writes to the sub-handlers in an asynchronous thread. Used for handlers which
+                introduce a substantial amount of lag.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="queue-length" type="queueLengthType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="overflow-action" type="overflowActionType" minOccurs="0"/>
+            <xs:element name="subhandlers" type="handlersType"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="customHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a custom handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="encoding" type="valueType" minOccurs="0"/>
+            <xs:element name="filter-spec" type="valueType" minOccurs="0"/>
+            <xs:element name="formatter" type="handlerFormatterType" minOccurs="0"/>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogHandlerType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a syslog handler for UNIX/Linux based operating systems.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="level" type="refType" minOccurs="0"/>
+            <xs:element name="server-address" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The address of the syslog server. The default is localhost.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="hostname" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The name of the host the messages are being sent from. For example the name of the host the
+                        application server is running on.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="port" type="positiveIntType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The port the syslog server is listening on. The default is 514.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="app-name" type="valueType" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>
+                        The app name used when formatting the message in RFC5424 format. By default the app name is
+                        &quot;java&quot;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="formatter" type="syslogFormatterType" minOccurs="0" maxOccurs="1"/>
+            <xs:element name="facility" type="facilityType" minOccurs="0" maxOccurs="1"/>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+        <xs:attribute name="enabled" type="xs:boolean" use="optional" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="queueLengthType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:positiveInteger">
+                    <xs:minExclusive value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="overflowActionType">
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="block"/>
+                    <xs:enumeration value="discard"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="positiveIntType">
+        <xs:attribute name="value" use="required" type="xs:positiveInteger"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanValueType">
+        <xs:attribute name="value" use="required" type="xs:boolean"/>
+    </xs:complexType>
+
+    <xs:complexType name="booleanTrueValueType">
+        <xs:attribute name="value" type="xs:boolean" default="true"/>
+    </xs:complexType>
+
+    <xs:complexType name="valueType">
+        <xs:attribute name="value" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="pathType">
+        <xs:attribute name="relative-to" use="optional" type="xs:string"/>
+        <xs:attribute name="path" use="required" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="sizeType">
+        <xs:attribute name="value">
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <!-- XSD doesn't allow ^ or $ so ^[0-9]+[bkmgtp]?$ is invalid -->
+                    <xs:pattern value="[0-9]+[bkmgtp]"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="facilityType">
+        <xs:annotation>
+            <xs:documentation>
+                Facility as defined by RFC-5424 (http://tools.ietf.org/html/rfc5424)and RFC-3164
+                (http://tools.ietf.org/html/rfc3164).
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="value" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="kernel"/>
+                    <xs:enumeration value="user-level"/>
+                    <xs:enumeration value="mail-system"/>
+                    <xs:enumeration value="system-daemons"/>
+                    <xs:enumeration value="security"/>
+                    <xs:enumeration value="syslogd"/>
+                    <xs:enumeration value="line-printer"/>
+                    <xs:enumeration value="network-news"/>
+                    <xs:enumeration value="uucp"/>
+                    <xs:enumeration value="clock-daemon"/>
+                    <xs:enumeration value="security2"/>
+                    <xs:enumeration value="ftp-daemon"/>
+                    <xs:enumeration value="ntp"/>
+                    <xs:enumeration value="log-audit"/>
+                    <xs:enumeration value="log-alert"/>
+                    <xs:enumeration value="clock-daemon2"/>
+                    <xs:enumeration value="local-use-0"/>
+                    <xs:enumeration value="local-use-1"/>
+                    <xs:enumeration value="local-use-2"/>
+                    <xs:enumeration value="local-use-3"/>
+                    <xs:enumeration value="local-use-4"/>
+                    <xs:enumeration value="local-use-5"/>
+                    <xs:enumeration value="local-use-6"/>
+                    <xs:enumeration value="local-use-7"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <!-- Formatters -->
+
+    <xs:complexType name="formatterType">
+        <xs:annotation>
+            <xs:documentation>
+                A formatter that can be assigned to a handler.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="patternFormatterType" maxOccurs="1"/>
+            <xs:element name="custom-formatter" type="customFormatterType" maxOccurs="1"/>
+        </xs:choice>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="handlerFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="pattern-formatter" type="handlerPatternFormatterType" maxOccurs="1"/>
+            <xs:element name="named-formatter" type="namedFormatterType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="handlerPatternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter.  See the documentation for org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="patternFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a pattern formatter.  See the documentation for org.jboss.logmanager.formatters.FormatStringParser
+                for more information about the format string.
+
+                The color-map attribute allows for a comma delimited list of colors to be used for different levels. The
+                format is level-name:color-name.
+
+                Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred, brightgreen,
+                brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="pattern" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The format pattern as defined in org.jboss.logmanager.formatters.FormatStringParser.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="color-map" type="xs:string">
+            <xs:annotation>
+                <xs:documentation>
+                    The color-map attribute allows for a comma delimited list of colors to be used for different levels. The
+                    format is level-name:color-name.
+
+                    Valid Levels; severe, fatal, error, warn, warning, info, debug, trace, config, fine, finer, finest
+
+                    Valid Colors; black, green, red, yellow, blue, magenta, cyan, white, brightblack, brightred, brightgreen,
+                    brightblue, brightyellow, brightmagenta, brightcyan, brightwhite
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="customFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                 Defines a formatter to be used to format log messages.
+
+                 Note that most log records are formatted in the printf format. Formatters may require invocation of org.jboss.logmanager.ExtLogRecord#getFormattedMessage() for the message to be properly formatted.
+                 ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="properties" type="propertiesType" minOccurs="0"/>
+        </xs:all>
+        <xs:attribute name="module" type="xs:string" use="required"/>
+        <xs:attribute name="class" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="namedFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                The name of a defined formatter that will be used to format the log message.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatterType">
+        <xs:annotation>
+            <xs:documentation>
+                Defines a formatter.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice minOccurs="1" maxOccurs="1">
+            <xs:element name="syslog-format" type="syslogFormatType" maxOccurs="1"/>
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="syslogFormatType">
+        <xs:annotation>
+            <xs:documentation>
+                Formats the log message according to the RFC specification.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="syslog-type" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:token">
+                    <xs:enumeration value="RFC5424">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-5424 specification
+                                (http://tools.ietf.org/html/rfc5424#section-6)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                    <xs:enumeration value="RFC3164">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Formats the message according the the RFC-3164 specification
+                                (http://tools.ietf.org/html/rfc3164#section-4.1)
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:enumeration>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+</xs:schema>

--- a/clustering/common/src/main/java/org/jboss/as/clustering/concurrent/CachedThreadPoolExecutorService.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/concurrent/CachedThreadPoolExecutorService.java
@@ -25,7 +25,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
+import org.jboss.as.clustering.msc.AsynchronousService;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 import org.jboss.threads.JBossExecutors;
@@ -36,11 +40,15 @@ import org.jboss.threads.JBossExecutors;
  */
 public class CachedThreadPoolExecutorService implements Service<ExecutorService> {
 
+    public static ServiceBuilder<ExecutorService> build(ServiceTarget target, ServiceName name, ThreadFactory factory) {
+        return AsynchronousService.addService(target, name, new CachedThreadPoolExecutorService(factory), false, true);
+    }
+
     private final ThreadFactory threadFactory;
 
     private volatile ExecutorService executor;
 
-    public CachedThreadPoolExecutorService(ThreadFactory threadFactory) {
+    private CachedThreadPoolExecutorService(ThreadFactory threadFactory) {
         this.threadFactory = threadFactory;
     }
 
@@ -56,6 +64,7 @@ public class CachedThreadPoolExecutorService implements Service<ExecutorService>
 
     @Override
     public void stop(StopContext context) {
-        this.executor.shutdownNow();
+        this.executor.shutdown();
+        this.executor = null;
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanEvictionScheduler.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanEvictionScheduler.java
@@ -43,11 +43,11 @@ import org.wildfly.clustering.ejb.Bean;
 public class BeanEvictionScheduler<G, I, T> implements Scheduler<Bean<G, I, T>> {
 
     private final Set<I> evictionQueue = new LinkedHashSet<>();
-    final Batcher batcher;
+    final Batcher<TransactionBatch> batcher;
     final Evictor<I> evictor;
     private final PassivationConfiguration<?> config;
 
-    public BeanEvictionScheduler(Batcher batcher, Evictor<I> evictor, PassivationConfiguration<?> config) {
+    public BeanEvictionScheduler(Batcher<TransactionBatch> batcher, Evictor<I> evictor, PassivationConfiguration<?> config) {
         this.batcher = batcher;
         this.evictor = evictor;
         this.config = config;

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanExpirationScheduler.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanExpirationScheduler.java
@@ -44,11 +44,11 @@ import org.wildfly.clustering.ejb.Time;
  */
 public class BeanExpirationScheduler<G, I, T> implements Scheduler<Bean<G, I, T>> {
     final Map<I, Future<?>> expirationFutures = new ConcurrentHashMap<>();
-    final Batcher batcher;
+    final Batcher<TransactionBatch> batcher;
     final BeanRemover<I, T> remover;
     final ExpirationConfiguration<T> expiration;
 
-    public BeanExpirationScheduler(Batcher batcher, BeanRemover<I, T> remover, ExpirationConfiguration<T> expiration) {
+    public BeanExpirationScheduler(Batcher<TransactionBatch> batcher, BeanRemover<I, T> remover, ExpirationConfiguration<T> expiration) {
         this.batcher = batcher;
         this.remover = remover;
         this.expiration = expiration;

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
@@ -66,7 +66,7 @@ import org.wildfly.clustering.registry.Registry;
  * @param <T> the bean type
  */
 @Listener
-public class InfinispanBeanManager<G, I, T> implements BeanManager<G, I, T>, KeyFilter {
+public class InfinispanBeanManager<G, I, T> implements BeanManager<G, I, T, TransactionBatch>, KeyFilter {
 
     final Cache<G, BeanGroupEntry<I, T>> groupCache;
     private final String beanName;
@@ -82,7 +82,7 @@ public class InfinispanBeanManager<G, I, T> implements BeanManager<G, I, T>, Key
     private final PassivationConfiguration<T> passivation;
     private final List<Scheduler<Bean<G, I, T>>> schedulers = new ArrayList<>(2);
     private final AtomicInteger passiveCount = new AtomicInteger();
-    private final Batcher batcher;
+    private final Batcher<TransactionBatch> batcher;
 
     public InfinispanBeanManager(String beanName, final Configuration<I, BeanKey<I>, BeanEntry<G>, BeanFactory<G, I, T>> beanConfiguration, final Configuration<G, G, BeanGroupEntry<I, T>, BeanGroupFactory<G, I, T>> groupConfiguration, KeyAffinityServiceFactory affinityFactory, Registry<String, ?> registry, NodeFactory<Address> nodeFactory, ExpirationConfiguration<T> expiration, PassivationConfiguration<T> passivation) {
         this.beanName = beanName;
@@ -216,7 +216,7 @@ public class InfinispanBeanManager<G, I, T> implements BeanManager<G, I, T>, Key
     }
 
     @Override
-    public Batcher getBatcher() {
+    public Batcher<TransactionBatch> getBatcher() {
         return this.batcher;
     }
 

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactory.java
@@ -65,9 +65,9 @@ import org.wildfly.clustering.registry.Registry;
  * @param <T> the bean type
  */
 @SuppressWarnings("rawtypes")
-public class InfinispanBeanManagerFactory<G, I, T> extends AbstractService<BeanManagerFactory<G, I, T>> implements BeanManagerFactory<G, I, T> {
+public class InfinispanBeanManagerFactory<G, I, T> extends AbstractService<BeanManagerFactory<G, I, T, TransactionBatch>> implements BeanManagerFactory<G, I, T, TransactionBatch> {
 
-    public static <G, I, T> ServiceBuilder<BeanManagerFactory<G, I, T>> build(String name, ServiceTarget target, ServiceName serviceName, BeanManagerFactoryBuilderConfiguration config, BeanContext context) {
+    public static <G, I, T> ServiceBuilder<BeanManagerFactory<G, I, T, TransactionBatch>> build(String name, ServiceTarget target, ServiceName serviceName, BeanManagerFactoryBuilderConfiguration config, BeanContext context) {
         InfinispanBeanManagerFactory<G, I, T> factory = new InfinispanBeanManagerFactory<>(context, config);
         String containerName = config.getContainerName();
         ServiceName deploymentUnitServiceName = context.getDeploymentUnitServiceName();
@@ -99,7 +99,7 @@ public class InfinispanBeanManagerFactory<G, I, T> extends AbstractService<BeanM
     }
 
     @Override
-    public BeanManager<G, I, T> createBeanManager(final IdentifierFactory<G> groupIdentifierFactory, final IdentifierFactory<I> beanIdentifierFactory, final PassivationListener<T> passivationListener, final RemoveListener<T> removeListener) {
+    public BeanManager<G, I, T, TransactionBatch> createBeanManager(final IdentifierFactory<G> groupIdentifierFactory, final IdentifierFactory<I> beanIdentifierFactory, final PassivationListener<T> passivationListener, final RemoveListener<T> removeListener) {
         MarshallingContext context = new SimpleMarshallingContextFactory().createMarshallingContext(this.config.getValue(), this.context.getClassLoader());
         MarshalledValueFactory<MarshallingContext> factory = new SimpleMarshalledValueFactory(context);
         Cache<G, BeanGroupEntry<I, T>> groupCache = this.cache.getValue();
@@ -168,7 +168,7 @@ public class InfinispanBeanManagerFactory<G, I, T> extends AbstractService<BeanM
     }
 
     @Override
-    public BeanManagerFactory<G, I, T> getValue() {
+    public BeanManagerFactory<G, I, T, TransactionBatch> getValue() {
         return this;
     }
 

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilder.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilder.java
@@ -99,11 +99,11 @@ public class InfinispanBeanManagerFactoryBuilder<G, I> implements BeanManagerFac
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install()
         ;
-        target.addService(deploymentUnitServiceName.append(this.name, "expiration"), new RemoveOnCancelScheduledExecutorService(EXPIRATION_THREAD_FACTORY))
+        RemoveOnCancelScheduledExecutorService.build(target, deploymentUnitServiceName.append(this.name, "expiration"), EXPIRATION_THREAD_FACTORY)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install()
         ;
-        target.addService(deploymentUnitServiceName.append(this.name, "eviction"), new CachedThreadPoolExecutorService(EVICTION_THREAD_FACTORY))
+        CachedThreadPoolExecutorService.build(target, deploymentUnitServiceName.append(this.name, "eviction"), EVICTION_THREAD_FACTORY)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install()
         ;

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilder.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilder.java
@@ -54,7 +54,7 @@ import org.wildfly.security.manager.action.GetAccessControlContextAction;
  * @param <G> the group identifier type
  * @param <I> the bean identifier type
  */
-public class InfinispanBeanManagerFactoryBuilder<G, I> implements BeanManagerFactoryBuilder<G, I> {
+public class InfinispanBeanManagerFactoryBuilder<G, I> implements BeanManagerFactoryBuilder<G, I, TransactionBatch> {
 
     private static final ThreadFactory EXPIRATION_THREAD_FACTORY = new JBossThreadFactory(new ThreadGroup(BeanExpirationScheduler.class.getSimpleName()), Boolean.FALSE, null, "%G - %t", null, null, AccessController.doPrivileged(GetAccessControlContextAction.getInstance()));
     private static final ThreadFactory EVICTION_THREAD_FACTORY = new JBossThreadFactory(new ThreadGroup(BeanEvictionScheduler.class.getSimpleName()), Boolean.FALSE, null, "%G - %t", null, null, AccessController.doPrivileged(GetAccessControlContextAction.getInstance()));
@@ -110,7 +110,7 @@ public class InfinispanBeanManagerFactoryBuilder<G, I> implements BeanManagerFac
     }
 
     @Override
-    public <T> ServiceBuilder<? extends BeanManagerFactory<G, I, T>> build(ServiceTarget target, ServiceName name, BeanContext context) {
+    public <T> ServiceBuilder<? extends BeanManagerFactory<G, I, T, TransactionBatch>> build(ServiceTarget target, ServiceName name, BeanContext context) {
         return InfinispanBeanManagerFactory.build(this.name, target, name, this.config, context);
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/TransactionBatch.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/TransactionBatch.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,19 +19,20 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.wildfly.clustering.ejb.infinispan;
 
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilder;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderProvider;
+import javax.transaction.Transaction;
+
+import org.wildfly.clustering.ejb.Batch;
 
 /**
  * @author Paul Ferraro
  */
-public class InfinispanBeanManagerFactoryBuilderProvider implements BeanManagerFactoryBuilderProvider<TransactionBatch> {
-
-    @Override
-    public <G, I> BeanManagerFactoryBuilder<G, I, TransactionBatch> getBeanManagerFactoryBuilder(String name, BeanManagerFactoryBuilderConfiguration config) {
-        return new InfinispanBeanManagerFactoryBuilder<>(name, config);
-    }
+public interface TransactionBatch extends Batch {
+    /**
+     * Returns the transaction associated with this batch
+     * @return a transaction
+     */
+    Transaction getTransaction();
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
@@ -80,7 +80,7 @@ public class InfinispanBean<G, I, T> implements Bean<G, I, T> {
         if (this.timeout == null) return false;
         Date lastAccessedTime = this.entry.getLastAccessedTime();
         long timeout = this.timeout.convert(TimeUnit.MILLISECONDS);
-        return (lastAccessedTime != null) && (timeout > 0) ? ((System.currentTimeMillis() - lastAccessedTime.getTime()) > timeout) : false;
+        return (lastAccessedTime != null) && (timeout > 0) ? ((System.currentTimeMillis() - lastAccessedTime.getTime()) >= timeout) : false;
     }
 
     @Override

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BatchContext.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BatchContext.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2014, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,19 +19,16 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.ejb.infinispan;
-
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilder;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderProvider;
+package org.wildfly.clustering.ejb;
 
 /**
+ * Handles batch context switching.
  * @author Paul Ferraro
  */
-public class InfinispanBeanManagerFactoryBuilderProvider implements BeanManagerFactoryBuilderProvider<TransactionBatch> {
-
+public interface BatchContext extends AutoCloseable {
+    /**
+     * Closes this batch context.
+     */
     @Override
-    public <G, I> BeanManagerFactoryBuilder<G, I, TransactionBatch> getBeanManagerFactoryBuilder(String name, BeanManagerFactoryBuilderConfiguration config) {
-        return new InfinispanBeanManagerFactoryBuilder<>(name, config);
-    }
+    void close();
 }

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/Batcher.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/Batcher.java
@@ -25,10 +25,17 @@ package org.wildfly.clustering.ejb;
  * Exposes a mechanism to start a batch.
  * @author Paul Ferraro
  */
-public interface Batcher {
+public interface Batcher<B extends Batch> {
     /**
      * Starts a batch.
      * @return a batch.
      */
-    Batch startBatch();
+    B startBatch();
+
+    /**
+     * Resumes a batch.
+     * @param batch an existing batch
+     * @return the context of the resumed batch
+     */
+    BatchContext resume(B batch);
 }

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManager.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManager.java
@@ -30,7 +30,7 @@ package org.wildfly.clustering.ejb;
  * @param <I> the bean identifier type
  * @param <T> the bean instance type
  */
-public interface BeanManager<G, I, T> extends AffinitySupport<I>, BeanManagerStatistics {
+public interface BeanManager<G, I, T, B extends Batch> extends AffinitySupport<I>, BeanManagerStatistics {
     Bean<G, I, T> createBean(I id, G group, T bean);
     Bean<G, I, T> findBean(I id);
 
@@ -39,7 +39,7 @@ public interface BeanManager<G, I, T> extends AffinitySupport<I>, BeanManagerSta
     IdentifierFactory<G> getGroupIdentifierFactory();
     IdentifierFactory<I> getBeanIdentifierFactory();
 
-    Batcher getBatcher();
+    Batcher<B> getBatcher();
 
     void start();
     void stop();

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManagerFactory.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManagerFactory.java
@@ -30,6 +30,6 @@ package org.wildfly.clustering.ejb;
  * @param <I> the bean identifier type
  * @param <T> the bean type
  */
-public interface BeanManagerFactory<G, I, T> {
-    BeanManager<G, I, T> createBeanManager(IdentifierFactory<G> groupIdentifierFactory, IdentifierFactory<I> beanIdentifierFactory, PassivationListener<T> passivationListener, RemoveListener<T> removeListener);
+public interface BeanManagerFactory<G, I, T, B extends Batch> {
+    BeanManager<G, I, T, B> createBeanManager(IdentifierFactory<G> groupIdentifierFactory, IdentifierFactory<I> beanIdentifierFactory, PassivationListener<T> passivationListener, RemoveListener<T> removeListener);
 }

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManagerFactoryBuilder.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManagerFactoryBuilder.java
@@ -25,7 +25,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 
-public interface BeanManagerFactoryBuilder<G, I> {
+public interface BeanManagerFactoryBuilder<G, I, B extends Batch> {
     /**
      * Installs dependencies for a deployment unit
      * @param target the service target
@@ -40,5 +40,5 @@ public interface BeanManagerFactoryBuilder<G, I> {
      * @param context the bean context
      * @return a service builder
      */
-    <T> ServiceBuilder<? extends BeanManagerFactory<G, I, T>> build(ServiceTarget target, ServiceName name, BeanContext context);
+    <T> ServiceBuilder<? extends BeanManagerFactory<G, I, T, B>> build(ServiceTarget target, ServiceName name, BeanContext context);
 }

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManagerFactoryBuilderProvider.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManagerFactoryBuilderProvider.java
@@ -24,6 +24,6 @@ package org.wildfly.clustering.ejb;
 /**
  * @author Paul Ferraro
  */
-public interface BeanManagerFactoryBuilderProvider {
-    <G, I> BeanManagerFactoryBuilder<G, I> getBeanManagerFactoryBuilder(String name, BeanManagerFactoryBuilderConfiguration config);
+public interface BeanManagerFactoryBuilderProvider<B extends Batch> {
+    <G, I> BeanManagerFactoryBuilder<G, I, B> getBeanManagerFactoryBuilder(String name, BeanManagerFactoryBuilderConfiguration config);
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/invoker/RetryingCacheInvoker.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/invoker/RetryingCacheInvoker.java
@@ -26,7 +26,11 @@ import static org.jboss.as.clustering.infinispan.InfinispanMessages.MESSAGES;
 
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.Set;
+
+import javax.transaction.Status;
+import javax.transaction.SystemException;
 
 import org.infinispan.Cache;
 import org.infinispan.context.Flag;
@@ -39,6 +43,7 @@ import org.infinispan.util.concurrent.TimeoutException;
  * @author Paul Ferraro
  */
 public class RetryingCacheInvoker implements CacheInvoker {
+    private static final Set<Integer> ALLOWED_RETRY_STATUS = new HashSet<>(Arrays.asList(Status.STATUS_NO_TRANSACTION, Status.STATUS_ACTIVE, Status.STATUS_COMMITTING, Status.STATUS_PREPARING));
 
     private final CacheInvoker invoker;
     private final int[] backOffIntervals;
@@ -80,10 +85,19 @@ public class RetryingCacheInvoker implements CacheInvoker {
             boolean retry = (i < this.backOffIntervals.length);
             try {
                 return this.invoker.invoke(cache, operation, retry ? attemptFlags : allFlags);
-            } catch (TimeoutException e) {
+            } catch (TimeoutException | SuspectException e) {
                 exception = e;
-            } catch (SuspectException e) {
-                exception = e;
+                if (cache.getCacheConfiguration().transaction().transactionMode().isTransactional()) {
+                    // We can only retry if the transaction status allows it
+                    try {
+                        int status = cache.getAdvancedCache().getTransactionManager().getStatus();
+                        if (!ALLOWED_RETRY_STATUS.contains(status)) {
+                            throw e;
+                        }
+                    } catch (SystemException se) {
+                        throw e;
+                    }
+                }
             }
 
             if (retry) {

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/invoker/RetryingCacheInvokerTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/invoker/RetryingCacheInvokerTestCase.java
@@ -1,0 +1,124 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.invoker;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.commons.CacheException;
+import org.infinispan.configuration.cache.Configuration;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.infinispan.context.Flag;
+import org.infinispan.remoting.transport.jgroups.SuspectException;
+import org.infinispan.transaction.TransactionMode;
+import org.infinispan.util.concurrent.TimeoutException;
+import org.junit.Test;
+
+/**
+ * @author Paul Ferraro
+ */
+public class RetryingCacheInvokerTestCase {
+    private final TransactionManager tm = mock(TransactionManager.class);
+    private final CacheInvoker invoker = mock(CacheInvoker.class);
+    private final AdvancedCache<Object, Object> cache = mock(AdvancedCache.class);
+    private final CacheInvoker.Operation<Object, Object, Object> operation = mock(CacheInvoker.Operation.class);
+    private final CacheInvoker subject = new RetryingCacheInvoker(this.invoker, 0);
+
+    @Test
+    public void nonTransactionalRetry() {
+        this.nonTransactionalRetry(new TimeoutException(), true);
+        this.nonTransactionalRetry(new SuspectException(), true);
+        this.nonTransactionalRetry(new CacheException(), false);
+    }
+
+    private void nonTransactionalRetry(Throwable exception, boolean allowsRetry) {
+        Flag flag = Flag.FORCE_SYNCHRONOUS;
+        Object expected = new Object();
+        Configuration config = new ConfigurationBuilder().transaction().transactionMode(TransactionMode.NON_TRANSACTIONAL).build();
+
+        when(this.cache.getCacheConfiguration()).thenReturn(config);
+        when(this.invoker.invoke(this.cache, this.operation, flag)).thenThrow(exception).thenReturn(expected);
+
+        try {
+            Object result = this.subject.invoke(this.cache, this.operation, flag);
+            if (allowsRetry) {
+                assertSame(expected, result);
+            } else {
+                fail("Retry should not have been allowed for exception: " + exception.getClass().getName());
+            }
+        } catch (RuntimeException e) {
+            if (!allowsRetry) {
+                assertSame(exception, e);
+            } else {
+                fail("Retry should have been allowed for exception: " + exception.getClass().getName());
+            }
+        }
+    }
+
+    @Test
+    public void transactionalRetry() throws SystemException {
+        this.transactionalRetry(Status.STATUS_ACTIVE, true);
+        this.transactionalRetry(Status.STATUS_COMMITTED, false);
+        this.transactionalRetry(Status.STATUS_COMMITTING, true);
+        this.transactionalRetry(Status.STATUS_MARKED_ROLLBACK, false);
+        this.transactionalRetry(Status.STATUS_NO_TRANSACTION, true);
+        this.transactionalRetry(Status.STATUS_PREPARED, false);
+        this.transactionalRetry(Status.STATUS_PREPARING, true);
+        this.transactionalRetry(Status.STATUS_ROLLEDBACK, false);
+        this.transactionalRetry(Status.STATUS_ROLLING_BACK, false);
+        this.transactionalRetry(Status.STATUS_UNKNOWN, false);
+    }
+
+    private void transactionalRetry(int status, boolean allowsRetry) throws SystemException {
+        Flag flag = Flag.FORCE_SYNCHRONOUS;
+        Throwable expectedException = new TimeoutException();
+        Object expected = new Object();
+        Configuration config = new ConfigurationBuilder().transaction().transactionMode(TransactionMode.TRANSACTIONAL).build();
+
+        when(this.cache.getAdvancedCache()).thenReturn(this.cache);
+        when(this.cache.getCacheConfiguration()).thenReturn(config);
+        when(this.cache.getTransactionManager()).thenReturn(this.tm);
+        when(this.tm.getStatus()).thenReturn(status);
+        when(this.invoker.invoke(this.cache, this.operation, flag)).thenThrow(expectedException).thenReturn(expected);
+
+        try {
+            Object result = this.subject.invoke(this.cache, this.operation, flag);
+            if (allowsRetry) {
+                assertSame(expected, result);
+            } else {
+                fail("Retry should not have been allowed for tx status: " + status);
+            }
+        } catch (RuntimeException e) {
+            if (!allowsRetry) {
+                assertSame(expectedException, e);
+            } else {
+                fail("Retry should have been allowed for tx status: " + status);
+            }
+        }
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationScheduler.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SessionExpirationScheduler.java
@@ -24,6 +24,7 @@ package org.wildfly.clustering.web.infinispan.session;
 import java.security.AccessController;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -62,6 +63,7 @@ public class SessionExpirationScheduler implements Scheduler<ImmutableSession> {
     private static ScheduledExecutorService createScheduledExecutor(ThreadFactory factory) {
         ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, factory);
         executor.setRemoveOnCancelPolicy(true);
+        executor.setExecuteExistingDelayedTasksAfterShutdownPolicy(false);
         return executor;
     }
 
@@ -85,13 +87,31 @@ public class SessionExpirationScheduler implements Scheduler<ImmutableSession> {
         if (timeout > 0) {
             String id = session.getId();
             InfinispanWebLogger.ROOT_LOGGER.tracef("Session %s will expire in %d ms", id, timeout);
-            this.expirationFutures.put(id, this.executor.schedule(new ExpirationTask(id), timeout, TimeUnit.MILLISECONDS));
+            Runnable task = new ExpirationTask(id);
+            synchronized (task) {
+                this.expirationFutures.put(id, this.executor.schedule(task, timeout, TimeUnit.MILLISECONDS));
+            }
         }
     }
 
     @Override
     public void close() {
         this.executor.shutdown();
+        for (Future<?> future: this.expirationFutures.values()) {
+            future.cancel(false);
+        }
+        for (Future<?> future: this.expirationFutures.values()) {
+            if (!future.isDone()) {
+                try {
+                    future.get();
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    // Ignore
+                }
+            }
+        }
+        this.expirationFutures.clear();
     }
 
     private class ExpirationTask implements Runnable {
@@ -103,18 +123,23 @@ public class SessionExpirationScheduler implements Scheduler<ImmutableSession> {
 
         @Override
         public void run() {
-            SessionExpirationScheduler.this.expirationFutures.remove(this.id);
             InfinispanWebLogger.ROOT_LOGGER.tracef("Expiring session %s", this.id);
-            Batch batch = SessionExpirationScheduler.this.batcher.startBatch();
-            boolean success = false;
             try {
-                SessionExpirationScheduler.this.remover.remove(this.id);
-                success = true;
+                Batch batch = SessionExpirationScheduler.this.batcher.startBatch();
+                boolean success = false;
+                try {
+                    SessionExpirationScheduler.this.remover.remove(this.id);
+                    success = true;
+                } finally {
+                    if (success) {
+                        batch.close();
+                    } else {
+                        batch.discard();
+                    }
+                }
             } finally {
-                if (success) {
-                    batch.close();
-                } else {
-                    batch.discard();
+                synchronized (this) {
+                    SessionExpirationScheduler.this.expirationFutures.remove(this.id);
                 }
             }
         }

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionMetaData.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionMetaData.java
@@ -52,7 +52,7 @@ public class SimpleSessionMetaData implements SessionMetaData {
     @Override
     public boolean isExpired() {
         long maxInactiveInterval = this.getMaxInactiveInterval(TimeUnit.MILLISECONDS);
-        return (maxInactiveInterval > 0) ? (System.currentTimeMillis() - this.lastAccessedTime.getTime()) > maxInactiveInterval : false;
+        return (maxInactiveInterval > 0) ? (System.currentTimeMillis() - this.lastAccessedTime.getTime()) >= maxInactiveInterval : false;
     }
 
     @Override

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
@@ -51,6 +51,7 @@ public class ClientConstants {
     public static final String OP_ADDR = "address";
     public static final String OUTCOME = "outcome";
     public static final String PATH = "path";
+    public static final String PROXIES = "proxies";
     public static final String READ_ATTRIBUTE_OPERATION = "read-attribute";
     public static final String READ_CHILDREN_NAMES_OPERATION = "read-children-names";
     public static final String READ_RESOURCE_OPERATION = "read-resource";

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
@@ -56,6 +56,7 @@ public class ClientConstants {
     public static final String READ_CHILDREN_NAMES_OPERATION = "read-children-names";
     public static final String READ_RESOURCE_OPERATION = "read-resource";
     public static final String RECURSIVE = "recursive";
+    public static final String RECURSIVE_DEPTH = "recursive-depth";
     public static final String REMOVE_OPERATION = "remove";
     public static final String RESULT = "result";
     public static final String ROLLBACK_ON_RUNTIME_FAILURE = "rollback-on-runtime-failure";

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -172,8 +172,7 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
 
         final int recursiveDepth = operation.get(ModelDescriptionConstants.RECURSIVE_DEPTH).asInt(0);
-        final boolean recursive = operation.get(ModelDescriptionConstants.RECURSIVE).asBoolean(false) &&
-                (!operation.get(ModelDescriptionConstants.RECURSIVE_DEPTH).isDefined() || recursiveDepth > 0);
+        final boolean recursive = recursiveDepth > 0 || operation.get(ModelDescriptionConstants.RECURSIVE).asBoolean(false);
         final boolean queryRuntime = operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).asBoolean(false);
         final boolean proxies = operation.get(ModelDescriptionConstants.PROXIES).asBoolean(false);
         final boolean aliases = operation.get(ModelDescriptionConstants.INCLUDE_ALIASES).asBoolean(false);

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -172,7 +172,8 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
 
         final int recursiveDepth = operation.get(ModelDescriptionConstants.RECURSIVE_DEPTH).asInt(0);
-        final boolean recursive = recursiveDepth > 0 || operation.get(ModelDescriptionConstants.RECURSIVE).asBoolean(false);
+        final boolean recursive = operation.get(ModelDescriptionConstants.RECURSIVE).asBoolean(false) &&
+                (!operation.get(ModelDescriptionConstants.RECURSIVE_DEPTH).isDefined() || recursiveDepth > 0);
         final boolean queryRuntime = operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).asBoolean(false);
         final boolean proxies = operation.get(ModelDescriptionConstants.PROXIES).asBoolean(false);
         final boolean aliases = operation.get(ModelDescriptionConstants.INCLUDE_ALIASES).asBoolean(false);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryBuilderService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryBuilderService.java
@@ -53,21 +53,21 @@ public class DistributableCacheFactoryBuilderService<K, V extends Identifiable<K
     }
 
     private final String name;
-    private final BeanManagerFactoryBuilder<UUID, K> builder;
+    private final BeanManagerFactoryBuilder<UUID, K, Batch> builder;
     private final BeanManagerFactoryBuilderConfiguration config;
 
     public DistributableCacheFactoryBuilderService(String name, BeanManagerFactoryBuilderConfiguration config) {
         this(name, load(), config);
     }
 
-    private static BeanManagerFactoryBuilderProvider load() {
-        for (BeanManagerFactoryBuilderProvider provider: ServiceLoader.load(BeanManagerFactoryBuilderProvider.class, BeanManagerFactoryBuilderProvider.class.getClassLoader())) {
+    private static BeanManagerFactoryBuilderProvider<Batch> load() {
+        for (BeanManagerFactoryBuilderProvider<Batch> provider: ServiceLoader.load(BeanManagerFactoryBuilderProvider.class, BeanManagerFactoryBuilderProvider.class.getClassLoader())) {
             return provider;
         }
         return null;
     }
 
-    public DistributableCacheFactoryBuilderService(String name, BeanManagerFactoryBuilderProvider provider, BeanManagerFactoryBuilderConfiguration config) {
+    public DistributableCacheFactoryBuilderService(String name, BeanManagerFactoryBuilderProvider<Batch> provider, BeanManagerFactoryBuilderConfiguration config) {
         this.name = name;
         this.config = config;
         this.builder = provider.<UUID, K>getBeanManagerFactoryBuilder(name, config);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryService.java
@@ -43,7 +43,7 @@ public class DistributableCacheFactoryService<K, V extends Identifiable<K> & Con
         ;
     }
 
-    private final InjectedValue<BeanManagerFactory<UUID, K, V>> factory = new InjectedValue<>();
+    private final InjectedValue<BeanManagerFactory<UUID, K, V, Batch>> factory = new InjectedValue<>();
     private final InjectedValue<ServerEnvironment> environment = new InjectedValue<>();
 
     private DistributableCacheFactoryService() {
@@ -57,7 +57,7 @@ public class DistributableCacheFactoryService<K, V extends Identifiable<K> & Con
 
     @Override
     public Cache<K, V> createCache(IdentifierFactory<K> identifierFactory, StatefulObjectFactory<V> factory, PassivationListener<V> passivationListener) {
-        BeanManager<UUID, K, V> manager = this.factory.getValue().createBeanManager(new GroupIdentifierFactory(), identifierFactory, passivationListener, new RemoveListenerAdapter<>(factory));
+        BeanManager<UUID, K, V, Batch> manager = this.factory.getValue().createBeanManager(new GroupIdentifierFactory(), identifierFactory, passivationListener, new RemoveListenerAdapter<>(factory));
         return new DistributableCache<>(manager, factory, this.environment.getValue());
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCacheFactoryBuilderService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCacheFactoryBuilderService.java
@@ -64,7 +64,7 @@ public class SimpleCacheFactoryBuilderService<K, V extends Identifiable<K>> exte
 
     @Override
     public void installDeploymentUnitDependencies(ServiceTarget target, ServiceName deploymentUnitServiceName) {
-        target.addService(deploymentUnitServiceName.append(this.name, "expiration"), new RemoveOnCancelScheduledExecutorService(THREAD_FACTORY))
+        RemoveOnCancelScheduledExecutorService.build(target, deploymentUnitServiceName.append(this.name, "expiration"), THREAD_FACTORY)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install()
         ;

--- a/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
+++ b/logging/src/main/java/org/jboss/as/logging/KnownModelVersion.java
@@ -11,6 +11,7 @@ enum KnownModelVersion {
     VERSION_1_1_0(ModelVersion.create(1, 1, 0), true),
     VERSION_1_2_0(ModelVersion.create(1, 2, 0), true),
     VERSION_1_3_0(ModelVersion.create(1, 3, 0), true),
+    VERSION_1_4_0(ModelVersion.create(1, 4, 0), true),
     VERSION_2_0_0(ModelVersion.create(2, 0, 0), false),
     ;
     private final ModelVersion modelVersion;

--- a/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingRootResource.java
@@ -62,7 +62,6 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.services.path.PathManager;
 import org.jboss.as.controller.services.path.PathResourceDefinition;
-import org.jboss.as.controller.transform.description.AttributeTransformationDescriptionBuilder;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -188,12 +187,16 @@ public class LoggingRootResource extends TransformerResourceDefinition {
             case VERSION_1_1_0:
             case VERSION_1_2_0:
             case VERSION_1_3_0: {
-                AttributeTransformationDescriptionBuilder attributeBuilder = rootResourceBuilder.getAttributeBuilder();
-                for (SimpleAttributeDefinition attribute : ATTRIBUTES) {
-                    attributeBuilder.setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, attribute.getDefaultValue()), attribute)
-                            .addRejectCheck(RejectAttributeChecker.DEFINED, attribute);
-                }
-                attributeBuilder.end();
+                rootResourceBuilder.getAttributeBuilder()
+                        .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, ADD_LOGGING_API_DEPENDENCIES.getDefaultValue()), ADD_LOGGING_API_DEPENDENCIES)
+                        .addRejectCheck(RejectAttributeChecker.DEFINED, ADD_LOGGING_API_DEPENDENCIES)
+                        .end();
+            }
+            case VERSION_1_4_0: {
+                rootResourceBuilder.getAttributeBuilder()
+                        .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, USE_DEPLOYMENT_LOGGING_CONFIG.getDefaultValue()), USE_DEPLOYMENT_LOGGING_CONFIG)
+                        .addRejectCheck(RejectAttributeChecker.DEFINED, USE_DEPLOYMENT_LOGGING_CONFIG)
+                        .end();
             }
         }
     }

--- a/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
+++ b/logging/src/main/java/org/jboss/as/logging/LoggingSubsystemParser.java
@@ -142,6 +142,7 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                 case LOGGING_1_1:
                 case LOGGING_1_2:
                 case LOGGING_1_3:
+                case LOGGING_1_4:
                 case LOGGING_2_0: {
                     final Element element = Element.forName(reader.getLocalName());
                     switch (element) {
@@ -155,7 +156,8 @@ public class LoggingSubsystemParser implements XMLStreamConstants, XMLElementRea
                         }
                         case USE_DEPLOYMENT_LOGGING_CONFIG:{
                             if (namespace == Namespace.LOGGING_1_0 || namespace == Namespace.LOGGING_1_1 ||
-                                    namespace == Namespace.LOGGING_1_2 || namespace == Namespace.LOGGING_1_3)
+                                    namespace == Namespace.LOGGING_1_2 || namespace == Namespace.LOGGING_1_3 ||
+                                    namespace == Namespace.LOGGING_1_4)
                                 throw unexpectedElement(reader);
                             final String value = ParseUtils.readStringAttributeElement(reader, Attribute.VALUE.getLocalName());
                             LoggingRootResource.USE_DEPLOYMENT_LOGGING_CONFIG.parseAndSetParameter(value, subsystemAddOp, reader);

--- a/logging/src/main/java/org/jboss/as/logging/Namespace.java
+++ b/logging/src/main/java/org/jboss/as/logging/Namespace.java
@@ -43,6 +43,8 @@ public enum Namespace {
 
     LOGGING_1_3("urn:jboss:domain:logging:1.3"),
 
+    LOGGING_1_4("urn:jboss:domain:logging:1.4"),
+
     LOGGING_2_0("urn:jboss:domain:logging:2.0");
 
     /**

--- a/logging/src/test/resources/expressions_1_3.xml
+++ b/logging/src/test/resources/expressions_1_3.xml
@@ -1,0 +1,137 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:logging:1.3">
+    <async-handler name="async">
+        <queue-length value="${test.queue.length:10}"/>
+        <overflow-action value="${test.overflow.action:block}"/>
+        <subhandlers>
+            <handler name="sizeLogger"/>
+        </subhandlers>
+    </async-handler>
+
+    <console-handler name="CONSOLE" autoflush="${test.autoflush:true}">
+        <level name="${test.console.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <filter-spec value="${test.console.filter:levelRange(TRACE,WARN)}" />
+        <formatter>
+            <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+        </formatter>
+    </console-handler>
+
+    <file-handler name="anotherFile" enabled="${test.file.enabled:false}" autoflush="${test.autoflush:true}">
+        <level name="${test.file.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <file relative-to="jboss.server.log.dir" path="${test.another.filter:another.log}"/>
+        <append value="${test.file.append:true}"/>
+    </file-handler>
+
+    <periodic-rotating-file-handler name="FILE" autoflush="${test.autoflush:true}">
+        <level name="${test.file.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <filter-spec value="${test.file.filter:any(levels(INFO),not(levels(TRACE)))}"/>
+        <formatter>
+            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="${test.server.log.file:server.log}"/>
+        <suffix value="${test.file.suffix:.yyyy-MM-dd}"/>
+    </periodic-rotating-file-handler>
+
+    <size-rotating-file-handler name="sizeLogger" autoflush="${test.autoflush:true}" rotate-on-boot="${test.rotate-on-boot:true}">
+        <level name="${test.file.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <formatter>
+            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="${test.size.log.file:sizeLogger.log}"/>
+        <rotate-size value="${test.rotate.size:64m}"/>
+        <max-backup-index value="${test.max.backup.index:1024}"/>
+        <append value="${test.file.append:false}"/>
+    </size-rotating-file-handler>
+
+    <syslog-handler name="syslog" enabled="${test.syslog.enabled:false}">
+        <level name="${test.default.level:INFO}"/>
+        <server-address value="${test.syslog.server-address:127.0.0.1}"/>
+        <hostname value="${test.syslog.hostname:jboss.org}"/>
+        <port value="${test.syslog.port:514}"/>
+        <app-name value="${test.syslog.appname:jboss-as7}"/>
+        <formatter>
+            <syslog-format syslog-type="${test.syslog.format:RFC5424}"/>
+        </formatter>
+        <facility value="${test.syslog.facility:user-level}"/>
+    </syslog-handler>
+
+    <logger category="com.example" use-parent-handlers="${test.logger.use.parent.handlers:false}">
+        <level name="${test.logger.level:INFO}"/>
+        <filter-spec value="${test.logger.filter:levelRange[TRACE,WARN)}"/>
+        <handlers>
+            <handler name="sizeLogger"/>
+            <handler name="CONSOLE"/>
+        </handlers>
+    </logger>
+
+    <root-logger>
+        <level name="${test.root.level:INFO}"/>
+        <handlers>
+            <handler name="CONSOLE"/>
+            <handler name="FILE"/>
+        </handlers>
+    </root-logger>
+
+    <logging-profiles>
+        <logging-profile name="test-profile">
+
+            <console-handler name="CONSOLE" autoflush="${test.autoflush:true}">
+                <level name="${test.console.level:INFO}"/>
+                <encoding value="${test.encoding:UTF-8}"/>
+                <filter-spec value="${test.console.filter:levelRange(TRACE,WARN)}" />
+                <formatter>
+                    <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+                </formatter>
+            </console-handler>
+
+            <syslog-handler name="syslog" enabled="${test.syslog.enabled:false}">
+                <level name="${test.default.level:INFO}"/>
+                <server-address value="${test.syslog.server-address:127.0.0.1}"/>
+                <hostname value="${test.syslog.hostname:jboss.org}"/>
+                <port value="${test.syslog.port:514}"/>
+                <app-name value="${test.syslog.appname:jboss-as7}"/>
+                <formatter>
+                    <syslog-format syslog-type="${test.syslog.format:RFC5424}"/>
+                </formatter>
+                <facility value="${test.syslog.facility:user-level}"/>
+            </syslog-handler>
+
+            <logger category="com.example" use-parent-handlers="${test.logger.use.parent.handlers:false}">
+                <level name="${test.logger.level:INFO}"/>
+                <filter-spec value="${test.logger.filter:levelRange[TRACE,WARN)}"/>
+            </logger>
+
+            <root-logger>
+                <level name="${test.root.level:INFO}"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                </handlers>
+            </root-logger>
+        </logging-profile>
+    </logging-profiles>
+</subsystem>

--- a/logging/src/test/resources/expressions_1_4.xml
+++ b/logging/src/test/resources/expressions_1_4.xml
@@ -1,0 +1,159 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:logging:1.4">
+    <add-logging-api-dependencies value="${test.add.deps:true}"/>
+    <async-handler name="async">
+        <queue-length value="${test.queue.length:10}"/>
+        <overflow-action value="${test.overflow.action:block}"/>
+        <subhandlers>
+            <handler name="sizeLogger"/>
+        </subhandlers>
+    </async-handler>
+
+    <console-handler name="CONSOLE" autoflush="${test.autoflush:true}">
+        <level name="${test.console.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <filter-spec value="${test.console.filter:levelRange(TRACE,WARN)}" />
+        <formatter>
+            <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+        </formatter>
+    </console-handler>
+
+    <file-handler name="anotherFile" enabled="${test.file.enabled:false}" autoflush="${test.autoflush:true}">
+        <level name="${test.file.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="${test.another.filter:another.log}"/>
+        <append value="${test.file.append:true}"/>
+    </file-handler>
+
+    <periodic-rotating-file-handler name="FILE" autoflush="${test.autoflush:true}">
+        <level name="${test.file.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <filter-spec value="${test.file.filter:any(levels(INFO),not(levels(TRACE)))}"/>
+        <formatter>
+            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="${test.server.log.file:server.log}"/>
+        <suffix value="${test.file.suffix:.yyyy-MM-dd}"/>
+    </periodic-rotating-file-handler>
+
+    <size-rotating-file-handler name="sizeLogger" autoflush="${test.autoflush:true}" rotate-on-boot="${test.rotate-on-boot:true}">
+        <level name="${test.file.level:INFO}"/>
+        <encoding value="${test.encoding:UTF-8}"/>
+        <formatter>
+            <pattern-formatter pattern="${test.console.pattern:%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="${test.size.log.file:sizeLogger.log}"/>
+        <rotate-size value="${test.rotate.size:64m}"/>
+        <max-backup-index value="${test.max.backup.index:1024}"/>
+        <append value="${test.file.append:false}"/>
+    </size-rotating-file-handler>
+
+    <syslog-handler name="syslog" enabled="${test.syslog.enabled:false}">
+        <level name="${test.default.level:INFO}"/>
+        <server-address value="${test.syslog.server-address:127.0.0.1}"/>
+        <hostname value="${test.syslog.hostname:jboss.org}"/>
+        <port value="${test.syslog.port:514}"/>
+        <app-name value="${test.syslog.appname:jboss-as7}"/>
+        <formatter>
+            <syslog-format syslog-type="${test.syslog.format:RFC5424}"/>
+        </formatter>
+        <facility value="${test.syslog.facility:user-level}"/>
+    </syslog-handler>
+
+    <logger category="com.example" use-parent-handlers="${test.logger.use.parent.handlers:false}">
+        <level name="${test.logger.level:INFO}"/>
+        <filter-spec value="${test.logger.filter:levelRange[TRACE,WARN)}"/>
+        <handlers>
+            <handler name="sizeLogger"/>
+            <handler name="CONSOLE"/>
+        </handlers>
+    </logger>
+
+    <root-logger>
+        <level name="${test.root.level:INFO}"/>
+        <handlers>
+            <handler name="CONSOLE"/>
+            <handler name="FILE"/>
+        </handlers>
+    </root-logger>
+
+    <formatter name="PATTERN">
+        <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
+    </formatter>
+
+    <logging-profiles>
+        <logging-profile name="test-profile">
+
+            <console-handler name="CONSOLE" autoflush="${test.autoflush:true}">
+                <level name="${test.console.level:INFO}"/>
+                <encoding value="${test.encoding:UTF-8}"/>
+                <filter-spec value="${test.console.filter:levelRange(TRACE,WARN)}" />
+                <formatter>
+                    <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}"/>
+                </formatter>
+            </console-handler>
+
+            <file-handler name="anotherFile" enabled="${test.file.enabled:false}" autoflush="${test.autoflush:true}">
+                <level name="${test.file.level:INFO}"/>
+                <encoding value="${test.encoding:UTF-8}"/>
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="${test.another.filter:anotherProfile.log}"/>
+                <append value="${test.file.append:true}"/>
+            </file-handler>
+
+            <syslog-handler name="syslog" enabled="${test.syslog.enabled:false}">
+                <level name="${test.default.level:INFO}"/>
+                <server-address value="${test.syslog.server-address:127.0.0.1}"/>
+                <hostname value="${test.syslog.hostname:jboss.org}"/>
+                <port value="${test.syslog.port:514}"/>
+                <app-name value="${test.syslog.appname:jboss-as7}"/>
+                <formatter>
+                    <syslog-format syslog-type="${test.syslog.format:RFC5424}"/>
+                </formatter>
+                <facility value="${test.syslog.facility:user-level}"/>
+            </syslog-handler>
+
+            <logger category="com.example" use-parent-handlers="${test.logger.use.parent.handlers:false}">
+                <level name="${test.logger.level:INFO}"/>
+                <filter-spec value="${test.logger.filter:levelRange[TRACE,WARN)}"/>
+            </logger>
+
+            <root-logger>
+                <level name="${test.root.level:INFO}"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                </handlers>
+            </root-logger>
+
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
+            </formatter>
+        </logging-profile>
+    </logging-profiles>
+</subsystem>

--- a/logging/src/test/resources/logging_1_3.xml
+++ b/logging/src/test/resources/logging_1_3.xml
@@ -1,0 +1,165 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:logging:1.3">
+    <async-handler name="async">
+        <queue-length value="10"/>
+        <overflow-action value="block"/>
+        <subhandlers>
+            <handler name="sizeLogger"/>
+            <handler name="simpleFile"/>
+        </subhandlers>
+    </async-handler>
+
+    <console-handler name="CONSOLE">
+        <level name="INFO"/>
+        <filter-spec value="levelRange(TRACE,WARN)" />
+        <formatter>
+            <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+        </formatter>
+    </console-handler>
+
+    <file-handler name="anotherFile" enabled="false">
+        <filter-spec value="levelRange(TRACE,WARN]" />
+        <file relative-to="jboss.server.log.dir" path="another.log"/>
+        <append value="true"/>
+    </file-handler>
+
+    <file-handler name="simpleFile">
+        <level name="INFO"/>
+        <filter-spec value="deny"/>
+        <file relative-to="jboss.server.log.dir" path="fileHandler.log"/>
+        <append value="true"/>
+    </file-handler>
+
+    <!-- Can't use custom handlers as they require JBoss Modules
+    <custom-handler name="customHandler" module="org.jboss.logmanager" class="org.jboss.logmanager.handler.ConsoleHandler">
+        <filter>
+            <replace pattern="\b(Name)|\b(name)" replacement="user" replace-all="true"/>
+        </filter>
+        <properties>
+            <property name="autoFlush" value="true" />
+            <property name="target" value="SYSTEM_OUT" />
+        </properties>
+    </custom-handler>
+
+    <custom-handler name="log4jAppender" module="org.apache.log4j" class="org.apache.log4j.ConsoleAppender">
+        <properties>
+            <property name="target" value="System.out"/>
+        </properties>
+    </custom-handler> -->
+
+    <periodic-rotating-file-handler name="FILE">
+        <encoding value="UTF-8"/>
+        <filter-spec value="any(levels(INFO),not(levels(TRACE)))"/>
+        <formatter>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="server.log"/>
+        <suffix value=".yyyy-MM-dd"/>
+    </periodic-rotating-file-handler>
+
+    <size-rotating-file-handler name="sizeLogger" rotate-on-boot="true">
+        <level name="DEBUG"/>
+        <encoding value="UTF-8"/>
+        <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>
+        <formatter>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="sizeLogger.log"/>
+        <rotate-size value="64m"/>
+        <max-backup-index value="1024"/>
+        <append value="false"/>
+    </size-rotating-file-handler>
+
+    <syslog-handler name="syslog" enabled="false">
+        <level name="INFO"/>
+        <server-address value="127.0.0.1"/>
+        <hostname value="jboss.org"/>
+        <port value="514"/>
+        <app-name value="my-app"/>
+        <formatter>
+            <syslog-format syslog-type="RFC5424"/>
+        </formatter>
+        <facility value="user-level"/>
+    </syslog-handler>
+
+    <logger category="com.example" use-parent-handlers="false">
+        <level name="TRACE"/>
+        <filter-spec value="levelRange[TRACE,WARN)"/>
+        <handlers>
+            <handler name="sizeLogger"/>
+            <handler name="CONSOLE"/>
+        </handlers>
+    </logger>
+
+    <logger category="com.arjuna">
+        <level name="WARN"/>
+        <filter-spec value="levelRange[TRACE,WARN]"/>
+    </logger>
+
+    <root-logger>
+        <level name="INFO"/>
+        <handlers>
+            <handler name="CONSOLE"/>
+            <handler name="FILE"/>
+        </handlers>
+    </root-logger>
+
+    <logging-profiles>
+        <logging-profile name="test-profile">
+
+            <console-handler name="CONSOLE">
+                <level name="ALL"/>
+                <filter-spec value="levelRange(TRACE,WARN)"/>
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+            </console-handler>
+
+            <syslog-handler name="syslog">
+                <level name="WARN"/>
+                <server-address value="localhost"/>
+                <hostname value="community.jboss.org"/>
+                <port value="514"/>
+                <app-name value="my-app"/>
+                <formatter>
+                    <syslog-format syslog-type="RFC3164"/>
+                </formatter>
+                <facility value="user-level"/>
+            </syslog-handler>
+
+            <logger category="org.jboss.as.logging">
+                <level name="TRACE"/>
+                <filter-spec value="levelRange[TRACE,WARN)"/>
+            </logger>
+
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="syslog"/>
+                </handlers>
+            </root-logger>
+        </logging-profile>
+    </logging-profiles>
+</subsystem>

--- a/logging/src/test/resources/logging_1_4.xml
+++ b/logging/src/test/resources/logging_1_4.xml
@@ -1,0 +1,190 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:logging:1.4">
+    <add-logging-api-dependencies value="false"/>
+    <async-handler name="async">
+        <queue-length value="10"/>
+        <overflow-action value="block"/>
+        <subhandlers>
+            <handler name="sizeLogger"/>
+            <handler name="simpleFile"/>
+        </subhandlers>
+    </async-handler>
+
+    <console-handler name="CONSOLE">
+        <level name="INFO"/>
+        <filter-spec value="levelRange(TRACE,WARN)" />
+        <formatter>
+            <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+        </formatter>
+    </console-handler>
+
+    <file-handler name="anotherFile" enabled="false">
+        <filter-spec value="levelRange(TRACE,WARN]" />
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="another.log"/>
+        <append value="true"/>
+    </file-handler>
+
+    <file-handler name="simpleFile">
+        <level name="INFO"/>
+        <filter-spec value="deny"/>
+        <formatter>
+            <named-formatter name="PATTERN"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="fileHandler.log"/>
+        <append value="true"/>
+    </file-handler>
+
+    <!-- Can't use custom handlers as they require JBoss Modules
+    <custom-handler name="customHandler" module="org.jboss.logmanager" class="org.jboss.logmanager.handler.ConsoleHandler">
+        <filter>
+            <replace pattern="\b(Name)|\b(name)" replacement="user" replace-all="true"/>
+        </filter>
+        <properties>
+            <property name="autoFlush" value="true" />
+            <property name="target" value="SYSTEM_OUT" />
+        </properties>
+    </custom-handler>
+
+    <custom-handler name="log4jAppender" module="org.apache.log4j" class="org.apache.log4j.ConsoleAppender">
+        <properties>
+            <property name="target" value="System.out"/>
+        </properties>
+    </custom-handler> -->
+
+    <periodic-rotating-file-handler name="FILE">
+        <encoding value="UTF-8"/>
+        <filter-spec value="any(levels(INFO),not(levels(TRACE)))"/>
+        <formatter>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="server.log"/>
+        <suffix value=".yyyy-MM-dd"/>
+    </periodic-rotating-file-handler>
+
+    <size-rotating-file-handler name="sizeLogger" rotate-on-boot="true">
+        <level name="DEBUG"/>
+        <encoding value="UTF-8"/>
+        <filter-spec value="all(levelChange(DEBUG),match(&quot;JBAS+\\d&quot;))"/>
+        <formatter>
+            <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+        </formatter>
+        <file relative-to="jboss.server.log.dir" path="sizeLogger.log"/>
+        <rotate-size value="64m"/>
+        <max-backup-index value="1024"/>
+        <append value="false"/>
+    </size-rotating-file-handler>
+
+    <syslog-handler name="syslog" enabled="false">
+        <level name="INFO"/>
+        <server-address value="127.0.0.1"/>
+        <hostname value="jboss.org"/>
+        <port value="514"/>
+        <app-name value="my-app"/>
+        <formatter>
+            <syslog-format syslog-type="RFC5424"/>
+        </formatter>
+        <facility value="user-level"/>
+    </syslog-handler>
+
+    <logger category="com.example" use-parent-handlers="false">
+        <level name="TRACE"/>
+        <filter-spec value="levelRange[TRACE,WARN)"/>
+        <handlers>
+            <handler name="sizeLogger"/>
+            <handler name="CONSOLE"/>
+        </handlers>
+    </logger>
+
+    <logger category="com.arjuna">
+        <level name="WARN"/>
+        <filter-spec value="levelRange[TRACE,WARN]"/>
+    </logger>
+
+    <root-logger>
+        <level name="INFO"/>
+        <handlers>
+            <handler name="CONSOLE"/>
+            <handler name="FILE"/>
+        </handlers>
+    </root-logger>
+
+    <formatter name="PATTERN">
+        <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
+    </formatter>
+
+    <logging-profiles>
+        <logging-profile name="test-profile">
+
+            <console-handler name="CONSOLE">
+                <level name="ALL"/>
+                <filter-spec value="levelRange(TRACE,WARN)"/>
+                <formatter>
+                    <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
+                </formatter>
+            </console-handler>
+
+            <file-handler name="simpleFile">
+                <level name="INFO"/>
+                <filter-spec value="deny"/>
+                <formatter>
+                    <named-formatter name="PATTERN"/>
+                </formatter>
+                <file relative-to="jboss.server.log.dir" path="profileFileHandler.log"/>
+                <append value="true"/>
+            </file-handler>
+
+            <syslog-handler name="syslog">
+                <level name="WARN"/>
+                <server-address value="localhost"/>
+                <hostname value="community.jboss.org"/>
+                <port value="514"/>
+                <app-name value="my-app"/>
+                <formatter>
+                    <syslog-format syslog-type="RFC3164"/>
+                </formatter>
+                <facility value="user-level"/>
+            </syslog-handler>
+
+            <logger category="org.jboss.as.logging">
+                <level name="TRACE"/>
+                <filter-spec value="levelRange[TRACE,WARN)"/>
+            </logger>
+
+            <root-logger>
+                <level name="INFO"/>
+                <handlers>
+                    <handler name="CONSOLE"/>
+                    <handler name="syslog"/>
+                </handlers>
+            </root-logger>
+
+            <formatter name="PATTERN">
+                <pattern-formatter pattern="${test.console.pattern:%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n}" color-map="${test.console.color:info:cyan,warn:yellow,error:red}"/>
+            </formatter>
+        </logging-profile>
+    </logging-profiles>
+</subsystem>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>
         <version.org.hibernate>4.3.6.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.4.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.validator>5.1.1.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>5.1.2.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.0.0.Alpha6</version.org.hibernate.hql>
         <version.org.hibernate.search>4.5.1.Final</version.org.hibernate.search>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <version.org.jboss.genericjms>1.0.5.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.invocation>1.2.1.Final</version.org.jboss.invocation>
-        <version.org.jboss.ironjacamar>1.1.6.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.ironjacamar>1.1.7.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jandex>1.2.1.Final</version.org.jboss.jandex>
         <version.org.jboss.jboss-dmr>1.2.0.Final</version.org.jboss.jboss-dmr>
         <version.org.jboss.jboss-transaction-spi>7.1.0.Final</version.org.jboss.jboss-transaction-spi>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.org.codehaus.woodstox.woodstox-core-asl>4.2.0</version.org.codehaus.woodstox.woodstox-core-asl>
         <version.org.eclipse.jdt.core.compiler>4.3.1</version.org.eclipse.jdt.core.compiler>
         <version.org.fusesource.jansi>1.9</version.org.fusesource.jansi>
-        <version.org.glassfish.javax.el>3.0.0</version.org.glassfish.javax.el>
+        <version.org.glassfish.javax.el>3.0.1-b05</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>
         <version.org.hibernate>4.3.6.Final</version.org.hibernate>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@
         <version.org.jboss.xnio>3.2.2.Final</version.org.jboss.xnio>
         <version.org.jboss.xnio.xnio-api>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-api>
         <version.org.jboss.xnio.xnio-nio>${version.org.jboss.xnio}</version.org.jboss.xnio.xnio-nio>
-        <version.org.jgroups>3.4.3.Final</version.org.jgroups>
+        <version.org.jgroups>3.4.5.Final</version.org.jgroups>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.mockito>1.9.5</version.org.mockito>

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/ClusterTestUtil.java
@@ -21,6 +21,14 @@
  */
 package org.jboss.as.test.clustering;
 
+import javax.naming.NamingException;
+
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.container.ClassContainer;
+import org.jboss.shrinkwrap.api.container.ManifestContainer;
+
 /**
  * Utility class for cluster test.
  *
@@ -41,7 +49,17 @@ public class ClusterTestUtil {
         }
     }
 
-    private ClusterTestUtil() {
+    public static <A extends Archive<A> & ClassContainer<A> & ManifestContainer<A>> A addTopologyListenerDependencies(A archive) {
+        archive.addClasses(TopologyChangeListener.class, TopologyChangeListenerBean.class, TopologyChangeListenerServlet.class);
+        archive.setManifest(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.jboss.as.server, org.infinispan\n"));
+        return archive;
     }
 
+    public static void establishTopology(EJBDirectory directory, String container, String cache, String... nodes) throws NamingException, InterruptedException {
+        TopologyChangeListener listener = directory.lookupStateless(TopologyChangeListenerBean.class, TopologyChangeListener.class);
+        listener.establishTopology(container, cache, nodes);
+    }
+
+    private ClusterTestUtil() {
+    }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListener.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListener.java
@@ -1,0 +1,36 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+/**
+ * @author Paul Ferraro
+ */
+public interface TopologyChangeListener {
+    /**
+     * Waits until the specified topology is established on the specified cache.
+     * @param containerName the cache container name
+     * @param cacheName the cache name
+     * @param nodes the anticipated topology
+     * @throws InterruptedException if topology to stabilize did not stabilize within a reasonable amount of time - or the process was interrupted.
+     */
+    void establishTopology(String containerName, String cacheName, String... nodes) throws InterruptedException;
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerBean.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerBean.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.clustering;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+import org.infinispan.Cache;
+import org.infinispan.notifications.Listener;
+import org.infinispan.notifications.cachelistener.annotation.TopologyChanged;
+import org.infinispan.notifications.cachelistener.event.TopologyChangedEvent;
+import org.infinispan.remoting.transport.Address;
+import org.jboss.as.clustering.msc.ServiceContainerHelper;
+import org.jboss.as.server.CurrentServiceContainer;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceRegistry;
+
+/**
+ * EJB that establishes a stable topology.
+ * @author Paul Ferraro
+ */
+@Stateless
+@Remote(TopologyChangeListener.class)
+@Listener(sync = false)
+public class TopologyChangeListenerBean implements TopologyChangeListener {
+    public static final long TIMEOUT = 15000;
+
+    @Override
+    public void establishTopology(String containerName, String cacheName, String... nodes) throws InterruptedException {
+        Set<String> expectedMembers = new TreeSet<>();
+        if (nodes != null) {
+            for (String name: nodes) {
+                expectedMembers.add(name + "/" + containerName);
+            }
+        }
+        ServiceRegistry registry = CurrentServiceContainer.getServiceContainer();
+        ServiceName name = ServiceName.JBOSS.append("infinispan", containerName, cacheName);
+        ServiceController<Cache<?, ?>> controller = ServiceContainerHelper.<Cache<?, ?>>findService(registry, name);
+        if (controller == null) {
+            throw new IllegalStateException(String.format("Failed to locate %s", name));
+        }
+        Cache<?, ?> cache = controller.getValue();
+        cache.addListener(this);
+        try
+        {
+            long start = System.currentTimeMillis();
+            long now = start;
+            long timeout = start + TIMEOUT;
+            synchronized (this) {
+                Set<String> members = getMembers(cache);
+                while (!expectedMembers.equals(members)) {
+                    System.out.println(String.format("%s != %s, waiting for a topology change event...", expectedMembers, members));
+                    this.wait(timeout - now);
+                    now = System.currentTimeMillis();
+                    if (now >= timeout) {
+                        throw new InterruptedException(String.format("Cache %s/%s failed to establish view %s within %d ms.  Current view is: %s", containerName, cacheName, expectedMembers, TIMEOUT, members));
+                    }
+                    members = getMembers(cache);
+                }
+                System.out.println(String.format("Cache %s/%s successfully established view %s within %d ms.", containerName, cacheName, expectedMembers, now - start));
+            }
+        } finally {
+            cache.removeListener(this);
+        }
+    }
+
+    private static Set<String> getMembers(Cache<?, ?> cache) {
+        Set<String> members = new TreeSet<>();
+        for (Address address: cache.getAdvancedCache().getComponentRegistry().getStateTransferManager().getCacheTopology().getMembers()) {
+            members.add(address.toString());
+        }
+        return members;
+    }
+
+    @TopologyChanged
+    public void topologyChanged(TopologyChangedEvent<?, ?> event) {
+        synchronized (this) {
+            this.notify();
+        }
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerServlet.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/TopologyChangeListenerServlet.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.clustering;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import javax.ejb.EJB;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Utility servlet that delegates to an EJB to perform topology stabilization.
+ * @author Paul Ferraro
+ */
+@WebServlet(urlPatterns = { TopologyChangeListenerServlet.SERVLET_PATH })
+public class TopologyChangeListenerServlet extends HttpServlet {
+    private static final long serialVersionUID = -4382952409558738642L;
+    private static final String SERVLET_NAME = "membership";
+    static final String SERVLET_PATH = "/" + SERVLET_NAME;
+    private static final String CONTAINER = "container";
+    private static final String CACHE = "cache";
+    private static final String NODES = "nodes";
+
+    public static URI createURI(URL baseURL, String container, String cache, String... nodes) throws URISyntaxException {
+        StringBuilder builder = new StringBuilder(baseURL.toURI().resolve(SERVLET_NAME).toString());
+        builder.append('?').append(CONTAINER).append('=').append(container);
+        builder.append('&').append(CACHE).append('=').append(cache);
+        for (String node: nodes) {
+            builder.append('&').append(NODES).append('=').append(node);
+        }
+        return URI.create(builder.toString());
+    }
+
+    @EJB
+    private TopologyChangeListener listener;
+
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+
+        String container = getRequiredParameter(request, CONTAINER);
+        String cache = getRequiredParameter(request, CACHE);
+        String[] nodes = request.getParameterValues(NODES);
+        try {
+            this.listener.establishTopology(container, cache, nodes);
+        } catch (InterruptedException e) {
+            throw new ServletException(e);
+        }
+    }
+
+    private static String getRequiredParameter(HttpServletRequest request, String name) throws ServletException {
+        String value = request.getParameter(name);
+        if (value == null) {
+            throw new ServletException(String.format("No '%s' parameter specified", name));
+        }
+        return value;
+    }
+}

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -23,7 +23,6 @@ package org.jboss.as.test.clustering.cluster;
 
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
@@ -33,7 +32,6 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.clustering.ClusteringTestConstants;
 import org.jboss.as.test.clustering.NodeUtil;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.as.web.session.RoutingSupport;
 import org.jboss.as.web.session.SimpleRoutingSupport;
 import org.jboss.logging.Logger;
@@ -91,7 +89,6 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
     public void beforeTestMethod() {
         NodeUtil.start(this.controller, CONTAINERS);
         NodeUtil.deploy(this.deployer, DEPLOYMENTS);
-        this.waitForTopologyChange();
     }
 
     /**
@@ -104,40 +101,22 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
         NodeUtil.undeploy(this.deployer, DEPLOYMENTS);
     }
 
-    protected void waitForTopologyChange() {
-        // For now, just sleep a moment
-        // TODO replace this with a server side check for rehash completion
-        this.sleep(TimeoutUtil.adjust(500), TimeUnit.MILLISECONDS);
-    }
-
-    protected void sleep(long value, TimeUnit unit) {
-        try {
-            unit.sleep(value);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
     // Node and deployment lifecycle management convenience methods
 
     protected void start(String... containers) {
         NodeUtil.start(this.controller, containers);
-        this.waitForTopologyChange();
     }
 
     protected void stop(String... containers) {
         NodeUtil.stop(this.controller, containers);
-        this.waitForTopologyChange();
     }
 
     protected void deploy(String... deployments) {
         NodeUtil.deploy(this.deployer, deployments);
-        this.waitForTopologyChange();
     }
 
     protected void undeploy(String... deployments) {
         NodeUtil.undeploy(this.deployer, deployments);
-        this.waitForTopologyChange();
     }
 
     protected String findDeployment(String node) {

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/session/persistence/SessionClusterDbPersistenceTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/session/persistence/SessionClusterDbPersistenceTestCase.java
@@ -4,11 +4,11 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.cluster.web.ClusteredWebFailoverAbstractCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.runner.RunWith;
 
@@ -16,6 +16,7 @@ import org.junit.runner.RunWith;
 @RunAsClient
 @org.junit.Ignore("WFLY-2409")
 public class SessionClusterDbPersistenceTestCase extends ClusteredWebFailoverAbstractCase {
+    private static final String MODULE_NAME = "session-db-cluster";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -30,13 +31,17 @@ public class SessionClusterDbPersistenceTestCase extends ClusteredWebFailoverAbs
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "session-db-cluster.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClass(SimpleServlet.class);
+        ClusterTestUtil.addTopologyListenerDependencies(war);
         war.setWebXML(SessionClusterDbPersistenceTestCase.class.getPackage(), "web.xml");
-        war.setManifest(new StringAsset(
-                "Manifest-Version: 1.0\nDependencies: org.jboss.msc, org.jboss.as.clustering.common, org.infinispan\n"));
         war.addAsWebInfResource("WEB-INF/jboss-web.xml","jboss-web.xml");
         log.info(war.toString(true));
         return war;
+    }
+
+    @Override
+    protected String getModuleName() {
+        return MODULE_NAME;
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -30,13 +30,14 @@ import java.util.Map;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.utils.HttpClientUtils;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.clustering.ClusterHttpClientUtil;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.junit.Assert;
@@ -52,6 +53,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 @RunAsClient
 public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTestCase {
+
+    protected abstract String getModuleName();
 
     /**
      * Test simple graceful shutdown failover:
@@ -97,11 +100,13 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
         testFailover(new RedeployLifecycle(), baseURL1, baseURL2);
     }
 
-    private static void testFailover(Lifecycle lifecycle, URL baseURL1, URL baseURL2) throws IOException, URISyntaxException {
-        DefaultHttpClient client = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
+    private void testFailover(Lifecycle lifecycle, URL baseURL1, URL baseURL2) throws IOException, URISyntaxException {
+        HttpClient client = org.jboss.as.test.http.util.HttpClientUtils.relaxedCookieHttpClient();
 
         URI uri1 = SimpleServlet.createURI(baseURL1);
         URI uri2 = SimpleServlet.createURI(baseURL2);
+
+        this.establishTopology(baseURL1, NODES);
 
         try {
             HttpResponse response = client.execute(new HttpGet(uri1));
@@ -128,6 +133,8 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
             // Gracefully shutdown the 1st container.
             lifecycle.stop(NODE_1);
+
+            this.establishTopology(baseURL2, NODE_2);
 
             // Now check on the 2nd server
 
@@ -158,6 +165,8 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
             lifecycle.start(NODE_1);
 
+            this.establishTopology(baseURL2, NODES);
+
             response = client.execute(new HttpGet(uri2));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -181,6 +190,8 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
             // Gracefully shutdown the 1st container.
             lifecycle.stop(NODE_2);
+
+            this.establishTopology(baseURL1, NODE_1);
 
             // Now check on the 2nd server
 
@@ -211,6 +222,8 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
 
             lifecycle.start(NODE_2);
 
+            this.establishTopology(baseURL1, NODES);
+
             response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -234,5 +247,9 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
         } finally {
             HttpClientUtils.closeQuietly(client);
         }
+    }
+
+    private void establishTopology(URL baseURL, String... nodes) throws URISyntaxException, IOException {
+        ClusterHttpClientUtil.establishTopology(baseURL, "web", "default-host/" + this.getModuleName(), nodes);
     }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/CoarseWebFailoverTestCase.java
@@ -23,12 +23,14 @@ package org.jboss.as.test.clustering.cluster.web;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 public class CoarseWebFailoverTestCase extends ClusteredWebFailoverAbstractCase {
+    private static final String MODULE_NAME = "coarse-distributable";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -43,12 +45,17 @@ public class CoarseWebFailoverTestCase extends ClusteredWebFailoverAbstractCase 
     }
 
     private static Archive<?> getDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClass(SimpleServlet.class);
+        ClusterTestUtil.addTopologyListenerDependencies(war);
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         log.info(war.toString(true));
         return war;
     }
 
+    @Override
+    protected String getModuleName() {
+        return MODULE_NAME;
+    }
 }

--- a/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
+++ b/testsuite/integration/clust/src/test/java/org/jboss/as/test/clustering/cluster/web/GranularWebFailoverTestCase.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.clustering.cluster.web;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.as.test.clustering.ClusterTestUtil;
 import org.jboss.as.test.clustering.single.web.SimpleServlet;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -33,6 +34,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
  * @version April 2012
  */
 public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCase {
+    private static final String MODULE_NAME = "granular-distributable";
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -47,12 +49,18 @@ public class GranularWebFailoverTestCase extends ClusteredWebFailoverAbstractCas
     }
 
     private static Archive<?> createDeployment() {
-        WebArchive war = ShrinkWrap.create(WebArchive.class, "granular-distributable.war");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, MODULE_NAME + ".war");
         war.addClass(SimpleServlet.class);
+        ClusterTestUtil.addTopologyListenerDependencies(war);
         // Take web.xml from the managed test.
         war.setWebXML(ClusteredWebSimpleTestCase.class.getPackage(), "web.xml");
         war.addAsWebInfResource(ClusteredWebSimpleTestCase.class.getPackage(), "jboss-web_granular.xml", "jboss-web.xml");
         log.info(war.toString(true));
         return war;
+    }
+
+    @Override
+    protected String getModuleName() {
+        return MODULE_NAME;
     }
 }


### PR DESCRIPTION
Fix for WFLY-3703 "arq.container.domain.ManagementClient.readRootNode does not see servers on remote hosts" against 8.x branch.

integration into master and/or wildfly/wildfly-arquillian would be required.
