### PR TITLE
WFLY-3630: Fixes for Timer testcase and Timer impl.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerImpl.java
@@ -555,7 +555,7 @@ public class TimerImpl implements Timer {
         sb.append(this.id);
         sb.append(" ");
         sb.append("timedObjectId=");
-        sb.append(timedObjectId);
+        sb.append(this.timedObjectId);
         sb.append(" ");
         sb.append("auto-timer?:");
         sb.append(this.isAutoTimer());
@@ -574,6 +574,9 @@ public class TimerImpl implements Timer {
         sb.append(" ");
         sb.append("nextExpiration=");
         sb.append(this.nextExpiration);
+        sb.append(" ");
+        sb.append("previousRun=");
+        sb.append(this.previousRun);
         sb.append(" ");
         sb.append("timerState=");
         sb.append(this.timerState);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/CalendarTimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/CalendarTimerTask.java
@@ -72,6 +72,10 @@ public class CalendarTimerTask extends TimerTask<CalendarTimer> {
         if (currentTimeout == null) {
             return null;
         }
+        long now = System.currentTimeMillis();
+        if (currentTimeout.getTime() > now) {
+            return currentTimeout;
+        }
         Calendar cal = new GregorianCalendar();
         cal.setTime(currentTimeout);
         // now compute the next timeout date

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
@@ -132,18 +132,17 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
             }
 
             //we lock the timer for this check, because if a cancel is in progress then
-            //we do not want to do the isActive check, but wait for the cancelling transaction to finish
+            //we do not want to do the isActive check, but wait for the canceling transaction to finish
             //one way or another
             timer.lock();
             try {
                 if (!timer.isActive()) {
-                    ROOT_LOGGER.debug("Timer is not active, skipping this scheduled execution at: " + now + "for " + timer);
+                    ROOT_LOGGER.debug("Timer is not active, skipping this scheduled execution at: " + now + " for " + timer);
                     return;
                 }
                 // set the current date as the "previous run" of the timer.
                 timer.setPreviousRun(new Date());
-                Date nextTimeout = this.calculateNextTimeout(timer);
-                timer.setNextTimeout(nextTimeout);
+                timer.setNextTimeout(this.calculateNextTimeout(timer));
                 // change the state to mark it as in timeout method
                 timer.setTimerState(TimerState.IN_TIMEOUT);
 
@@ -189,10 +188,13 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
     protected Date calculateNextTimeout(TimerImpl timer) {
         long intervalDuration = timer.getInterval();
         if (intervalDuration > 0) {
-            long now = new Date().getTime();
+            long now = System.currentTimeMillis();
             long nextExpiration = timer.getNextExpiration().getTime();
+            if (nextExpiration > now) {
+                return timer.getNextExpiration();
+            }
             // compute skipped number of interval
-            int periods = (int) ((now - nextExpiration) / intervalDuration);
+            long periods = (now - nextExpiration) / intervalDuration;
             // compute the next timeout date
             return new Date(nextExpiration + (periods * intervalDuration) + intervalDuration);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/AbstractTimerManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/mgmt/AbstractTimerManagementTestCase.java
@@ -26,6 +26,7 @@ import org.junit.Assert;
  * @author: baranowb
  */
 public abstract class AbstractTimerManagementTestCase {
+
     @ContainerResource
     protected ManagementClient managementClient;
     private static final String APP_NAME = "ejb-mgmt-timers";
@@ -128,7 +129,7 @@ public abstract class AbstractTimerManagementTestCase {
         assertNoTimers();
         this.bean.createTimer();
         Assert.assertEquals("Wrong initial timer ticks!", 0, this.bean.getTimerTicks());
-        triggerTimer();
+        this.triggerTimer();
         Assert.assertEquals("Wrong after trigger timer ticks!", 1, this.bean.getTimerTicks());
         this.bean.waitOnTimeout();
         Assert.assertEquals("Timer should fire twice!", 2, this.bean.getTimerTicks());
@@ -138,14 +139,17 @@ public abstract class AbstractTimerManagementTestCase {
         assertNoTimers();
         this.bean.createTimer();
         Assert.assertEquals("Wrong initial timer ticks!", 0, this.bean.getTimerTicks());
-        triggerTimer();
+        this.triggerTimer();
         Assert.assertEquals("Wrong after trigger timer ticks!", 1, this.bean.getTimerTicks());
         this.suspendTimer();
         this.waitOverTimer();
         Assert.assertEquals("Timer should fire once!", 1, this.bean.getTimerTicks());
         this.activateTimer();
-        this.bean.waitOnTimeout();
+        // give the timer task time to fire after activation
+        this.shortWait();
         Assert.assertEquals("Timer should fire twice!", 2, this.bean.getTimerTicks());
+        this.bean.waitOnTimeout();
+        Assert.assertEquals("Timer should fire 3 times!", 3, this.bean.getTimerTicks());
     }
 
     protected void suspendTimer() throws Exception {
@@ -215,7 +219,7 @@ public abstract class AbstractTimerManagementTestCase {
         final Set<String> lst = tmp.keys();
         Assert.assertEquals(1, lst.size());
         this.timerId = lst.iterator().next();
-        this.timerAddress = address.pathAddress(address, PathElement.pathElement("timer", this.timerId));
+        this.timerAddress = PathAddress.pathAddress(address, PathElement.pathElement("timer", this.timerId));
         return this.timerAddress;
     }
 
@@ -257,8 +261,12 @@ public abstract class AbstractTimerManagementTestCase {
         return 3000;
     }
 
+    protected void shortWait() throws Exception {
+        Thread.sleep(500);
+    }
+
     protected void waitOverTimer() throws Exception {
-        Thread.currentThread().sleep(this.getDelay() + 1000);
+        Thread.sleep(this.getDelay() + 1000);
     }
 
     protected void assertNoTimers() {


### PR DESCRIPTION
triggering a timer caused an increment of the nextExpiration, although nextExpiration already is in the future.
Depending on the power of the test machine and granularity of System.currentTimeMillis sometimes calculateNextTimeout came out with the same time, because periods resulted to -1. This made the testcase fail then on my Windows system sometimes and never on my much slower Unix testsystem.

The relevant changes are in methods calculateNextTimeout in CalendarTimerTask and TimerTask.
If nextExpiration is greater than now, return nextExpiration as it is.
For calendarTimer I got 2 Task for the same timer for the same expiration time then. To avoid it, I added the oldTask.cancel().

Old other changes cosmetic or elimination of dead code.
