### PR TITLE
WFLY-3879: Remove picketbox-infinispan from /pom.xml

### DIFF
--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -120,10 +120,6 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-                <groupId>org.picketbox</groupId>
-                <artifactId>picketbox</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>
@@ -135,7 +131,7 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
-						<type>pom</type>
+            <type>pom</type>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -108,10 +108,6 @@
             <artifactId>jboss-interceptors-api_1.2_spec</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.picketbox</groupId>
-            <artifactId>picketbox</artifactId>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/jacorb/pom.xml
+++ b/jacorb/pom.xml
@@ -123,15 +123,10 @@
         </dependency>
 
         <dependency>
-         <groupId>org.picketbox</groupId>
-         <artifactId>picketbox</artifactId>
-        </dependency>
-
-        <dependency>
-         <groupId>org.wildfly.core</groupId>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test</artifactId>
-         <type>pom</type>
-         <scope>test</scope>
+            <type>pom</type>
+            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,6 @@
         <version.org.opensaml.opensaml>2.6.1</version.org.opensaml.opensaml>
         <version.org.opensaml.openws>1.5.1</version.org.opensaml.openws>
         <version.org.opensaml.xmltooling>1.4.1</version.org.opensaml.xmltooling>
-        <version.org.picketbox>4.9.0.Beta1</version.org.picketbox>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.7.0.Beta2</version.org.picketlink>
         <version.org.powermock>1.5</version.org.powermock>
@@ -6234,30 +6233,6 @@
                 <groupId>org.picketlink.distribution</groupId>
                 <artifactId>picketlink-wildfly8</artifactId>
                 <version>${version.org.picketlink}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.picketbox</groupId>
-                <artifactId>picketbox-infinispan</artifactId>
-                <version>${version.org.picketbox}</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>org.picketbox</groupId>
-                    <artifactId>picketbox-spi-bare</artifactId>
-                  </exclusion>
-                  <exclusion>
-                    <groupId>org.picketbox</groupId>
-                    <artifactId>jbosssx-bare</artifactId>
-                  </exclusion>
-                  <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging-spi</artifactId>
-                  </exclusion>
-                  <exclusion>
-                    <groupId>org.infinispan</groupId>
-                    <artifactId>infinispan-core</artifactId>
-                  </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
I'm not sure about the other occurrences
connector/pom.xml:                <artifactId>picketbox</artifactId>
ee/pom.xml:            <artifactId>picketbox</artifactId>
jacorb/pom.xml:         <artifactId>picketbox</artifactId>
security/subsystem/pom.xml:             <artifactId>picketbox</artifactId>
security/subsystem/pom.xml:          <artifactId>picketbox-infinispan</artifactId>
web-feature-pack/pom.xml:            <artifactId>picketbox</artifactId>
web-feature-pack/pom.xml:            <artifactId>picketbox-infinispan</artifactId>
