### PR TITLE
[WFLY-3776] : ClassNotFound exception when running Arquillian test

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
@@ -46,6 +46,7 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.jboss.as.protocol"/>
         <module name="javax.api" />
     </dependencies>
 </module>


### PR DESCRIPTION
Addition of <module name="org.jboss.as.protocol"/> to module.xml of "org.jboss.as.embedded module"

[WFLY-3776] : https://issues.jboss.org/browse/WFLY-3776
