### PR TITLE
WFLY-3766: fixing traditional cron behaviour in calendar based timeouts

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
@@ -37,6 +37,7 @@ import org.jboss.as.ejb3.timerservice.schedule.attribute.Minute;
 import org.jboss.as.ejb3.timerservice.schedule.attribute.Month;
 import org.jboss.as.ejb3.timerservice.schedule.attribute.Second;
 import org.jboss.as.ejb3.timerservice.schedule.attribute.Year;
+import org.jboss.as.ejb3.timerservice.schedule.util.CalendarUtil;
 
 import static org.jboss.as.ejb3.logging.EjbLogger.ROOT_LOGGER;
 
@@ -157,7 +158,7 @@ public class CalendarBasedTimeout {
         // determine and set the first timeout (relative to the current time)
         // of this CalendarBasedTimeout
         setFirstTimeout();
-        }
+    }
 
     public Calendar getNextTimeout() {
         return getNextTimeout(new GregorianCalendar(this.timezone), true);
@@ -195,6 +196,11 @@ public class CalendarBasedTimeout {
         return getNextTimeout(currentCal, true);
     }
 
+    /**
+     * @param currentCal
+     * @param increment if true then current cal is not an acceptable next timeout
+     * @return
+     */
     private Calendar getNextTimeout(Calendar currentCal, boolean increment) {
         if (this.noMoreTimeouts(currentCal)) {
             return null;
@@ -212,7 +218,17 @@ public class CalendarBasedTimeout {
         }
         nextCal.add(Calendar.MILLISECOND, -nextCal.get(Calendar.MILLISECOND));
         nextCal.setFirstDayOfWeek(Calendar.SUNDAY);
+        nextCal = computeNextTimeout(nextCal);
+        nextCal = processDstRollback(currentCal, nextCal);
+        return nextCal;
+    }
 
+    /**
+     * Computes the next timeout.
+     * @param nextCal
+     * @return
+     */
+    private Calendar computeNextTimeout(Calendar nextCal) {
         nextCal = this.computeNextTime(nextCal);
         if (nextCal == null) {
             return null;
@@ -408,8 +424,6 @@ public class CalendarBasedTimeout {
         } else {
             // since the next day is before the current day we need to shift to the next month
             nextCal.add(Calendar.MONTH, 1);
-            // also we need to reset the time
-            resetTimeToFirstValues(nextCal);
             nextCal = this.computeNextMonth(nextCal);
             if (nextCal == null) {
                 return null;
@@ -460,8 +474,6 @@ public class CalendarBasedTimeout {
     }
 
     private Calendar advanceTillMonthHasDate(Calendar cal, Integer date) {
-        resetTimeToFirstValues(cal);
-
         // make sure the month can handle the date
         while (monthHasDate(cal, date) == false) {
             if (cal.get(Calendar.YEAR) > Year.MAX_YEAR) {
@@ -480,6 +492,7 @@ public class CalendarBasedTimeout {
             }
         }
         cal.set(Calendar.DAY_OF_MONTH, date);
+        resetTimeToFirstValues(cal);
         return cal;
     }
 
@@ -553,7 +566,7 @@ public class CalendarBasedTimeout {
     }
 
     /**
-     *
+     * Resets the time fields of the specified calendar to the first values that match the schedule expression.
      * @param calendar
      */
     private void resetTimeToFirstValues(Calendar calendar) {
@@ -568,13 +581,78 @@ public class CalendarBasedTimeout {
         }
     }
 
+    /**
+     * Sets the time fields of the specified calendar. In case the time does not exists, due to a DST forward, the calendar is automatically adjusted to the 1st timeout since DST begins.
+     * @param calendar
+     * @param hour
+     * @param minute
+     * @param second
+     */
     private void setTime(Calendar calendar, int hour, int minute, int second) {
+        calendar.clear(Calendar.DST_OFFSET);
         calendar.clear(Calendar.HOUR_OF_DAY);
         calendar.set(Calendar.HOUR_OF_DAY, hour);
         calendar.clear(Calendar.MINUTE);
         calendar.set(Calendar.MINUTE, minute);
         calendar.clear(Calendar.SECOND);
         calendar.set(Calendar.SECOND, second);
+        // process STD -> DST transitions
+        if (timezone.useDaylightTime()) {
+            if (calendar.get(Calendar.SECOND) != second || calendar.get(Calendar.MINUTE) != minute || calendar.get(Calendar.HOUR_OF_DAY) != hour) {
+                // new calendar time is not the expected, this happens when the time to set does not exists
+                // the JDK Calendar time adjustment may be problematic, it may go over other timeout since DST begins, so:
+                // 1. find 1st minute on DST
+                calendar.add(Calendar.MILLISECOND, -timezone.getDSTSavings());
+                CalendarUtil.advanceCalendarTillDST(calendar);
+                // 2. recompute calendar
+                computeNextTimeout(calendar);
+            }
+        }
+    }
+
+    /**
+     * Logic that handles the specifics of DST rollback wrt JDK Calendar:
+     * 1. when setting time Calendar opts for STD version of repeated times, which would result in skipped timeouts, this method detects such cases and opts instead for DST
+     * 2. when timeouts adjusted by 1. ends then time must be reverted to beginning of STD repeated period
+     *
+     * @param currentCal
+     * @param nextCal
+     * @return
+     */
+    private Calendar processDstRollback(Calendar currentCal, Calendar nextCal) {
+        if (timezone.useDaylightTime()) {
+            // case 1
+            if (nextCal != null && !timezone.inDaylightTime(nextCal.getTime())) {
+                // next cal is on STD
+                Calendar nextCalClone = (Calendar) nextCal.clone();
+                nextCalClone.add(Calendar.MILLISECOND, -timezone.getDSTSavings());
+                if (timezone.inDaylightTime(nextCalClone.getTime())) {
+                    // removing DST savings puts it in DST, i.e. next cal is in DST rollback ambiguous period
+                    if (currentCal == null || nextCalClone.after(currentCal)) {
+                        // DST version is after current cal, opt for it
+                        return nextCalClone;
+                    }
+                }
+            }
+            // case 2
+            // if current cal is dst version of a repeated time, and next cal is after repeated period then it's time to rollback time to beginning of std repeated period
+            if (currentCal != null && timezone.inDaylightTime(currentCal.getTime())) {
+                // current cal is on DST
+                Calendar currentCalClone = (Calendar) currentCal.clone();
+                currentCalClone.add(Calendar.MILLISECOND, timezone.getDSTSavings());
+                if (!timezone.inDaylightTime(currentCalClone.getTime())) {
+                    // adding DST savings puts it on STD, i.e. current cal is in the DST rollback ambiguous period
+                    // compute beginning of STD
+                    currentCalClone.add(Calendar.MILLISECOND, -timezone.getDSTSavings());
+                    CalendarUtil.advanceCalendarTillSTD(currentCalClone);
+                    // if next cal is after it, recompute timeout since such time
+                    if (nextCal == null || nextCal.after(currentCalClone)) {
+                        return computeNextTimeout(currentCalClone);
+                    }
+                }
+            }
+        }
+        return nextCal;
     }
 
 }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
@@ -26,6 +26,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
+import java.util.SimpleTimeZone;
 import java.util.TimeZone;
 
 import javax.ejb.ScheduleExpression;
@@ -495,7 +496,6 @@ public class CalendarBasedTimeoutTestCase {
 
     }
 
-
     /**
      * WFLY-1468
      * Create a Timeout with a schedule start date in the past (day before) to ensure the time is set correctly.
@@ -530,63 +530,976 @@ public class CalendarBasedTimeoutTestCase {
     }
 
     /**
-     * Testcase #1 for WFLY-3947
+     * Tests correct timeouts going through a 1h DST forward (Europe/Lisbon, 31 Mar 2013, 01:00),
+     * using a "any hour" expression.
+     *
+     * The expression defines timeouts every 30 min.
+     *
+     * Starting at 31 Mar 2013 0:30, first 3 timeouts should be:
+     *
+     * Traditional Cron - 0:30, 2:00, 2:30
+     * Modern Cron - same as Traditional Cron
      */
     @Test
-    public void testWFLY3947_1() {
+    public void testDstForward_1HourDstTimezone_AnyHour() {
         TimeZone timeZone = TimeZone.getTimeZone("Europe/Lisbon");
         int year = 2013;
         int month = Calendar.MARCH;
         int dayOfMonth = 31;
-        int hourOfDay = 3;
+        int hourOfDay = 0;
         int minute = 30;
         int second = 0;
 
         Calendar start = new GregorianCalendar(timeZone);
         start.clear();
         start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
 
-        ScheduleExpression expression = new ScheduleExpression().timezone(timeZone.getID()).dayOfMonth("*").hour("1").minute("30").second("0").start(start.getTime());
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("*");
+        expression.minute("0, 30");
+        expression.second("0");
+        expression.start(start.getTime());
 
         CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
-        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
-        Assert.assertNotNull(firstTimeout);
-        Assert.assertEquals(year, firstTimeout.get(Calendar.YEAR));
-        Assert.assertEquals(Calendar.APRIL, firstTimeout.get(Calendar.MONTH));
-        Assert.assertEquals(1, firstTimeout.get(Calendar.DAY_OF_MONTH));
-        Assert.assertEquals(1, firstTimeout.get(Calendar.HOUR_OF_DAY));
-        Assert.assertEquals(30, firstTimeout.get(Calendar.MINUTE));
-        Assert.assertEquals(second, firstTimeout.get(Calendar.SECOND));
+
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(0, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(00, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(timeout1.getTimeInMillis() + (30 * 60 * 1000), timeout2.getTimeInMillis());
+
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(timeout2.getTimeInMillis() + (30 * 60 * 1000), timeout3.getTimeInMillis());
     }
 
     /**
-     * Testcase #2 for WFLY-3947
+     * Tests correct timeouts going through a 1h DST forward (Europe/Lisbon, 31 Mar 2013, 01:00),
+     * using specific hour expression.
+     *
+     * Starting at 30 Mar 2013 0:30, first 3 timeouts should be:
+     *
+     * Traditional Cron - 1:30 of day 30, 1:30 of day 1, 1:30 of day 2 (skips non existent day 31 1:30)
+     * Modern Cron - 1:30 of day 30, 2:30 of day 31, 1:30 of day 1 (replaces non existent day 31 1:30 by adding DST savings of 1h )
      */
     @Test
-    public void testWFLY3947_2() {
-        TimeZone timeZone = TimeZone.getTimeZone("Australia/Lord_Howe");
+    public void testDstForward_1HourDstTimezone_SpecificHour() {
+        TimeZone timeZone = TimeZone.getTimeZone("Europe/Lisbon");
         int year = 2013;
-        int month = Calendar.OCTOBER;
-        int dayOfMonth = 6;
-        int hourOfDay = 2;
-        int minute = 41;
+        int month = Calendar.MARCH;
+        int dayOfMonth = 30;
+        int hourOfDay = 0;
+        int minute = 30;
         int second = 0;
 
         Calendar start = new GregorianCalendar(timeZone);
         start.clear();
         start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
 
-        ScheduleExpression expression = new ScheduleExpression().timezone(timeZone.getID()).dayOfMonth("*").hour("2, 3").minute("20, 40").second("0").start(start.getTime());
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("1");
+        expression.minute("30");
+        expression.second("0");
+        expression.start(start.getTime());
 
         CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
-        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
-        Assert.assertNotNull(firstTimeout);
-        Assert.assertEquals(year, firstTimeout.get(Calendar.YEAR));
-        Assert.assertEquals(month, firstTimeout.get(Calendar.MONTH));
-        Assert.assertEquals(dayOfMonth, firstTimeout.get(Calendar.DAY_OF_MONTH));
-        Assert.assertEquals(3, firstTimeout.get(Calendar.HOUR_OF_DAY));
-        Assert.assertEquals(20, firstTimeout.get(Calendar.MINUTE));
-        Assert.assertEquals(second, firstTimeout.get(Calendar.SECOND));
+
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month+1, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(1, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+
+    }
+
+    /**
+     * Tests correct timeouts going through a 0h30m DST forward (Australia/Lord_Howe, 6 Oct 2013, 02:00),
+     * using a "any hour" expression.
+     *
+     * The expression defines timeouts every 30 min.
+     *
+     * Starting at 6 Oct 2013 1:15, first 3 timeouts should be:
+     *
+     * Traditional Cron - 1:30, 2:30, 3:00 (skips non existent 2:00)
+     * Modern Cron - same as Traditional Cron
+     */
+    @Test
+    public void testDstForward_30MinDstTimezone_AnyHour() {
+        TimeZone timeZone = TimeZone.getTimeZone("Australia/Lord_Howe");
+        int year = 2013;
+        int month = Calendar.OCTOBER;
+        int dayOfMonth = 6;
+        int hourOfDay = 1;
+        int minute = 15;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("*");
+        expression.minute("0, 30");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout1.get(Calendar.DST_OFFSET));
+
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout2.get(Calendar.DST_OFFSET));
+
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(3, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout3.get(Calendar.DST_OFFSET));
+    }
+
+    /**
+     * Tests correct timeouts going through a 0h30m DST forward (Australia/Lord_Howe, 6 Oct 2013, 02:00),
+     * using a specific hour expression.
+     *
+     * The expression defines timeouts every day at 1:20, 1:40, 2:20, 2:40, 3:20 and 3:40.
+     *
+     * Starting at 6 Oct 2013 1:30 STD, first 3 timeouts should be:
+     *
+     * Traditional Cron - 1:40, 2:40, 3:20 (skips non existent 2:20)
+     * Modern Cron - 1:40, 2:40, 2:50 (replaces 2:20 with 2:50)
+     */
+    @Test
+    public void testDstForward_30MinDstTimezone_SpecificHour() {
+        TimeZone timeZone = TimeZone.getTimeZone("Australia/Lord_Howe");
+        int year = 2013;
+        int month = Calendar.OCTOBER;
+        int dayOfMonth = 6;
+        int hourOfDay = 1;
+        int minute = 30;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("1, 2, 3");
+        expression.minute("20, 40");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(40, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(40, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(3, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(20, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+    }
+
+    /**
+     * Tests correct timeouts going through a 2h30m DST forward (custom timezone, 15 Jan 2013, 01:00),
+     * using a "any hour" expression.
+     *
+     * The expression defines timeouts every hour.
+     *
+     * Starting at 15 Jan 2013 0:00, first 3 timeouts should be:
+     *
+     * Traditional Cron - 0:00, 4:00, 5:00 (skips non existent 1:00, 2:00 and 3:00)
+     * Modern Cron - same as Traditional Cron
+     */
+    @Test
+    public void testDstForward_2Hour30MinDstTimezone_AnyHour() {
+
+        SimpleTimeZone timeZone = new SimpleTimeZone(0, "Custom/Custom");
+        timeZone.setStartYear(2014);
+        // 2.5h of dst savings
+        int dstSavings = 150*60*1000;
+        // dst forward on jan 15 01:00, skipped interval is 1:00 to 03:30
+        timeZone.setStartRule(Calendar.JANUARY, 15, 1*60*60*1000);
+        // dst roll on feb 15 12:00
+        timeZone.setEndRule(Calendar.FEBRUARY, 15, 12*60*60*1000);
+
+        timeZone.setDSTSavings(dstSavings);
+        TimeZone.setDefault(timeZone);
+
+        int year = 2014;
+        int month = Calendar.JANUARY;
+        int dayOfMonth = 15;
+        int hourOfDay = 0;
+        int minute = 0;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        // any day of year; any hour allowed; minutes allowed are 30
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("*");
+        expression.minute("0");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(0, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout1.get(Calendar.DST_OFFSET));
+
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(4, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(5, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+    }
+
+    /**
+     * Tests correct timeouts going through a 2h30m DST forward (custom timezone, 15 Jan 2013, 01:00),
+     * using a specific hour expression.
+     *
+     * The expression defines timeouts every day at 0:30, 1:30, 2:30 and 3:30.
+     *
+     * Starting at 15 Jan 2013 0:00, first 3 timeouts should be:
+     *
+     * Traditional Cron - 0:30, 3:30, 0:30 day after (skips non existent 1:30 and 2:30)
+     * Modern Cron - 0:30, 3:30, 4:00, 5:00 (replaces 1:30 with 4:00, 2:30 with 5:00)
+     */
+    @Test
+    public void testDstForward_2Hour30MinDstTimezone_SpecificHour() {
+
+        SimpleTimeZone timeZone = new SimpleTimeZone(0, "Custom/Custom");
+        timeZone.setStartYear(2014);
+        // 2.5h of dst savings
+        int dstSavings = 150*60*1000;
+        // dst forward on jan 15 01:00, skipped interval is 1:00 to 03:30
+        timeZone.setStartRule(Calendar.JANUARY, 15, 1*60*60*1000);
+        // dst roll on feb 15 12:00
+        timeZone.setEndRule(Calendar.FEBRUARY, 15, 12*60*60*1000);
+
+        timeZone.setDSTSavings(dstSavings);
+        TimeZone.setDefault(timeZone);
+
+        int year = 2014;
+        int month = Calendar.JANUARY;
+        int dayOfMonth = 15;
+        int hourOfDay = 0;
+        int minute = 0;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("0, 1, 2, 3");
+        expression.minute("30");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(0, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(3, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth+1, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(0, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+    }
+
+    /**
+     * Tests correct timeouts going through a 1h DST rollback (Europe/Lisbon, 27 Oct 2013, 02:00),
+     * using a "any hour" expression.
+     */
+    @Test
+    public void testDstRollback_1HourDstTimezone_AnyHour() {
+        TimeZone timeZone = TimeZone.getTimeZone("Europe/Lisbon");
+        int year = 2013;
+        int month = Calendar.OCTOBER;
+        int dayOfMonth = 27;
+        int hourOfDay = 0;
+        int minute = 30;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("*");
+        expression.minute("0, 30");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        // 1st timeout should be 0:30 DST
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(0, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout1.get(Calendar.DST_OFFSET));
+
+        // 2nd timeout should advance to 1:00 DST
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout2.get(Calendar.DST_OFFSET));
+
+        // 3rd timeout should advance to 01:30 DST
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout3.get(Calendar.DST_OFFSET));
+
+        // 4th timeout should advance to 01:00 STD
+        Calendar timeout4 = calendarTimeout.getNextTimeout(timeout3);
+        Assert.assertNotNull(timeout4);
+        Assert.assertEquals(year, timeout4.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout4.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout4.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout4.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout4.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout4.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout4.get(Calendar.DST_OFFSET));
+
+        // 5th timeout should be 01:30 STD
+        Calendar timeout5 = calendarTimeout.getNextTimeout(timeout4);
+        Assert.assertNotNull(timeout5);
+        Assert.assertEquals(year, timeout5.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout5.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout5.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout5.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout5.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout5.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout5.get(Calendar.DST_OFFSET));
+
+        // 6th timeout should be 02:00 STD
+        Calendar timeout6 = calendarTimeout.getNextTimeout(timeout5);
+        Assert.assertNotNull(timeout6);
+        Assert.assertEquals(year, timeout6.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout6.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout6.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout6.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout6.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout6.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout6.get(Calendar.DST_OFFSET));
+    }
+
+    /**
+     * Tests correct timeouts going through a 1h DST rollback (Europe/Lisbon, 27 Oct 2013, 02:00),
+     * using a specific hour expression.
+     */
+    @Test
+    public void testDstRollback_1HourDstTimezone_SpecificHour() {
+        TimeZone timeZone = TimeZone.getTimeZone("Europe/Lisbon");
+        int year = 2013;
+        int month = Calendar.OCTOBER;
+        int dayOfMonth = 27;
+        int hourOfDay = 0;
+        int minute = 0;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        // any day of year, time allowed is 01:00, 02:00
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("1, 2");
+        expression.minute("0");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        // 1st timeout should be 01:00 DST
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout1.get(Calendar.DST_OFFSET));
+
+        // 2nd timeout should be 01:00 STD
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout2.get(Calendar.DST_OFFSET));
+
+        // 3rd timeout should be 02:00 STD
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout3.get(Calendar.DST_OFFSET));
+    }
+
+    /**
+     * Tests correct timeouts going through a 2h30m DST rollback (Custom timezone, 15 Feb 2014, 12:00),
+     * using a "any hour" expression.
+     */
+    @Test
+    public void testDstRollback_2Hour30MinDstTimezone_AnyHour() {
+
+        SimpleTimeZone timeZone = new SimpleTimeZone(0, "Custom/Custom");
+        timeZone.setStartYear(2014);
+        // dst forward on jan 15 01:00
+        timeZone.setStartRule(Calendar.JANUARY, 15, 1*60*60*1000);
+        // dst roll on feb 15 12:00
+        timeZone.setEndRule(Calendar.FEBRUARY, 15, 12*60*60*1000);
+        // 2.5h of dst savings
+        int dstSavings = 150*60*1000;
+        timeZone.setDSTSavings(dstSavings);
+        TimeZone.setDefault(timeZone);
+
+        int year = 2014;
+        int month = Calendar.FEBRUARY;
+        int dayOfMonth = 15;
+        int hourOfDay = 11;
+        int minute = 30;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        // ensure we start on DST
+        start.set(Calendar.DST_OFFSET, timeZone.getDSTSavings());
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        // any day of year; any hour, minutes allowed are 0 and 30
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("*");
+        expression.minute("30");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        // 1st timeout should be 11:30 DST
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(11, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout1.get(Calendar.DST_OFFSET));
+
+        // 2nd timeout should be 9:30 STD
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(9, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout2.get(Calendar.DST_OFFSET));
+
+        // 3rd timeout should be 10:30 STD
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(10, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout3.get(Calendar.DST_OFFSET));
+
+        // 4th timeout should be 11:30 STD
+        Calendar timeout4 = calendarTimeout.getNextTimeout(timeout3);
+        Assert.assertNotNull(timeout4);
+        Assert.assertEquals(year, timeout4.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout4.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout4.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(11, timeout4.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout4.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout4.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout4.get(Calendar.DST_OFFSET));
+
+        // 5th timeout should be 12:30 STD
+        Calendar timeout5 = calendarTimeout.getNextTimeout(timeout4);
+        Assert.assertNotNull(timeout5);
+        Assert.assertEquals(year, timeout5.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout5.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout5.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(12, timeout5.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout5.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout5.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout5.get(Calendar.DST_OFFSET));
+    }
+
+    /**
+     * Tests correct timeouts going through a 2h30m DST rollback (Custom timezone, 15 Feb 2014, 12:00),
+     * using a specific expression.
+     */
+    @Test
+    public void testDstRollback_2Hour30MinDstTimezone_SpecificHour() {
+
+        SimpleTimeZone timeZone = new SimpleTimeZone(0, "Custom/Custom");
+        timeZone.setStartYear(2014);
+        // dst forward on jan 15 01:00
+        timeZone.setStartRule(Calendar.JANUARY, 15, 1*60*60*1000);
+        // dst roll on feb 15 12:00
+        timeZone.setEndRule(Calendar.FEBRUARY, 15, 12*60*60*1000);
+        // 2.5h of dst savings
+        int dstSavings = 150*60*1000;
+        timeZone.setDSTSavings(dstSavings);
+        TimeZone.setDefault(timeZone);
+
+        int year = 2014;
+        int month = Calendar.FEBRUARY;
+        int dayOfMonth = 15;
+        int hourOfDay = 9;
+        int minute = 0;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        // any day of year; hours allowed are 11, 12; minutes allowed are 30
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("11, 12");
+        expression.minute("30");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        // 1st timeout should be 11:30 DST
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(11, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout1.get(Calendar.DST_OFFSET));
+
+        // 2nd timeout should be 11:30 STD
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(11, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout2.get(Calendar.DST_OFFSET));
+
+        // 3rd timeout should be 12:30 STD
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(12, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(30, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout3.get(Calendar.DST_OFFSET));
+
+    }
+
+    /**
+     * Tests correct timeouts going through a 30m DST rollback (Australia/Lord_Howe, 7 Apr 2013, 02:00),
+     * using a "any hour" expression.
+     */
+    @Test
+    public void testDstRollback_30MinDstTimezone_AnyHour() {
+        TimeZone timeZone = TimeZone.getTimeZone("Australia/Lord_Howe");
+        int year = 2013;
+        int month = Calendar.APRIL;
+        int dayOfMonth = 7;
+        int hourOfDay = 1;
+        int minute = 20;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        // any day of year, any hour, minutes allowed are 0, 20 and 40
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("*");
+        expression.minute("0, 20, 40");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        // 1st timeout should be 01:20 DST
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(20, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout1.get(Calendar.DST_OFFSET));
+
+        // 2nd timeout should be 01:40 DST
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(40, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout2.get(Calendar.DST_OFFSET));
+
+        // 3rd timeout should be 01:40 STD
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(40, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout3.get(Calendar.DST_OFFSET));
+
+        // 4th timeout should be 02:00 STD
+        Calendar timeout4 = calendarTimeout.getNextTimeout(timeout3);
+        Assert.assertNotNull(timeout4);
+        Assert.assertEquals(year, timeout4.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout4.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout4.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout4.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout4.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout4.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout4.get(Calendar.DST_OFFSET));
+    }
+
+    /**
+     * Tests correct timeouts going through a 30m DST rollback (Australia/Lord_Howe, 7 Apr 2013, 02:00),
+     * using a specific hour expression.
+     */
+    @Test
+    public void testDstRollback_30MinDstTimezone_SpecificHour() {
+        TimeZone timeZone = TimeZone.getTimeZone("Australia/Lord_Howe");
+        int year = 2013;
+        int month = Calendar.APRIL;
+        int dayOfMonth = 7;
+        int hourOfDay = 1;
+        int minute = 0;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar(timeZone);
+        start.clear();
+        start.set(Calendar.DST_OFFSET, timeZone.getDSTSavings());
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+        Assert.assertEquals(year, start.get(Calendar.YEAR));
+        Assert.assertEquals(month, start.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, start.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(hourOfDay, start.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(minute, start.get(Calendar.MINUTE));
+        Assert.assertEquals(second, start.get(Calendar.SECOND));
+
+        // any day of year; hour 1 or 2; minutes allowed are 0, 20, and 40
+        ScheduleExpression expression = new ScheduleExpression();
+        expression.timezone(timeZone.getID());
+        expression.dayOfMonth("*");
+        expression.hour("1, 2");
+        expression.minute("0, 20, 40");
+        expression.second("0");
+        expression.start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+
+        // 1st timeout should be 01:00 DST
+        Calendar timeout1 = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(timeout1);
+        Assert.assertEquals(year, timeout1.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout1.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout1.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout1.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout1.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout1.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout1.get(Calendar.DST_OFFSET));
+
+        // 2nd timeout should be 01:20 DST
+        Calendar timeout2 = calendarTimeout.getNextTimeout(timeout1);
+        Assert.assertNotNull(timeout2);
+        Assert.assertEquals(year, timeout2.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout2.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout2.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout2.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(20, timeout2.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout2.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout2.get(Calendar.DST_OFFSET));
+
+        // 3rd timeout should be 01:40 DST
+        Calendar timeout3 = calendarTimeout.getNextTimeout(timeout2);
+        Assert.assertNotNull(timeout3);
+        Assert.assertEquals(year, timeout3.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout3.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout3.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout3.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(40, timeout3.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout3.get(Calendar.SECOND));
+        Assert.assertEquals(timeZone.getDSTSavings(), timeout3.get(Calendar.DST_OFFSET));
+
+        // 4th timeout should be 01:40 STD
+        Calendar timeout4 = calendarTimeout.getNextTimeout(timeout3);
+        Assert.assertNotNull(timeout4);
+        Assert.assertEquals(year, timeout4.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout4.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout4.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(1, timeout4.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(40, timeout4.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout4.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout4.get(Calendar.DST_OFFSET));
+
+        // 5th timeout should be 02:00 STD
+        Calendar timeout5 = calendarTimeout.getNextTimeout(timeout4);
+        Assert.assertNotNull(timeout5);
+        Assert.assertEquals(year, timeout5.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout5.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout5.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout5.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, timeout5.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout5.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout5.get(Calendar.DST_OFFSET));
+
+        // 6th timeout should be 02:20 STD
+        Calendar timeout6 = calendarTimeout.getNextTimeout(timeout5);
+        Assert.assertNotNull(timeout6);
+        Assert.assertEquals(year, timeout6.get(Calendar.YEAR));
+        Assert.assertEquals(month, timeout6.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, timeout6.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(2, timeout6.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(20, timeout6.get(Calendar.MINUTE));
+        Assert.assertEquals(second, timeout6.get(Calendar.SECOND));
+        Assert.assertEquals(0, timeout6.get(Calendar.DST_OFFSET));
     }
 
     private ScheduleExpression getTimezoneSpecificScheduleExpression() {


### PR DESCRIPTION
Currently we leave our EJB expression based scheduling DST changes handling up to JDK Calendar, which is problematic in some use cases:
- when setting a time in DST rollback repeated period it will choose the later STD version, skipping the earlier DST version, this means period scheduling such as every 30 min will have skipped timeouts
- when setting a time in DST forward skipped period it will adjust time to original time + DST savings, which may skip timeouts between the beginning of DST period and such adjustment

This PR fixes the issues above implementing the traditional cron behaviour, i.e. on DST rollback "ambiguous" timeouts will be repeated, and on DST forward "non existent" timeouts will be skipped instead of adjusted.
Modern cron is not a must, will add later if requested.
