### PR TITLE
[WFLY-3751] JGroups UNICAST protocol cannot be used, timeout property ha...

### DIFF
--- a/clustering/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/src/main/resources/jgroups-defaults.xml
@@ -40,7 +40,7 @@
         thread_pool.queue_enabled="true"
         thread_pool.queue_max_size="1000"
         thread_pool.rejection_policy="discard"
-        
+
         oob_thread_pool.enabled="true"
         oob_thread_pool.min_threads="20"
         oob_thread_pool.max_threads="300"
@@ -103,9 +103,7 @@
         xmit_table_num_rows="100"
         xmit_table_msgs_per_row="10000"
         xmit_table_max_compaction_time="10000"/>
-    <UNICAST timeout="300,600,1200,2400,3600"
-        stable_interval="5000"
-        max_bytes="1m"/>
+    <UNICAST/>
     <UNICAST2 stable_interval="5000"
         max_bytes="1m"
         max_msg_batch_size="100"
@@ -118,7 +116,7 @@
     <pbcast.STABLE stability_delay="1000"
         desired_avg_gossip="50000"
         max_bytes="400000"/>
-    <pbcast.GMS print_local_addr="true" 
+    <pbcast.GMS print_local_addr="true"
         join_timeout="3000"
         view_bundling="true"
         view_ack_collection_timeout="5000"

--- a/clustering/jgroups/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/src/main/resources/jgroups-defaults.xml
@@ -90,24 +90,12 @@
     <MPING timeout="3000" num_initial_members="3" ip_ttl="2"/>
     <MERGE2 max_interval="100000" min_interval="20000"/>
     <MERGE3 max_interval="100000" min_interval="20000"/>
-    <FD_SOCK/>
     <FD timeout="6000" max_tries="5"/>
     <FD_ALL timeout="15000" interval="3000"/>
     <VERIFY_SUSPECT timeout="1500"/>
-    <BARRIER/>
-    <pbcast.NAKACK use_mcast_xmit="true"
-        retransmit_timeout="300,600,1200,2400,4800"
-        discard_delivered_msgs="true"/>
     <pbcast.NAKACK2 max_msg_batch_size="100"
         xmit_interval="1000"
         xmit_table_num_rows="100"
-        xmit_table_msgs_per_row="10000"
-        xmit_table_max_compaction_time="10000"/>
-    <UNICAST/>
-    <UNICAST2 stable_interval="5000"
-        max_bytes="1m"
-        max_msg_batch_size="100"
-        xmit_table_num_rows="20"
         xmit_table_msgs_per_row="10000"
         xmit_table_max_compaction_time="10000"/>
     <UNICAST3 xmit_table_num_rows="20"
@@ -125,6 +113,4 @@
     <MFC max_credits="1m" min_threshold="0.40"/>
     <FRAG2 frag_size="30k"/>
     <RSVP timeout="60000" resend_interval="500" ack_on_delivery="false"/>
-    <pbcast.STATE_TRANSFER/>
-    <pbcast.FLUSH timeout="0" start_flush_timeout="10000"/>
 </config>


### PR DESCRIPTION
...s been deprecated and has no effect

https://issues.jboss.org/browse/WFLY-3751
