### PR TITLE
Testsuite calls to low-level reload ops should deal with CancellationExc...

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveHostControllerAuthenticationTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/SlaveHostControllerAuthenticationTestCase.java
@@ -44,6 +44,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VAU
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
 
 import java.io.IOException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
 import javax.security.auth.callback.CallbackHandler;
@@ -180,7 +181,8 @@ public class SlaveHostControllerAuthenticationTestCase {
         try {
             domainSlaveClient.execute(new OperationBuilder(op).build());
         } catch(IOException e) {
-            if (!(e.getCause() instanceof ExecutionException)) {
+            final Throwable cause = e.getCause();
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
                 throw e;
             } // else ignore, this might happen if the channel gets closed before we got the response
         }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/HornetQBackupActivationTestCase.java
@@ -41,13 +41,13 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.wildfly.test.api.Authentication;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.as.test.shared.TimeoutUtil;
@@ -56,6 +56,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.wildfly.test.api.Authentication;
 
 /**
  *
@@ -287,11 +288,9 @@ public class HornetQBackupActivationTestCase {
             execute(client, operation);
         } catch(IOException e) {
             final Throwable cause = e.getCause();
-            if (cause instanceof ExecutionException) {
-                // ignore, this might happen if the channel gets closed before we got the response
-            } else {
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
                 throw e;
-            }
+            } // else ignore, this might happen if the channel gets closed before we got the response
         }
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/AbstractCertificateLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/AbstractCertificateLoginModuleTestCase.java
@@ -39,6 +39,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Locale;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 
 import javax.net.ssl.SSLHandshakeException;
@@ -75,7 +76,7 @@ import org.xnio.IoUtils;
  * Abstract class which serve as a base for CertificateLoginModule tests. It is
  * used for setting up server/client keystores, https connector and contains
  * useful methods for testing two-way SSL connection.
- * 
+ *
  * @author Filip Bogyai
  */
 public abstract class AbstractCertificateLoginModuleTestCase {
@@ -100,7 +101,7 @@ public abstract class AbstractCertificateLoginModuleTestCase {
      * trusted certificates. Client with trusted certificate is allowed to
      * access both secured/unsecured resource. Client with untrusted certificate
      * can only access unprotected resources.
-     * 
+     *
      * @throws Exception
      */
     public void testLoginWithCertificate(String appName) throws Exception {
@@ -185,12 +186,9 @@ public abstract class AbstractCertificateLoginModuleTestCase {
             Assert.assertEquals("success", result.get(ClientConstants.OUTCOME).asString());
         } catch (IOException e) {
             final Throwable cause = e.getCause();
-            if (cause instanceof ExecutionException) {
-                // ignore, this might happen if the channel gets closed before
-                // we got the response
-            } else {
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
                 throw e;
-            }
+            } // else ignore, this might happen if the channel gets closed before we got the response
         }
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
@@ -28,6 +28,7 @@ import java.net.ProxySelector;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -144,11 +145,9 @@ public class ReloadWSDLPublisherTestCase {
             Assert.assertTrue(Operations.isSuccessfulOutcome(client.execute(operation)));
         } catch(IOException e) {
             final Throwable cause = e.getCause();
-            if (cause instanceof ExecutionException) {
-                // ignore, this might happen if the channel gets closed before we got the response
-            } else {
+            if (!(cause instanceof ExecutionException) && !(cause instanceof CancellationException)) {
                 throw e;
-            }
+            } // else ignore, this might happen if the channel gets closed before we got the response
         } finally {
             client.close();
         }


### PR DESCRIPTION
...eption as it can happen if the channel gets closed

This will fix reload failures like the CertificateRolesLoginModuleTestCase ones in http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=29836&buildTypeId=WildFlyCore_PullRequest_WildFlyCoreFullIntegration
