### PR TITLE
Revert making jackson public

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-core-asl/main/module.xml
@@ -22,6 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-core-asl">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-core-asl}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-jaxrs/main/module.xml
@@ -22,6 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-jaxrs">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-jaxrs}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-mapper-asl/main/module.xml
@@ -22,6 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-mapper-asl">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-mapper-asl}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/codehaus/jackson/jackson-xc/main/module.xml
@@ -22,6 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <module xmlns="urn:jboss:module:1.3" name="org.codehaus.jackson.jackson-xc">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
         <artifact name="${org.codehaus.jackson:jackson-xc}"/>


### PR DESCRIPTION
This reverts commit 73f1c64a276fecfbef21ab414a12496651887a89, reversing
changes made to 473611d95d4339c0a4ffdd2872f7d6609c2d63a2.

Internal discussions lead to this being reverted in the product.
Original PR was https://github.com/wildfly/wildfly/pull/6785
In anticipation of this getting merged I have set https://issues.jboss.org/browse/WFLY-3937 as Rejected
