### PR TITLE
WFLY-3937 removed private API property for org.codehaus.jackson.* modules

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
@@ -22,9 +22,6 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-core-asl">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-core-asl}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
@@ -22,9 +22,6 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-jaxrs">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-jaxrs}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
@@ -22,9 +22,6 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-mapper-asl">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-mapper-asl}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
@@ -22,9 +22,6 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-xc">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-xc}"/>


### PR DESCRIPTION
creating org.codehaus.jackson.\* modules public modules for resteasy usage.
