### PR TITLE
[WFLY-3656] Use chained transformers for messaging subsystem

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -56,14 +56,14 @@ import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
  * Domain extension that integrates HornetQ.
  *
  * <dl>
- *   <dt>WildFly 9</dt>
+ *   <dt><strong>Current</strong> - WildFly 9</dt>
  *   <dd>
  *     <ul>
  *       <li>XML namespace: urn:jboss:domain:messaging:3.0
  *       <li>Management model: 3.0.0
  *     </ul>
  *   </dd>
- *   <dt>WildFly 8.0.1</dt>
+ *   <dt>WildFly 8.1.0</dt>
  *   <dd>
  *     <ul>
  *       <li>XML namespace: urn:jboss:domain:messaging:2.0
@@ -77,7 +77,7 @@ import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
  *       <li>Management model: 2.0.0
  *     </ul>
  *   </dd>
- *   <dt>AS 7.3</dt>
+ *   <dt>AS 7.3.0</dt>
  *   <dd>
  *     <ul>
  *       <li>XML namespace: urn:jboss:domain:messaging:1.4
@@ -125,7 +125,6 @@ public class MessagingExtension implements Extension {
 
     public static final ModelVersion VERSION_2_1_0 = ModelVersion.create(2, 1, 0);
     public static final ModelVersion VERSION_2_0_0 = ModelVersion.create(2, 0, 0);
-    public static final ModelVersion VERSION_1_4_0 = ModelVersion.create(1, 4, 0);
     public static final ModelVersion VERSION_1_3_0 = ModelVersion.create(1, 3, 0);
     public static final ModelVersion VERSION_1_2_1 = ModelVersion.create(1, 2, 1);
     public static final ModelVersion VERSION_1_2_0 = ModelVersion.create(1, 2, 0);

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingDependencies.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingDependencies.java
@@ -85,6 +85,15 @@ public class MessagingDependencies {
                 "org.hornetq:hornetq-jms-client:2.3.5.Final-redhat-2",
                 "org.hornetq:hornetq-ra:2.3.5.Final-redhat-2"});
 
+        map.put(ModelTestControllerVersion.EAP_6_2_0, new String[] {
+                "org.hornetq:hornetq-server:2.3.12.Final-redhat-1",
+                "org.hornetq:hornetq-jms-server:2.3.12.Final-redhat-1",
+                "org.hornetq:hornetq-core-client:2.3.12.Final-redhat-1",
+                "org.hornetq:hornetq-jms-client:2.3.12.Final-redhat-1",
+                "org.hornetq:hornetq-ra:2.3.12.Final-redhat-1",
+
+        });
+
         HORNETQ_DEPENDENCIES = Collections.unmodifiableMap(map);
     }
 

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem20TestCase.java
@@ -22,38 +22,18 @@
 
 package org.jboss.as.messaging.test;
 
-import static org.jboss.as.controller.PathElement.pathElement;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.messaging.CommonAttributes.CALL_FAILOVER_TIMEOUT;
-import static org.jboss.as.messaging.CommonAttributes.CHECK_FOR_LIVE_SERVER;
-import static org.jboss.as.messaging.CommonAttributes.MAX_SAVED_REPLICATED_JOURNAL_SIZE;
-import static org.jboss.as.messaging.CommonAttributes.PARAM;
-import static org.jboss.as.messaging.HornetQServerResourceDefinition.HORNETQ_SERVER_PATH;
-import static org.jboss.as.messaging.MessagingExtension.VERSION_1_1_0;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_0;
-import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_1;
-import static org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Regular.FACTORY_TYPE;
 import static org.jboss.as.messaging.test.MessagingDependencies.getHornetQDependencies;
 import static org.jboss.as.messaging.test.MessagingDependencies.getMessagingGAV;
-import static org.jboss.as.messaging.test.ModelFixers.FIXER_1_1_0;
-import static org.jboss.as.messaging.test.ModelFixers.FIXER_1_2_0;
-import static org.jboss.as.messaging.test.TransformerUtils.concat;
-import static org.jboss.as.messaging.test.TransformerUtils.createChainedConfig;
-import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_0_0;
-import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_0_1;
-import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_1_0;
-import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_1_1;
-import static org.jboss.as.model.test.ModelTestControllerVersion.V7_1_2_FINAL;
-import static org.jboss.as.model.test.ModelTestControllerVersion.V7_1_3_FINAL;
+import static org.jboss.as.messaging.test.ModelFixers.PATH_FIXER;
 import static org.jboss.as.model.test.ModelTestControllerVersion.V7_2_0_FINAL;
-import static org.jboss.as.model.test.ModelTestUtils.checkFailedTransformedBootOperations;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -61,44 +41,18 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.List;
 
 import javax.xml.stream.XMLStreamException;
 
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.transform.OperationTransformer;
-import org.jboss.as.messaging.AddressSettingDefinition;
-import org.jboss.as.messaging.BridgeDefinition;
-import org.jboss.as.messaging.BroadcastGroupDefinition;
-import org.jboss.as.messaging.ClusterConnectionDefinition;
 import org.jboss.as.messaging.CommonAttributes;
