### PR TITLE
WFLY-3717 Attach root cause when TldParsingDeploymentProcessor.parseTLD ...

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/TldParsingDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/TldParsingDeploymentProcessor.java
@@ -228,7 +228,7 @@ public class TldParsingDeploymentProcessor implements DeploymentUnitProcessor {
             return TldMetaDataParser.parse(xmlReader);
         } catch (XMLStreamException e) {
             throw new DeploymentUnitProcessingException(UndertowLogger.ROOT_LOGGER.failToParseXMLDescriptor(tld, e.getLocation().getLineNumber(),
-                    e.getLocation().getColumnNumber()));
+                    e.getLocation().getColumnNumber()), e);
         } catch (IOException e) {
             throw new DeploymentUnitProcessingException(UndertowLogger.ROOT_LOGGER.failToParseXMLDescriptor(tld), e);
         } finally {


### PR DESCRIPTION
...catches XMLStreamException
