### PR TITLE
Upgrade to Apache CXF 2.7.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,8 @@
         <version.log4j>1.2.16</version.log4j>
         <version.net.jcip>1.0</version.net.jcip>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
-        <version.org.apache.cxf>2.7.11</version.org.apache.cxf>
-        <version.org.apache.cxf.xjcplugins>2.6.1</version.org.apache.cxf.xjcplugins>
+        <version.org.apache.cxf>2.7.12</version.org.apache.cxf>
+        <version.org.apache.cxf.xjcplugins>2.6.2</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpclient>4.2.6</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpcore>4.2.5</version.org.apache.httpcomponents.httpcore>
@@ -132,9 +132,9 @@
         <version.org.apache.myfaces.core>2.1.8</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.0.2</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.4</version.org.apache.qpid.proton>
-        <version.org.apache.santuario>1.5.6</version.org.apache.santuario>
+        <version.org.apache.santuario>1.5.7</version.org.apache.santuario>
         <version.org.apache.velocity>1.7</version.org.apache.velocity>
-        <version.org.apache.ws.security>1.6.15</version.org.apache.ws.security>
+        <version.org.apache.ws.security>1.6.16</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.0.2</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-1</version.org.apache.xalan>
         <version.org.apache.xerces>2.9.1-jbossas-2</version.org.apache.xerces>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3748

Needed in order to upgrade EAP.

Added related upgrades:
Apache CXF XJCPlugins : https://issues.jboss.org/browse/WFLY-3755
Apache WSS4J: https://issues.jboss.org/browse/WFLY-3752
Apache Santuario : https://issues.jboss.org/browse/WFLY-3753