-import org.jboss.as.messaging.ConnectorServiceDefinition;
-import org.jboss.as.messaging.ConnectorServiceParamDefinition;
-import org.jboss.as.messaging.DiscoveryGroupDefinition;
-import org.jboss.as.messaging.DivertDefinition;
-import org.jboss.as.messaging.GroupingHandlerDefinition;
-import org.jboss.as.messaging.HTTPAcceptorDefinition;
-import org.jboss.as.messaging.HTTPConnectorDefinition;
 import org.jboss.as.messaging.HornetQServerResourceDefinition;
-import org.jboss.as.messaging.InVMTransportDefinition;
 import org.jboss.as.messaging.MessagingExtension;
-import org.jboss.as.messaging.QueueDefinition;
-import org.jboss.as.messaging.TransportParamDefinition;
-import org.jboss.as.messaging.jms.ConnectionFactoryAttributes;
-import org.jboss.as.messaging.jms.ConnectionFactoryDefinition;
-import org.jboss.as.messaging.jms.JMSQueueDefinition;
-import org.jboss.as.messaging.jms.JMSTopicDefinition;
-import org.jboss.as.messaging.jms.PooledConnectionFactoryDefinition;
-import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
-import org.jboss.as.messaging.test.TransformerUtils.RejectExpressionsConfigWithAddOnlyParam;
-import org.jboss.as.model.test.FailedOperationTransformationConfig;
-import org.jboss.as.model.test.FailedOperationTransformationConfig.RejectExpressionsConfig;
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
@@ -125,93 +79,9 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testTransformersAS720() throws Exception {
-        testTransformers(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0);
-    }
-
-    @Test
-    public void testTransformersAS712() throws Exception {
-        testTransformers(V7_1_2_FINAL, VERSION_1_1_0, FIXER_1_1_0);
-    }
-
-    @Test
-    public void testTransformersAS713() throws Exception {
-        testTransformers(V7_1_3_FINAL, VERSION_1_1_0, FIXER_1_1_0);
-    }
-
-    @Test
-    public void testTransformersEAP600() throws Exception {
-        testTransformers(EAP_6_0_0, VERSION_1_1_0, FIXER_1_1_0);
-    }
-
-    @Test
-    public void testTransformersEAP601() throws Exception {
-        testTransformers(EAP_6_0_1, VERSION_1_1_0, FIXER_1_1_0);
-    }
-
-    @Test
-    public void testTransformersEAP610() throws Exception {
-        testTransformers(EAP_6_1_0, VERSION_1_2_1, FIXER_1_2_0);
-    }
-
-    @Test
-    public void testTransformersEAP611() throws Exception {
-        testTransformers(EAP_6_1_1, VERSION_1_2_1, FIXER_1_2_0);
-    }
-
-    @Test
-    public void testRejectExpressionsAS712() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_2_FINAL, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
-
-        doTestRejectExpressions_1_1_0(V7_1_2_FINAL, builder);
-    }
-
-    @Test
-    public void testRejectExpressionsAS713() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_3_FINAL, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
-
-        doTestRejectExpressions_1_1_0(V7_1_3_FINAL, builder);
-    }
-
-    @Test
-    public void testRejectExpressionsAS720() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0, "empty_subsystem_2_0.xml");
-
-        doTestRejectExpressions_1_2_0(V7_2_0_FINAL, builder);
-    }
-
-    @Test
-    public void testRejectExpressionsEAP600() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_0, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
-
-        doTestRejectExpressions_1_1_0(EAP_6_0_0, builder);
-    }
-
-    @Test
-    public void testRejectExpressionsEAP601() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_1, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_2_0.xml");
-
-        doTestRejectExpressions_1_1_0(EAP_6_0_1, builder);
-    }
-
-    @Test
-    public void testRejectExpressionsEAP610() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_0, VERSION_1_2_1, FIXER_1_2_0, "empty_subsystem_2_0.xml");
-
-        doTestRejectExpressions_1_2_1(EAP_6_1_0, builder);
-    }
-
-    @Test
-    public void testRejectExpressionsEAP611() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_1, VERSION_1_2_1, FIXER_1_2_0, "empty_subsystem_2_0.xml");
-
-        doTestRejectExpressions_1_2_1(EAP_6_1_1, builder);
-    }
-
-    @Test
     public void testClusteredTo120() throws Exception {
         // this hornetq-server has 1 cluster-connection resource defined and so is clustered.
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0, "subsystem_with_cluster_connection_2_0.xml");
+        KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, PATH_FIXER, "subsystem_with_cluster_connection_2_0.xml");
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_2_0);
@@ -227,6 +97,7 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
     public void testMessageCounterEnabled() throws Exception {
         standardSubsystemTest("subsystem_2_0_message_counter.xml", false);
     }
+
     protected void compareXml(String configId, final String original, final String marshalled) throws Exception {
         // XML from messaging 2.0 does not have the same output than 3.0
         return;
@@ -258,270 +129,6 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
         assertNull(transformedOperation.getTransformedOperation());
     }
 
