### PR TITLE
WFLY-4029 Upgrading Hibernate Validator to 5.1.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>
         <version.org.hibernate>4.3.6.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>4.0.4.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.validator>5.1.2.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>5.1.3.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.1.0.Alpha3</version.org.hibernate.hql>
         <version.org.hibernate.search>5.0.0.Alpha7</version.org.hibernate.search>


### PR DESCRIPTION
In particular includes a fix for https://hibernate.atlassian.net/browse/HV-930
