### PR TITLE
[WFLY-3776] : ClassNotFound exception when running Arquillian test

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
@@ -42,5 +42,6 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.jboss.as.protocol"/>
     </dependencies>
 </module>


### PR DESCRIPTION
Addition of to module.xml of "org.jboss.as.embedded module"

[WFLY-3776] : https://issues.jboss.org/browse/WFLY-3776
Upstream PR : https://github.com/wildfly/wildfly/pull/6879
