### PR TITLE
Rename version.org.picketbox to version.org.picketbox.picketbox-infinisp...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,7 @@
         <version.org.opensaml.opensaml>2.6.1</version.org.opensaml.opensaml>
         <version.org.opensaml.openws>1.5.1</version.org.opensaml.openws>
         <version.org.opensaml.xmltooling>1.4.1</version.org.opensaml.xmltooling>
-        <version.org.picketbox>4.9.0.Beta1</version.org.picketbox>
+        <version.org.picketbox.picketbox-infinispan>4.9.0.Beta1</version.org.picketbox.picketbox-infinispan>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.6.0.Final</version.org.picketlink>
         <version.org.powermock>1.5</version.org.powermock>
@@ -6141,7 +6141,7 @@
             <dependency>
                 <groupId>org.picketbox</groupId>
                 <artifactId>picketbox-infinispan</artifactId>
-                <version>${version.org.picketbox}</version>
+                <version>${version.org.picketbox.picketbox-infinispan}</version>
                 <exclusions>
                   <exclusion>
                     <groupId>org.picketbox</groupId>


### PR DESCRIPTION
...an, because it's not the version of picketbox itself.
After this, version variable name fits repository location and is inline with version variable for picketbox-commons.
.m2/repository/org/picketbox/picketbox-infinispan/4.9.0.Beta1/picketbox-infinispan-4.9.0.Beta1.jar
.m2/repository/org/picketbox/picketbox-commons/1.0.0.final/picketbox-commons-1.0.0.final.jar
