### PR TITLE
WFLY-3189 - Do not use schema location in schema element. 

### DIFF
--- a/ejb3/src/main/resources/schema/jboss-ejb-security_1_0.xsd
+++ b/ejb3/src/main/resources/schema/jboss-ejb-security_1_0.xsd
@@ -27,9 +27,8 @@
            xmlns:javaee="http://java.sun.com/xml/ns/javaee"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
-           version="1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd">
-   <xs:import namespace="http://java.sun.com/xml/ns/javaee" schemaLocation="http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd"/>
+           version="1.0">
+   <xs:import namespace="http://java.sun.com/xml/ns/javaee"/>
 
    <xs:element name="security" type="securityType" substitutionGroup="javaee:assembly-descriptor-entry"/>
 

--- a/ejb3/src/main/resources/schema/jboss-ejb-security_1_1.xsd
+++ b/ejb3/src/main/resources/schema/jboss-ejb-security_1_1.xsd
@@ -28,9 +28,8 @@
            xmlns:javaee="http://java.sun.com/xml/ns/javaee"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
-           version="1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd">
-   <xs:import namespace="http://java.sun.com/xml/ns/javaee" schemaLocation="http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd"/>
+           version="1.1">
+   <xs:import namespace="http://java.sun.com/xml/ns/javaee"/>
 
    <xs:element name="security" type="securityType" substitutionGroup="javaee:assembly-descriptor-entry"/>
 


### PR DESCRIPTION
Do not use schemaLocation when importing a namespace.

XML validators seem to get confused when schema location is specified
and imports / includes are circular. Instead rely on entries in XML
catalogue.

Related to https://github.com/wildfly/wildfly/pull/6720/
Related to https://github.com/jboss/metadata/pull/72