-    /**
-     * Tests rejection of expressions in 1.1.0 model.
-     *
-     * @throws Exception
-     */
-    private void doTestRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
-        KernelServices mainServices = builder.build();
-        assertTrue(mainServices.isSuccessfulBoot());
-        KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_1_0);
-        assertNotNull(legacyServices);
-        assertTrue(legacyServices.isSuccessfulBoot());
-
-
-        //Use the real xml with expressions for testing all the attributes
-        PathAddress subsystemAddress = PathAddress.pathAddress(pathElement(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME));
-        List<ModelNode> modelNodes = builder.parseXmlResource("subsystem_2_0_expressions.xml");
-        // remote the messaging subsystem add operation that fails on AS7 7.1.2.Final
-        modelNodes.remove(0);
-        checkFailedTransformedBootOperations(
-                mainServices,
-                VERSION_1_1_0,
-                modelNodes,
-                new FailedOperationTransformationConfig()
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH),
-                                createChainedConfig(
-                                        HornetQServerResourceDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
-                                        concat(new AttributeDefinition[]{CommonAttributes.BACKUP_GROUP_NAME, CommonAttributes.REPLICATION_CLUSTERNAME,
-                                                CommonAttributes.REMOTING_INCOMING_INTERCEPTORS, CommonAttributes.REMOTING_OUTGOING_INTERCEPTORS}, MAX_SAVED_REPLICATED_JOURNAL_SIZE, CHECK_FOR_LIVE_SERVER)))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(ModelDescriptionConstants.PATH)),
-                                new RejectExpressionsConfig(ModelDescriptionConstants.PATH))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.IN_VM_ACCEPTOR)),
-                                new RejectExpressionsConfigWithAddOnlyParam(concat(new AttributeDefinition[]{InVMTransportDefinition.SERVER_ID}, PARAM)))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.IN_VM_ACCEPTOR)).append(TransportParamDefinition.PATH),
-                                new RejectExpressionsConfig(TransportParamDefinition.VALUE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.IN_VM_CONNECTOR)),
-                                new RejectExpressionsConfigWithAddOnlyParam(concat(new AttributeDefinition[]{InVMTransportDefinition.SERVER_ID}, PARAM)))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.IN_VM_CONNECTOR), TransportParamDefinition.PATH),
-                                new RejectExpressionsConfig(TransportParamDefinition.VALUE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.REMOTE_ACCEPTOR)),
-                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.REMOTE_ACCEPTOR), TransportParamDefinition.PATH),
-                                new RejectExpressionsConfig(TransportParamDefinition.VALUE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.REMOTE_CONNECTOR)),
-                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.REMOTE_CONNECTOR), TransportParamDefinition.PATH),
-                                new RejectExpressionsConfig(TransportParamDefinition.VALUE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR)),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR), TransportParamDefinition.PATH),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_ACCEPTOR)),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_ACCEPTOR), TransportParamDefinition.PATH),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.ACCEPTOR)),
-                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.ACCEPTOR), TransportParamDefinition.PATH),
-                                new RejectExpressionsConfig(TransportParamDefinition.VALUE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.CONNECTOR)),
-                                new RejectExpressionsConfigWithAddOnlyParam(PARAM))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.CONNECTOR), TransportParamDefinition.PATH),
-                                new RejectExpressionsConfig(TransportParamDefinition.VALUE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, BroadcastGroupDefinition.PATH),
-                                new RejectExpressionsConfig(BroadcastGroupDefinition.BROADCAST_PERIOD) {
-                                    @Override
-                                    public boolean expectFailed(ModelNode operation) {
-                                        if ("groupT".equals(operation.get(OP_ADDR).get(2).get(CommonAttributes.BROADCAST_GROUP).asString())) {
-                                            // groupT use JGroups and do not define socket-binding or local address
-                                            return true;
-                                        }
-                                        return super.expectFailed(operation);
-                                    }
-                                })
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(DiscoveryGroupDefinition.PATH),
-                                new RejectExpressionsConfig(DiscoveryGroupDefinition.REFRESH_TIMEOUT, DiscoveryGroupDefinition.INITIAL_WAIT_TIMEOUT) {
-                                    @Override
-                                    public boolean expectFailed(ModelNode operation) {
-                                        if ("groupU".equals(operation.get(OP_ADDR).get(2).get(CommonAttributes.DISCOVERY_GROUP).asString())) {
-                                            // groupU use JGroups and do not define socket-binding or local address
-                                            return true;
-                                        }
-                                        return super.expectFailed(operation);
-                                    }
-                                })
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, DivertDefinition.PATH),
-                                new RejectExpressionsConfig(DivertDefinition.ROUTING_NAME, DivertDefinition.ADDRESS, DivertDefinition.FORWARDING_ADDRESS, CommonAttributes.FILTER,
-                                        DivertDefinition.EXCLUSIVE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, QueueDefinition.PATH),
-                                new RejectExpressionsConfig(QueueDefinition.ADDRESS, CommonAttributes.FILTER, CommonAttributes.DURABLE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, ClusterConnectionDefinition.PATH),
-                                createChainedConfig(ClusterConnectionDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
-                                        new AttributeDefinition[]{CommonAttributes.CALL_FAILOVER_TIMEOUT, ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS,
-                                                ClusterConnectionDefinition.NOTIFICATION_INTERVAL}))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, BridgeDefinition.PATH),
-                                createChainedConfig(BridgeDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
-                                        new AttributeDefinition[]{BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE}))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, GroupingHandlerDefinition.PATH),
-                                createChainedConfig(new AttributeDefinition[] { GroupingHandlerDefinition.TYPE, GroupingHandlerDefinition.GROUPING_HANDLER_ADDRESS, GroupingHandlerDefinition.TIMEOUT },
-                                        new AttributeDefinition[] { GroupingHandlerDefinition.GROUP_TIMEOUT, GroupingHandlerDefinition.REAPER_PERIOD }))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, AddressSettingDefinition.PATH),
-                                createChainedConfig(AddressSettingDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
-                                        new AttributeDefinition[]{AddressSettingDefinition.EXPIRY_DELAY}))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, ConnectorServiceDefinition.PATH, ConnectorServiceParamDefinition.PATH),
-                                new RejectExpressionsConfig(ConnectorServiceParamDefinition.VALUE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, ConnectionFactoryDefinition.PATH),
-                                createChainedConfig(ConnectionFactoryDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
-                                        new AttributeDefinition[]{CALL_FAILOVER_TIMEOUT}).setReadOnly(FACTORY_TYPE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, PooledConnectionFactoryDefinition.PATH),
-                                createChainedConfig(PooledConnectionFactoryDefinition.ATTRIBUTES_WITH_EXPRESSION_ALLOWED_IN_1_2_0,
-                                        concat(PooledConnectionFactoryDefinition.ATTRIBUTES_ADDED_IN_1_2_0, CALL_FAILOVER_TIMEOUT))
-                                .setReadOnly(ConnectionFactoryAttributes.Pooled.TRANSACTION))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, JMSQueueDefinition.PATH),
-                                new RejectExpressionsConfig(CommonAttributes.DESTINATION_ENTRIES, CommonAttributes.SELECTOR, CommonAttributes.DURABLE))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, JMSTopicDefinition.PATH),
-                                new RejectExpressionsConfig(CommonAttributes.DESTINATION_ENTRIES))
-                        .addFailedAttribute(
-                                subsystemAddress.append(JMSBridgeDefinition.PATH),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-        );
-    }
-
-
-    /**
-     * Tests rejection of expressions in 1.2.0 model.
-     *
-     * @throws Exception
-     */
-    private void doTestRejectExpressions_1_2_0(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
-
-        KernelServices mainServices = builder.build();
-        assertTrue(mainServices.isSuccessfulBoot());
-        KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_2_0);
-        assertNotNull(legacyServices);
-        assertTrue(legacyServices.isSuccessfulBoot());
-
-
-        //Use the real xml with expressions for testing all the attributes
-        PathAddress subsystemAddress = PathAddress.pathAddress(pathElement(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME));
-        List<ModelNode> modelNodes = builder.parseXmlResource("subsystem_2_0_expressions.xml");
-        // remove the messaging subsystem add operation that fails on AS7 7.2.0.Final
-        modelNodes.remove(0);
-        checkFailedTransformedBootOperations(
-                mainServices,
-                VERSION_1_2_0,
-                modelNodes,
-                new FailedOperationTransformationConfig()
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH),
-                                createChainedConfig(new AttributeDefinition[]{},
-                                        new AttributeDefinition[]{MAX_SAVED_REPLICATED_JOURNAL_SIZE}))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, BridgeDefinition.PATH),
-                                createChainedConfig(new AttributeDefinition[]{},
-                                        new AttributeDefinition[]{BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE}))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR)),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR), pathElement(CommonAttributes.PARAM)),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, HTTPAcceptorDefinition.PATH),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, HTTPAcceptorDefinition.PATH, pathElement(CommonAttributes.PARAM)),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, GroupingHandlerDefinition.PATH),
-                                createChainedConfig(new AttributeDefinition[] {},
-                                        new AttributeDefinition[] { GroupingHandlerDefinition.GROUP_TIMEOUT, GroupingHandlerDefinition.REAPER_PERIOD }))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(AddressSettingDefinition.PATH),
-                                createChainedConfig(new AttributeDefinition[]{},
-                                        new AttributeDefinition[]{AddressSettingDefinition.EXPIRY_DELAY}))
-        );
-    }
-
-
-    /**
-     * Tests rejection of expressions in 1.2.1 model.
-     *
-     * @throws Exception
-     */
-    private void doTestRejectExpressions_1_2_1(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
-
-        KernelServices mainServices = builder.build();
-        assertTrue(mainServices.isSuccessfulBoot());
-        KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_2_1);
-        assertNotNull(legacyServices);
-        assertTrue(legacyServices.isSuccessfulBoot());
-
-
-        //Use the real xml with expressions for testing all the attributes
-        PathAddress subsystemAddress = PathAddress.pathAddress(pathElement(SUBSYSTEM, MessagingExtension.SUBSYSTEM_NAME));
-        List<ModelNode> modelNodes = builder.parseXmlResource("subsystem_2_0_expressions.xml");
-        // remove the messaging subsystem add operation that fails on AS7 7.2.0.Final
-        modelNodes.remove(0);
-        checkFailedTransformedBootOperations(
-                mainServices,
-                VERSION_1_2_1,
-                modelNodes,
-                new FailedOperationTransformationConfig()
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH),
-                                createChainedConfig(new AttributeDefinition[]{},
-                                        new AttributeDefinition[]{MAX_SAVED_REPLICATED_JOURNAL_SIZE}))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, BridgeDefinition.PATH),
-                                createChainedConfig(new AttributeDefinition[]{},
-                                        new AttributeDefinition[]{BridgeDefinition.RECONNECT_ATTEMPTS_ON_SAME_NODE}))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR)),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, pathElement(CommonAttributes.HTTP_CONNECTOR), TransportParamDefinition.PATH),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, HTTPAcceptorDefinition.PATH),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, HTTPAcceptorDefinition.PATH, TransportParamDefinition.PATH),
-                                FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH, GroupingHandlerDefinition.PATH),
-                                createChainedConfig(new AttributeDefinition[] {},
-                                        new AttributeDefinition[] { GroupingHandlerDefinition.GROUP_TIMEOUT, GroupingHandlerDefinition.REAPER_PERIOD }))
-                        .addFailedAttribute(
-                                subsystemAddress.append(HORNETQ_SERVER_PATH).append(AddressSettingDefinition.PATH),
-                                createChainedConfig(new AttributeDefinition[]{},
-                                        new AttributeDefinition[]{AddressSettingDefinition.EXPIRY_DELAY}))
-        );
-    }
-
     private KernelServicesBuilder createKernelServicesBuilder(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion, ModelFixer fixer, String xmlFileName) throws IOException, XMLStreamException, ClassNotFoundException {
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource(xmlFileName);
@@ -532,21 +139,4 @@ public class MessagingSubsystem20TestCase extends AbstractSubsystemBaseTest {
                 .addMavenResourceURL(getHornetQDependencies(controllerVersion));
         return builder;
     }
-
-    private void testTransformers(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion, ModelFixer fixer) throws Exception {
-        //Boot up empty controllers with the resources needed for the ops coming from the xml to work
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
-                .setSubsystemXmlResource("subsystem_2_0.xml");
-        builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, messagingVersion)
-                .addMavenResourceURL(getMessagingGAV(controllerVersion))
-                .configureReverseControllerCheck(null, fixer)
-                .addMavenResourceURL(getHornetQDependencies(controllerVersion));
-
-        KernelServices mainServices = builder.build();
-        assertTrue(mainServices.isSuccessfulBoot());
-        assertTrue(mainServices.getLegacyServices(messagingVersion).isSuccessfulBoot());
-
-        checkSubsystemModelTransformation(mainServices, messagingVersion);
-    }
-
 }

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem30TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem30TestCase.java
@@ -34,18 +34,21 @@ import static org.jboss.as.messaging.HornetQServerResourceDefinition.HORNETQ_SER
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_1_0;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_0;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_1;
+import static org.jboss.as.messaging.MessagingExtension.VERSION_1_3_0;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_2_0_0;
 import static org.jboss.as.messaging.jms.ConnectionFactoryAttributes.Regular.FACTORY_TYPE;
 import static org.jboss.as.messaging.test.MessagingDependencies.getHornetQDependencies;
 import static org.jboss.as.messaging.test.MessagingDependencies.getMessagingGAV;
