### PR TITLE
[WFLY-3883] use a LIST for the JMS connection-factory's connector attribute

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/AttributeMarshallers.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AttributeMarshallers.java
@@ -76,9 +76,9 @@ public final class AttributeMarshallers {
         public void marshallAsElement(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {
             if (resourceModel.hasDefined(Element.CONNECTOR.getLocalName())) {
                 writer.writeStartElement(Element.CONNECTORS.getLocalName());
-                for (Property connProp : resourceModel.get(Element.CONNECTOR.getLocalName()).asPropertyList()) {
+                for (ModelNode connector : resourceModel.get(Element.CONNECTOR.getLocalName()).asList()) {
                     writer.writeStartElement(Element.CONNECTOR_REF.getLocalName());
-                    writer.writeAttribute(Attribute.CONNECTOR_NAME.getLocalName(), connProp.getName());
+                    writer.writeAttribute(Attribute.CONNECTOR_NAME.getLocalName(), connector.asString());
                     writer.writeEndElement();
                 }
                 writer.writeEndElement();

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -1540,7 +1540,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
             ParseUtils.requireNoContent(reader);
 
             // create the connector node
-            connectors.get(name);
+            connectors.add(name);
         }
         return connectors;
     }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryAdd.java
@@ -118,7 +118,10 @@ public class ConnectionFactoryAdd extends AbstractAddStepHandler {
         config.setConnectionTTL(Common.CONNECTION_TTL.resolveModelAttribute(context, model).asLong());
         if (model.hasDefined(CONNECTOR)) {
             ModelNode connectorRefs = model.get(CONNECTOR);
-            List<String> connectorNames = new ArrayList<String>(connectorRefs.keys());
+            List<String> connectorNames = new ArrayList<>();
+            for (ModelNode connectorRef : connectorRefs.asList()) {
+                connectorNames.add(connectorRef.asString());
+            }
             config.setConnectorNames(connectorNames);
         }
         config.setConsumerMaxRate(Common.CONSUMER_MAX_RATE.resolveModelAttribute(context, model).asInt());

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/PooledConnectionFactoryAdd.java
@@ -127,8 +127,8 @@ public class PooledConnectionFactoryAdd extends AbstractAddStepHandler {
     static List<String> getConnectors(final ModelNode model) {
         List<String> connectorNames = new ArrayList<String>();
         if (model.hasDefined(CONNECTOR)) {
-            for (String connectorName : model.get(CONNECTOR).keys()) {
-                connectorNames.add(connectorName);
+            for (ModelNode connectorRef : model.get(CONNECTOR).asList()) {
+                connectorNames.add(connectorRef.asString());
             }
         }
         return connectorNames;


### PR DESCRIPTION
and for the pooled-connection-factory too.
- for legacy versions, the LIST of STRING is converted to a MAP by the
  messaging transformers
- the attribute defines a value converter to ensure than legacy
  operations (that uses a MAP) can still be executed on the latest
  version.

JIRA: https://issues.jboss.org/browse/WFLY-3883
