### PR TITLE
Eliminate some Warnings during compilation

### DIFF
--- a/clustering/ejb/infinispan/pom.xml
+++ b/clustering/ejb/infinispan/pom.xml
@@ -71,19 +71,4 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgument>
-                        -AgeneratedTranslationFilesPath=${project.basedir}/target/generated-translation-files
-                    </compilerArgument>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/clustering/ejb/spi/pom.xml
+++ b/clustering/ejb/spi/pom.xml
@@ -67,19 +67,4 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <compilerArgument>
-                        -AgeneratedTranslationFilesPath=${project.basedir}/target/generated-translation-files
-                    </compilerArgument>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
 </project>

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -26,7 +26,6 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE
 import static org.jboss.as.connector.subsystems.datasources.Constants.ENABLED;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
-import static org.jboss.as.connector.subsystems.datasources.Constants.STATISTICS_ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.sql.Driver;
@@ -123,7 +122,6 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
         final String dsName = PathAddress.pathAddress(address).getLastElement().getValue();
         final String jndiName = model.get(JNDI_NAME.getName()).asString();
         boolean jta = JTA.resolveModelAttribute(context, operation).asBoolean();
-        final boolean statsEnabled = STATISTICS_ENABLED.resolveModelAttribute(context, model).asBoolean();
 
         final ServiceTarget serviceTarget = context.getServiceTarget();
 
@@ -134,13 +132,12 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
         final ServiceName driverServiceName = ServiceName.JBOSS.append("jdbc-driver", driverName.replaceAll("\\.", "_"));
 
 
-        ValueInjectionService driverDemanderService = new ValueInjectionService<Driver>();
+        ValueInjectionService<Driver> driverDemanderService = new ValueInjectionService<Driver>();
 
         final ServiceName driverDemanderServiceName = ServiceName.JBOSS.append("driver-demander").append(jndiName);
                 final ServiceBuilder<?> driverDemanderBuilder = serviceTarget
                         .addService(driverDemanderServiceName, driverDemanderService)
-                        .addDependency(driverServiceName, Driver.class,
-                                driverDemanderService.getInjector());
+                        .addDependency(driverServiceName, Driver.class, driverDemanderService.getInjector());
         driverDemanderBuilder.addListener(verificationHandler);
         driverDemanderBuilder.setInitialMode(ServiceController.Mode.ACTIVE);
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -26,6 +26,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE
 import static org.jboss.as.connector.subsystems.datasources.Constants.ENABLED;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
+import static org.jboss.as.connector.subsystems.datasources.Constants.STATISTICS_ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
 import java.sql.Driver;
@@ -106,8 +107,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
     }
 
     /**
-     * Method is {@code final}, and throws unsupported operation exception to prevent subclasses inadvertently
-     * overridding it.
+     * Method is {@code final}, and throws unsupported operation exception to prevent subclasses inadvertently overriding it.
      *
      * {@inheritDoc}
      */
@@ -121,7 +121,11 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
         final ModelNode address = operation.require(OP_ADDR);
         final String dsName = PathAddress.pathAddress(address).getLastElement().getValue();
         final String jndiName = model.get(JNDI_NAME.getName()).asString();
-        boolean jta = JTA.resolveModelAttribute(context, operation).asBoolean();
+        final boolean jta = JTA.resolveModelAttribute(context, operation).asBoolean();
+        // The STATISTICS_ENABLED.resolveModelAttribute(context, model) call should remain as it serves to validate that any
+        // expression in the model can be resolved to a correct value.
+        @SuppressWarnings("unused")
+        final boolean statsEnabled = STATISTICS_ENABLED.resolveModelAttribute(context, model).asBoolean();
 
         final ServiceTarget serviceTarget = context.getServiceTarget();
 

