### PR TITLE
Remove usage of deprecated AbstractAddStepHandler methods that reference ServiceVerificationHandler.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredAddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredAddStepHandler.java
@@ -23,14 +23,12 @@
 package org.jboss.as.clustering.controller;
 
 import java.util.Collection;
-import java.util.List;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
-import org.jboss.as.controller.ServiceVerificationHandler;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
 
 /**
  * @author Paul Ferraro
@@ -46,7 +44,12 @@ public class ReloadRequiredAddStepHandler extends AbstractAddStepHandler {
     }
 
     @Override
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) {
+    protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) {
         context.reloadRequired();
+    }
+
+    @Override
+    protected void rollbackRuntime(OperationContext context, ModelNode operation, Resource resource) {
+        context.revertReloadRequired();
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemoveHandler.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemoveHandler.java
@@ -22,28 +22,14 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import java.util.ServiceLoader;
-
-import org.jboss.as.clustering.dmr.ModelNodes;
-import org.jboss.as.clustering.infinispan.CacheContainer;
-import org.jboss.as.clustering.infinispan.affinity.KeyAffinityServiceFactoryService;
-import org.jboss.as.clustering.jgroups.subsystem.ChannelService;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
-import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.spi.CacheServiceInstaller;
-import org.wildfly.clustering.spi.ClusteredGroupServiceInstaller;
-import org.wildfly.clustering.spi.ClusteredCacheServiceInstaller;
-import org.wildfly.clustering.spi.GroupServiceInstaller;
-import org.wildfly.clustering.spi.LocalCacheServiceInstaller;
-import org.wildfly.clustering.spi.LocalGroupServiceInstaller;
 
 /**
  * Remove a cache container, taking care to remove any child cache resources as well.
@@ -55,53 +41,20 @@ public class CacheContainerRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-
-        final PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
+        PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
 
         // remove any existing cache entries
-        removeExistingCacheServices(context, address, model);
-
-        final String containerName = address.getLastElement().getValue();
-
-        // need to remove all container-related services started, in reverse order
-        context.removeService(KeyAffinityServiceFactoryService.getServiceName(containerName));
-
-        // remove the BinderService entry
-        String jndiName = ModelNodes.asString(CacheContainerResourceDefinition.JNDI_NAME.resolveModelAttribute(context, model));
-        context.removeService(CacheContainerAddHandler.createCacheContainerBinding(jndiName, containerName).getBinderServiceName());
-
-        // remove the cache container
-        context.removeService(EmbeddedCacheManagerService.getServiceName(containerName));
-        context.removeService(EmbeddedCacheManagerConfigurationService.getServiceName(containerName));
-
-        if (model.hasDefined(TransportResourceDefinition.PATH.getKey())) {
-            removeServices(context, ClusteredGroupServiceInstaller.class, containerName);
-
-            context.removeService(ChannelService.createChannelBinding(containerName).getBinderServiceName());
-            context.removeService(ChannelService.getServiceName(containerName));
-            context.removeService(ChannelService.getFactoryServiceName(containerName));
-        } else {
-            removeServices(context, LocalGroupServiceInstaller.class, containerName);
-        }
-
-        String defaultCache = ModelNodes.asString(CacheContainerResourceDefinition.DEFAULT_CACHE.resolveModelAttribute(context, model));
-
-        if ((defaultCache != null) && !defaultCache.equals(CacheContainer.DEFAULT_CACHE_ALIAS)) {
-            Class<? extends CacheServiceInstaller> installerClass = model.hasDefined(TransportResourceDefinition.PATH.getKey()) ? ClusteredCacheServiceInstaller.class : LocalCacheServiceInstaller.class;
-            for (CacheServiceInstaller installer : ServiceLoader.load(installerClass, installerClass.getClassLoader())) {
-                for (ServiceName serviceName : installer.getServiceNames(containerName, CacheContainer.DEFAULT_CACHE_ALIAS)) {
-                    context.removeService(serviceName);
+        for (CacheType type: CacheType.values()) {
+            CacheAddHandler addHandler = type.getAddHandler();
+            if (model.hasDefined(type.pathElement().getKey())) {
+                for (Property property: model.get(type.pathElement().getKey()).asPropertyList()) {
+                    ModelNode removeOperation = Util.createRemoveOperation(address.append(type.pathElement(property.getName())));
+                    addHandler.removeRuntimeServices(context, removeOperation, model, property.getValue());
                 }
             }
         }
-    }
 
-    private static <I extends GroupServiceInstaller> void removeServices(OperationContext context, Class<I> installerClass, String group) {
-        for (I installer: ServiceLoader.load(installerClass, installerClass.getClassLoader())) {
-            for (ServiceName name: installer.getServiceNames(group)) {
-                context.removeService(name);
-            }
-        }
+        CacheContainerAddHandler.removeRuntimeServices(context, operation, model);
     }
 
     /**
@@ -115,49 +68,18 @@ public class CacheContainerRemoveHandler extends AbstractRemoveStepHandler {
     @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
 
-        final PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
-        final ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
+        PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
 
         // re-install the cache container services
-        CacheContainerAddHandler.installRuntimeServices(context, operation, model, verificationHandler);
+        CacheContainerAddHandler.installRuntimeServices(context, operation, model);
 
         // re-install any existing cache services
-        reinstallExistingCacheServices(context, address, model, verificationHandler);
-    }
-
-
-    /**
-     * Method to reinstall any services associated with existing caches.
-     *
-     * @param context
-     * @param containerModel
-     * @param containerName
-     * @throws OperationFailedException
-     */
-    private static void reinstallExistingCacheServices(OperationContext context, PathAddress containerAddress, ModelNode containerModel, ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-
         for (CacheType type: CacheType.values()) {
             CacheAddHandler addHandler = type.getAddHandler();
-            if (containerModel.hasDefined(type.pathElement().getKey())) {
-                for (Property property: containerModel.get(type.pathElement().getKey()).asPropertyList()) {
-                    ModelNode addOperation = Util.createAddOperation(containerAddress.append(type.pathElement(property.getName())));
-                    addHandler.installRuntimeServices(context, addOperation, containerModel, property.getValue(), verificationHandler);
-                }
-            }
-        }
-    }
-
-    /**
-     * Method to remove any services associated with existing caches.
-     */
-    private static void removeExistingCacheServices(OperationContext context, PathAddress containerAddress, ModelNode containerModel) throws OperationFailedException {
-
-        for (CacheType type: CacheType.values()) {
-            CacheAddHandler addHandler = type.getAddHandler();
-            if (containerModel.hasDefined(type.pathElement().getKey())) {
-                for (Property property: containerModel.get(type.pathElement().getKey()).asPropertyList()) {
-                    ModelNode removeOperation = Util.createRemoveOperation(containerAddress.append(type.pathElement(property.getName())));
-                    addHandler.removeRuntimeServices(context, removeOperation, containerModel, property.getValue());
+            if (model.hasDefined(type.pathElement().getKey())) {
+                for (Property property: model.get(type.pathElement().getKey()).asPropertyList()) {
+                    ModelNode addOperation = Util.createAddOperation(address.append(type.pathElement(property.getName())));
+                    addHandler.installRuntimeServices(context, addOperation, model, property.getValue());
                 }
             }
         }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemoveHandler.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemoveHandler.java
@@ -28,7 +28,6 @@ import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -59,7 +58,6 @@ public class CacheRemoveHandler extends AbstractRemoveStepHandler {
         PathAddress containerAddress = cacheAddress.subAddress(0, cacheAddress.size() - 1);
         ModelNode containerModel = context.readResourceFromRoot(containerAddress).getModel();
 
-        ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
-        type.getAddHandler().installRuntimeServices(context, operation, containerModel, cacheModel, verificationHandler);
+        type.getAddHandler().installRuntimeServices(context, operation, containerModel, cacheModel);
     }
 }

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EmbeddedCacheManagerService.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EmbeddedCacheManagerService.java
@@ -31,10 +31,12 @@ import org.jboss.as.clustering.infinispan.DefaultCacheContainer;
 import org.jboss.as.clustering.infinispan.InfinispanLogger;
 import org.jboss.logging.Logger;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
-import org.jboss.msc.value.Value;
+import org.jboss.msc.value.InjectedValue;
 
 /**
  * @author Paul Ferraro
@@ -49,11 +51,17 @@ public class EmbeddedCacheManagerService implements Service<EmbeddedCacheManager
         return BASE_SERVICE_NAME.append(name);
     }
 
-    private final Value<EmbeddedCacheManagerConfiguration> config;
+    static ServiceBuilder<EmbeddedCacheManager> build(ServiceTarget target, String name) {
+        EmbeddedCacheManagerService service = new EmbeddedCacheManagerService();
+        return target.addService(getServiceName(name), service)
+                .addDependency(EmbeddedCacheManagerConfigurationService.getServiceName(name), EmbeddedCacheManagerConfiguration.class, service.config)
+        ;
+    }
+
+    private final InjectedValue<EmbeddedCacheManagerConfiguration> config = new InjectedValue<>();
     private volatile EmbeddedCacheManager container;
 
-    public EmbeddedCacheManagerService(Value<EmbeddedCacheManagerConfiguration> config) {
-        this.config = config;
+    private EmbeddedCacheManagerService() {
     }
 
     @Override

--- a/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemAddHandler.java
+++ b/clustering/infinispan/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemAddHandler.java
@@ -24,21 +24,18 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import static org.jboss.as.clustering.infinispan.InfinispanLogger.ROOT_LOGGER;
 
-import java.util.List;
-
 import org.jboss.as.clustering.infinispan.deployment.ClusteringDependencyProcessor;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.server.AbstractDeploymentChainStep;
 import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceController;
 
 /**
  * @author Paul Ferraro
@@ -61,7 +58,7 @@ public class InfinispanSubsystemAddHandler extends AbstractBoottimeAddStepHandle
     }
 
     @Override
-    protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+    protected void performBoottime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         ROOT_LOGGER.activatingSubsystem();
 
         OperationStepHandler step = new AbstractDeploymentChainStep() {
@@ -71,10 +68,5 @@ public class InfinispanSubsystemAddHandler extends AbstractBoottimeAddStepHandle
             }
         };
         context.addStep(step, OperationContext.Stage.RUNTIME);
-    }
-
-    @Override
-    protected boolean requiresRuntimeVerification() {
-        return false;
     }
 }

--- a/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
+++ b/clustering/infinispan/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
@@ -90,8 +90,8 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
     @Test
     @BMRule(name="Test remove rollback operation",
-            targetClass="org.jboss.as.clustering.infinispan.subsystem.CacheContainerRemoveHandler",
-            targetMethod="removeExistingCacheServices",
+            targetClass="org.jboss.as.clustering.infinispan.subsystem.CacheContainerAddHandler",
+            targetMethod="removeRuntimeServices",
             targetLocation="AT ENTRY",
             action="$1.setRollbackOnly()")
     public void testCacheContainerRemoveRollback() throws Exception {

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelRemoveHandler.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelRemoveHandler.java
@@ -23,20 +23,14 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-import java.util.ServiceLoader;
-
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RunningMode;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.registry.Resource.ResourceEntry;
 import org.jboss.dmr.ModelNode;
-import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.spi.ClusteredGroupServiceInstaller;
-import org.wildfly.clustering.spi.GroupServiceInstaller;
 
 /**
  * Handler for /subsystem=jgroups/channel=*:remove() operations
@@ -66,27 +60,12 @@ public class ChannelRemoveHandler extends AbstractRemoveStepHandler {
     }
 
     @Override
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        PathAddress channelAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
-        String channelName = channelAddress.getLastElement().getValue();
-
-        context.removeService(ChannelService.getServiceName(channelName));
-        context.removeService(ChannelService.createChannelBinding(channelName).getBinderServiceName());
-        context.removeService(ChannelService.getFactoryServiceName(channelName));
-        context.removeService(ConnectedChannelService.getServiceName(channelName));
-
-        context.removeService(ChannelFactoryService.getServiceName(channelName));
-        context.removeService(ChannelFactoryService.createChannelFactoryBinding(channelName).getBinderServiceName());
-
-        for (GroupServiceInstaller installer : ServiceLoader.load(ClusteredGroupServiceInstaller.class, ClusteredGroupServiceInstaller.class.getClassLoader())) {
-            for (ServiceName serviceName : installer.getServiceNames(channelName)) {
-                context.removeService(serviceName);
-            }
-        }
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+        ChannelAddHandler.removeRuntimeServices(context, operation, model);
     }
 
     @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        ChannelAddHandler.installRuntimeServices(context, operation, model, new ServiceVerificationHandler());
+        ChannelAddHandler.installRuntimeServices(context, operation, model);
     }
 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemRemoveHandler.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemRemoveHandler.java
@@ -23,20 +23,13 @@ package org.jboss.as.clustering.jgroups.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
-import java.util.ServiceLoader;
-
-import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
-import org.jboss.msc.service.ServiceName;
-import org.wildfly.clustering.spi.ClusteredGroupServiceInstaller;
-import org.wildfly.clustering.spi.GroupServiceInstaller;
 
 /**
  * Handler for JGroups subsystem remove operations.
@@ -80,30 +73,11 @@ public class JGroupsSubsystemRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        // remove the ProtocolDefaultsService
-        context.removeService(ProtocolDefaultsService.SERVICE_NAME);
-
-        String defaultStack = ModelNodes.asString(JGroupsSubsystemResourceDefinition.DEFAULT_STACK.resolveModelAttribute(context, model));
-        if ((defaultStack != null) && !defaultStack.equals(ChannelFactoryService.DEFAULT)) {
-            context.removeService(ChannelFactoryService.getServiceName(ChannelFactoryService.DEFAULT));
-        }
-
-        String defaultChannel = ModelNodes.asString(JGroupsSubsystemResourceDefinition.DEFAULT_CHANNEL.resolveModelAttribute(context, model));
-        if ((defaultChannel != null) && !defaultChannel.equals(ChannelService.DEFAULT)) {
-            context.removeService(ChannelService.getServiceName(ChannelService.DEFAULT));
-            context.removeService(ConnectedChannelService.getServiceName(ChannelService.DEFAULT));
-            context.removeService(ChannelService.getFactoryServiceName(ChannelService.DEFAULT));
-
-            for (GroupServiceInstaller installer : ServiceLoader.load(ClusteredGroupServiceInstaller.class, ClusteredGroupServiceInstaller.class.getClassLoader())) {
-                for (ServiceName name : installer.getServiceNames(ChannelService.DEFAULT)) {
-                    context.removeService(name);
-                }
-            }
-        }
+        JGroupsSubsystemAddHandler.removeRuntimeServices(context, operation, model);
     }
 
     @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        JGroupsSubsystemAddHandler.installRuntimeServices(context, operation, model, new ServiceVerificationHandler());
+        JGroupsSubsystemAddHandler.installRuntimeServices(context, operation, model);
     }
 }

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PropertyResourceDefinition.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PropertyResourceDefinition.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import java.util.List;
-
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
@@ -31,7 +29,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -41,7 +38,6 @@ import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
-import org.jboss.msc.service.ServiceController;
 
 /**
  * Resource description for the addressable resources:
@@ -80,7 +76,7 @@ public class PropertyResourceDefinition extends SimpleResourceDefinition {
         }
 
         @Override
-        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model, ServiceVerificationHandler verificationHandler, List<ServiceController<?>> newControllers) throws OperationFailedException {
+        protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
             reloadRequiredStep(context);
         }
     };

--- a/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackRemoveHandler.java
+++ b/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackRemoveHandler.java
@@ -24,9 +24,6 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ServiceVerificationHandler;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -37,19 +34,11 @@ public class StackRemoveHandler extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
-        PathAddress address = PathAddress.pathAddress(operation.get(ModelDescriptionConstants.OP_ADDR));
-        String name = address.getLastElement().getValue();
-
-        // remove the ChannelFactoryServiceService
-        context.removeService(ChannelFactoryService.getServiceName(name));
-        context.removeService(ChannelFactoryService.createChannelFactoryBinding(name).getBinderServiceName());
+        StackAddHandler.removeRuntimeServices(context, operation, model);
     }
 
     @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException{
-        // re-install the ProtocolStack services using the information in model
-        ServiceVerificationHandler verificationHandler = new ServiceVerificationHandler();
-
-        StackAddHandler.installRuntimeServices(context, operation, model, verificationHandler);
+        StackAddHandler.installRuntimeServices(context, operation, model);
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandDispatcherFactoryServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/CommandDispatcherFactoryServiceInstaller.java
@@ -26,11 +26,9 @@ import java.util.Collection;
 
 import org.jboss.as.clustering.naming.BinderServiceBuilder;
 import org.jboss.as.clustering.naming.JndiNameFactory;
-import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.logging.Logger;
 import org.jboss.modules.ModuleIdentifier;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
@@ -62,15 +60,13 @@ public class CommandDispatcherFactoryServiceInstaller implements GroupServiceIns
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String group, ModuleIdentifier module) {
+    public void install(ServiceTarget target, String group, ModuleIdentifier module) {
         ServiceName name = GroupServiceNames.COMMAND_DISPATCHER.getServiceName(group);
         ContextNames.BindInfo bindInfo = createBinding(group);
 
         this.logger.debugf("Installing %s service, bound to ", name.getCanonicalName(), bindInfo.getAbsoluteJndiName());
 
-        ServiceBuilder<CommandDispatcherFactory> builder = this.builder.build(target, name, group, module).setInitialMode(ServiceController.Mode.ON_DEMAND);
-        ServiceBuilder<ManagedReferenceFactory> binderBuilder = new BinderServiceBuilder(target).build(bindInfo, name, CommandDispatcherFactory.class);
-
-        return Arrays.asList(builder.install(), binderBuilder.install());
+        this.builder.build(target, name, group, module).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
+        new BinderServiceBuilder(target).build(bindInfo, name, CommandDispatcherFactory.class).install();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheGroupServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheGroupServiceInstaller.java
@@ -26,10 +26,8 @@ import java.util.Collection;
 
 import org.jboss.as.clustering.naming.BinderServiceBuilder;
 import org.jboss.as.clustering.naming.JndiNameFactory;
-import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.logging.Logger;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
@@ -63,16 +61,14 @@ public class CacheGroupServiceInstaller implements CacheServiceInstaller {
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String container, String cache) {
+    public void install(ServiceTarget target, String container, String cache) {
         ServiceName name = CacheServiceNames.GROUP.getServiceName(container, cache);
         ContextNames.BindInfo bindInfo = createBinding(container, cache);
 
         this.logger.debugf("Installing %s service, bound to ", name.getCanonicalName(), bindInfo.getAbsoluteJndiName());
 
-        ServiceBuilder<Group> builder = this.builder.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND);
+        this.builder.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
 
-        ServiceBuilder<ManagedReferenceFactory> binderBuilder = new BinderServiceBuilder(target).build(bindInfo, name, Group.class);
-
-        return Arrays.asList(builder.install(), binderBuilder.install());
+        new BinderServiceBuilder(target).build(bindInfo, name, Group.class).install();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheNodeFactoryServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheNodeFactoryServiceInstaller.java
@@ -24,11 +24,9 @@ package org.wildfly.clustering.server.group;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.wildfly.clustering.group.NodeFactory;
 import org.wildfly.clustering.spi.CacheServiceNames;
 import org.wildfly.clustering.spi.ClusteredCacheServiceInstaller;
 import org.wildfly.clustering.spi.LocalCacheServiceInstaller;
@@ -44,11 +42,8 @@ public class CacheNodeFactoryServiceInstaller implements LocalCacheServiceInstal
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String container, String cache) {
+    public void install(ServiceTarget target, String container, String cache) {
         ServiceName name = CacheServiceNames.NODE_FACTORY.getServiceName(container, cache);
-        ServiceBuilder<? extends NodeFactory<?>> builder = CacheNodeFactoryService.build(target, name, container, cache);
-        ServiceController<? extends NodeFactory<?>> controller = builder.setInitialMode(ServiceController.Mode.ON_DEMAND).install();
-
-        return Collections.<ServiceController<?>>singleton(controller);
+        CacheNodeFactoryService.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/GroupNodeFactoryServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/GroupNodeFactoryServiceInstaller.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 
 import org.jboss.modules.ModuleIdentifier;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
@@ -50,11 +49,8 @@ public class GroupNodeFactoryServiceInstaller implements GroupServiceInstaller {
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String group, ModuleIdentifier module) {
+    public void install(ServiceTarget target, String group, ModuleIdentifier module) {
         ServiceName name = GroupServiceNames.NODE_FACTORY.getServiceName(group);
-        ServiceBuilder<JGroupsNodeFactory> builder = this.builder.build(target, name, group, module);
-        ServiceController<JGroupsNodeFactory> controller = builder.setInitialMode(ServiceController.Mode.ON_DEMAND).install();
-
-        return Collections.<ServiceController<?>>singleton(controller);
+        this.builder.build(target, name, group, module).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/GroupServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/GroupServiceInstaller.java
@@ -26,15 +26,12 @@ import static org.jboss.msc.service.ServiceController.Mode.ON_DEMAND;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
 
 import org.jboss.as.clustering.naming.BinderServiceBuilder;
 import org.jboss.as.clustering.naming.JndiNameFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.logging.Logger;
 import org.jboss.modules.ModuleIdentifier;
-import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.clustering.group.Group;
@@ -64,18 +61,14 @@ public class GroupServiceInstaller implements org.wildfly.clustering.spi.GroupSe
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String group, ModuleIdentifier module) {
-        List<ServiceController<?>> controllers = new LinkedList<>();
-
+    public void install(ServiceTarget target, String group, ModuleIdentifier module) {
         ServiceName name = GroupServiceNames.GROUP.getServiceName(group);
         ContextNames.BindInfo bindInfo = createBinding(group);
 
         this.logger.debugf("Installing %s service, bound to ", name.getCanonicalName(), bindInfo.getAbsoluteJndiName());
 
-        controllers.add(this.builder.build(target, name, group, module).setInitialMode(ON_DEMAND).install());
+        this.builder.build(target, name, group, module).setInitialMode(ON_DEMAND).install();
 
-        controllers.add(new BinderServiceBuilder(target).build(bindInfo, name, Group.class).install());
-
-        return controllers;
+        new BinderServiceBuilder(target).build(bindInfo, name, Group.class).install();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/ServiceProviderRegistrationFactoryServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/ServiceProviderRegistrationFactoryServiceInstaller.java
@@ -26,10 +26,8 @@ import java.util.Collection;
 
 import org.jboss.as.clustering.naming.BinderServiceBuilder;
 import org.jboss.as.clustering.naming.JndiNameFactory;
-import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.logging.Logger;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
@@ -61,16 +59,14 @@ public class ServiceProviderRegistrationFactoryServiceInstaller implements Cache
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String container, String cache) {
+    public void install(ServiceTarget target, String container, String cache) {
         ServiceName name = CacheServiceNames.SERVICE_PROVIDER_REGISTRATION.getServiceName(container, cache);
         ContextNames.BindInfo bindInfo = createBinding(container, cache);
 
         this.logger.debugf("Installing %s service, bound to ", name.getCanonicalName(), bindInfo.getAbsoluteJndiName());
 
-        ServiceBuilder<ServiceProviderRegistrationFactory> builder = this.builder.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND);
+        this.builder.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
 
-        ServiceBuilder<ManagedReferenceFactory> binderBuilder = new BinderServiceBuilder(target).build(bindInfo, name, ServiceProviderRegistrationFactory.class);
-
-        return Arrays.asList(builder.install(), binderBuilder.install());
+        new BinderServiceBuilder(target).build(bindInfo, name, ServiceProviderRegistrationFactory.class).install();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/RegistryFactoryServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/RegistryFactoryServiceInstaller.java
@@ -26,14 +26,11 @@ import java.util.Collection;
 
 import org.jboss.as.clustering.naming.BinderServiceBuilder;
 import org.jboss.as.clustering.naming.JndiNameFactory;
-import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.logging.Logger;
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
-import org.wildfly.clustering.registry.Registry;
 import org.wildfly.clustering.registry.RegistryFactory;
 import org.wildfly.clustering.server.CacheServiceBuilder;
 import org.wildfly.clustering.spi.CacheServiceInstaller;
@@ -62,18 +59,16 @@ public class RegistryFactoryServiceInstaller implements CacheServiceInstaller {
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String container, String cache) {
+    public void install(ServiceTarget target, String container, String cache) {
         ServiceName name = CacheServiceNames.REGISTRY_FACTORY.getServiceName(container, cache);
         ContextNames.BindInfo bindInfo = createBinding(container, cache);
 
         this.logger.debugf("Installing %s service, bound to ", name.getCanonicalName(), bindInfo.getAbsoluteJndiName());
 
-        ServiceBuilder<RegistryFactory<Object, Object>> factoryBuilder = this.builder.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND);
+        this.builder.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
 
-        ServiceBuilder<Registry<Object, Object>> builder = RegistryService.build(target, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND);
+        RegistryService.build(target, container, cache).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
 
-        ServiceBuilder<ManagedReferenceFactory> binderBuilder = new BinderServiceBuilder(target).build(bindInfo, name, RegistryFactory.class);
-
-        return Arrays.asList(factoryBuilder.install(), builder.install(), binderBuilder.install());
+        new BinderServiceBuilder(target).build(bindInfo, name, RegistryFactory.class).install();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonServiceBuilderFactoryServiceInstaller.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonServiceBuilderFactoryServiceInstaller.java
@@ -24,7 +24,6 @@ package org.wildfly.clustering.server.singleton;
 import java.util.Collection;
 import java.util.Collections;
 
-import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
@@ -50,11 +49,9 @@ public class SingletonServiceBuilderFactoryServiceInstaller implements CacheServ
     }
 
     @Override
-    public Collection<ServiceController<?>> install(ServiceTarget target, String container, String cache) {
+    public void install(ServiceTarget target, String container, String cache) {
         ServiceName name = CacheServiceNames.SINGLETON_SERVICE_BUILDER.getServiceName(container, cache);
 
-        ServiceBuilder<SingletonServiceBuilderFactory> builder = this.builder.build(target, name, container, cache);
-
-        return Collections.<ServiceController<?>>singleton(builder.setInitialMode(ServiceController.Mode.ACTIVE).install());
+        this.builder.build(target, name, container, cache).setInitialMode(ServiceController.Mode.ACTIVE).install();
     }
 }

--- a/clustering/spi/src/main/java/org/wildfly/clustering/spi/CacheServiceInstaller.java
+++ b/clustering/spi/src/main/java/org/wildfly/clustering/spi/CacheServiceInstaller.java
@@ -23,7 +23,6 @@ package org.wildfly.clustering.spi;
 
 import java.util.Collection;
 
-import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 
@@ -45,7 +44,6 @@ public interface CacheServiceInstaller {
      * @param target the service target in which to install services
      * @param container the name of the cache container to which the installed services are associated
      * @param cache the name of the cache to which the installed services are associated
-     * @return a collection of installed services
      */
-    Collection<ServiceController<?>> install(ServiceTarget target, String container, String cache);
+    void install(ServiceTarget target, String container, String cache);
 }

--- a/clustering/spi/src/main/java/org/wildfly/clustering/spi/GroupServiceInstaller.java
+++ b/clustering/spi/src/main/java/org/wildfly/clustering/spi/GroupServiceInstaller.java
@@ -24,7 +24,6 @@ package org.wildfly.clustering.spi;
 import java.util.Collection;
 
 import org.jboss.modules.ModuleIdentifier;
-import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 
@@ -45,7 +44,6 @@ public interface GroupServiceInstaller {
      * @param target the service target in which to install services
      * @param group the group to which the installed services are associated
      * @param module the unique identifier of the module upon which these services should operate
-     * @return a collection of installed services
      */
-    Collection<ServiceController<?>> install(ServiceTarget target, String group, ModuleIdentifier module);
+    void install(ServiceTarget target, String group, ModuleIdentifier module);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ChannelCreationOptionResource.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/ChannelCreationOptionResource.java
@@ -32,7 +32,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.RestartParentResourceAddHandler;
 import org.jboss.as.controller.RestartParentResourceRemoveHandler;
 import org.jboss.as.controller.RestartParentWriteAttributeHandler;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
@@ -86,9 +85,8 @@ class ChannelCreationOptionResource extends SimpleResourceDefinition {
         resourceRegistration.registerReadWriteAttribute(CHANNEL_CREATION_OPTION_TYPE, null, new ChannelCreationOptionWriteAttributeHandler(CHANNEL_CREATION_OPTION_TYPE));
     }
 
-    private static void recreateParentService(OperationContext context, ModelNode ejb3RemoteServiceModelNode,
-                                              ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-        EJB3RemoteServiceAdd.INSTANCE.installRuntimeServices(context, ejb3RemoteServiceModelNode, verificationHandler);
+    private static void recreateParentService(OperationContext context, ModelNode ejb3RemoteServiceModelNode) throws OperationFailedException {
+        EJB3RemoteServiceAdd.INSTANCE.installRuntimeServices(context, ejb3RemoteServiceModelNode);
     }
 
     /**
@@ -101,9 +99,8 @@ class ChannelCreationOptionResource extends SimpleResourceDefinition {
         }
 
         @Override
-        protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel,
-                                             ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-            ChannelCreationOptionResource.recreateParentService(context, parentModel, verificationHandler);
+        protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
+            ChannelCreationOptionResource.recreateParentService(context, parentModel);
         }
 
         @Override
@@ -127,9 +124,8 @@ class ChannelCreationOptionResource extends SimpleResourceDefinition {
         }
 
         @Override
-        protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel,
-                                             ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-            ChannelCreationOptionResource.recreateParentService(context, parentModel, verificationHandler);
+        protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
+            ChannelCreationOptionResource.recreateParentService(context, parentModel);
         }
 
         @Override
@@ -147,9 +143,8 @@ class ChannelCreationOptionResource extends SimpleResourceDefinition {
         }
 
         @Override
-        protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode ejb3RemoteServiceModelNode,
-                                             ServiceVerificationHandler verificationHandler) throws OperationFailedException {
-            ChannelCreationOptionResource.recreateParentService(context, ejb3RemoteServiceModelNode, verificationHandler);
+        protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode ejb3RemoteServiceModelNode) throws OperationFailedException {
+            ChannelCreationOptionResource.recreateParentService(context, ejb3RemoteServiceModelNode);
         }
 
         @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceRemove.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceRemove.java
@@ -49,7 +49,7 @@ public class EJB3RemoteServiceRemove extends AbstractRemoveStepHandler {
     @Override
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         if (context.isResourceServiceRestartAllowed()) {
-            EJB3RemoteServiceAdd.INSTANCE.installRuntimeServices(context, model, null);
+            EJB3RemoteServiceAdd.INSTANCE.installRuntimeServices(context, model);
         } else {
             context.revertReloadRequired();
         }


### PR DESCRIPTION
We also no longer need to collect the ServiceControllers of installed services.
