### PR TITLE
WFLY-3809 Fix JBOSS_HOME path substitution on Windows.

### DIFF
--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/JdrZipFile.java
@@ -121,7 +121,7 @@ public class JdrZipFile {
      * @throws Exception
      */
     public void add(VirtualFile file, InputStream is) throws Exception {
-        String name = "JBOSS_HOME" + file.getPathName().substring(this.jbossHome.length());
+        String name = "JBOSS_HOME" + file.getPhysicalFile().getAbsolutePath().substring(this.jbossHome.length());
         this.add(is, name);
     }
 


### PR DESCRIPTION
Given JBOSS_HOME=c:\foo\bar\baz, Windows VirtualFile.getPathName()
returns something like:

/c:/foo/bar/baz

This differs from File.getAbsolutePath() which is used elsewhere in JDR.
This caused an issue where $JBOSS_HOME was not being properly replaced
in the generated archive.
