### PR TITLE
[WFLY-3830] Make NamingContext.lookup more portable 

### DIFF
--- a/naming/src/main/java/org/jboss/as/naming/NamingContext.java
+++ b/naming/src/main/java/org/jboss/as/naming/NamingContext.java
@@ -228,7 +228,10 @@ public class NamingContext implements EventContext {
             if (namingContext instanceof NamingContext) {
                 return ((NamingContext)namingContext).lookup(resolveResult.getRemainingName(), dereference);
             } else {
-                return namingContext.lookup(resolveResult.getRemainingName());
+                // use the lookup(String) version as it is the most portable one.
+                // some JNDI providers will not work if the Name instance is a CompositeName as they accept only
+                // CompoundName.
+                return namingContext.lookup(resolveResult.getRemainingName().toString());
             }
         } else if (result instanceof LinkRef) {
             result = resolveLink(result,dereference);


### PR DESCRIPTION
- use the lookup(String) version in NamingContext as some JNDI providers
  expect a specific type of Name (e.g. CompoundName) instead of the
  CompositeName instances we use.

JIRA: https://issues.jboss.org/browse/WFLY-3830
