### PR TITLE
WFLY-3623 (hang with invalid @Resource name) fix + testcase

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/deployment/ContextNames.java
+++ b/naming/src/main/java/org/jboss/as/naming/deployment/ContextNames.java
@@ -138,6 +138,7 @@ public class ContextNames {
                 namespace = context.substring(5, i);
             }
 
+            sanitazeNameSpace(namespace,context);
             if (namespace.equals("global")) {
                 return new BindInfo(GLOBAL_CONTEXT_SERVICE_NAME, context.substring(12));
             } else if (namespace.equals("jboss")) {
@@ -161,6 +162,13 @@ public class ContextNames {
         }
     }
 
+    private static void sanitazeNameSpace(final String namespace, final String inContext) {
+        //URL might be:
+        // java:context/restOfURL - where nameSpace is part between ':' and '/'
+        if(namespace.contains(":")){
+            throw NamingLogger.ROOT_LOGGER.jndiNameViolation(namespace, inContext);
+        }
+    }
     /**
      * Get the service name of an environment entry
      *

--- a/naming/src/main/java/org/jboss/as/naming/deployment/ContextNames.java
+++ b/naming/src/main/java/org/jboss/as/naming/deployment/ContextNames.java
@@ -166,7 +166,7 @@ public class ContextNames {
         //URL might be:
         // java:context/restOfURL - where nameSpace is part between ':' and '/'
         if(namespace.contains(":")){
-            throw NamingLogger.ROOT_LOGGER.jndiNameViolation(namespace, inContext);
+            throw NamingLogger.ROOT_LOGGER.invalidJndiName(inContext);
         }
     }
     /**

--- a/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
+++ b/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
@@ -590,4 +590,15 @@ public interface NamingLogger extends BasicLogger {
     @Message(id = 63, value = "%s service not started")
     IllegalStateException serviceNotStarted(ServiceName serviceName);
 
+    /**
+     * Creates exception which indicate that part of JNDI URL is not correct. That is it does not follow
+     * 'java:context/restOfURL'
+     *
+     * @param culprit - section of JNDI URL which violates specification.
+     * @param context - whole entry
+     * @return a {@link NamingException} with explanation of error
+     */
+    @Message(id = 64, value = "Context part '%s' violates JNDI name syntax in '%s' entry.")
+    IllegalArgumentException jndiNameViolation(String culprit, String context);
+
 }

