### PR TITLE
add missing call to registerNotifications()

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
+++ b/controller/src/main/java/org/jboss/as/controller/registry/ManagementResourceRegistration.java
@@ -592,6 +592,7 @@ public interface ManagementResourceRegistration extends ImmutableManagementResou
             resourceDefinition.registerAttributes(resourceRegistration);
             resourceDefinition.registerOperations(resourceRegistration);
             resourceDefinition.registerChildren(resourceRegistration);
+            resourceDefinition.registerNotifications(resourceRegistration);
             return resourceRegistration;
         }
     }

--- a/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
+++ b/core-model-test/framework/src/main/java/org/jboss/as/core/model/test/TestModelControllerService.java
@@ -561,6 +561,14 @@ class TestModelControllerService extends ModelTestModelControllerService {
             }
             super.registerAttributes(resourceRegistration);
         }
+
+        @Override
+        public void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+            if (type == TestModelType.DOMAIN) {
+                return;
+            }
+            super.registerNotifications(resourceRegistration);
+        }
     }
 
 


### PR DESCRIPTION
Without these calls, the logs are polluted by thousands of "notification not defined" warnings when resources are added.
