### PR TITLE
WFLY-3842 Netty Direct Buffer warning - depends on HORNETQ-1406

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -29,5 +29,6 @@
 
     <dependencies>
         <module name="sun.jdk"/>
+        <module name="org.javassist"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -28,5 +28,6 @@
     </resources>
 
     <dependencies>
+        <module name="sun.jdk"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -29,6 +29,6 @@
 
     <dependencies>
         <module name="sun.jdk"/>
-        <module name="org.javassist"/>
+        <module name="org.javassist" optional="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
When deploying Wildfly 8.x, you'll see this in the server.log:

```
INFO [io.netty.util.internal.PlatformDependent] Your platform does not provide complete low-level API for accessing direct buffers reliably. Unless explicitly requested, heap buffer will always be preferred to av
oid potential system unstability.
```

Following this into netty, here:
https://github.com/netty/netty/blob/master/common/src/main/java/io/netty/util/internal/PlatformDependent.java#L581
Down to here:
https://github.com/netty/netty/blob/netty-4.0.15.Final/common/src/main/java/io/netty/util/internal/PlatformDependent0.java#L82

We need access to sun.misc to see if direct buffers are available.
