### PR TITLE
[WFLY-3710] Switch to a version independent parseVault call.

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/parsing/AppClientXml.java
@@ -268,22 +268,7 @@ public class AppClientXml extends CommonXml {
         }
 
         if (element == Element.VAULT) {
-            switch (namespace) {
-                //Less than 1.1 does not end up in this method
-                case DOMAIN_1_1:
-                case DOMAIN_1_2:
-                case DOMAIN_1_3:
-                case DOMAIN_1_4:
-                case DOMAIN_1_5:
-                case DOMAIN_2_0:
-                case DOMAIN_2_1: {
-                    parseVault_1_1(reader, address, namespace, list);
-                    break;
-                }
-                default: {
-                    parseVault_3_0(reader, address, namespace, list);
-                }
-            }
+            parseVault(reader, address, namespace, list);
             element = nextElement(reader, namespace);
         }
         // Single profile


### PR DESCRIPTION
The relationship between CommonXml and AppClientXml is very sensitive, making use of non version specific calls will help reduce breakages.