--- a/ee/src/main/java/org/jboss/as/ee/component/DefaultInterceptorConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/DefaultInterceptorConfigurator.java
@@ -35,7 +35,7 @@ import org.jboss.invocation.proxy.MethodIdentifier;
  */
 class DefaultInterceptorConfigurator extends AbstractComponentConfigurator implements ComponentConfigurator {
 
-    private static final Class[] EMPTY_CLASS_ARRAY = new Class[0];
+    private static final Class<?>[] EMPTY_CLASS_ARRAY = new Class<?>[0];
 
     public void configure(final DeploymentPhaseContext context, final ComponentDescription description, final ComponentConfiguration configuration) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = context.getDeploymentUnit();
@@ -87,7 +87,7 @@ class DefaultInterceptorConfigurator extends AbstractComponentConfigurator imple
         } else {
             final ClassReflectionIndex<?> componentClassIndex = deploymentReflectionIndex.getClassIndex(configuration.getComponentClass());
             //use the default constructor if no instanceFactory has been set
-            final Constructor<Object> constructor = (Constructor<Object>) componentClassIndex.getConstructor(EMPTY_CLASS_ARRAY);
+            final Constructor<?> constructor = componentClassIndex.getConstructor(EMPTY_CLASS_ARRAY);
             if (constructor == null) {
                 throw EeLogger.ROOT_LOGGER.defaultConstructorNotFound(configuration.getComponentClass());
             }

--- a/jacorb/pom.xml
+++ b/jacorb/pom.xml
@@ -49,9 +49,6 @@
                 <compilerArguments>
                    <endorseddirs>${project.build.directory}/endorsed</endorseddirs>
                 </compilerArguments>
-                <compilerArgument>
-                   -AgeneratedTranslationFilesPath=${project.build.directory}/generated-translation-files
-                </compilerArgument>
              </configuration>
           </plugin>
           <plugin>

--- a/jacorb/src/main/java/org/jboss/as/jacorb/naming/jndi/WrapperInitialContext.java
+++ b/jacorb/src/main/java/org/jboss/as/jacorb/naming/jndi/WrapperInitialContext.java
@@ -37,11 +37,12 @@ import javax.naming.NamingException;
  */
 public class WrapperInitialContext implements Context {
 
-    private final Hashtable environment;
+    private final Hashtable<Object,Object> environment;
 
-    public WrapperInitialContext(final Hashtable environment) {
+    @SuppressWarnings("unchecked")
+    public WrapperInitialContext(final Hashtable<Object,Object> environment) {
         if (environment != null) {
-            this.environment = (Hashtable) environment.clone();
+            this.environment = (Hashtable<Object,Object>) environment.clone();
         } else {
             this.environment = null;
         }
@@ -59,7 +60,8 @@ public class WrapperInitialContext implements Context {
             if (index != -1) {
                 final String server = name.substring(0, index);
                 final String lookup = name.substring(index + 1);
-                final Hashtable environment = (Hashtable) this.environment.clone();
+                @SuppressWarnings("unchecked")
+                final Hashtable<Object,Object> environment = (Hashtable<Object,Object>) this.environment.clone();
                 environment.put(Context.PROVIDER_URL, server);
                 return CNCtxFactory.INSTANCE.getInitialContext(environment).lookup(lookup);
             } else {

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsScanningProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsScanningProcessor.java
@@ -197,6 +197,7 @@ public class JaxrsScanningProcessor implements DeploymentUnitProcessor {
             try {
                 for (ClassInfo c : applicationClasses) {
                     if (Modifier.isAbstract(c.flags())) continue;
+                    @SuppressWarnings("unchecked")
                     Class<? extends Application> scanned = (Class<? extends Application>) classLoader.loadClass(c.name().toString());
                     resteasyDeploymentData.getScannedApplicationClasses().add(scanned);
                 }

--- a/jpa/src/main/java/org/jboss/as/jpa/interceptor/SFSBCreateInterceptor.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/interceptor/SFSBCreateInterceptor.java
@@ -56,8 +56,8 @@ public class SFSBCreateInterceptor implements Interceptor {
             entityManagers = new HashMap<String, ExtendedEntityManager>();
             componentInstance.setInstanceData(SFSBInvocationInterceptor.CONTEXT_KEY, new ImmediateManagedReference(entityManagers));
         } else {
-            ManagedReference ref = (ManagedReference) componentInstance.getInstanceData(SFSBInvocationInterceptor.CONTEXT_KEY);
-            entityManagers = (Map<String, ExtendedEntityManager>)ref.getInstance();
+            ManagedReference entityManagerRef = (ManagedReference) componentInstance.getInstanceData(SFSBInvocationInterceptor.CONTEXT_KEY);
+            entityManagers = (Map<String, ExtendedEntityManager>)entityManagerRef.getInstance();
         }
         final List<ExtendedEntityManager> ems = CreatedEntityManagers.getDeferredEntityManagers();
         for (ExtendedEntityManager e : ems) {

--- a/naming/src/main/java/org/jboss/as/naming/InitialContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContext.java
@@ -85,14 +85,15 @@ public class InitialContext extends InitialLdapContext {
         }
     }
 
-    public InitialContext(Hashtable environment) throws NamingException {
+    public InitialContext(Hashtable<?,?> environment) throws NamingException {
         super(environment, null);
     }
 
+    @SuppressWarnings("unchecked")
     @Override
-    protected void init(Hashtable environment) throws NamingException {
+    protected void init(Hashtable<?,?> environment) throws NamingException {
         // the jdk initial context already worked out the env, no need to do it again
-        myProps = environment;
+        myProps = (Hashtable<Object, Object>) environment;
         if (myProps != null && myProps.get(Context.INITIAL_CONTEXT_FACTORY) != null) {
             // user has specified initial context factory; try to get it
             getDefaultInitCtx();
@@ -169,7 +170,7 @@ public class InitialContext extends InitialLdapContext {
 
     static class DefaultInitialContext extends NamingContext {
 
-        public DefaultInitialContext(Hashtable environment) {
+        public DefaultInitialContext(Hashtable<Object,Object> environment) {
             super(environment);
         }
 

--- a/naming/src/main/java/org/jboss/as/naming/InitialContextFactory.java
+++ b/naming/src/main/java/org/jboss/as/naming/InitialContextFactory.java
@@ -39,7 +39,6 @@ public class InitialContextFactory implements javax.naming.spi.InitialContextFac
      * @return A naming context instance
      * @throws NamingException
      */
-    @SuppressWarnings("unchecked")
     public Context getInitialContext(Hashtable<?, ?> environment) throws NamingException {
         return new InitialContext(environment);
     }

--- a/naming/src/main/java/org/jboss/as/naming/deployment/ContextNames.java
+++ b/naming/src/main/java/org/jboss/as/naming/deployment/ContextNames.java
@@ -74,7 +74,7 @@ public class ContextNames {
     public static final ServiceName APPLICATION_CONTEXT_SERVICE_NAME = JAVA_CONTEXT_SERVICE_NAME.append("app");
 
     /**
-     * Parent ServiceName for java:module namespacef
+     * Parent ServiceName for java:module namespace
      */
     public static final ServiceName MODULE_CONTEXT_SERVICE_NAME = JAVA_CONTEXT_SERVICE_NAME.append("module");
 

--- a/naming/src/test/java/org/jboss/as/naming/WritableServiceBasedNamingStoreTestCase.java
+++ b/naming/src/test/java/org/jboss/as/naming/WritableServiceBasedNamingStoreTestCase.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+
 import javax.naming.CompositeName;
 import javax.naming.Name;
 import javax.naming.NameNotFoundException;
@@ -58,7 +59,6 @@ public class WritableServiceBasedNamingStoreTestCase {
     private static final ServiceName OWNER_FOO = ServiceName.of("Foo");
     private static final ServiceName OWNER_BAR = ServiceName.of("Bar");
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     @Before
     public void setup() throws Exception {
         container = ServiceContainer.Factory.create();
@@ -94,8 +94,8 @@ public class WritableServiceBasedNamingStoreTestCase {
         final CountDownLatch latch1 = new CountDownLatch(1);
         container.addService(JndiNamingDependencyProcessor.serviceName(owner), new RuntimeBindReleaseService())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
-                .addListener(new AbstractServiceListener() {
-                    public void transition(ServiceController controller, ServiceController.Transition transition) {
+                .addListener(new AbstractServiceListener<Object>() {
+                    public void transition(ServiceController<?> controller, ServiceController.Transition transition) {
                         switch (transition) {
                             case STARTING_to_UP: {
                                 latch1.countDown();

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SimpleSecurityManager.java
@@ -23,9 +23,6 @@ package org.jboss.as.security.service;
 
 import static java.security.AccessController.doPrivileged;
 
-import javax.security.auth.Subject;
-import javax.security.jacc.PolicyContext;
-
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.CodeSource;
@@ -39,6 +36,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import javax.security.auth.Subject;
+import javax.security.jacc.PolicyContext;
+
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.core.security.SubjectUserInfo;
 import org.jboss.as.domain.management.security.PasswordCredential;
@@ -49,7 +49,6 @@ import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.security.UserInfo;
 import org.jboss.security.AuthenticationManager;
-import org.jboss.security.AuthorizationManager;
 import org.jboss.security.ISecurityManagement;
 import org.jboss.security.RunAs;
 import org.jboss.security.RunAsIdentity;
@@ -64,9 +63,7 @@ import org.jboss.security.audit.AuditEvent;
 import org.jboss.security.audit.AuditLevel;
 import org.jboss.security.audit.AuditManager;
 import org.jboss.security.authorization.resources.EJBResource;
-import org.jboss.security.callbacks.SecurityContextCallbackHandler;
 import org.jboss.security.identity.Identity;
-import org.jboss.security.identity.RoleGroup;
 import org.jboss.security.identity.plugins.SimpleIdentity;
 import org.jboss.security.identity.plugins.SimpleRoleGroup;
 import org.jboss.security.javaee.AbstractEJBAuthorizationHelper;
@@ -451,20 +448,6 @@ public class SimpleSecurityManager implements ServerSecurityManager {
             @Override
             public SubjectInfo run() {
                 return context.getSubjectInfo();
-            }
-        });
-    }
-
-
-    private RoleGroup getSubjectRoles(final AuthorizationManager am, final SecurityContextCallbackHandler scb, final Subject authenticatedSubject) {
-
-        if (System.getSecurityManager() == null) {
-            return am.getSubjectRoles(authenticatedSubject, scb);
-        }
-        return AccessController.doPrivileged(new PrivilegedAction<RoleGroup>() {
-            @Override
-            public RoleGroup run() {
-                return am.getSubjectRoles(authenticatedSubject, scb);
             }
         });
     }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/LogStoreConstants.java
@@ -64,7 +64,9 @@ class LogStoreConstants {
     static final String LOG_STORE_TYPE_ATTRIBUTE = "type";
 
     static final Map<String, String> MODEL_TO_JMX_TXN_NAMES =
-            Collections.unmodifiableMap(new HashMap<String, String>() {{
+            Collections.unmodifiableMap(new HashMap<String, String>() {
+                private static final long serialVersionUID = 1L;
+            {
                 put(JMX_ON_ATTRIBUTE, null);
                 put("id", "Id");
                 put("age-in-seconds", "AgeInSeconds");
@@ -72,7 +74,9 @@ class LogStoreConstants {
             }});
 
     static final Map<String, String> MODEL_TO_JMX_PARTICIPANT_NAMES =
-            Collections.unmodifiableMap(new HashMap<String, String>() {{
+            Collections.unmodifiableMap(new HashMap<String, String>() {
+                private static final long serialVersionUID = 1L;
+            {
                 put(JMX_ON_ATTRIBUTE, null);
                 put("type", "Type");
                 put("status", "Status");
@@ -118,7 +122,7 @@ class LogStoreConstants {
             .setAllowNull(true)
             .setDefaultValue(new ModelNode())
             .setMeasurementUnit(MeasurementUnit.NONE)
-            .setValidator(new EnumValidator(ParticipantStatus.class, true, false))
+            .setValidator(new EnumValidator<ParticipantStatus>(ParticipantStatus.class, true, false))
             .build();
 
     static SimpleAttributeDefinition PARTICIPANT_JNDI_NAME = (new SimpleAttributeDefinitionBuilder(JNDI_ATTRIBUTE, ModelType.STRING))

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
@@ -22,14 +22,15 @@
 
 package org.wildfly.extension.undertow;
 
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.OpenListener;
+
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.undertow.server.HandlerWrapper;
-import io.undertow.server.HttpHandler;
-import io.undertow.server.OpenListener;
 import org.jboss.as.network.ManagedBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.msc.service.Service;
@@ -61,6 +62,7 @@ public abstract class ListenerService<T> implements Service<T> {
     protected final InjectedValue<XnioWorker> worker = new InjectedValue<>();
     protected final InjectedValue<SocketBinding> binding = new InjectedValue<>();
     protected final InjectedValue<SocketBinding> redirectSocket = new InjectedValue<>();
+    @SuppressWarnings("rawtypes")
     protected final InjectedValue<Pool> bufferPool = new InjectedValue<>();
     protected final InjectedValue<Server> serverService = new InjectedValue<>();
     protected final List<HandlerWrapper> listenerHandlerWrappers = new ArrayList<>();
@@ -89,6 +91,7 @@ public abstract class ListenerService<T> implements Service<T> {
         return redirectSocket;
     }
 
+    @SuppressWarnings("rawtypes")
     public InjectedValue<Pool> getBufferPool() {
         return bufferPool;
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerService.java
@@ -22,14 +22,14 @@
 
 package org.wildfly.extension.undertow;
 
-import io.undertow.server.HandlerWrapper;
-import io.undertow.server.HttpHandler;
-import io.undertow.server.OpenListener;
-
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
+
+import io.undertow.server.HandlerWrapper;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.OpenListener;
 
 import org.jboss.as.network.ManagedBinding;
 import org.jboss.as.network.SocketBinding;


### PR DESCRIPTION
because of
- unchecked or unsafe operations
- dead code (unused private method)
- [WARNING] The following options were not recognized by any processor: '[generatedTranslationFilesPath]'
