### PR TITLE
[WFLY-2879] - Remove duplicated code from test cases where custom module...

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/SetupModuleServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/SetupModuleServerSetupTask.java
@@ -22,10 +22,9 @@
 
 package org.jboss.as.test.integration.ejb.singleton.dependson.mdb;
 
-import java.io.File;
-
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
 
 /**
@@ -34,15 +33,16 @@ import org.jboss.as.test.shared.ModuleUtils;
  */
 public class SetupModuleServerSetupTask implements ServerSetupTask{
 
+    private TestModule testModule;
+
     @Override
     public void setup(ManagementClient arg0, String arg1) throws Exception {
-        ModuleUtils.createSimpleTestModule(Constants.TEST_MODULE_NAME, CallCounterInterface.class);
+        this.testModule = ModuleUtils.createSimpleTestModule(Constants.TEST_MODULE_NAME, CallCounterInterface.class);
     }
 
     @Override
     public void tearDown(ManagementClient arg0, String arg1) throws Exception {
-        //test is prefix from ModuleUtils.
-        ModuleUtils.deleteRecursively(new File(ModuleUtils.getModulePath(), "test"));
+        this.testModule.remove();
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/SetupModuleServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/mdb/SetupModuleServerSetupTask.java
@@ -24,8 +24,8 @@ package org.jboss.as.test.integration.ejb.singleton.dependson.mdb;
 
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
+import org.jboss.as.test.shared.TempTestModule;
 
 /**
  * @author baranowb
@@ -33,16 +33,19 @@ import org.jboss.as.test.shared.ModuleUtils;
  */
 public class SetupModuleServerSetupTask implements ServerSetupTask{
 
-    private TestModule testModule;
-
+    private volatile TempTestModule testModule;
     @Override
     public void setup(ManagementClient arg0, String arg1) throws Exception {
-        this.testModule = ModuleUtils.createSimpleTestModule(Constants.TEST_MODULE_NAME, CallCounterInterface.class);
+        testModule = ModuleUtils.createTestModuleWithEEDependencies(Constants.TEST_MODULE_NAME);
+        testModule.addResource("module.jar").addClass(CallCounterInterface.class);
+        testModule.create();
     }
 
     @Override
     public void tearDown(ManagementClient arg0, String arg1) throws Exception {
-        this.testModule.remove();
+        if (testModule != null) {
+            testModule.remove();
+        }
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/session/SetupModuleServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/session/SetupModuleServerSetupTask.java
@@ -25,8 +25,8 @@ package org.jboss.as.test.integration.ejb.singleton.dependson.session;
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.ejb.singleton.dependson.mdb.CallCounterInterface;
-import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
+import org.jboss.as.test.shared.TempTestModule;
 
 /**
  * @author baranowb
@@ -34,16 +34,20 @@ import org.jboss.as.test.shared.ModuleUtils;
  */
 public class SetupModuleServerSetupTask implements ServerSetupTask{
 
-    private TestModule testModule;
-
+    private volatile TempTestModule testModule;
     @Override
     public void setup(ManagementClient arg0, String arg1) throws Exception {
-        this.testModule = ModuleUtils.createSimpleTestModule(SessionConstants.TEST_MODULE_NAME, CallCounterInterface.class,Trigger.class);
+        testModule = ModuleUtils.createTestModuleWithEEDependencies(SessionConstants.TEST_MODULE_NAME);
+        testModule.addResource("module.jar").addClasses(CallCounterInterface.class, Trigger.class);
+        testModule.create();
+
     }
+
 
     @Override
     public void tearDown(ManagementClient arg0, String arg1) throws Exception {
-        this.testModule.remove();
+        if (testModule != null) {
+            testModule.remove();
+        }
     }
-
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/session/SetupModuleServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/dependson/session/SetupModuleServerSetupTask.java
@@ -22,11 +22,10 @@
 
 package org.jboss.as.test.integration.ejb.singleton.dependson.session;
 
-import java.io.File;
-
 import org.jboss.as.arquillian.api.ServerSetupTask;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.test.integration.ejb.singleton.dependson.mdb.CallCounterInterface;
+import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
 
 /**
@@ -35,15 +34,16 @@ import org.jboss.as.test.shared.ModuleUtils;
  */
 public class SetupModuleServerSetupTask implements ServerSetupTask{
 
+    private TestModule testModule;
+
     @Override
     public void setup(ManagementClient arg0, String arg1) throws Exception {
-        ModuleUtils.createSimpleTestModule(SessionConstants.TEST_MODULE_NAME, CallCounterInterface.class,Trigger.class);
+        this.testModule = ModuleUtils.createSimpleTestModule(SessionConstants.TEST_MODULE_NAME, CallCounterInterface.class,Trigger.class);
     }
 
     @Override
     public void tearDown(ManagementClient arg0, String arg1) throws Exception {
-        //'test' is prefix from ModuleUtils.
-        ModuleUtils.deleteRecursively(new File(ModuleUtils.getModulePath(), "test"));
+        this.testModule.remove();
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/PortableExtensionInExternalModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/PortableExtensionInExternalModuleTestCase.java
@@ -21,7 +21,8 @@
  */
 package org.jboss.as.test.integration.weld.modules;
 
-import static org.jboss.as.test.shared.ModuleUtils.createTestModule;
+import java.io.File;
+import java.net.URL;
 
 import javax.ejb.EJB;
 import javax.enterprise.inject.spi.BeanManager;
@@ -29,10 +30,12 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.ModuleUtils;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -65,7 +68,7 @@ public class PortableExtensionInExternalModuleTestCase {
     private static final String MANIFEST = "MANIFEST.MF";
 
     private static final String MODULE_NAME = "portable-extension";
-    private static TestModule testModule;
+    private static TempTestModule testModule;
 
     @Inject
     private PortableExtension extension;
@@ -77,8 +80,15 @@ public class PortableExtensionInExternalModuleTestCase {
     private PortableExtensionLookup ejbInjectionTarget;
 
     public static void doSetup() throws Exception {
-        testModule = createTestModule(MODULE_NAME, MODULE_NAME + "-module.xml", PortableExtension.class, PortableExtensionLookup.class,
-                PortableExtensionModuleLookup.class);
+        URL url = PortableExtension.class.getResource(MODULE_NAME + "-module.xml");
+        File moduleXmlFile = new File(url.toURI());
+        testModule = new TempTestModule("test." + MODULE_NAME, moduleXmlFile);
+        testModule.addResource("portable-extension.jar")
+            .addClasses(PortableExtension.class, PortableExtensionLookup.class, PortableExtensionModuleLookup.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        testModule.addClassCallback(ModuleUtils.ENTERPRISE_INJECT);
+        testModule.create();
+
     }
 
     @AfterClass
@@ -102,7 +112,7 @@ public class PortableExtensionInExternalModuleTestCase {
 
         WebArchive webSubdeployment = ShrinkWrap.create(WebArchive.class, "web-subdeployment.war")
                 .addClass(PortableExtensionInExternalModuleTestCase.class)
-                .addClass(TestModule.class)
+                .addClass(TempTestModule.class)
                 .addAsWebInfResource(newBeans11Descriptor("annotated"), "beans.xml");
 
         return ShrinkWrap.create(EnterpriseArchive.class, "test.ear").addAsLibrary(library).addAsModule(ejbSubdeployment)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/PortableExtensionInExternalModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/PortableExtensionInExternalModuleTestCase.java
@@ -22,10 +22,6 @@
 package org.jboss.as.test.integration.weld.modules;
 
 import static org.jboss.as.test.shared.ModuleUtils.createTestModule;
-import static org.jboss.as.test.shared.ModuleUtils.deleteRecursively;
-import static org.jboss.as.test.shared.ModuleUtils.getModulePath;
-
-import java.io.File;
 
 import javax.ejb.EJB;
 import javax.enterprise.inject.spi.BeanManager;
@@ -33,6 +29,7 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.module.util.TestModule;
 import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.Asset;
@@ -68,6 +65,7 @@ public class PortableExtensionInExternalModuleTestCase {
     private static final String MANIFEST = "MANIFEST.MF";
 
     private static final String MODULE_NAME = "portable-extension";
+    private static TestModule testModule;
 
     @Inject
     private PortableExtension extension;
@@ -79,14 +77,13 @@ public class PortableExtensionInExternalModuleTestCase {
     private PortableExtensionLookup ejbInjectionTarget;
 
     public static void doSetup() throws Exception {
-        tearDown();
-        createTestModule(MODULE_NAME, MODULE_NAME + "-module.xml", PortableExtension.class, PortableExtensionLookup.class,
+        testModule = createTestModule(MODULE_NAME, MODULE_NAME + "-module.xml", PortableExtension.class, PortableExtensionLookup.class,
                 PortableExtensionModuleLookup.class);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        deleteRecursively(new File(getModulePath(), "test"));
+        testModule.remove();
     }
 
     @Deployment
@@ -105,6 +102,7 @@ public class PortableExtensionInExternalModuleTestCase {
 
         WebArchive webSubdeployment = ShrinkWrap.create(WebArchive.class, "web-subdeployment.war")
                 .addClass(PortableExtensionInExternalModuleTestCase.class)
+                .addClass(TestModule.class)
                 .addAsWebInfResource(newBeans11Descriptor("annotated"), "beans.xml");
 
         return ShrinkWrap.create(EnterpriseArchive.class, "test.ear").addAsLibrary(library).addAsModule(ejbSubdeployment)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
@@ -21,17 +21,19 @@
  */
 package org.jboss.as.test.integration.weld.modules.access;
 
-import static org.jboss.as.test.shared.ModuleUtils.createTestModule;
+import java.io.File;
+import java.net.URL;
 
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -43,11 +45,19 @@ public class BuiltInBeanWithPackagePrivateConstructorTest {
 
     @Inject
     private InjectedBean injectedBean;
-    private static TestModule testModule;
+    private static TempTestModule testModule;
 
     public static void doSetup() throws Exception {
         tearDown();
-        testModule = createTestModule("module-accessibility", "test-module.xml", BuiltInBeanWithPackagePrivateConstructor.class);
+
+        URL url = BuiltInBeanWithPackagePrivateConstructor.class.getResource("test-module.xml");
+        File moduleXmlFile = new File(url.toURI());
+        testModule = new TempTestModule("test.module-accessibility", moduleXmlFile);
+        JavaArchive jar = testModule.addResource("module-accessibility.jar");
+        jar.addClass(BuiltInBeanWithPackagePrivateConstructor.class);
+        jar.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        testModule.create(true);
+
     }
 
     @AfterClass

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/access/BuiltInBeanWithPackagePrivateConstructorTest.java
@@ -22,15 +22,12 @@
 package org.jboss.as.test.integration.weld.modules.access;
 
 import static org.jboss.as.test.shared.ModuleUtils.createTestModule;
-import static org.jboss.as.test.shared.ModuleUtils.deleteRecursively;
-import static org.jboss.as.test.shared.ModuleUtils.getModulePath;
-
-import java.io.File;
 
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.module.util.TestModule;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -46,15 +43,18 @@ public class BuiltInBeanWithPackagePrivateConstructorTest {
 
     @Inject
     private InjectedBean injectedBean;
+    private static TestModule testModule;
 
     public static void doSetup() throws Exception {
         tearDown();
-        createTestModule("module-accessibility", "test-module.xml", BuiltInBeanWithPackagePrivateConstructor.class);
+        testModule = createTestModule("module-accessibility", "test-module.xml", BuiltInBeanWithPackagePrivateConstructor.class);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        deleteRecursively(new File(getModulePath(), "test"));
+        if (testModule != null) {
+            testModule.remove();
+        }
     }
 
     @Deployment

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityEarTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityEarTest.java
@@ -21,15 +21,11 @@
  */
 package org.jboss.as.test.integration.weld.modules.deployment;
 
-import static org.jboss.as.test.shared.ModuleUtils.deleteRecursively;
-import static org.jboss.as.test.shared.ModuleUtils.getModulePath;
-
-import java.io.File;
-
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -54,22 +50,22 @@ import org.junit.runner.RunWith;
 public class StaticModuleToDeploymentVisibilityEarTest {
 
     private static final String MODULE_NAME = "weld-modules-deployment-ear";
+    private static TestModule testModule;
 
     public static void doSetup() throws Exception {
-        tearDown();
-        ModuleUtils.createSimpleTestModule(MODULE_NAME, ModuleBean.class, Foo.class);
+        testModule = ModuleUtils.createSimpleTestModule(MODULE_NAME, ModuleBean.class, Foo.class);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        deleteRecursively(new File(getModulePath(), "test"));
+        testModule.remove();
     }
 
     @Deployment
     public static Archive<?> getDeployment() throws Exception {
         doSetup();
         WebArchive war1 = ShrinkWrap.create(WebArchive.class)
-                .addClasses(StaticModuleToDeploymentVisibilityEarTest.class, FooImpl1.class)
+                .addClasses(StaticModuleToDeploymentVisibilityEarTest.class, FooImpl1.class, TestModule.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         WebArchive war2 = ShrinkWrap.create(WebArchive.class)
                 .addClasses(FooImpl2.class)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityEarTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityEarTest.java
@@ -25,8 +25,8 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -50,10 +50,14 @@ import org.junit.runner.RunWith;
 public class StaticModuleToDeploymentVisibilityEarTest {
 
     private static final String MODULE_NAME = "weld-modules-deployment-ear";
-    private static TestModule testModule;
+    private static TempTestModule testModule;
 
     public static void doSetup() throws Exception {
-        testModule = ModuleUtils.createSimpleTestModule(MODULE_NAME, ModuleBean.class, Foo.class);
+        testModule = ModuleUtils.createTestModuleWithEEDependencies(MODULE_NAME);
+        testModule.addResource("test-module.jar")
+            .addClasses(ModuleBean.class, Foo.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        testModule.create();
     }
 
     @AfterClass
@@ -65,7 +69,7 @@ public class StaticModuleToDeploymentVisibilityEarTest {
     public static Archive<?> getDeployment() throws Exception {
         doSetup();
         WebArchive war1 = ShrinkWrap.create(WebArchive.class)
-                .addClasses(StaticModuleToDeploymentVisibilityEarTest.class, FooImpl1.class, TestModule.class)
+                .addClasses(StaticModuleToDeploymentVisibilityEarTest.class, FooImpl1.class, TempTestModule.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
         WebArchive war2 = ShrinkWrap.create(WebArchive.class)
                 .addClasses(FooImpl2.class)

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityWarTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityWarTest.java
@@ -25,8 +25,8 @@ import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -47,10 +47,15 @@ import org.junit.runner.RunWith;
 public class StaticModuleToDeploymentVisibilityWarTest {
 
     private static final String MODULE_NAME = "weld-modules-deployment-war";
-    private static TestModule testModule;
+    private static TempTestModule testModule;
 
     public static void doSetup() throws Exception {
-        testModule = ModuleUtils.createSimpleTestModule(MODULE_NAME, ModuleBean.class, Foo.class);
+        testModule = ModuleUtils.createTestModuleWithEEDependencies(MODULE_NAME);
+        testModule.addResource("test-module.jar")
+            .addClasses(ModuleBean.class, Foo.class)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        testModule.create();
+
     }
 
     @AfterClass
@@ -62,7 +67,7 @@ public class StaticModuleToDeploymentVisibilityWarTest {
     public static Archive<?> getDeployment() throws Exception {
         doSetup();
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(StaticModuleToDeploymentVisibilityWarTest.class, FooImpl1.class, TestModule.class)
+                .addClasses(StaticModuleToDeploymentVisibilityWarTest.class, FooImpl1.class, TempTestModule.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(new StringAsset("Dependencies: test." + MODULE_NAME + " meta-inf\n"), "MANIFEST.MF");
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityWarTest.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/modules/deployment/StaticModuleToDeploymentVisibilityWarTest.java
@@ -21,15 +21,11 @@
  */
 package org.jboss.as.test.integration.weld.modules.deployment;
 
-import static org.jboss.as.test.shared.ModuleUtils.deleteRecursively;
-import static org.jboss.as.test.shared.ModuleUtils.getModulePath;
-
-import java.io.File;
-
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.module.util.TestModule;
 import org.jboss.as.test.shared.ModuleUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -51,22 +47,22 @@ import org.junit.runner.RunWith;
 public class StaticModuleToDeploymentVisibilityWarTest {
 
     private static final String MODULE_NAME = "weld-modules-deployment-war";
+    private static TestModule testModule;
 
     public static void doSetup() throws Exception {
-        tearDown();
-        ModuleUtils.createSimpleTestModule(MODULE_NAME, ModuleBean.class, Foo.class);
+        testModule = ModuleUtils.createSimpleTestModule(MODULE_NAME, ModuleBean.class, Foo.class);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        deleteRecursively(new File(getModulePath(), "test"));
+        testModule.remove();
     }
 
     @Deployment
     public static Archive<?> getDeployment() throws Exception {
         doSetup();
         return ShrinkWrap.create(WebArchive.class)
-                .addClasses(StaticModuleToDeploymentVisibilityWarTest.class, FooImpl1.class)
+                .addClasses(StaticModuleToDeploymentVisibilityWarTest.class, FooImpl1.class, TestModule.class)
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsManifestResource(new StringAsset("Dependencies: test." + MODULE_NAME + " meta-inf\n"), "MANIFEST.MF");
     }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/vault/CustomVaultInModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/vault/CustomVaultInModuleTestCase.java
@@ -42,7 +42,7 @@ import org.jboss.as.test.manualmode.vault.module.TestVaultParser;
 import org.jboss.as.test.manualmode.vault.module.TestVaultRemoveHandler;
 import org.jboss.as.test.manualmode.vault.module.TestVaultResolveExpressionHandler;
 import org.jboss.as.test.manualmode.vault.module.TestVaultSubsystemResourceDescription;
-import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.dmr.ModelNode;
@@ -73,7 +73,7 @@ public class CustomVaultInModuleTestCase {
     @ArquillianResource
     private static ContainerController containerController;
 
-    private TestModule testModule;
+    private TempTestModule testModule;
 
     @Test
     public void testCustomVault() throws Exception {
@@ -128,7 +128,7 @@ public class CustomVaultInModuleTestCase {
 
     private void createTestModule() throws Exception {
         File moduleXml = new File(CustomSecurityVault.class.getResource(CustomVaultInModuleTestCase.class.getSimpleName() + "-module.xml").toURI());
-        testModule = new TestModule(MODULE_NAME, moduleXml);
+        testModule = new TempTestModule(MODULE_NAME, moduleXml);
 
         JavaArchive archive = testModule.addResource("test-custom-vault-in-module.jar")
         	.addClass(CustomSecurityVault.class)

--- a/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/idm/CustomCredentialHandlerTestCase.java
+++ b/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/idm/CustomCredentialHandlerTestCase.java
@@ -22,6 +22,19 @@
 
 package org.wildfly.test.integration.security.picketlink.idm;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.junit.Assert.assertEquals;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.COMMON_CLASS_NAME;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.COMMON_MODULE;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.IDENTITY_STORE_CREDENTIAL_HANDLER;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE_DATASOURCE;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.annotation.Resource;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -29,7 +42,7 @@ import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -57,19 +70,6 @@ import org.wildfly.test.integration.security.picketlink.idm.entities.Relationshi
 import org.wildfly.test.integration.security.picketlink.idm.entities.RoleTypeEntity;
 import org.wildfly.test.integration.security.picketlink.idm.util.AbstractIdentityManagementServerSetupTask;
 
-import javax.annotation.Resource;
-
-import java.io.File;
-import java.io.IOException;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.junit.Assert.assertEquals;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.COMMON_CLASS_NAME;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.COMMON_MODULE;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.IDENTITY_STORE_CREDENTIAL_HANDLER;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE_DATASOURCE;
-
 /**
  * @author Pedro Igor
  */
@@ -87,7 +87,7 @@ public class CustomCredentialHandlerTestCase extends AbstractBasicIdentityManage
                    .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
                    .addAsManifestResource(new StringAsset("Dependencies: org.picketlink.idm.api meta-inf,test.picketlink-emf-module-test meta-inf,org.jboss.dmr meta-inf,org.jboss.as.controller meta-inf\n"), "MANIFEST.MF")
                    .addClass(CustomCredentialHandlerTestCase.class)
-                   .addClass(TestModule.class)
+                   .addClass(TempTestModule.class)
                    .addClass(AbstractIdentityManagementServerSetupTask.class)
                    .addClass(AbstractBasicIdentityManagementTestCase.class);
     }
@@ -120,7 +120,7 @@ public class CustomCredentialHandlerTestCase extends AbstractBasicIdentityManage
 
     static class IdentityManagementServerSetupTask extends AbstractIdentityManagementServerSetupTask {
 
-        private TestModule module;
+        private TempTestModule module;
 
         public IdentityManagementServerSetupTask() {
             super("jpa.ds.idm", PARTITION_MANAGER_JNDI_NAME);
@@ -176,12 +176,12 @@ public class CustomCredentialHandlerTestCase extends AbstractBasicIdentityManage
         }
 
 
-        private TestModule createModule() throws IOException {
+        private TempTestModule createModule() throws IOException {
             File moduleXml = new File(JPAEMFFromModuleBasedPartitionManagerTestCase.class
                 .getResource(JPAEMFFromModuleBasedPartitionManagerTestCase.class
                     .getSimpleName() + "-module.xml").getFile());
 
-            TestModule module = new TestModule("test.picketlink-emf-module-test", moduleXml);
+            TempTestModule module = new TempTestModule("test.picketlink-emf-module-test", moduleXml);
 
             module.addResource("picketlink-emf-module-test.jar")
                 .addClass(CustomCredential.class)

--- a/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/idm/JPAEMFFromModuleBasedPartitionManagerTestCase.java
+++ b/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/idm/JPAEMFFromModuleBasedPartitionManagerTestCase.java
@@ -22,13 +22,23 @@
 
 package org.wildfly.test.integration.security.picketlink.idm;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE_ENTITY_MODULE;
+import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE_ENTITY_MODULE_UNIT_NAME;
+
+import java.io.File;
+import java.io.IOException;
+
+import javax.annotation.Resource;
+
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.arquillian.api.ServerSetup;
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.test.module.util.TestModule;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
@@ -51,16 +61,6 @@ import org.wildfly.test.integration.security.picketlink.idm.entities.Relationshi
 import org.wildfly.test.integration.security.picketlink.idm.entities.RoleTypeEntity;
 import org.wildfly.test.integration.security.picketlink.idm.util.AbstractIdentityManagementServerSetupTask;
 
-import javax.annotation.Resource;
-
-import java.io.File;
-import java.io.IOException;
-
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE_ENTITY_MODULE;
-import static org.wildfly.extension.picketlink.common.model.ModelElement.JPA_STORE_ENTITY_MODULE_UNIT_NAME;
-
 /**
  * @author Pedro Igor
  */
@@ -78,7 +78,7 @@ public class JPAEMFFromModuleBasedPartitionManagerTestCase extends AbstractBasic
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
             .addAsManifestResource(new StringAsset("Dependencies: org.picketlink.idm.api meta-inf,org.jboss.dmr meta-inf,org.jboss.as.controller\n"), "MANIFEST.MF")
             .addClass(JPAEMFFromModuleBasedPartitionManagerTestCase.class)
-            .addClass(TestModule.class)
+            .addClass(TempTestModule.class)
             .addClass(AbstractBasicIdentityManagementTestCase.class)
             .addClass(AbstractIdentityManagementServerSetupTask.class);
     }
@@ -93,18 +93,18 @@ public class JPAEMFFromModuleBasedPartitionManagerTestCase extends AbstractBasic
 
     static class IdentityManagementServerSetupTask extends AbstractIdentityManagementServerSetupTask {
 
-        private TestModule module;
+        private TempTestModule module;
 
         public IdentityManagementServerSetupTask() {
             super("jpa.emf.idm", PARTITION_MANAGER_JNDI_NAME);
         }
 
-        private TestModule createModule() throws IOException {
+        private TempTestModule createModule() throws IOException {
             File moduleXml = new File(JPAEMFFromModuleBasedPartitionManagerTestCase.class
                 .getResource(JPAEMFFromModuleBasedPartitionManagerTestCase.class
                     .getSimpleName() + "-module.xml").getFile());
 
-            TestModule module = new TestModule("test.picketlink-emf-module-test", moduleXml);
+            TempTestModule module = new TempTestModule("test.picketlink-emf-module-test", moduleXml);
 
             module.addResource("picketlink-emf-module-test.jar")
                 .addClass(AbstractCredentialTypeEntity.class)

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/external/ExternalTagLibTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/taglib/external/ExternalTagLibTestCase.java
@@ -21,8 +21,8 @@
  */
 package org.jboss.as.test.integration.web.jsp.taglib.external;
 
-import java.io.File;
 import java.net.URL;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -33,6 +33,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.shared.ModuleUtils;
+import org.jboss.as.test.shared.TempTestModule;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
@@ -48,18 +49,18 @@ import org.junit.runner.RunWith;
 public class ExternalTagLibTestCase {
 
     private static final String MODULE_NAME = "external-tag-lib";
-
+    private static TempTestModule testModule;
     public static void doSetup() throws Exception {
-        tearDown();
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class);
+        testModule = ModuleUtils.createTestModuleWithEEDependencies(MODULE_NAME);
+        JavaArchive jar = testModule.addResource("module.jar");
         jar.addClass(ExternalTag.class);
         jar.addAsManifestResource(ExternalTagLibTestCase.class.getPackage(), "external.tld", "external.tld");
-        ModuleUtils.createSimpleTestModule(MODULE_NAME, jar);
+        testModule.create(true);
     }
 
     @AfterClass
     public static void tearDown() throws Exception {
-        ModuleUtils.deleteRecursively(new File(ModuleUtils.getModulePath(), "test"));
+        testModule.remove();
     }
 
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModuleUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/ModuleUtils.java
@@ -22,7 +22,6 @@
 package org.jboss.as.test.shared;
 
 import java.io.BufferedOutputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -34,80 +33,46 @@ import java.util.List;
 
 import javax.enterprise.inject.spi.Extension;
 
-import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexWriter;
-import org.jboss.jandex.Indexer;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.as.test.module.util.TestModule;
 import org.jboss.shrinkwrap.api.asset.Asset;
-import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.xnio.IoUtils;
 
 public class ModuleUtils {
 
-    public static void createSimpleTestModule(String moduleName, Class<?>... classes) throws IOException {
-        createTestModule(moduleName, createSimpleModuleDescriptor(moduleName).openStream(), classes);
+    public static TestModule createSimpleTestModule(String moduleName, Class<?>... classes) throws IOException {
+        return createTestModule(moduleName, createSimpleModuleDescriptor(moduleName).openStream(), classes);
     }
 
-    public static void createSimpleTestModule(String moduleName, JavaArchive jar) throws IOException {
-        createTestModule(moduleName, createSimpleModuleDescriptor(moduleName).openStream(), jar);
-    }
-
-    public static void createTestModule(String moduleName, String moduleXml, Class<?>... classes) throws IOException {
+    public static TestModule createTestModule(String moduleName, String moduleXml, Class<?>... classes) throws IOException {
         URL url = classes[0].getResource(moduleXml);
+
         if (url == null) {
             throw new IllegalStateException("Could not find module.xml: " + moduleXml);
         }
-        createTestModule(moduleName, url.openStream(), classes);
+
+        return createTestModule(moduleName, url.openStream(), classes);
     }
 
-    private static void createTestModule(String moduleName, InputStream moduleXml, Class<?>... classes) throws IOException {
+    private static TestModule createTestModule(String moduleName, InputStream moduleXml, Class<?>... classes) throws IOException {
+        File tempFile = File.createTempFile("test_module_tmp", ".tmp");
 
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, moduleName + ".jar");
-        jar.addClasses(classes);
-        jar.addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
-        addExtensionsIfAvailable(jar, classes);
+        copyFile(tempFile, moduleXml);
 
-        Indexer indexer = new Indexer();
-        for (Class<?> clazz : classes) {
-            try (final InputStream resource = clazz.getResourceAsStream(clazz.getSimpleName() + ".class")) {
-                indexer.index(resource);
-            }
-        }
+        TestModule testModule = new TestModule("test." + moduleName, tempFile);
+        JavaArchive moduleJar = testModule
+            .addResource(moduleName + ".jar")
+            .addClasses(classes)
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
 
-        Index index = indexer.complete();
-        ByteArrayOutputStream data = new ByteArrayOutputStream();
-        IndexWriter writer = new IndexWriter(data);
-        writer.write(index);
-        jar.addAsManifestResource(new ByteArrayAsset(data.toByteArray()), "jandex.idx");
-        createTestModule(moduleName, moduleXml, jar);
-
-    }
+        addExtensionsIfAvailable(moduleJar, classes);
 
 
-    private static void createTestModule(String moduleName, InputStream moduleXml, JavaArchive jar) throws IOException {
-        File testModuleRoot = new File(getModulePath(), "test" + File.separatorChar + moduleName);
-        if (testModuleRoot.exists()) {
-            throw new IllegalArgumentException(testModuleRoot + " already exists");
-        }
-        File file = new File(testModuleRoot, "main");
-        if (!file.mkdirs()) {
-            throw new IllegalArgumentException("Could not create " + file);
-        }
+        testModule.create();
 
-        copyFile(new File(file, "module.xml"), moduleXml);
-
-        FileOutputStream jarFile = new FileOutputStream(new File(file, moduleName + ".jar"));
-        try {
-            jar.as(ZipExporter.class).exportTo(jarFile);
-        } finally {
-            jarFile.flush();
-            jarFile.close();
-        }
-
+        return testModule;
     }
 
     private static void copyFile(File target, InputStream src) throws IOException {
@@ -120,38 +85,6 @@ public class ModuleUtils {
             }
         } finally {
             IoUtils.safeClose(out);
-        }
-    }
-
-    public static File getModulePath() {
-        String modulePath = System.getProperty("module.path", null);
-        if (modulePath == null) {
-            String jbossHome = System.getProperty("jboss.home", null);
-            if (jbossHome == null) {
-                throw new IllegalStateException("Neither -Dmodule.path nor -Djboss.home were set");
-            }
-            modulePath = jbossHome + File.separatorChar + "modules";
-        } else {
-            modulePath = modulePath.split(File.pathSeparator)[0];
-        }
-        File moduleDir = new File(modulePath);
-        if (!moduleDir.exists()) {
-            throw new IllegalStateException("Determined module path does not exist");
-        }
-        if (!moduleDir.isDirectory()) {
-            throw new IllegalStateException("Determined module path is not a dir");
-        }
-        return moduleDir;
-    }
-
-    public static void deleteRecursively(File file) {
-        if (file.exists()) {
-            if (file.isDirectory()) {
-                for (String name : file.list()) {
-                    deleteRecursively(new File(file, name));
-                }
-            }
-            file.delete();
         }
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/TempTestModule.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/TempTestModule.java
@@ -1,0 +1,307 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.shared;
+
+import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ *
+ * REMOVE THIS CLASS ONCE wildfly-core 1.0.0.Alpha6 IS OUT!!!!!!! See https://issues.jboss.org/browse/WFLY-3807 for details.
+ * If any changes are needed to this class, be sure to update the wildfly-core org.jboss.as.test.module.util.TestModule class as well.
+ *
+ * <p>Utility class with some convenience methods to create and remove modules.</p>
+ *
+ * @author Pedro Igor
+ */
+public class TempTestModule {
+
+    private final String moduleName;
+    private final File moduleXml;
+    private final String[] dependencies;
+    private final List<ClassCallback> classCallbacks = new ArrayList<TempTestModule.ClassCallback>();
+    private final List<JavaArchive> resources = new ArrayList<JavaArchive>();
+
+
+    /**
+     * <p>Creates a new module with the given name and module definition.</p>
+     *
+     * @param moduleName The name of the module.
+     * @param moduleXml The module definition file.
+     */
+    public TempTestModule(String moduleName, File moduleXml) {
+        if (!moduleXml.exists()) {
+            throw new IllegalArgumentException("The module definition must exists.");
+        }
+
+        this.moduleName = moduleName;
+        this.moduleXml = moduleXml;
+        this.dependencies = null;
+    }
+
+    /**
+     * <p>Creates a new module with the given name and module dependencies. The module.xml will be generated</p>
+     *
+     * @param moduleName The name of the module.
+     * @param moduleXml The module definition file.
+     */
+    public TempTestModule(String moduleName, String...dependencies) {
+        this.moduleName = moduleName;
+        this.moduleXml = null;
+        this.dependencies = dependencies;
+    }
+
+    /**
+     * <p>Creates the module directory. If the module already exists, it will deleted first.</p>
+     *
+     * @throws java.io.IOException If any error occurs during the module creation.
+     */
+    public void create() throws IOException {
+        create(true);
+    }
+
+
+    /**
+     * Add a callback to handle classes being added
+     *
+     * @param callback the call back to add
+     * @return this
+     */
+    public TempTestModule addClassCallback(ClassCallback callback) {
+        classCallbacks.add(callback);
+        return this;
+    }
+
+    /**
+     * <p>Creates the module directory.</p>
+     *
+     * @param deleteFirst If the module already exists, this argument specifies if it should be deleted before continuing.
+     *
+     * @throws java.io.IOException
+     */
+    public void create(boolean deleteFirst) throws IOException {
+        File moduleDirectory = getModuleDirectory();
+
+        if (moduleDirectory.exists()) {
+            if (!deleteFirst) {
+                throw new IllegalArgumentException(moduleDirectory + " already exists.");
+            }
+
+            remove();
+        }
+
+        File mainDirectory = new File(moduleDirectory, "main");
+
+        if (!mainDirectory.mkdirs()) {
+            throw new IllegalArgumentException("Could not create " + mainDirectory);
+        }
+
+        try {
+            if (moduleXml != null) {
+                copyFile(new File(mainDirectory, "module.xml"), new FileInputStream(this.moduleXml));
+            } else {
+                generateModuleXml(mainDirectory);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Could not create module definition.", e);
+        }
+
+        for (JavaArchive resourceRoot : this.resources) {
+
+            FileOutputStream jarFile = null;
+
+            try {
+                Indexer indexer = new Indexer();
+
+                List<Class<?>> classes = new ArrayList<Class<?>>();
+                for (Node content : resourceRoot.getContent().values()) {
+                    final String path = content.getPath().get();
+                    if (path.endsWith(".class")) {
+                        indexer.index(content.getAsset().openStream());
+                        if (classCallbacks.size() > 0) {
+                            //TODO load class
+                            String usePath = path.startsWith("/") ? path.substring(1, path.length() - 6) : path.substring(0, path.length() - 6);
+                            usePath = usePath.replaceAll("/", ".");
+                            Class<?> clazz = Class.forName(usePath);
+                            classes.add(clazz);
+                        }
+                    }
+                }
+                for (ClassCallback callback : classCallbacks) {
+                    callback.classesAdded(resourceRoot, classes);
+                }
+                Index index = indexer.complete();
+                ByteArrayOutputStream data = new ByteArrayOutputStream();
+                IndexWriter writer = new IndexWriter(data);
+
+                writer.write(index);
+
+                resourceRoot.addAsManifestResource(new ByteArrayAsset(data.toByteArray()), "jandex.idx");
+
+                jarFile = new FileOutputStream(new File(mainDirectory, resourceRoot.getName()));
+                resourceRoot.as(ZipExporter.class).exportTo(jarFile);
+            } catch (Exception e) {
+                throw new RuntimeException("Could not create module resource [" + resourceRoot.getName() + ".", e);
+            } finally {
+                if (jarFile != null) {
+                    jarFile.flush();
+                    jarFile.close();
+                }
+            }
+        }
+    }
+
+    /**
+     * <p>Removes the module from the modules directory. This operation can not be reverted.</p>
+     */
+    public void remove() {
+        remove(getModuleDirectory());
+    }
+
+    /**
+     * <p>Creates a {@link org.jboss.shrinkwrap.api.spec.JavaArchive} instance that will be used to create a jar file inside the
+     * module's directory.</p>
+     *
+     * <p>The name of the archive must match one of the <code>resource-root</code> definitions defined in the module
+     * definition.</p>
+     *
+     * @param fileName The name of the archive.
+     *
+     * @return
+     */
+    public JavaArchive addResource(String fileName) {
+        JavaArchive resource = ShrinkWrap.create(JavaArchive.class, fileName);
+        if (resources.size() == 0) {
+            //Add the test module to the first jar in the module to avoid having to do that from the tests
+            resource.addClass(TempTestModule.class);
+        }
+        resources.add(resource);
+        return resource;
+    }
+
+    private void remove(File file) {
+        if (file.exists()) {
+            if (file.isDirectory()) {
+                for (String name : file.list()) {
+                    remove(new File(file, name));
+                }
+            }
+
+            if (!file.delete()) {
+                throw new RuntimeException("Could not delete [" + file.getPath() + ".");
+            }
+        } else {
+            throw new IllegalStateException("Module [" + this.moduleName + "] does not exists.");
+        }
+    }
+
+    private File getModuleDirectory() {
+        return new File(getModulesDirectory(), this.moduleName.replace('.', File.separatorChar));
+    }
+
+    private File getModulesDirectory() {
+        String modulePath = System.getProperty("module.path", null);
+
+        if (modulePath == null) {
+            String jbossHome = System.getProperty("jboss.home", null);
+
+            if (jbossHome == null) {
+                throw new IllegalStateException("Neither -Dmodule.path nor -Djboss.home were set");
+            }
+
+            modulePath = jbossHome + File.separatorChar + "modules";
+        } else {
+            modulePath = modulePath.split(File.pathSeparator)[0];
+        }
+
+        File moduleDir = new File(modulePath);
+
+        if (!moduleDir.exists()) {
+            throw new IllegalStateException("Determined module path does not exist");
+        }
+
+        if (!moduleDir.isDirectory()) {
+            throw new IllegalStateException("Determined module path is not a dir");
+        }
+
+        return moduleDir;
+    }
+
+    private static void copyFile(File target, InputStream src) throws IOException {
+        final BufferedOutputStream out = new BufferedOutputStream(new FileOutputStream(target));
+        try {
+            int i = src.read();
+            while (i != -1) {
+                out.write(i);
+                i = src.read();
+            }
+        } finally {
+            out.close();
+        }
+    }
+
+    public String getName() {
+        return moduleName;
+    }
+
+    private void generateModuleXml(File mainDirectory) throws IOException {
+        BufferedWriter writer = new BufferedWriter(new FileWriter(new File(mainDirectory, "module.xml")));
+        try {
+            writer.write("<module xmlns=\"urn:jboss:module:1.1\" name=\"" + moduleName + "\">");
+            writer.write("<resources>");
+            for (JavaArchive jar : resources) {
+                writer.write("<resource-root path=\"" + jar.getName() + "\"/>");
+            }
+            writer.write("</resources>");
+            writer.write("<dependencies>");
+            for (String dependency : dependencies) {
+                writer.write("<module name=\"" + dependency + "\"/>");
+            }
+            writer.write("</dependencies>");
+            writer.write("</module>");
+        } finally {
+            writer.close();
+        }
+    }
+
+    public interface ClassCallback {
+        void classesAdded(JavaArchive jar, final List<Class<?>> classes);
+    }
+}


### PR DESCRIPTION
...s are needed.

This was originally https://github.com/wildfly/wildfly/pull/6577 but it appears that got closed rather than merged. I noticed this when doing https://github.com/jbossas/jboss-eap/pull/1629 which then showed that this work was not part of upstream.

The TempTestModule class needs to be removed once wildfly/wildfly-core#151 has been released, and updated to use TestModule from wildfly-core. https://issues.jboss.org/browse/WFLY-3807 is there to make sure this does not get forgotten.
