### PR TITLE
Remove test target from build script to run the default tests specified in testsuite

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -29,7 +29,7 @@ set CLASSPATH=
 set M2_HOME=
 set MAVEN_HOME=
 set MAVEN_OPTS=%MAVEN_OPTS% -Xmx768M
-powershell "& "tools\download-maven.ps1"
+powershell -noprofile -executionpolicy bypass -file "tools\download-maven.ps1"
 
 REM ******************************************************
 REM - "for" loops have been unrolled for compatibility
@@ -83,14 +83,11 @@ REM ************* Execute Batch file only once ***********
 REM ******************************************************
 
 :ExecuteBatch
-echo Calling %1 %2 %3 %4 %5 %6 %7 %8
 set GOAL=%2
 if "%GOAL%"=="" set GOAL=install
 
-REM run smoke tests by default
-set SMOKE_TESTS=-Dintegration.module -Dsmoke.integration.tests
-
-call %1 %GOAL% %SMOKE_TESTS% %3 %4 %5 %6 %7 %8
+echo Calling %1 %GOAL% %3 %4 %5 %6 %7 %8
+call %1 %GOAL% %3 %4 %5 %6 %7 %8
 
 :end
 

--- a/build.sh
+++ b/build.sh
@@ -156,12 +156,8 @@ main() {
     #  to be in the same directory as build.xml.
     cd $DIRNAME
 
-
-    . testsuite/groupDefs.sh
-
-    #  Add smoke integration test directives before calling maven.
+    #  Add default settings before calling maven.
     MVN_SETTINGS_XML_ARGS="-s tools/maven/conf/settings.xml"
-    TESTS=$SMOKE_TESTS
     MVN_GOAL="";
     ADDIT_PARAMS="";
     #  For each parameter, check for testsuite directives.
@@ -181,8 +177,6 @@ main() {
     done
     #  Default goal if none specified.
     if [ -z "$MVN_GOAL" ]; then MVN_GOAL="install"; fi
-
-    MVN_GOAL="$MVN_GOAL $TESTS"
 
     #  Export some stuff for maven.
     export MVN MAVEN_HOME MVN_OPTS MVN_GOAL

--- a/integration-tests.bat
+++ b/integration-tests.bat
@@ -32,8 +32,7 @@ set CLASSPATH=
 set M2_HOME=
 set MAVEN_HOME=
 set MAVEN_OPTS=%MAVEN_OPTS% -Xmx768M
-
-powershell "& "tools\download-maven.ps1"
+powershell -noprofile -executionpolicy bypass -file "tools\download-maven.ps1"
 
 REM ******************************************************
 REM - "for" loops have been unrolled for compatibility


### PR DESCRIPTION
Remove the arg specifying the smoke testcase to be run within build.sh/build.bat.
This is anyways the default target of the testsuite.
So let's take the testsuite as master of specifying the tests to run by default.

Also changed the calls of the powershell which makes pull request #6620 obsolete.
