### PR TITLE
WFLY-3703 arq.container.domain.ManagementClient.readRootNode does not see servers on remote hosts

### DIFF
--- a/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
+++ b/arquillian/common-domain/src/main/java/org/jboss/as/arquillian/container/domain/ManagementClient.java
@@ -406,7 +406,7 @@ public class ManagementClient {
             operation.get(RECURSIVE).set(true);
         }
         else {
-            // To make it compatible with WFLY-3705 and pre-WFLY-3705 behavior 
+            // To make it compatible with WFLY-3705 and pre-WFLY-3705 behavior
             // "recursive" is not set
             operation.get(RECURSIVE_DEPTH).set(recursiveDepth);
         }

--- a/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
+++ b/controller-client/src/main/java/org/jboss/as/controller/client/helpers/ClientConstants.java
@@ -51,10 +51,12 @@ public class ClientConstants {
     public static final String OP_ADDR = "address";
     public static final String OUTCOME = "outcome";
     public static final String PATH = "path";
+    public static final String PROXIES = "proxies";
     public static final String READ_ATTRIBUTE_OPERATION = "read-attribute";
     public static final String READ_CHILDREN_NAMES_OPERATION = "read-children-names";
     public static final String READ_RESOURCE_OPERATION = "read-resource";
     public static final String RECURSIVE = "recursive";
+    public static final String RECURSIVE_DEPTH = "recursive-depth";
     public static final String REMOVE_OPERATION = "remove";
     public static final String RESULT = "result";
     public static final String ROLLBACK_ON_RUNTIME_FAILURE = "rollback-on-runtime-failure";


### PR DESCRIPTION
Proxies must be enabled for remote servers
Recursive depth is limited to 3
Use of recursive attributes is consitent for
pre-WFLY-3705 and post-WFLY-3705 behavior
