### PR TITLE
Timer fixes for database timers

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
@@ -127,7 +127,7 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
 
             // Check whether we want to run the timer
             if(!timerService.shouldRun(timer)) {
-                ROOT_LOGGER.debugf("Skipping execution of timer for %s as it is being run on another node", timer.getTimedObjectId());
+                ROOT_LOGGER.debugf("Skipping execution of timer for %s as it is being run on another node or the execution is suppressed by configuration", timer.getTimedObjectId());
                 timer.setNextTimeout(calculateNextTimeout(timer));
                 scheduleTimeoutIfRequired(timer);
                 return;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
@@ -114,19 +114,21 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
                 return;
             }
 
-            if(!timerService.shouldRun(timer)) {
-                ROOT_LOGGER.debugf("Skipping execution of timer for %s as it is being run on another node", timer.getTimedObjectId());
-                timer.setNextTimeout(calculateNextTimeout(timer));
-                scheduleTimeoutIfRequired(timer);
-                return;
-            }
-
+            // Check whether the timer is running local
             // If the recurring timer running longer than the interval is, we don't want to allow another
             // execution until it is complete. See JIRA AS7-3119
             if (timer.getState() == TimerState.IN_TIMEOUT || timer.getState() == TimerState.RETRY_TIMEOUT) {
                 ROOT_LOGGER.skipOverlappingInvokeTimeout(timer.getTimedObjectId(), timer.getId(), now, timer.getState());
                 timer.setNextTimeout(this.calculateNextTimeout(timer));
                 timerService.persistTimer(timer, false);
+                scheduleTimeoutIfRequired(timer);
+                return;
+            }
+
+            // Check whether we want to run the timer
+            if(!timerService.shouldRun(timer)) {
+                ROOT_LOGGER.debugf("Skipping execution of timer for %s as it is being run on another node", timer.getTimedObjectId());
+                timer.setNextTimeout(calculateNextTimeout(timer));
                 scheduleTimeoutIfRequired(timer);
                 return;
             }


### PR DESCRIPTION
change checks to have the correct messages for overlapping timers
enhance the debug statement to reflect the allow-execution configuration
