### PR TITLE
synchronize jboss-modules version as same as in Wildfly Core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <version.org.jboss.marshalling.jboss-marshalling>1.4.6.Final</version.org.jboss.marshalling.jboss-marshalling>
         <version.org.jboss.metadata>8.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.3.0.Final</version.org.jboss.mod_cluster>
-        <version.org.jboss.modules.jboss-modules>1.3.3.Final</version.org.jboss.modules.jboss-modules>
+        <version.org.jboss.modules.jboss-modules>1.3.4.Final</version.org.jboss.modules.jboss-modules>
         <version.org.jboss.msc.jboss-msc>1.2.2.Final</version.org.jboss.msc.jboss-msc>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.1.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.remote-naming>2.0.1.Final</version.org.jboss.remote-naming>


### PR DESCRIPTION
synchronize jboss-modules version as same as in Wildfly Core
previous Wildfly Core PR is https://github.com/wildfly/wildfly-core/pull/73