-import static org.jboss.as.messaging.test.ModelFixers.FIXER_1_1_0;
-import static org.jboss.as.messaging.test.ModelFixers.FIXER_1_2_0;
+import static org.jboss.as.messaging.test.ModelFixers.AS7_1_FIXER;
+import static org.jboss.as.messaging.test.ModelFixers.FIXER_EAP_6_1_0;
+import static org.jboss.as.messaging.test.ModelFixers.PATH_FIXER;
 import static org.jboss.as.messaging.test.TransformerUtils.concat;
 import static org.jboss.as.messaging.test.TransformerUtils.createChainedConfig;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_0_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_0_1;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_1_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_1_1;
+import static org.jboss.as.model.test.ModelTestControllerVersion.EAP_6_2_0;
 import static org.jboss.as.model.test.ModelTestControllerVersion.V7_1_2_FINAL;
 import static org.jboss.as.model.test.ModelTestControllerVersion.V7_1_3_FINAL;
 import static org.jboss.as.model.test.ModelTestControllerVersion.V7_2_0_FINAL;
@@ -95,6 +98,7 @@ import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -111,109 +115,133 @@ public class MessagingSubsystem30TestCase extends AbstractSubsystemBaseTest {
         return readResource("subsystem_3_0_expressions.xml");
     }
 
