### PR TITLE
WFLY-4021 add Hibernate ORM 4.3 module alias so applications or other mo...

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<!-- Represents the Hibernate 4.3.x (org.hibernate:main) module  -->
+<module-alias xmlns="urn:jboss:module:1.3" name="org.hibernate.main" slot="4.3"  target-name="org.hibernate"/>
+


### PR DESCRIPTION
...dules can depend on the current org.hibernate:main version of Hibernate.  We should add an alias for the major/minor Hibernate orm release when changing org.hibernate:main in the future.
