### PR TITLE
WFLY-3849 logging improvement of vault property retrieval failure

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/logging/SecurityLogger.java
@@ -834,5 +834,14 @@ public interface SecurityLogger extends BasicLogger {
     @Message(id = NONE, value = "Task: Remove secured attribute")
     String taskRemoveSecuredAttribute();
 
+    /**
+     * Create a {@link SecurityException}
+     * @param vaultString vault string which failed to be retrieved
+     * @param t underlying exception
+     * @return {@link SecurityException}
+     */
+    @Message(id = 85, value = "Security Exception: Error resolving vault property: %s")
+    SecurityException failedToRetrieveFromVault(String vaultString, @Cause Throwable t);
+
 
 }

--- a/security/subsystem/src/main/java/org/jboss/as/security/vault/RuntimeVaultReader.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/vault/RuntimeVaultReader.java
@@ -116,7 +116,7 @@ public class RuntimeVaultReader extends AbstractVaultReader {
             try {
                 return getValueAsString(password);
             } catch (SecurityVaultException e) {
-                throw SecurityLogger.ROOT_LOGGER.securityException(e);
+                throw SecurityLogger.ROOT_LOGGER.failedToRetrieveFromVault(password, e);
             }
 
         }

--- a/security/subsystem/src/test/java/org/jboss/as/security/vault/MockRuntimeVaultReader.java
+++ b/security/subsystem/src/test/java/org/jboss/as/security/vault/MockRuntimeVaultReader.java
@@ -64,7 +64,7 @@ public class MockRuntimeVaultReader extends RuntimeVaultReader {
       try {
         return getValueAsString(password);
       } catch (SecurityVaultException e) {
-        throw SecurityLogger.ROOT_LOGGER.securityException(e);
+        throw SecurityLogger.ROOT_LOGGER.failedToRetrieveFromVault(password, e);
       }
 
     }


### PR DESCRIPTION
Improving the SecurityException message when retrieval from Vault fails.

https://issues.jboss.org/browse/WFLY-3849
