### PR TITLE
[WFLY-3720] Run clustering tests with ip_ttl=0 (use -Dmcast.ttl= to override)

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -47,11 +47,13 @@
                                         <echo>In Maven: node0: ${node0}</echo>
                                         <echo>In Maven: node1: ${node1}</echo>
                                         <echo>In Maven: mcast: ${mcast}</echo>
+                                        <echo>In Maven: mcast.ttl: ${mcast.ttl}</echo>
                                         <!-- Build the TCP server configs in target/ . -->
                                         <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
                                             <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
                                             <property name="node1" value="${node1}"/>
                                             <property name="mcast" value="${mcast}"/>
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
                                             <property name="cacheLoader" value="binary-keyed" />
                                             <property name="cacheType" value="replicated" />
                                             <property name="mode" value="${cacheMode}" />
@@ -151,11 +153,13 @@
                                         <echo>In Maven: node0: ${node0}</echo>
                                         <echo>In Maven: node1: ${node1}</echo>
                                         <echo>In Maven: mcast: ${mcast}</echo>
+                                        <echo>In Maven: mcast.ttl: ${mcast.ttl}</echo>
                                         <!-- Build the additional TCP server configs in target/ . -->
                                         <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
                                             <property name="node0" value="${node0}"/>
                                             <property name="node1" value="${node1}"/>
                                             <property name="mcast" value="${mcast}"/>
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
                                             <target name="build-clustering-extended"/>
                                         </ant>
                                     </target>
@@ -326,9 +330,11 @@
                                 <configuration>
                                     <target>
                                         <echo>In Maven: node0: ${node0}</echo>
+                                        <echo>In Maven: mcast.ttl: ${mcast.ttl}</echo>
                                         <!-- Build the UDP server configs in target/ . -->
                                         <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
                                             <property name="node0" value="${node0}"/> <!-- inheritAll="true" doesn't work. -->
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
                                             <property name="cacheLoader" value="string-keyed" />
                                             <property name="cacheType" value="local" />
                                             <property name="mode" value="${cacheMode}" />                                            
@@ -411,6 +417,7 @@
                                             <property name="mcast-nyc" value="${mcast1}"/>
                                             <property name="mcast-sfo" value="${mcast2}"/>
                                             <property name="mcast-mping" value="${mcast3}"/>
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
                                             <target name="build-clustering-xsite"/>
                                         </ant>
                                     </target>
@@ -491,11 +498,13 @@
                                         <echo>In Maven: node0: ${node0}</echo>
                                         <echo>In Maven: node1: ${node1}</echo>
                                         <echo>In Maven: mcast: ${mcast}</echo>
+                                        <echo>In Maven: mcast.ttl: ${mcast.ttl}</echo>
                                         <!-- Build the TCP server configs in target/ . -->
                                         <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
                                             <property name="node0" value="${node0}" /> <!-- inheritAll="true" doesn't work. -->
                                             <property name="node1" value="${node1}" />
                                             <property name="mcast" value="${mcast}" />
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
                                             <property name="cacheLoader" value="${cacheLoader}" />
                                             <property name="cacheType" value="${cacheType}" />
                                             <property name="mode" value="${mode}" />

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -264,6 +264,7 @@
                         <node0>${node0}</node0>
                         <node1>${node1}</node1>
                         <mcast>${mcast}</mcast>
+                        <mcast.ttl>${mcast.ttl}</mcast.ttl>
 
                         <node2>${node2}</node2>
                         <node3>${node3}</node3>
@@ -278,7 +279,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Dmcast.ttl=${mcast.ttl} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -27,6 +27,7 @@
         <ts.config-as.change-cache-mode name="wildfly-${cacheMode}-${stack}-0"
                                         cacheMode="${cacheMode}"
                 />
+        <ts.config-as.configure-multicast-ttl name="wildfly-${cacheMode}-${stack}-0" mcast.ttl="${mcast.ttl}"/>
 
         <echo message="  =========  Building config clustering-${cacheMode}-${stack}-1  =========  "/>
         <copy todir="target/wildfly-${cacheMode}-${stack}-1" overwrite="true">
@@ -43,6 +44,7 @@
         <ts.config-as.change-cache-mode name="wildfly-${cacheMode}-${stack}-1"
                                         cacheMode="${cacheMode}"
                 />
+        <ts.config-as.configure-multicast-ttl name="wildfly-${cacheMode}-${stack}-1" mcast.ttl="${mcast.ttl}"/>
 
     </target>
 
@@ -88,6 +90,7 @@
                                         mcast="${mcast}"
                 />
         <ts.config-as.add-port-offset name="wildfly-udp-jdbc-store"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-udp-jdbc-store" mcast.ttl="${mcast.ttl}"/>
 
     </target>
 
@@ -129,6 +132,7 @@
                                        cache-type="distributed-cache" cache="dist" backup.site="NYC"/>
         <ts.config-as.add-xsite-backup name="wildfly-xsite-LON-0" container="web"
                                        cache-type="distributed-cache" cache="dist" backup.site="SFO"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-xsite-LON-0" mcast.ttl="${mcast.ttl}"/>
 
         <!-- site LON, node 1, mcast 0 -->
         <echo message="Building config clustering-xsite-LON-1"/>
@@ -149,6 +153,7 @@
                                        cache-type="distributed-cache" cache="dist" backup.site="NYC"/>
         <ts.config-as.add-xsite-backup name="wildfly-xsite-LON-1" container="web"
                                        cache-type="distributed-cache" cache="dist" backup.site="SFO"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-xsite-LON-1" mcast.ttl="${mcast.ttl}"/>
 
         <!-- site NYC, node 2, mcast 1 -->
         <echo message="Building config clustering-xsite-NYC-0"/>
