### PR TITLE
WFLY-3850: NPE Deploying EJB @WebService without Security Domain

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/AbstractSecurityMetaDataAccessorEJB.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/AbstractSecurityMetaDataAccessorEJB.java
@@ -58,7 +58,7 @@ abstract class AbstractSecurityMetaDataAccessorEJB implements SecurityMetaDataAc
 
         for (final EJBEndpoint ejbEndpoint : getEjbEndpoints(dep)) {
             String nextSecurityDomain = ejbEndpoint.getSecurityDomain();
-            if(nextSecurityDomain.isEmpty()) {
+            if (nextSecurityDomain == null || nextSecurityDomain.isEmpty()) {
                 nextSecurityDomain = null;
             }
             securityDomain = getDomain(securityDomain, nextSecurityDomain);


### PR DESCRIPTION
Allow security domain to be null to disable security interceptors, and avoid NPE during deploy if missing.  See JIRA: https://issues.jboss.org/browse/WFLY-3850
