### PR TITLE
WFLY-3881 User shouldn't be able to use empty JDNI name ('java:/' or 'java:jboss/')

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -838,6 +838,8 @@ public interface ConnectorLogger extends BasicLogger {
     @Message(id = 89, value = "Exception during unregistering deployment")
     void exceptionDuringUnregistering(@Cause org.jboss.jca.core.spi.rar.NotFoundException nfe);
 
+    @Message(id = 90, value = "Jndi name shouldn't include '//' or end with '/'")
+    OperationFailedException jndiNameShouldValidate();
 }
 
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -265,6 +265,8 @@ public class Constants {
                             String str = value.asString();
                             if (!str.startsWith("java:/") && !str.startsWith("java:jboss/")) {
                                 throw ConnectorLogger.ROOT_LOGGER.jndiNameInvalidFormat();
+                            } else if (str.endsWith("/") || str.indexOf("//") != -1) {
+                                throw ConnectorLogger.ROOT_LOGGER.jndiNameShouldValidate();
                             }
                         }
                     } else {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3881
https://bugzilla.redhat.com/show_bug.cgi?id=1019260

Tested.
