### PR TITLE
WFLY-3989 Setup the right TCCL during endpoint instance creation as well as view instance creation

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/DDBasedMDB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/DDBasedMDB.java
@@ -51,6 +51,28 @@ public class DDBasedMDB implements MessageListener {
 
     private static final Logger logger = Logger.getLogger(DDBasedMDB.class);
 
+    static {
+        // @see https://issues.jboss.org/browse/WFLY-3989
+        // do an activity that depends on TCCL being the right one (== the application classloader)
+        final String className = DDBasedMDB.class.getName();
+        try {
+            loadClassThroughTCCL(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Could not load " + className + " through TCCL " + Thread.currentThread().getContextClassLoader() + " in the static block of MDB");
+        }
+    }
+
+    public DDBasedMDB() {
+        // @see https://issues.jboss.org/browse/WFLY-3989
+        // do an activity that depends on TCCL being the right one (== the application classloader)
+        final String className = this.getClass().getName();
+        try {
+            loadClassThroughTCCL(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Could not load " + className + " through TCCL " + Thread.currentThread().getContextClassLoader() + " in the constructor of MDB");
+        }
+    }
+
     @Override
     public void onMessage(Message message) {
         logger.info("Received message " + message + " in MDB " + this.getClass().getName());
@@ -87,4 +109,7 @@ public class DDBasedMDB implements MessageListener {
         }
     }
 
+    private static void loadClassThroughTCCL(String className) throws ClassNotFoundException {
+        Thread.currentThread().getContextClassLoader().loadClass(className);
+    }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-3989 describes the issue where the TCCL isn't set to the application's classloader when the MDB object instantiation is being done. As noted in an old (related) discussion http://lists.jboss.org/pipermail/jboss-as7-dev/2011-July/003339.html the user application code is expected to have the correct TCCL (which in this case should be the application's deployment classloader).

This commit fixes the issue by using the right TCCL during the endpoint instantiation as well as the component view instance creation (which in case of MDBs can lead to the MDB implementation object instantiation). The commit also updates the MDBTestCase to verify these changes.

P.S: This needs review from the EE team as well as JCA team. Specifically, the TCCL switch during the view instance creation in ViewService. Although the change fixes this issue and does seem logical, I haven't been in this code for a long time now and I'm not fully sure of its impact.