+    ////////////////////////////////////////
+    //      Tests for WidlFly versions    //
+    //                                    //
+    // put most recent version at the top //
+    ////////////////////////////////////////
+
     @Test
-    public void testTransformersWildFly800() throws Exception {
-        testTransformers(WILDFLY_8_0_0_FINAL, VERSION_2_0_0, FIXER_1_1_0);
+    public void testTransformersWildFly_8_0_0() throws Exception {
+        testTransformers(WILDFLY_8_0_0_FINAL, VERSION_2_0_0, PATH_FIXER);
     }
 
     @Test
-    public void testTransformersAS720() throws Exception {
-        testTransformers(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0);
+    public void testRejectExpressionsWildFLY_8_0_0() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(WILDFLY_8_0_0_FINAL, VERSION_2_0_0, PATH_FIXER, "empty_subsystem_3_0.xml");
+        doTestRejectExpressions_2_0_0(builder);
     }
 
     @Test
-    public void testTransformersAS712() throws Exception {
-        testTransformers(V7_1_2_FINAL, VERSION_1_1_0, FIXER_1_1_0);
+    public void testTransformersAS_7_2_0() throws Exception {
+        testTransformers(V7_2_0_FINAL, VERSION_1_2_0, PATH_FIXER);
     }
 
     @Test
-    public void testTransformersAS713() throws Exception {
-        testTransformers(V7_1_3_FINAL, VERSION_1_1_0, FIXER_1_1_0);
+    public void testRejectExpressionsAS_7_2_0() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, PATH_FIXER, "empty_subsystem_3_0.xml");
+
+        doTestRejectExpressions_1_2_0(builder);
     }
 
     @Test
-    public void testTransformersEAP600() throws Exception {
-        testTransformers(EAP_6_0_0, VERSION_1_1_0, FIXER_1_1_0);
+    public void testTransformersAS_7_1_3() throws Exception {
+        testTransformers(V7_1_3_FINAL, VERSION_1_1_0, PATH_FIXER, AS7_1_FIXER);
     }
 
     @Test
-    public void testTransformersEAP601() throws Exception {
-        testTransformers(EAP_6_0_1, VERSION_1_1_0, FIXER_1_1_0);
+    public void testRejectExpressionsAS_7_1_3() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_3_FINAL, VERSION_1_1_0, PATH_FIXER, "empty_subsystem_3_0.xml");
+
+        doTestRejectExpressions_1_1_0(builder);
     }
 
     @Test
-    public void testTransformersEAP610() throws Exception {
-        testTransformers(EAP_6_1_0, VERSION_1_2_1, FIXER_1_2_0);
+    public void testTransformersAS_7_1_2() throws Exception {
+        testTransformers(V7_1_2_FINAL, VERSION_1_1_0, PATH_FIXER, AS7_1_FIXER);
     }
 
     @Test
-    public void testTransformersEAP611() throws Exception {
-        testTransformers(EAP_6_1_1, VERSION_1_2_1, FIXER_1_2_0);
+    public void testRejectExpressionsAS_7_1_2() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_2_FINAL, VERSION_1_1_0, PATH_FIXER, "empty_subsystem_3_0.xml");
+
+        doTestRejectExpressions_1_1_0(builder);
+    }
+
+    ////////////////////////////////////////
+    //      Tests for EAP versions        //
+    //                                    //
+    // put most recent version at the top //
+    ////////////////////////////////////////
+
+    @Ignore("failing due to the absence of the legacy controller")
+    @Test
+    public void testTransformersEAP_6_2_0() throws Exception {
+        testTransformers(EAP_6_2_0, VERSION_1_3_0, PATH_FIXER);
+    }
+
+    @Ignore("failing due to the absence of the legacy controller")
+    @Test
+    public void testRejectExpressionsEAP_6_2_0() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_2_0, VERSION_1_3_0, PATH_FIXER, "empty_subsystem_3_0.xml");
+
+        doTestRejectExpressions_1_3_0(builder);
     }
 
     @Test
