### PR TITLE
[WFLY-3814] hostname in krb5.conf domain_realm section must not contain square brackets

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/KerberosServerSetupTask.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/KerberosServerSetupTask.java
@@ -72,10 +72,9 @@ import org.jboss.as.test.integration.security.common.servlets.RolePrintingServle
 import org.jboss.logging.Logger;
 
 /**
- * A server setup task which configures and starts two LDAP servers with Kerberos
- * capabilities.
+ * A server setup task which configures and starts two LDAP servers with Kerberos capabilities.
  * <p>
- * Based on {@link LdapExtLDAPServerSetupTask}
+ * Based on {@link org.jboss.as.test.integration.security.loginmodules.LdapExtLDAPServerSetupTask}
  */
 public class KerberosServerSetupTask implements ServerSetupTask {
 
@@ -243,7 +242,7 @@ public class KerberosServerSetupTask implements ServerSetupTask {
         
         Map<String,String> properties = new HashMap<String, String>();
         properties.put("krbHostAndPort", hostname + ":" + port);
-        properties.put("krbHost", hostname);
+        properties.put("krbHost", Utils.stripSquareBrackets(hostname));
         
         String content = StrSubstitutor.replace(IOUtils.toString(SAML2BasicAuthenticationTestCase.class.getResourceAsStream(KRB5_CONF_RESOURCE_FILENAME), "UTF-8"), properties);
         


### PR DESCRIPTION
The `SAML2AttributeMappingTestCase` in `testsuite/integration/basic` used a wrong hostname value in the generated `krb5.conf` file in case of IPv6 address.

This fix strips square brackets from the hostname in the `[domain_realm]` section of the `krb5.conf` file.
