### PR TITLE
[WFLY-3886] add org.jboss.remote-naming dep to org.hornetq.ra module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hornetq/ra/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hornetq/ra/main/module.xml
@@ -37,6 +37,8 @@
         <module name="org.jboss.as.messaging"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <module name="org.jboss.logging"/>
+        <!-- allow to create a RA that connects to a remote hornetq-server -->
+        <module name="org.jboss.remote-naming" optional="true"/>
         <module name="javax.api"/>
         <module name="javax.jms.api" />
         <module name="org.jboss.jts"/>


### PR DESCRIPTION
Add an optional dependency to org.jboss.remote-naming to the
org.hornetq.ra to be able to create a RA that connects to a remote
hornetq-server.

JIRA: https://issues.jboss.org/browse/WFLY-3886