@@ -164,6 +169,7 @@
                                       remote-site.site="LON" remote-site.stack="tcp" remote-site.cluster="bridge"/>
         <ts.config-as.add-xsite-remote-site name="wildfly-xsite-NYC-0" stack="udp"
                                       remote-site.site="SFO" remote-site.stack="tcp" remote-site.cluster="bridge"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-xsite-NYC-0" mcast.ttl="${mcast.ttl}"/>
 
         <!-- site SFO, node 3, mcast 2 -->
         <echo message="Building config clustering-xsite-SFO-0"/>
@@ -179,6 +185,7 @@
                                       remote-site.site="LON" remote-site.stack="tcp" remote-site.cluster="bridge"/>
         <ts.config-as.add-xsite-remote-site name="wildfly-xsite-SFO-0" stack="udp"
                                       remote-site.site="NYC" remote-site.stack="tcp" remote-site.cluster="bridge"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-xsite-SFO-0" mcast.ttl="${mcast.ttl}"/>
 
         <!-- site SFO, node 3, mcast 2 + backupFor -->
         <echo message="Building config clustering-xsite-SFO-0-backupFor"/>
@@ -200,6 +207,7 @@
                                        cache-type="distributed-cache" cache.base="dist" cache.name="LON"/>
         <ts.config-as.add-xsite-backup-for name="wildfly-xsite-SFO-0-backupFor" container="web"
                                        cache-type="distributed-cache" cache="LON" remote-site="LON" remote-cache="dist"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-xsite-SFO-0-backupFor" mcast.ttl="${mcast.ttl}"/>
 
     </target>
 

--- a/testsuite/integration/src/test/scripts/clustering-common-targets.xml
+++ b/testsuite/integration/src/test/scripts/clustering-common-targets.xml
@@ -229,6 +229,25 @@
         </sequential>
     </macrodef>
 
+    <!-- Configure multicast TTL -->
+    <macrodef name="ts.config-as.configure-multicast-ttl" description="Configures TTL for all multicast messages in JGroups subsystem">
+
+        <attribute name="name" default="wildfly"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+
+        <attribute name="mcast.ttl" default="0"/>
+
+        <sequential>
+            <echo message="Configuring TTL for all multicast messages to @{ip_ttl} in JGroups subsystem"/>
+            <execute-xslt-transform transform="changeMulticastTTL.xsl" name="@{name}" output.dir="@{output.dir}" config.dir.name="@{config.dir.name}">
+                <transform-params>
+                    <param name="mcast.ttl" expression="@{mcast.ttl}"/>
+                </transform-params>
+            </execute-xslt-transform>
+        </sequential>
+    </macrodef>
+
     <!--
         Make a copy of a cache in the Infinispan subsystem.
     -->

--- a/testsuite/integration/src/test/xslt/changeModule.xsl
+++ b/testsuite/integration/src/test/xslt/changeModule.xsl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:ml="urn:jboss:module:1.0">
     <xsl:output method="xml" indent="yes"/>
 

--- a/testsuite/integration/src/test/xslt/changeMulticastTTL.xsl
+++ b/testsuite/integration/src/test/xslt/changeMulticastTTL.xsl
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <!--
+      XSLT stylesheet that makes multicast in stacks less chatty by setting or rather reducing TTL of all packets
+      to given value by the 'mcast.ttl' variable.
+
+      It sets TTL for all of:
+      * transports of type UDP
+      * protocols of type MPING
+
+      The resulting configuration will look simiar to:
+
+        <subsystem xmlns="urn:jboss:domain:jgroups:3.0" default-stack="tcp">
+            <stack name="udp">
+                <transport type="UDP" socket-binding="jgroups-udp">
+                    <property name="ip_ttl">0</property>
+                </transport>
+        ...
+    -->
+
+    <xsl:variable name="jgroupsns" select="'urn:jboss:domain:jgroups:'"/>
+
+    <xsl:param name="mcast.ttl" select="'0'"/>
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <!-- Configure for all transport=UDP -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $jgroupsns)]
+                          /*[local-name()='stack']
+                          /*[local-name()='transport' and @type='UDP']">
+        <xsl:copy>
+            <xsl:call-template name="copy-attributes"/>
+            <xsl:call-template name="add-ttl-property"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Configure for all protocol=MPING -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $jgroupsns)]
+                          /*[local-name()='stack']
+                          /*[local-name()='protocol' and @type='MPING']">
+        <xsl:copy>
+            <xsl:call-template name="copy-attributes"/>
+            <xsl:call-template name="add-ttl-property"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Add property ip_ttl -->
+    <xsl:template name="add-ttl-property">
+        <xsl:element name="property" namespace="{namespace-uri()}">
+            <xsl:attribute name="name">
+                <xsl:value-of select="'ip_ttl'"/>
+            </xsl:attribute>
+            <xsl:value-of select="$mcast.ttl"/>
+        </xsl:element>
+    </xsl:template>
+
+    <xsl:template name="copy-attributes">
+        <xsl:for-each select="@*">
+            <xsl:copy/>
+        </xsl:for-each>
+    </xsl:template>
+
+    <!-- Copy everything else -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -96,6 +96,7 @@
         <node0>127.0.0.1</node0>
         <node1>127.0.0.1</node1>
         <mcast>230.0.0.4</mcast> <!-- Default multicast address. -->
+        <mcast.ttl>0</mcast.ttl> <!-- Multicast TTL. -->
 
         <!-- additional IP address defaults for xsite clustering tests -->
         <node2>127.0.0.1</node2>


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-3720

Value can be overridden from command line such as:

```
./integration-tests.sh ... -Dmcast.ttl=8
```
