### PR TITLE
[WFLY-3780] : DataSources stats return wrong value types

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolMetrics.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolMetrics.java
@@ -97,9 +97,7 @@ public abstract class PoolMetrics implements OperationStepHandler {
                                 ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE);
                         if (managementRepoService != null) {
                             try {
-                                final ModelNode result = context.getResult();
-                                result.set("" + stats.getValue(attributeName));
-
+                                setModelValue(context.getResult(), attributeName);
                             } catch (Exception e) {
                                throw new OperationFailedException(ConnectorLogger.ROOT_LOGGER.failedToGetMetrics(e.getLocalizedMessage()));
                             }
@@ -113,6 +111,15 @@ public abstract class PoolMetrics implements OperationStepHandler {
 
         }
 
+        private void setModelValue(ModelNode result, String attributeName) {
+            if (stats.getType(attributeName) == int.class) {
+                result.set((Integer) stats.getValue(attributeName));
+            } else if (stats.getType(attributeName) == long.class) {
+                result.set((Long) stats.getValue(attributeName));
+            } else {
+                result.set("" + stats.getValue(attributeName));
+            }
+        }
     }
 
 }


### PR DESCRIPTION
The attribute values are set using the attribute type instead of a generic String type.
Jira: https://issues.jboss.org/browse/WFLY-3780
