### PR TITLE
[WFLY-3348] Close the input stream from domain deployment content additions

### DIFF
--- a/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentUploadUtil.java
+++ b/host-controller/src/main/java/org/jboss/as/domain/controller/operations/deployment/DeploymentUploadUtil.java
@@ -45,6 +45,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.operations.CompositeOperationAwareTransformer;
 import org.jboss.as.controller.operations.DomainOperationTransformer;
 import org.jboss.as.controller.operations.OperationAttachments;
+import org.jboss.as.protocol.StreamUtils;
 import org.jboss.as.repository.ContentRepository;
 import org.jboss.dmr.ModelNode;
 
@@ -93,7 +94,11 @@ class DeploymentUploadUtil {
 
     private static byte[] storeDeploymentContent(OperationContext context, ModelNode operation, ContentRepository contentRepository) throws IOException, OperationFailedException {
         InputStream in = getContents(context, operation);
-        return contentRepository.addContent(in);
+        try {
+            return contentRepository.addContent(in);
+        } finally {
+            StreamUtils.safeClose(in);
+        }
     }
 
     private static InputStream getContents(OperationContext context, ModelNode operation) throws OperationFailedException {

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeploySingleServerGroupTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/DeploySingleServerGroupTestCase.java
@@ -73,7 +73,9 @@ public class DeploySingleServerGroupTestCase extends AbstractCliTestBase {
     @AfterClass
     public static void after() throws Exception {
         AbstractCliTestBase.closeCLI();
-        Assert.assertTrue(warFile.delete());
+        if (warFile != null && warFile.exists()) {
+            Assert.assertTrue(warFile.delete());
+        }
     }
 
     @Test


### PR DESCRIPTION
Master equivalent is https://github.com/wildfly/wildfly-core/pull/72. Once a release of core with that in is integrated into wildly I'll submit a small tweak to the testcase in master to reenable to assertion that was previously removed.
