### PR TITLE
WFLY-3815 - Rare fail of RolloutPlanTestCase due to TimeoutException

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/management/cli/RolloutPlanTestCase.java
@@ -417,7 +417,7 @@ public class RolloutPlanTestCase extends AbstractCliTestBase {
         boolean failed = false;
         String response = null;
         try {
-            response = HttpRequest.get(url.toString(), 10, TimeUnit.SECONDS);
+            response = HttpRequest.get(url.toString(), 60, TimeUnit.SECONDS);
         } catch (Exception e) {
             failed = true;
             if (!shouldFail) throw new Exception("Http request failed.", e);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3815

Increased timeout from 10 to 60s to get rid of failures seen by QA.