-    public void testRejectExpressionsAS712() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_2_FINAL, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_3_0.xml");
-
-        doTestRejectExpressions_1_1_0(V7_1_2_FINAL, builder);
+    public void testTransformersEAP_6_1_1() throws Exception {
+        testTransformers(EAP_6_1_1, VERSION_1_2_1, PATH_FIXER);
     }
 
     @Test
-    public void testRejectExpressionsAS713() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_1_3_FINAL, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_3_0.xml");
+    public void testRejectExpressionsEAP_6_1_1() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_1, VERSION_1_2_1, PATH_FIXER, "empty_subsystem_3_0.xml");
 
-        doTestRejectExpressions_1_1_0(V7_1_3_FINAL, builder);
+        doTestRejectExpressions_1_2_1(builder);
     }
 
     @Test
-    public void testRejectExpressionsAS720() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(V7_2_0_FINAL, VERSION_1_2_0, FIXER_1_2_0, "empty_subsystem_3_0.xml");
-
-        doTestRejectExpressions_1_2_0(V7_2_0_FINAL, builder);
+    public void testTransformersEAP_6_1_0() throws Exception {
+        testTransformers(EAP_6_1_0, VERSION_1_2_0, PATH_FIXER, FIXER_EAP_6_1_0);
     }
 
     @Test
-    public void testRejectExpressionsEAP600() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_0, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_3_0.xml");
+    public void testRejectExpressionsEAP_6_1_0() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_0, VERSION_1_2_0, PATH_FIXER, "empty_subsystem_3_0.xml");
 
