### PR TITLE
WFLY-3721 CommandDispatcher hides exceptions

### DIFF
--- a/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/CommandDispatcher.java
+++ b/clustering/api/src/main/java/org/wildfly/clustering/dispatcher/CommandDispatcher.java
@@ -41,8 +41,9 @@ public interface CommandDispatcher<C> extends AutoCloseable {
      * @param command the command to execute
      * @param node    the node to execute the command on
      * @return the result of the command execution
+     * @throws Exception if the command could not be sent
      */
-    <R> CommandResponse<R> executeOnNode(Command<R, C> command, Node node);
+    <R> CommandResponse<R> executeOnNode(Command<R, C> command, Node node) throws Exception;
 
     /**
      * Execute the specified command on all nodes in the group, excluding the specified nodes
@@ -51,8 +52,9 @@ public interface CommandDispatcher<C> extends AutoCloseable {
      * @param command       the command to execute
      * @param excludedNodes the set of nodes to exclude
      * @return a map of command execution results per node
+     * @throws Exception if the command could not be broadcast
      */
-    <R> Map<Node, CommandResponse<R>> executeOnCluster(Command<R, C> command, Node... excludedNodes);
+    <R> Map<Node, CommandResponse<R>> executeOnCluster(Command<R, C> command, Node... excludedNodes) throws Exception;
 
     /**
      * Submits the specified command on the specified node for execution.
@@ -61,8 +63,9 @@ public interface CommandDispatcher<C> extends AutoCloseable {
      * @param command the command to execute
      * @param node    the node to execute the command on
      * @return the result of the command execution
+     * @throws Exception if the command could not be sent
      */
-    <R> Future<R> submitOnNode(Command<R, C> command, Node node);
+    <R> Future<R> submitOnNode(Command<R, C> command, Node node) throws Exception;
 
     /**
      * Submits the specified command on all nodes in the group, excluding the specified nodes.
@@ -71,8 +74,9 @@ public interface CommandDispatcher<C> extends AutoCloseable {
      * @param command       the command to execute
      * @param excludedNodes the set of nodes to exclude
      * @return a map of command execution results per node.
+     * @throws Exception if the command could not be broadcast
      */
-    <R> Map<Node, Future<R>> submitOnCluster(Command<R, C> command, Node... excludedNodes);
+    <R> Map<Node, Future<R>> submitOnCluster(Command<R, C> command, Node... excludedNodes) throws Exception;
 
     /**
      * Closes any resources used by this dispatcher.

--- a/clustering/common/src/main/java/org/jboss/as/clustering/concurrent/Invoker.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/concurrent/Invoker.java
@@ -19,40 +19,20 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.server.dispatcher;
+package org.jboss.as.clustering.concurrent;
 
-import java.util.concurrent.ExecutionException;
-
-import org.wildfly.clustering.dispatcher.CommandResponse;
+import java.util.concurrent.Callable;
 
 /**
- * Simple {@link CommandResponse} implementation
+ * Defines a strategy for invoking a given task.
  * @author Paul Ferraro
- * @param <T> a response type
  */
-public class SimpleCommandResponse<T> implements CommandResponse<T> {
-    private final T value;
-    private final ExecutionException exception;
-
-    public SimpleCommandResponse(T value) {
-        this.value = value;
-        this.exception = null;
-    }
-
-    public SimpleCommandResponse(Throwable exception) {
-        this(new ExecutionException(exception));
-    }
-
-    public SimpleCommandResponse(ExecutionException exception) {
-        this.value = null;
-        this.exception = exception;
-    }
-
-    @Override
-    public T get() throws ExecutionException {
-        if (this.exception != null) {
-            throw this.exception;
-        }
-        return this.value;
-    }
+public interface Invoker {
+    /**
+     * Invokes the specified task
+     * @param task a task to be called
+     * @return the result of the task
+     * @throws Exception if task invocation fails
+     */
+    <R> R invoke(Callable<R> task) throws Exception;
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/concurrent/RetryingInvoker.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/concurrent/RetryingInvoker.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.clustering.concurrent;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.clustering.logging.ClusteringLogger;
+
+/**
+ * A invocation strategy that invokes a given task, retrying a configurable number of times on failure using backoff sleep intervals.
+ * @author Paul Ferraro
+ */
+public class RetryingInvoker implements Invoker {
+
+    private final long[] backOffIntervals;
+    private final TimeUnit unit;
+
+    public RetryingInvoker(long... backOffIntervals) {
+        this(backOffIntervals, TimeUnit.MILLISECONDS);
+    }
+
+    public RetryingInvoker(long[] backOffIntervals, TimeUnit unit) {
+        this.backOffIntervals = backOffIntervals;
+        this.unit = unit;
+    }
+
+    @Override
+    public <R> R invoke(Callable<R> task) throws Exception {
+        Exception exception = null;
+
+        for (int i = 0; i < this.backOffIntervals.length; ++i) {
+            if (i > 0) {
+                long delay = this.backOffIntervals[i];
+                if (delay > 0) {
+                    try {
+                        this.unit.sleep(delay);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                } else {
+                    Thread.yield();
+                }
+                if (Thread.currentThread().isInterrupted()) break;
+            }
+            try {
+                return task.call();
+            } catch (Exception e) {
+                exception = e;
+            }
+            ClusteringLogger.ROOT_LOGGER.debugf(exception, "Attempt #%d failed", i + 1);
+        }
+
+        throw exception;
+    }
+}

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBatcher.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBatcher.java
@@ -54,6 +54,7 @@ public class InfinispanBatcher implements Batcher<TransactionBatch> {
         this.tm = tm;
     }
 
+    @SuppressWarnings("resource")
     @Override
     public TransactionBatch startBatch() {
         try {

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
@@ -117,4 +117,22 @@ public class InfinispanBean<G, I, T> implements Bean<G, I, T> {
             this.group.close();
         }
     }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof Bean)) return false;
+        @SuppressWarnings("unchecked")
+        Bean<G, I, T> bean = (Bean<G, I, T>) object;
+        return this.id.equals(bean.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.id.toString();
+    }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanEntryExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanEntryExternalizer.java
@@ -52,6 +52,7 @@ public class InfinispanBeanEntryExternalizer<G> extends AbstractSimpleExternaliz
 
     @Override
     public InfinispanBeanEntry<G> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        @SuppressWarnings("unchecked")
         G groupId = (G) input.readObject();
         InfinispanBeanEntry<G> entry = new InfinispanBeanEntry<>(groupId);
         long time = input.readLong();

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroup.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroup.java
@@ -142,4 +142,22 @@ public class InfinispanBeanGroup<G, I, T> implements BeanGroup<G, I, T> {
             }
         }
     }
+
+    @Override
+    public boolean equals(Object object) {
+        if (!(object instanceof BeanGroup)) return false;
+        @SuppressWarnings("unchecked")
+        BeanGroup<G, I, T> group = (BeanGroup<G, I, T>) object;
+        return this.id.equals(group.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return this.id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return this.id.toString();
+    }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroupEntryExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/group/InfinispanBeanGroupEntryExternalizer.java
@@ -52,6 +52,7 @@ public class InfinispanBeanGroupEntryExternalizer<I, T> extends AbstractSimpleEx
 
     @Override
     public InfinispanBeanGroupEntry<I, T> readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        @SuppressWarnings("unchecked")
         MarshalledValue<Map<I, T>, MarshallingContext> value = (MarshalledValue<Map<I, T>, MarshallingContext>) input.readObject();
         return new InfinispanBeanGroupEntry<>(value);
     }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/logging/InfinispanEjbLogger.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/logging/InfinispanEjbLogger.java
@@ -59,6 +59,14 @@ public interface InfinispanEjbLogger extends BasicLogger {
     @Message(id = 4, value = "Failed to deserialize %s")
     IllegalStateException deserializationFailure(@Cause Throwable cause, Object key);
 
+    @LogMessage(level = WARN)
+    @Message(id = 5, value = "Failed to cancel expiration/passivation of bean %s on primary owner.")
+    void failedToCancelBean(@Cause Throwable cause, Object beanId);
+
+    @LogMessage(level = WARN)
+    @Message(id = 6, value = "Failed to schedule expiration/passivation of bean %s on primary owner.")
+    void failedToScheduleBean(@Cause Throwable cause, Object beanId);
+
     @Message(id = 8, value = "Stateful session bean %s refers to an invalid bean group %s")
     IllegalStateException invalidBeanGroup(Object beanId, Object groupId);
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
@@ -96,6 +96,7 @@ public class ChannelCommandDispatcherFactory implements CommandDispatcherFactory
             try (Unmarshaller unmarshaller = this.marshallingContext.createUnmarshaller(version)) {
                 unmarshaller.start(Marshalling.createByteInput(input));
                 Object clientId = unmarshaller.readObject();
+                @SuppressWarnings("unchecked")
                 Command<Object, Object> command = (Command<Object, Object>) unmarshaller.readObject();
                 AtomicReference<Object> context = this.contexts.get(clientId);
                 if (context == null) return new NoSuchService();

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/logging/InfinispanWebLogger.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/logging/InfinispanWebLogger.java
@@ -57,4 +57,12 @@ public interface InfinispanWebLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 4, value = "Failed to expire session %s")
     void failedToExpireSession(@Cause Throwable cause, String sessionId);
+
+    @LogMessage(level = WARN)
+    @Message(id = 5, value = "Failed to cancel expiration/passivation of session %s on primary owner.")
+    void failedToCancelSession(@Cause Throwable cause, String sessionId);
+
+    @LogMessage(level = WARN)
+    @Message(id = 6, value = "Failed to schedule expiration/passivation of session %s on primary owner.")
+    void failedToScheduleSession(@Cause Throwable cause, String sessionId);
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/bean/ClusterTopologyRetrieverBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/bean/ClusterTopologyRetrieverBean.java
@@ -3,7 +3,6 @@ package org.jboss.as.test.clustering.cluster.dispatcher.bean;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import javax.ejb.EJB;
 import javax.ejb.Remote;
@@ -46,7 +45,7 @@ public class ClusterTopologyRetrieverBean implements ClusterTopologyRetriever {
             }
 
             return new ClusterTopology(nodes, local, remote);
-        } catch (ExecutionException e) {
+        } catch (Exception e) {
             throw new IllegalStateException(e.getCause());
         }
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/bean/CommandDispatcherBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/dispatcher/bean/CommandDispatcherBean.java
@@ -35,22 +35,22 @@ public class CommandDispatcherBean implements CommandDispatcher<Node> {
     }
 
     @Override
-    public <R> CommandResponse<R> executeOnNode(Command<R, Node> command, Node node) {
+    public <R> CommandResponse<R> executeOnNode(Command<R, Node> command, Node node) throws Exception {
         return this.dispatcher.executeOnNode(command, node);
     }
 
     @Override
-    public <R> Map<Node, CommandResponse<R>> executeOnCluster(Command<R, Node> command, Node... excludedNodes) {
+    public <R> Map<Node, CommandResponse<R>> executeOnCluster(Command<R, Node> command, Node... excludedNodes) throws Exception  {
         return this.dispatcher.executeOnCluster(command, excludedNodes);
     }
 
     @Override
-    public <R> Future<R> submitOnNode(Command<R, Node> command, Node node) {
+    public <R> Future<R> submitOnNode(Command<R, Node> command, Node node) throws Exception  {
         return this.dispatcher.submitOnNode(command, node);
     }
 
     @Override
-    public <R> Map<Node, Future<R>> submitOnCluster(Command<R, Node> command, Node... excludedNodes) {
+    public <R> Map<Node, Future<R>> submitOnCluster(Command<R, Node> command, Node... excludedNodes) throws Exception  {
         return this.dispatcher.submitOnCluster(command, excludedNodes);
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3721

Modifies CommandDispatcher methods to throw Exception. This draws a cleaner distinction between sender exceptions and receiver-specific exceptions versus the previous behavior of null/empty responses.
