### PR TITLE
[8.x] WFLY-3779 IllegalAccessException when a built-in normal-scoped bean defines a package-private no-arg constructor

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
@@ -33,6 +33,8 @@
         <module name="javax.servlet.jstl.api"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.apache.xalan" services="import"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
     </dependencies>
 
     <resources>

--- a/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/hibernate/validator/main/module.xml
@@ -35,6 +35,8 @@
     <module name="javax.xml.bind.api"/>
     <module name="org.glassfish.javax.el"/>
     <module name="org.jboss.logging"/>
+    <module name="org.jboss.weld.core"/>
+    <module name="org.jboss.weld.spi"/>
     <module name="org.joda.time"/>
     <module name="org.jsoup"/>
     <module name="org.slf4j"/>

--- a/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-cdi/main/module.xml
@@ -38,5 +38,7 @@
         <module name="javax.ws.rs.api"/>
         <module name="javax.validation.api"/>
         <module name="org.jboss.resteasy.resteasy-jaxrs"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
     </dependencies>
 </module>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructor.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructor.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.modules.access;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class BuiltInBeanWithPackagePrivateConstructor {
+
+    private final AtomicReference<String> value;
+
+    BuiltInBeanWithPackagePrivateConstructor() {
+        this.value = new AtomicReference<>();
+    }
+
+    public String getValue() {
+        return value.get();
+    }
+
+    public void setValue(String value) {
+        this.value.set(value);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.modules.access;
+
+import static org.jboss.as.test.integration.weld.modules.ModuleUtils.createTestModule;
+import static org.jboss.as.test.integration.weld.modules.ModuleUtils.deleteRecursively;
+import static org.jboss.as.test.integration.weld.modules.ModuleUtils.getModulePath;
+
+import java.io.File;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@Ignore("WFLY-3779")
+public class BuiltInBeanWithPackagePrivateConstructorTest {
+
+    @Inject
+    private InjectedBean injectedBean;
+
+    public static void doSetup() throws Exception {
+        tearDown();
+        createTestModule("module-accessibility", "test-module.xml", BuiltInBeanWithPackagePrivateConstructor.class);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        deleteRecursively(new File(getModulePath(), "test"));
+    }
+
+    @Deployment
+    public static Archive<?> getDeployment() throws Exception {
+        doSetup();
+        return ShrinkWrap.create(WebArchive.class).addClasses(InjectedBean.class, BuiltInBeanWithPackagePrivateConstructorTest.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: test.module-accessibility meta-inf\n"), "MANIFEST.MF");
+
+    }
+
+    @Test
+    public void testBeanInjectable() throws IllegalArgumentException, IllegalAccessException {
+        BuiltInBeanWithPackagePrivateConstructor bean = injectedBean.getBean();
+        bean.setValue("foo");
+        Assert.assertEquals("foo", bean.getValue());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
@@ -38,12 +38,10 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-@Ignore("WFLY-3779")
 public class BuiltInBeanWithPackagePrivateConstructorTest {
 
     @Inject

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/InjectedBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/InjectedBean.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.weld.modules.access;
+
+import javax.inject.Inject;
+
+public class InjectedBean {
+
+    @Inject
+    private BuiltInBeanWithPackagePrivateConstructor bean;
+
+    public BuiltInBeanWithPackagePrivateConstructor getBean() {
+        return bean;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/test-module.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/test-module.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="test.module-accessibility">
+
+    <resources>
+        <resource-root path="module-accessibility.jar"/>
+    </resources>
+
+    <dependencies>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.inject.api"/>
+        <module name="org.jboss.weld.core"/>
+        <module name="org.jboss.weld.spi"/>
+    </dependencies>
+</module>

--- a/weld/src/main/java/org/jboss/as/weld/WeldLogger.java
+++ b/weld/src/main/java/org/jboss/as/weld/WeldLogger.java
@@ -33,6 +33,7 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.modules.ModuleIdentifier;
 import org.jboss.weld.bootstrap.spi.BeanDeploymentArchive;
 
 /**
@@ -136,4 +137,8 @@ public interface WeldLogger extends BasicLogger {
     @LogMessage(level = Logger.Level.DEBUG)
     @Message(value = "Unable to load annotation %s", id = Message.NONE)
     void unableToLoadAnnotation(String annotationClassName);
+
+    @LogMessage(level = Logger.Level.WARN)
+    @Message(value = "Using deployment classloader to load proxy classes for module %s. Package-private access will not work. To fix this the module should declare dependencies on %s", id = 16018)
+    void loadingProxiesUsingDeploymentClassLoader(ModuleIdentifier moduleIdentifier, String dependencies);
 }

--- a/weld/src/main/java/org/jboss/as/weld/services/bootstrap/ProxyServicesImpl.java
+++ b/weld/src/main/java/org/jboss/as/weld/services/bootstrap/ProxyServicesImpl.java
@@ -25,11 +25,19 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.jboss.as.server.moduleservice.ServiceModuleLoader;
+import org.jboss.as.weld.WeldLogger;
+import org.jboss.as.weld.util.Reflections;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleClassLoader;
+import org.jboss.modules.ModuleIdentifier;
+import org.jboss.weld.interceptor.proxy.LifecycleMixin;
 import org.jboss.weld.logging.BeanLogger;
+import org.jboss.weld.serialization.spi.BeanIdentifier;
 import org.jboss.weld.serialization.spi.ProxyServices;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -37,11 +45,24 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * {@link ProxyServices} implementation that delegates to the module class loader if the bean class loader cannot be determined
  *
  * @author Stuart Douglas
+ * @author Jozef Hartinger
  *
  */
 public class ProxyServicesImpl implements ProxyServices {
 
+    private static String[] REQUIRED_WELD_DEPENDENCIES = new String[] {
+        "org.jboss.weld.core",
+        "org.jboss.weld.spi"
+    };
+
+    // these are used to check whether a classloader is capable of loading Weld proxies
+    private static String[] WELD_CLASSES = new String[] {
+        BeanIdentifier.class.getName(),
+        LifecycleMixin.class.getName()
+    };
+
     private final Module module;
+    private final ConcurrentMap<ModuleIdentifier, Boolean> processedStaticModules = new ConcurrentHashMap<>();
 
     public ProxyServicesImpl(Module module) {
         this.module = module;
@@ -74,18 +95,47 @@ public class ProxyServicesImpl implements ProxyServices {
                 //we can use it to load the proxy
                 return proxiedBeanType.getClassLoader();
             } else {
-                //otherwise we use the deployments CL
-                //rather than using a server modules CL
-                return module.getClassLoader();
+                // this class comes from a static module
+                // first, check if we can use its classloader to load proxy classes
+                final Module  definingModule = loader.getModule();
+                Boolean hasWeldDependencies = processedStaticModules.get(definingModule.getIdentifier());
+                boolean logWarning = false; // only log for the first class in the module
+
+                if (hasWeldDependencies == null) {
+                    hasWeldDependencies = canLoadWeldProxies(definingModule); // may be run multiple times but that does not matter
+                    logWarning = processedStaticModules.putIfAbsent(definingModule.getIdentifier(), hasWeldDependencies) == null;
+                }
+                if (hasWeldDependencies) {
+                    // this module declares weld dependencies - we can use module's classloader to load the proxy class
+                    // pros: package-private members will work fine
+                    // cons: proxy classes will remain loaded by the module's classloader after undeployment (nothing else leaks)
+                    return proxiedBeanType.getClassLoader();
+                } else {
+                    // no weld dependencies - we use deployment's classloader to load the proxy class
+                    // pros: proxy classes unloaded with undeployment
+                    // cons: package-private methods and constructors will yield IllegalAccessException
+                    if (logWarning) {
+                        WeldLogger.ROOT_LOGGER.loadingProxiesUsingDeploymentClassLoader(definingModule.getIdentifier(), Arrays.toString(REQUIRED_WELD_DEPENDENCIES));
+                    }
+                    return this.module.getClassLoader();
+                }
             }
         } else {
             return proxiedBeanType.getClassLoader();
         }
     }
 
-    public void cleanup() {
-        // This implementation requires no cleanup
+    private static boolean canLoadWeldProxies(Module module) {
+        for (String weldClass : WELD_CLASSES) {
+            if (!Reflections.isAccessible(weldClass, module.getClassLoader())) {
+                return false;
+            }
+        }
+        return true;
+    }
 
+    public void cleanup() {
+        processedStaticModules.clear();
     }
 
     public Class<?> loadBeanClass(final String className) {


### PR DESCRIPTION
PR for master https://github.com/wildfly/wildfly/pull/6644
