### PR TITLE
WFLY-3705 read-resource recursive-depth has no effect when recursive=true

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/ReadResourceHandler.java
@@ -172,7 +172,8 @@ public class ReadResourceHandler extends GlobalOperationHandlers.AbstractMultiTa
         final PathAddress address = PathAddress.pathAddress(operation.get(OP_ADDR));
 
         final int recursiveDepth = operation.get(ModelDescriptionConstants.RECURSIVE_DEPTH).asInt(0);
-        final boolean recursive = recursiveDepth > 0 || operation.get(ModelDescriptionConstants.RECURSIVE).asBoolean(false);
+        final boolean recursive = operation.get(ModelDescriptionConstants.RECURSIVE).asBoolean(false) &&
+                (!operation.get(ModelDescriptionConstants.RECURSIVE_DEPTH).isDefined() || recursiveDepth > 0);
         final boolean queryRuntime = operation.get(ModelDescriptionConstants.INCLUDE_RUNTIME).asBoolean(false);
         final boolean proxies = operation.get(ModelDescriptionConstants.PROXIES).asBoolean(false);
         final boolean aliases = operation.get(ModelDescriptionConstants.INCLUDE_ALIASES).asBoolean(false);


### PR DESCRIPTION
The snippet works as follows: recurs IF recursive is set AND (either recursive-depth is not defined OR recursive-depth is greater than 0).
