### PR TITLE
WFLY-3833 Cannot run mixed-domain tests on IPv6 hosts

### DIFF
--- a/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/domain.xml
@@ -34,8 +34,6 @@
         <extension module="org.wildfly.extension.undertow"/>
     </extensions>
     <system-properties>
-        <!-- IPv4 is not required, but setting this helps avoid unintended use of IPv6 -->
-        <property name="java.net.preferIPv4Stack" value="true"/>
     </system-properties>
     <management>
         <access-control provider="simple">


### PR DESCRIPTION
Removed forced IPV4 for mixed-domain tests.

https://issues.jboss.org/browse/WFLY-3833
