### PR TITLE
[WFLY-3846] JMS resources allows duplicate JNDI entries

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/CommonAttributes.java
@@ -33,6 +33,7 @@ import static org.jboss.as.controller.client.helpers.MeasurementUnit.PERCENTAGE;
 import static org.jboss.as.controller.registry.AttributeAccess.Flag.RESTART_ALL_SERVICES;
 import static org.jboss.as.messaging.AttributeMarshallers.NOOP_MARSHALLER;
 import static org.jboss.as.messaging.MessagingExtension.VERSION_1_2_0;
+import static org.jboss.as.messaging.jms.Validators.noDuplicateElements;
 import static org.jboss.dmr.ModelType.BIG_DECIMAL;
 import static org.jboss.dmr.ModelType.BOOLEAN;
 import static org.jboss.dmr.ModelType.INT;
@@ -209,7 +210,7 @@ public interface CommonAttributes {
 
     PrimitiveListAttributeDefinition DESTINATION_ENTRIES = PrimitiveListAttributeDefinition.Builder.of(ENTRIES, ModelType.STRING)
             .setAllowNull(false)
-            .setElementValidator(new StringLengthValidator(1, false, true))
+            .setListValidator(noDuplicateElements(new StringLengthValidator(1, false, true)))
             .setAllowExpression(true)
             .setAttributeMarshaller(new AttributeMarshallers.JndiEntriesAttributeMarshaller(true))
             .setRestartAllServices()

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAttributes.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAttributes.java
@@ -195,7 +195,7 @@ public interface ConnectionFactoryAttributes {
                 .setAllowNull(false)
                 .setAllowExpression(true)
                 .setRestartAllServices()
-                .setElementValidator(new StringLengthValidator(1, false, true))
+                .setListValidator(Validators.noDuplicateElements(new StringLengthValidator(1, false, true)))
                 .setAttributeMarshaller(new AttributeMarshallers.JndiEntriesAttributeMarshaller(false))
                 .build();
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryDefinition.java
@@ -123,10 +123,14 @@ public class PooledConnectionFactoryDefinition extends SimpleResourceDefinition 
         AbstractAttributeDefinitionBuilder builder;
         if (attribute instanceof  SimpleListAttributeDefinition) {
             builder =  new SimpleListAttributeDefinition.Builder((SimpleListAttributeDefinition)attribute);
+            // TODO remove once WFCORE-95 is fixed
+            ((SimpleListAttributeDefinition.Builder)builder).setListValidator(attribute.getValidator());
         } else if (attribute instanceof  SimpleMapAttributeDefinition) {
             builder = new SimpleMapAttributeDefinition.Builder((SimpleMapAttributeDefinition)attribute);
         } else if (attribute instanceof PrimitiveListAttributeDefinition) {
             builder = new PrimitiveListAttributeDefinition.Builder((PrimitiveListAttributeDefinition)attribute);
+            // TODO remove once WFCORE-95 is fixed
+            ((PrimitiveListAttributeDefinition.Builder)builder).setListValidator(attribute.getValidator());
         } else {
             builder = new SimpleAttributeDefinitionBuilder((SimpleAttributeDefinition)attribute);
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/Validators.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/Validators.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.operations.validation.ListValidator;
+import org.jboss.as.controller.operations.validation.ParameterValidator;
+import org.jboss.as.messaging.logging.MessagingLogger;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2014 Red Hat inc.
+ */
+public class Validators {
+
+    public static ListValidator noDuplicateElements(ParameterValidator elementValidator) {
+        return new ListValidator(elementValidator, false, 1, Integer.MAX_VALUE) {
+            @Override
+            public void validateParameter(String parameterName, ModelNode value) throws OperationFailedException {
+                super.validateParameter(parameterName, value);
+
+                int elementsSize = value.asList().size();
+
+                // use a set to check whether the list contains duplicate elements
+                Set<ModelNode> set = new HashSet<>(value.asList());
+
+                if (set.size() != elementsSize) {
+                    throw MessagingLogger.ROOT_LOGGER.duplicateElements(parameterName, value);
+                }
+            }
+        };
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -37,6 +37,7 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.messaging.Element;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
@@ -792,4 +793,7 @@ public interface MessagingLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 75, value = "AIO wasn't located on this platform, it will fall back to using pure Java NIO. Your platform is Linux, install LibAIO to enable the AIO journal.")
     void aioWarningLinux();
+
+    @Message(id = 76, value = "Parameter %s contains duplicate elements [%s]")
+    OperationFailedException duplicateElements(String parameterName, ModelNode elements);
 }


### PR DESCRIPTION
- use noDuplicateElements ListValidator for attribute definitions
  representing JNDI Entries.

JIRA: https://issues.jboss.org/browse/WFLY-3846
