### PR TITLE
[WFLY-3690] [BZ1077156] Not possible to start XTS transaction on IPv6 with server bound to ::1

### DIFF
--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
@@ -154,7 +154,31 @@ class XTSSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final String hostName = HOST_NAME.resolveModelAttribute(context, model).asString();
 
         final ModelNode coordinatorURLAttribute = ENVIRONMENT_URL.resolveModelAttribute(context, model);
-        final String coordinatorURL = coordinatorURLAttribute.isDefined() ? coordinatorURLAttribute.asString() : null;
+        String coordinatorURL = coordinatorURLAttribute.isDefined() ? coordinatorURLAttribute.asString() : null;
+
+        if (coordinatorURL != null) {
+            String[] attrs = coordinatorURL.split("/");
+            boolean isIPv6Address = false;
+
+            for (int i = 0; i < attrs.length; i++) {
+                if (attrs[i].startsWith("::1")) {
+                    attrs[i] = "[" + attrs[i].substring(0, 3) + "]" + attrs[i].substring(3);
+                    isIPv6Address = true;
+                    break;
+                }
+            }
+
+            if (isIPv6Address) {
+                StringBuffer sb = new StringBuffer(attrs[0]);
+
+                for (int i = 1; i < attrs.length; i++) {
+                    sb.append('/').append(attrs[i]);
+                }
+
+                coordinatorURL = sb.toString();
+            }
+        }
+
         if (coordinatorURL != null && XtsAsLogger.ROOT_LOGGER.isDebugEnabled()) {
             XtsAsLogger.ROOT_LOGGER.debugf("nodeIdentifier=%s\n", coordinatorURL);
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3690
https://bugzilla.redhat.com/show_bug.cgi?id=1077156