-        doTestRejectExpressions_1_1_0(EAP_6_0_0, builder);
+        doTestRejectExpressions_1_2_0(builder);
     }
 
     @Test
-    public void testRejectExpressionsEAP601() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_1, VERSION_1_1_0, FIXER_1_1_0, "empty_subsystem_3_0.xml");
-
-        doTestRejectExpressions_1_1_0(EAP_6_0_1, builder);
+    public void testTransformersEAP_6_0_1() throws Exception {
+        testTransformers(EAP_6_0_1, VERSION_1_1_0, PATH_FIXER, AS7_1_FIXER);
     }
 
     @Test
-    public void testRejectExpressionsEAP610() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_0, VERSION_1_2_1, FIXER_1_2_0, "empty_subsystem_3_0.xml");
+    public void testRejectExpressionsEAP_6_0_1() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_1, VERSION_1_1_0, PATH_FIXER, "empty_subsystem_3_0.xml");
 
-        doTestRejectExpressions_1_2_1(EAP_6_1_0, builder);
+        doTestRejectExpressions_1_1_0(builder);
     }
 
     @Test
-    public void testRejectExpressionsEAP611() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_1_1, VERSION_1_2_1, FIXER_1_2_0, "empty_subsystem_3_0.xml");
-
-        doTestRejectExpressions_1_2_1(EAP_6_1_1, builder);
+    public void testTransformersEAP_6_0_0() throws Exception {
+        testTransformers(EAP_6_0_0, VERSION_1_1_0, PATH_FIXER, AS7_1_FIXER);
     }
 
     @Test
-    public void testRejectExpressionsWildFLY800() throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(WILDFLY_8_0_0_FINAL, VERSION_2_0_0, FIXER_1_1_0, "empty_subsystem_3_0.xml");
+    public void testRejectExpressionsEAP_6_0_0() throws Exception {
+        KernelServicesBuilder builder = createKernelServicesBuilder(EAP_6_0_0, VERSION_1_1_0, PATH_FIXER, "empty_subsystem_3_0.xml");
 
-        doTestRejectExpressions_2_0_0(WILDFLY_8_0_0_FINAL, builder);
+        doTestRejectExpressions_1_1_0(builder);
     }
-
 
     /**
      * Tests rejection of expressions in 1.1.0 model.
      *
      * @throws Exception
      */
-    private void doTestRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
+    private void doTestRejectExpressions_1_1_0(KernelServicesBuilder builder) throws Exception {
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
         KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_1_0);
