### PR TITLE
[WFLY-3733] ChannelInstanceResourceDefinition doesn't expose non-pri...

### DIFF
--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -122,10 +122,10 @@ public interface JGroupsLogger extends BasicLogger {
     @Message(id = 16, value = "Unable to load protocol class %s")
     OperationFailedException unableToLoadProtocolClass(String protocolName);
 
-    @Message(id = 17, value = "Privileged access exception on attribute %s")
+    @Message(id = 17, value = "Privileged access exception on attribute/method %s")
     String privilegedAccessExceptionForAttribute(String attrName);
 
-    @Message(id = 18, value = "Instantiation exception on converter for attribute %s")
+    @Message(id = 18, value = "Instantiation exception on converter for attribute/method %s")
     String instantiationExceptionOnConverterForAttribute(String attrName);
 
     @Message(id = 19, value = "Protocol %s not found in current stack")


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-3733

Now you can also access non-primitive types such as AtomicLong

```
[standalone@localhost:9990 /] /subsystem=jgroups/channel=web/protocol=FRAG2:read-attribute(name=num_frags_sent)
{
    "outcome" => "success",
    "result" => "0"
}
```

and also get interesting information like suspected members

```
[standalone@localhost:9990 /] /subsystem=jgroups/channel=web/protocol=FD_ALL:read-attribute(name=getSuspectedMembers
{
    "outcome" => "success",
    "result" => "[]"
}
```

PS: I have accidentally put the formatting changes in the same commit, sorry about that but it was quite messy.
