### PR TITLE
WFLY-3731 StatefulSessionSynchronizationInterceptor should not register a Synchronization if the transaction was rolled back

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionSynchronizationInterceptor.java
@@ -105,7 +105,7 @@ public class StatefulSessionSynchronizationInterceptor extends AbstractEJBInterc
                             final int status = transactionSynchronizationRegistry.getTransactionStatus();
                             // if this SFSB instance is already associated with a different transaction, then it's an error
                             // if the thread is currently associated with a tx, then register a tx synchronization
-                            if (currentTransactionKey != null && status != Status.STATUS_COMMITTED) {
+                            if (currentTransactionKey != null && status != Status.STATUS_COMMITTED && status != Status.STATUS_ROLLEDBACK) {
                                 // register a tx synchronization for this SFSB instance
                                 final Synchronization statefulSessionSync = new StatefulSessionSynchronization(instance, lockOwner);
                                 transactionSynchronizationRegistry.registerInterposedSynchronization(statefulSessionSync);


### PR DESCRIPTION
Doing so will cause an ISE "IllegalStateException: No transaction is running" to be thrown when registering the Synchronization (see http://fpaste.org/125252 for call stack).
