### PR TITLE
WFLY-3189 - validation errors on schema

### DIFF
--- a/ejb3/src/main/resources/schema/jboss-ejb-clustering_1_0.xsd
+++ b/ejb3/src/main/resources/schema/jboss-ejb-clustering_1_0.xsd
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    targetNamespace="urn:clustering:1.0" xmlns="urn:clustering:1.0"
+    xmlns:javaee="http://java.sun.com/xml/ns/javaee"
+    elementFormDefault="qualified" attributeFormDefault="unqualified"
+    version="1.0">
+    <xs:import namespace="http://java.sun.com/xml/ns/javaee"/>
+    <xs:element name="clustering" type="clusteringType"
+        substitutionGroup="javaee:assembly-descriptor-entry" />
+    <xs:complexType name="clusteringType">
+        <xs:complexContent>
+            <xs:extension
+                base="javaee:jboss-assembly-descriptor-bean-entryType">
+                <xs:sequence>
+                    <xs:element name="clustered" type="xs:string" />
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/ejb3/src/main/resources/schema/jboss-ejb-security_1_0.xsd
+++ b/ejb3/src/main/resources/schema/jboss-ejb-security_1_0.xsd
@@ -26,10 +26,8 @@
            xmlns="urn:security"
            xmlns:javaee="http://java.sun.com/xml/ns/javaee"
            elementFormDefault="qualified"
-           attributeFormDefault="unqualified"
-           version="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd">
-   <xs:import namespace="http://java.sun.com/xml/ns/javaee" schemaLocation="http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd"/>
+           attributeFormDefault="unqualified">
+   <xs:import namespace="http://java.sun.com/xml/ns/javaee"/>
 
    <xs:element name="security" type="securityType" substitutionGroup="javaee:assembly-descriptor-entry"/>
 

--- a/ejb3/src/main/resources/schema/jboss-ejb-security_1_1.xsd
+++ b/ejb3/src/main/resources/schema/jboss-ejb-security_1_1.xsd
@@ -28,9 +28,8 @@
            xmlns:javaee="http://java.sun.com/xml/ns/javaee"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
-           version="1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd">
-   <xs:import namespace="http://java.sun.com/xml/ns/javaee" schemaLocation="http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd"/>
+           version="1.1">
+   <xs:import namespace="http://java.sun.com/xml/ns/javaee"/>
 
    <xs:element name="security" type="securityType" substitutionGroup="javaee:assembly-descriptor-entry"/>
 

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
@@ -82,6 +82,7 @@ public class AbstractValidationUnitTest {
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb-security_1_0.xsd");
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb-security_1_1.xsd");
         EXCLUDED_SCHEMA_FILES.add("jboss-ejb-security-role_1_0.xsd");
+        EXCLUDED_SCHEMA_FILES.add("jboss-ejb-clustering_1_0.xsd");
     }
 
     static {


### PR DESCRIPTION
The ejb schema fail to validate properly in eclipse. Setting of schemaLocation confuses the XML Catalogs. Setting schemaLocation when importing a namespace is also not portable unless the schema exists in the same folder. 

This PR also adds a schema file jboss-ejb-clustering_1_0.xsd  who's namespace is declared in an online jboss ejb3 example, but does not exist in any existing schema. If the example is intentional, a new schema (such as provided here) should be added to the release. If the example is out of date, this second commit should be rejected and the online example should be fixed. 
