### PR TITLE
Fix ClusteredSingleSignOnTestCase failure with Undertow 1.1.0.Beta7.

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOn.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOn.java
@@ -24,7 +24,9 @@ package org.wildfly.clustering.web.undertow.sso;
 import io.undertow.security.api.AuthenticatedSessionManager.AuthenticatedSession;
 import io.undertow.security.idm.Account;
 import io.undertow.security.impl.SingleSignOn;
+import io.undertow.server.HttpServerExchange;
 import io.undertow.server.session.Session;
+import io.undertow.server.session.SessionConfig;
 import io.undertow.server.session.SessionManager;
 
 import java.util.ArrayList;
@@ -79,7 +81,7 @@ public class DistributableSingleSignOn implements SingleSignOn {
                 if (sessionId != null) {
                     Session session = manager.getSession(sessions.getSession(deployment));
                     if (session != null) {
-                        result.add(session);
+                        result.add(new InvalidatableSession(session));
                     }
                 }
             }
@@ -111,5 +113,114 @@ public class DistributableSingleSignOn implements SingleSignOn {
     @Override
     public void close() {
         this.batch.close();
+    }
+
+    private static class InvalidatableSession implements Session {
+        private final Session session;
+
+        InvalidatableSession(Session session) {
+            this.session = session;
+        }
+
+        @Override
+        public void invalidate(HttpServerExchange exchange) {
+            Session session = this.session.getSessionManager().getSession(exchange, new SimpleSessionConfig(this.session.getId()));
+            if (session != null) {
+                session.invalidate(exchange);
+            }
+        }
+
+        @Override
+        public String changeSessionId(HttpServerExchange exchange, SessionConfig config) {
+            return this.session.changeSessionId(exchange, config);
+        }
+
+        @Override
+        public Object getAttribute(String name) {
+            return this.session.getAttribute(name);
+        }
+
+        @Override
+        public Set<String> getAttributeNames() {
+            return this.session.getAttributeNames();
+        }
+
+        @Override
+        public long getCreationTime() {
+            return this.session.getCreationTime();
+        }
+
+        @Override
+        public String getId() {
+            return this.session.getId();
+        }
+
+        @Override
+        public long getLastAccessedTime() {
+            return this.session.getLastAccessedTime();
+        }
+
+        @Override
+        public int getMaxInactiveInterval() {
+            return this.session.getMaxInactiveInterval();
+        }
+
+        @Override
+        public SessionManager getSessionManager() {
+            return this.session.getSessionManager();
+        }
+
+        @Override
+        public Object removeAttribute(String name) {
+            return this.session.removeAttribute(name);
+        }
+
+        @Override
+        public void requestDone(HttpServerExchange exchange) {
+            this.session.requestDone(exchange);
+        }
+
+        @Override
+        public Object setAttribute(String name, Object value) {
+            return this.session.setAttribute(name, value);
+        }
+
+        @Override
+        public void setMaxInactiveInterval(int interval) {
+            this.session.setMaxInactiveInterval(interval);
+        }
+    }
+
+    private static class SimpleSessionConfig implements SessionConfig {
+        private final String id;
+
+        SimpleSessionConfig(String id) {
+            this.id = id;
+        }
+
+        @Override
+        public String findSessionId(HttpServerExchange exchange) {
+            return this.id;
+        }
+
+        @Override
+        public void setSessionId(HttpServerExchange exchange, String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void clearSession(HttpServerExchange exchange, String sessionId) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SessionCookieSource sessionCookieSource(HttpServerExchange exchange) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String rewriteUrl(String originalUrl, String sessionId) {
+            throw new UnsupportedOperationException();
+        }
     }
 }

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOnTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOnTestCase.java
@@ -26,7 +26,9 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 import io.undertow.security.api.AuthenticatedSessionManager.AuthenticatedSession;
 import io.undertow.security.idm.Account;
+import io.undertow.server.HttpServerExchange;
 import io.undertow.server.session.Session;
+import io.undertow.server.session.SessionConfig;
 import io.undertow.server.session.SessionManager;
 
 import java.util.Collections;
@@ -35,6 +37,7 @@ import java.util.Iterator;
 import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Test;
+import org.mockito.Matchers;
 import org.wildfly.clustering.ee.Batch;
 import org.wildfly.clustering.web.sso.SSO;
 import org.wildfly.clustering.web.sso.Sessions;
@@ -106,14 +109,27 @@ public class DistributableSingleSignOnTestCase {
         when(sessions.getSession(deployment)).thenReturn(sessionId);
         when(this.registry.getSessionManager(deployment)).thenReturn(manager);
         when(manager.getSession(sessionId)).thenReturn(session);
+        when(session.getId()).thenReturn(sessionId);
 
-        Iterator<Session> result = this.subject.iterator();
+        Iterator<Session> results = this.subject.iterator();
 
-        assertTrue(result.hasNext());
-        assertSame(session, result.next());
-        assertFalse(result.hasNext());
+        assertTrue(results.hasNext());
+        Session result = results.next();
+        assertEquals(session.getId(), result.getId());
+        assertFalse(results.hasNext());
 
         verifyZeroInteractions(this.batch);
+
+        // Validate that returned sessions can be invalidated
+        HttpServerExchange exchange = new HttpServerExchange(null);
+        Session mutableSession = mock(Session.class);
+
+        when(session.getSessionManager()).thenReturn(manager);
+        when(manager.getSession(same(exchange), Matchers.<SessionConfig>any())).thenReturn(mutableSession);
+
+        result.invalidate(exchange);
+
+        verify(mutableSession).invalidate(same(exchange));
     }
 
     @Test


### PR DESCRIPTION
Sessions returned via SingleSignOn.iterator() need to support Session.invalidate(...).