--- a/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
+++ b/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
@@ -590,15 +590,4 @@ public interface NamingLogger extends BasicLogger {
     @Message(id = 63, value = "%s service not started")
     IllegalStateException serviceNotStarted(ServiceName serviceName);
 
-    /**
-     * Creates exception which indicate that part of JNDI URL is not correct. That is it does not follow
-     * 'java:context/restOfURL'
-     *
-     * @param culprit - section of JNDI URL which violates specification.
-     * @param context - whole entry
-     * @return a {@link NamingException} with explanation of error
-     */
-    @Message(id = 64, value = "Context part '%s' violates JNDI name syntax in '%s' entry.")
-    IllegalArgumentException jndiNameViolation(String culprit, String context);
-
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/BadResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/BadResourceTestCase.java
@@ -111,7 +111,7 @@ public class BadResourceTestCase {
         // just to blow up
         Assert.assertTrue("Failed to deploy: " + result, !Operations.isSuccessfulOutcome(result));
 
-        Assert.assertTrue(result.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).toString()
+        Assert.assertTrue(""+result,result.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).toString()
                 .contains(Constants.ERROR_MESSAGE));
 
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/BadResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/BadResourceTestCase.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.jndi.bad;
+
+import javax.ejb.EJB;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.OperationBuilder;
+import org.jboss.as.controller.client.helpers.ClientConstants;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.management.util.ModelUtil;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author baranowb
+ * 
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class BadResourceTestCase {
+
+    private static ModelControllerClient controllerClient = TestSuiteEnvironment.getModelControllerClient();
+
+    public static Archive<?> getTestedArchive() throws Exception {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, Constants.TESTED_ARCHIVE_NAME);
+        jar.addClasses(SampleEJBImpl.class, ResourceEJBImpl.class);
+        jar.addClasses(Constants.class, SampleEJB.class, ResourceEJB.class);
+
+        return jar;
+    }
+
+    @Before
+    public void createDeployment() throws Exception {
+        final ModelNode addDeploymentOp = new ModelNode();
+        addDeploymentOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.DEPLOYMENT,
+                Constants.TESTED_DU_NAME);
+        addDeploymentOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        addDeploymentOp.get(ModelDescriptionConstants.CONTENT).get(0).get(ModelDescriptionConstants.INPUT_STREAM_INDEX).set(0);
+
+        final OperationBuilder ob = new OperationBuilder(addDeploymentOp, true);
+        ob.addInputStream(getTestedArchive().as(ZipExporter.class).exportAsInputStream());
+        final ModelNode result = controllerClient.execute(ob.build());
+
+        // just to blow up
+        Assert.assertTrue("Failed to deploy: " + result, Operations.isSuccessfulOutcome(result));
+    }
+
+    @After
+    public void removeDeployment() throws Exception {
+        final ModelNode remove = Util.getEmptyOperation(ModelDescriptionConstants.REMOVE,
+                new ModelNode().add(ModelDescriptionConstants.DEPLOYMENT, Constants.TESTED_DU_NAME));
+        final OperationBuilder ob = new OperationBuilder(remove, true);
+        final ModelNode result = controllerClient.execute(ob.build());
+
+        // just to blow up
+        Assert.assertTrue("Failed to deploy: " + result, Operations.isSuccessfulOutcome(result));
+    }
+
+    @Test
+    public void testBadDU() throws Exception {
+
+        final ModelNode deployOp = new ModelNode();
+        deployOp.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.DEPLOY);
+        deployOp.get(ModelDescriptionConstants.ADDRESS).add(ModelDescriptionConstants.DEPLOYMENT, Constants.TESTED_DU_NAME);
+        deployOp.get(ModelDescriptionConstants.ENABLED).set(true);
+        final OperationBuilder ob = new OperationBuilder(deployOp, true);
+        final ModelNode result = controllerClient.execute(ob.build());
+
+        // just to blow up
+        Assert.assertTrue("Failed to deploy: " + result, !Operations.isSuccessfulOutcome(result));
+
+        Assert.assertTrue(result.get(ModelDescriptionConstants.FAILURE_DESCRIPTION).toString()
+                .contains(Constants.ERROR_MESSAGE));
+
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/Constants.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/Constants.java
@@ -33,13 +33,10 @@ public interface Constants {
     
     String TESTED_DU_NAME = "BadTest";
     String TESTED_ARCHIVE_NAME = TESTED_DU_NAME + ".jar";
-    
 
-    String TEST_DU_NAME = "BadTestCase";
-    String TEST_ARCHIVE_NAME = TEST_DU_NAME + ".jar";
     
-    String JNDI_NAME_GLOBAL = "java:global/" + TEST_DU_NAME + "/ResourceEJBImpl";
-    String JNDI_NAME_BAD = "java:jboss:/" + TEST_DU_NAME + "/ResourceEJBImpl";
+    String JNDI_NAME_GLOBAL = "java:global/" + TESTED_DU_NAME + "/ResourceEJBImpl";
+    String JNDI_NAME_BAD = "java:jboss:/" + TESTED_DU_NAME + "/ResourceEJBImpl";
     
-    String ERROR_MESSAGE = "Context part 'jboss:' violates JNDI name syntax in 'java:jboss:/BadTestCase/ResourceEJBImpl' entry.";
+    String ERROR_MESSAGE = "A valid JNDI name must be provided: java:jboss:/BadTest/ResourceEJBImpl";
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/Constants.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/Constants.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ee.injection.resource.jndi.bad;
+
+/**
+ * @author baranowb
+ * 
+ */
+public interface Constants {
+
+    String TEST_MODULE_NAME = "BadDonkeyModule";
+    String TEST_MODULE_NAME_FULL = "test." + TEST_MODULE_NAME;
+    
+    String TESTED_DU_NAME = "BadTest";
+    String TESTED_ARCHIVE_NAME = TESTED_DU_NAME + ".jar";
+    
+
+    String TEST_DU_NAME = "BadTestCase";
+    String TEST_ARCHIVE_NAME = TEST_DU_NAME + ".jar";
+    
+    String JNDI_NAME_GLOBAL = "java:global/" + TEST_DU_NAME + "/ResourceEJBImpl";
+    String JNDI_NAME_BAD = "java:jboss:/" + TEST_DU_NAME + "/ResourceEJBImpl";
+    
+    String ERROR_MESSAGE = "Context part 'jboss:' violates JNDI name syntax in 'java:jboss:/BadTestCase/ResourceEJBImpl' entry.";
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/ResourceEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/ResourceEJB.java
@@ -1,0 +1,6 @@
+package org.jboss.as.test.integration.ee.injection.resource.jndi.bad;
+
+public interface ResourceEJB {
+	public String echo(String param);
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/ResourceEJBImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/ResourceEJBImpl.java
@@ -1,0 +1,14 @@
+package org.jboss.as.test.integration.ee.injection.resource.jndi.bad;
+
+import javax.ejb.Stateless;
+
+@Stateless
+public class ResourceEJBImpl implements ResourceEJB {
+	
+	@Override
+	public String echo(String param) {
+		return param+"......"+param+"..."+param;
+		
+	}
+}
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/SampleEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/SampleEJB.java
@@ -1,0 +1,5 @@
+package org.jboss.as.test.integration.ee.injection.resource.jndi.bad;
+
+public interface SampleEJB {
+    public String sayHello() throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/SampleEJBImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/injection/resource/jndi/bad/SampleEJBImpl.java
@@ -1,0 +1,22 @@
+package org.jboss.as.test.integration.ee.injection.resource.jndi.bad;
+
+import javax.annotation.Resource;
+import javax.annotation.Resources;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+@Resources({ @Resource(
+name = Constants.JNDI_NAME_BAD, 
+type = org.jboss.as.test.integration.ee.injection.resource.jndi.bad.ResourceEJB.class, lookup = Constants.JNDI_NAME_GLOBAL) })
+@Stateless
+@Remote(SampleEJB.class)
+public class SampleEJBImpl implements SampleEJB {
+
+    @Resource(lookup = Constants.JNDI_NAME_GLOBAL)
+    ResourceEJB resEJB;
+
+    @Override
+    public String sayHello() throws Exception {
+        return null;
+    }
+}


### PR DESCRIPTION
Spurious ":" in @Resource annotation 'name' value results in invalid binding but no deployment error

Upstream + 8.x: https://issues.jboss.org/browse/WFLY-3623
BZ 6.x:  https://issues.jboss.org/browse/WFLY-3623

PRs:
master: https://github.com/wildfly/wildfly/pull/6587
8.x : https://github.com/wildfly/wildfly/pull/6588
EAP 6.x: https://github.com/jbossas/jboss-eap/pull/1554
