### PR TITLE
[WFLY-838] Don't throw exceptions for jsr 77 queryObjectNames()

### DIFF
--- a/jsr77/src/main/java/org/jboss/as/jsr77/logging/JSR77Logger.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/logging/JSR77Logger.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Method;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.ObjectName;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Cause;
@@ -105,8 +106,8 @@ public interface JSR77Logger extends BasicLogger {
     @Message(id = 5, value = "No mbean found called %s")
     InstanceNotFoundException noMBeanCalled(ObjectName name);
 
-    @Message(id = 6, value = "Should not get called")
-    IllegalStateException shouldNotGetCalled();
+    //@Message(id = 6, value = "Should not get called")
+    //IllegalStateException shouldNotGetCalled();
 
     @Message(id = 7, value = "Could not find %s")
     InstanceNotFoundException couldNotFindJ2eeType(String j2eeType);

--- a/jsr77/src/main/java/org/jboss/as/jsr77/managedobject/J2EEDeployedObjectHandlers.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/managedobject/J2EEDeployedObjectHandlers.java
@@ -193,7 +193,7 @@ public class J2EEDeployedObjectHandlers extends Handler {
                             handler = AppClientModuleHandler.INSTANCE;
                         } else if (j2eeType.equals(J2EE_TYPE_EJB_MODULE) && actualDeployment.endsWith(".jar") &&
                                 (deploymentNode.hasDefined(SUBSYSTEM) && deploymentNode.get(SUBSYSTEM).asString().equals("ejb3"))) {
-                            handler = AppClientModuleHandler.INSTANCE;
+                            handler = EJBModuleHandler.INSTANCE;
                         } else if (j2eeType.equals(J2EE_TYPE_WEB_MODULE) && actualDeployment.endsWith(".war")) {
                             handler = WebModuleHandler.INSTANCE;
                         } else {
@@ -214,7 +214,7 @@ public class J2EEDeployedObjectHandlers extends Handler {
 
         @Override
         Set<ObjectName> queryObjectNames(ModelReader reader, ObjectName name, QueryExp query) {
-            throw JSR77Logger.ROOT_LOGGER.shouldNotGetCalled();
+            return Collections.singleton(name);
         }
 
         @Override
@@ -242,7 +242,7 @@ public class J2EEDeployedObjectHandlers extends Handler {
 
         @Override
         Set<ObjectName> queryObjectNames(ModelReader reader, ObjectName name, QueryExp query) {
-            throw JSR77Logger.ROOT_LOGGER.shouldNotGetCalled();
+            return Collections.singleton(name);
         }
 
         @Override


### PR DESCRIPTION
This replaces #6545 
The use case in https://issues.jboss.org/browse/WFLY-838 works, and the TCK passes. I did not try the TCK against 6545 though.

This also addresses Brian's AppClientModuleHandler vs EJBModuleHandler concerns.