@@ -366,7 +394,7 @@ public class MessagingSubsystem30TestCase extends AbstractSubsystemBaseTest {
      *
      * @throws Exception
      */
-    private void doTestRejectExpressions_1_2_0(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
+    private void doTestRejectExpressions_1_2_0(KernelServicesBuilder builder) throws Exception {
 
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
@@ -423,7 +451,7 @@ public class MessagingSubsystem30TestCase extends AbstractSubsystemBaseTest {
      *
      * @throws Exception
      */
-    private void doTestRejectExpressions_1_2_1(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
+    private void doTestRejectExpressions_1_2_1(KernelServicesBuilder builder) throws Exception {
 
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
@@ -473,12 +501,21 @@ public class MessagingSubsystem30TestCase extends AbstractSubsystemBaseTest {
         );
     }
 
+    private void doTestRejectExpressions_1_3_0(KernelServicesBuilder builder) throws Exception {
+        KernelServices mainServices = builder.build();
+        assertTrue(mainServices.isSuccessfulBoot());
+        KernelServices legacyServices = mainServices.getLegacyServices(VERSION_1_3_0);
+        assertNotNull(legacyServices);
+        assertTrue(legacyServices.isSuccessfulBoot());
+    }
+
+
     /**
      * Tests rejection of expressions in 2.0.0 model.
      *
      * @throws Exception
      */
-    private void doTestRejectExpressions_2_0_0(ModelTestControllerVersion controllerVersion, KernelServicesBuilder builder) throws Exception {
+    private void doTestRejectExpressions_2_0_0(KernelServicesBuilder builder) throws Exception {
 
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
@@ -520,19 +557,23 @@ public class MessagingSubsystem30TestCase extends AbstractSubsystemBaseTest {
     }
 
     private void testTransformers(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion, ModelFixer fixer) throws Exception {
+        testTransformers(controllerVersion, messagingVersion, fixer, null);
+    }
+
+    private void testTransformers(ModelTestControllerVersion controllerVersion, ModelVersion messagingVersion, ModelFixer fixer, ModelFixer legacyModelFixer) throws Exception {
         //Boot up empty controllers with the resources needed for the ops coming from the xml to work
         KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
                 .setSubsystemXmlResource("subsystem_3_0.xml");
         builder.createLegacyKernelServicesBuilder(createAdditionalInitialization(), controllerVersion, messagingVersion)
                 .addMavenResourceURL(getMessagingGAV(controllerVersion))
-                .configureReverseControllerCheck(null, fixer)
                 .addMavenResourceURL(getHornetQDependencies(controllerVersion))
+                .configureReverseControllerCheck(null, fixer)
                 .dontPersistXml();
 
         KernelServices mainServices = builder.build();
         assertTrue(mainServices.isSuccessfulBoot());
         assertTrue(mainServices.getLegacyServices(messagingVersion).isSuccessfulBoot());
 
-        checkSubsystemModelTransformation(mainServices, messagingVersion);
+        checkSubsystemModelTransformation(mainServices, messagingVersion, legacyModelFixer);
     }
 }

--- a/messaging/src/test/java/org/jboss/as/messaging/test/ModelFixers.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/ModelFixers.java
@@ -24,11 +24,13 @@ package org.jboss.as.messaging.test;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.messaging.CommonAttributes.BRIDGE;
+import static org.jboss.as.messaging.CommonAttributes.CLUSTERED;
 import static org.jboss.as.messaging.CommonAttributes.FAILOVER_ON_SERVER_SHUTDOWN;
 import static org.jboss.as.messaging.CommonAttributes.HORNETQ_SERVER;
 
 import org.jboss.as.model.test.ModelFixer;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
 
 /**
  * Model Fixers for messaging extension.
@@ -36,7 +38,17 @@ import org.jboss.dmr.ModelNode;
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
  */
 public class ModelFixers {
-    static final ModelFixer FIXER_1_1_0 = new ModelFixer() {
+    static final ModelFixer FIXER_EAP_6_1_0 = new ModelFixer() {
+        @Override
+        public ModelNode fixModel(ModelNode modelNode) {
+            for (Property property : modelNode.get(HORNETQ_SERVER).asPropertyList()) {
+                modelNode.get(HORNETQ_SERVER, property.getName()).remove(CLUSTERED.getName());
+            }
+            return modelNode;
+        }
+    };
+
+    static final ModelFixer PATH_FIXER = new ModelFixer() {
         @Override
         public ModelNode fixModel(ModelNode modelNode) {
             // Since AS7-5417, messaging's paths resources are always created.
@@ -51,22 +63,19 @@ public class ModelFixers {
             return modelNode;
         }
     };
-    static final ModelFixer FIXER_1_2_0 = new ModelFixer() {
+
+    static final ModelFixer AS7_1_FIXER = new ModelFixer() {
         @Override
         public ModelNode fixModel(ModelNode modelNode) {
-            // Since AS7-5417, messaging's paths resources are always created.
-            // however for legacy version, they were only created if the path attributes were different from the defaults.
-            // The 'empty' hornetq-server does not set any messaging's path so we discard them to "fix" the model and
-            // compare the current and legacy versions
-            for (String serverWithDefaultPath  : new String[] {"empty", "stuff"}) {
-                if (modelNode.get(HORNETQ_SERVER).has(serverWithDefaultPath)) {
-                    modelNode.get(HORNETQ_SERVER, serverWithDefaultPath, PATH).set(new ModelNode());
-                }
+            for (Property property : modelNode.get(HORNETQ_SERVER).asPropertyList()) {
+                modelNode.get(HORNETQ_SERVER, property.getName()).remove(CLUSTERED.getName());
             }
             if (modelNode.get(HORNETQ_SERVER).has("default")) {
-                modelNode.get(HORNETQ_SERVER, "default", BRIDGE, "bridge1", FAILOVER_ON_SERVER_SHUTDOWN.getName()).set(true);
+                modelNode.get(HORNETQ_SERVER, "default", BRIDGE, "bridge1").remove(FAILOVER_ON_SERVER_SHUTDOWN.getName());
             }
             return modelNode;
         }
     };
+
+
 }

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_3_0.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_3_0.xml
@@ -13,8 +13,8 @@
             <wild-card-routing-enabled>false</wild-card-routing-enabled>
             <management-address>my.management.address</management-address>
             <management-notification-address>my.management.notif.address</management-notification-address>
-            <cluster-user>${messaging.cluster.user.name}</cluster-user>
-            <cluster-password>${messaging.cluster.user.password}</cluster-password>
+            <cluster-user>${messaging.cluster.user.name:myuser}</cluster-user>
+            <cluster-password>${messaging.cluster.user.password:mypassword}</cluster-password>
             <jmx-management-enabled>false</jmx-management-enabled>
             <jmx-domain>my.jmx.domain</jmx-domain>
             <statistics-enabled>true</statistics-enabled>
@@ -408,6 +408,12 @@
            </jms-connection-factories>
 
            <jms-destinations>
+              <jms-queue name="ExpiryQueue">
+                 <entry name="java:/jms/queue/ExpiryQueue"/>
+              </jms-queue>
+              <jms-queue name="DLQ">
+                 <entry name="java:/jms/queue/DLQ"/>
+              </jms-queue>
               <jms-queue name="testQueue">
                  <entry name="queue/test"/>
                  <selector string="color='red'"/>


### PR DESCRIPTION
This PR only contains the refactoring of the messaging subsystem transformers.
I renamed and reordered the tests in a sane way but there is no changes in the versions that are tested (from AS7 7.1.2 up to WildFly 8.0.0) for the latest messaging version (3.0).
I removed the transformers test from previous messaging version (2.0).

EAP 6.2 will be addressed in a later commit as it likely need a new test-controller version.

JIRA: https://issues.jboss.org/browse/WFLY-3656
