### PR TITLE
Finish clust -> clustering rename (and keep compatibility with -Dts.clus...

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -238,7 +238,7 @@
 
 
                             <!-- Multinode UDP clustering tests with manual containers with unmanaged deployment. -->
-                            <!-- Tests which are placed in clust module but they're not run by default -->
+                            <!-- Tests which are placed in clustering module but they're not run by default -->
                             <execution>
                                 <id>ts.surefire.clustering.multinode-manual-tcp-sync-extended</id>
                                 <phase>test</phase> 
@@ -281,7 +281,7 @@
                         <artifactId>maven-antrun-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>ts.config-as.clustering.jdbc-store</id> 
+                                <id>ts.config-as.clustering.jdbc-store</id>
                                 <phase>none</phase>
                             </execution>
                         </executions>
@@ -291,11 +291,11 @@
                         <artifactId>maven-surefire-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>ts.surefire.clustering.jdbc-store</id>  
+                                <id>ts.surefire.clustering.jdbc-store</id>
                                 <phase>none</phase>
                             </execution>
                             <execution>
-                                <id>ts.surefire.clustering.single-node</id> 
+                                <id>ts.surefire.clustering.single-node</id>
                                 <phase>none</phase>
                             </execution>
                         </executions>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -109,6 +109,15 @@
             </modules>
         </profile>
 
+        <!-- Keep -Dts.clust compatibility -->
+        <profile>
+            <id>ts.integ.group.clustering.compatibility</id>
+            <activation><property><name>ts.clust</name></property></activation>
+            <modules>
+                <module>clustering</module>
+            </modules>
+        </profile>
+
         <!-- -Dts.iiop -->
         <profile>
             <id>ts.integ.group.iiop</id>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -473,6 +473,12 @@
             <activation><property><name>ts.clustering</name></property></activation>
             <modules><module>integration</module></modules>
         </profile>
+        <!-- Keep -Dts.clust compatibility -->
+        <profile>
+            <id>integ-clustering.module.profile.compability</id>
+            <activation><property><name>ts.clust</name></property></activation>
+            <modules><module>integration</module></modules>
+        </profile>
         <profile>
             <id>integ-iiop.module.profile</id>
             <activation><property><name>ts.iiop</name></property></activation>


### PR DESCRIPTION
...t)

I dont see a point in breaking an old switch if its few lines of code to keep the compatibility. It will also make bash commands reusable wildfly/eap. Probably affects dev, QE, GSS, SET so lets be sustainable. Thus, i would keep it.
