### PR TITLE
WFLY-3829 linux - allow server to run in directory which has more than one \s

### DIFF
--- a/feature-pack/src/main/resources/content/bin/appclient.sh
+++ b/feature-pack/src/main/resources/content/bin/appclient.sh
@@ -109,18 +109,17 @@ if $cygwin; then
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
-CLASSPATH="$CLASSPATH:$JBOSS_HOME/jboss-modules.jar"
-
+CLASSPATH="$CLASSPATH:\""$JBOSS_HOME"\"/jboss-modules.jar"
 # Execute the JVM in the foreground
 eval \"$JAVA\" $JAVA_OPTS \
  -cp "$CLASSPATH" \
- \"-Dorg.jboss.boot.log.file=$JBOSS_HOME/appclient/log/appclient.log\" \
- \"-Dlogging.configuration=file:$JBOSS_HOME/appclient/configuration/logging.properties\" \
+ \"-Dorg.jboss.boot.log.file="$JBOSS_HOME"/appclient/log/appclient.log\" \
+ \"-Dlogging.configuration=file:"$JBOSS_HOME"/appclient/configuration/logging.properties\" \
  org.jboss.modules.Main \
- -mp \"${JBOSS_MODULEPATH}\" \
+ -mp \""${JBOSS_MODULEPATH}"\" \
  org.jboss.as.appclient \
- -Djboss.home.dir=\"$JBOSS_HOME\" \
- -Djboss.server.base.dir=\"$JBOSS_HOME/appclient\" \
+ -Djboss.home.dir=\""$JBOSS_HOME"\" \
+ -Djboss.server.base.dir=\""$JBOSS_HOME"/appclient\" \
  '"$@"'
 JBOSS_STATUS=$?
 exit $JBOSS_STATUS

--- a/feature-pack/src/main/resources/content/bin/jconsole.sh
+++ b/feature-pack/src/main/resources/content/bin/jconsole.sh
@@ -74,7 +74,7 @@ fi
 
 CLASSPATH=$JAVA_HOME/lib/jconsole.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
-CLASSPATH="$CLASSPATH:$JBOSS_HOME/bin/client/jboss-cli-client.jar"
+CLASSPATH="$CLASSPATH:\""$JBOSS_HOME"\"/bin/client/jboss-cli-client.jar"
 
 echo CLASSPATH $CLASSPATH
 

--- a/feature-pack/src/main/resources/content/bin/jdr.sh
+++ b/feature-pack/src/main/resources/content/bin/jdr.sh
@@ -60,8 +60,8 @@ if $cygwin; then
 fi
 
 eval \"$JAVA\" $JAVA_OPTS \
-         -Djboss.home.dir=\"$JBOSS_HOME\" \
-         -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-         -mp \"${JBOSS_MODULEPATH}\" \
+         -Djboss.home.dir=\""$JBOSS_HOME"\" \
+         -jar \""$JBOSS_HOME"/jboss-modules.jar\" \
+         -mp \""${JBOSS_MODULEPATH}"\" \
          org.jboss.as.jdr \
          "$@" 

--- a/feature-pack/src/main/resources/content/bin/wsconsume.sh
+++ b/feature-pack/src/main/resources/content/bin/wsconsume.sh
@@ -72,8 +72,8 @@ fi
 
 # Execute the command
 eval \"$JAVA\" $JAVA_OPTS \
-    -classpath \"$JBOSS_CLASSPATH\" \
+    -classpath \""$JBOSS_CLASSPATH"\" \
     org.jboss.modules.Main \
-    -mp \"$JBOSS_HOME/modules\" \
+    -mp \""$JBOSS_HOME"/modules\" \
     org.jboss.ws.tools.wsconsume \
     '"$@"'

--- a/feature-pack/src/main/resources/content/bin/wsprovide.sh
+++ b/feature-pack/src/main/resources/content/bin/wsprovide.sh
@@ -68,7 +68,7 @@ fi
 
 # Execute the command
 eval \"$JAVA\" $JAVA_OPTS \
-    -jar \"$JBOSS_HOME/jboss-modules.jar\" \
-    -mp \"$JBOSS_HOME/modules\" \
+    -jar \""$JBOSS_HOME"/jboss-modules.jar\" \
+    -mp \""$JBOSS_HOME"/modules\" \
     org.jboss.ws.tools.wsprovide \
     '"$@"'


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3829
Related to: https://issues.jboss.org/browse/WFCORE-93 & https://github.com/wildfly/wildfly-core/pull/168
