### PR TITLE
Revert "Upgrade to httpclient 4.3.6"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <version.org.apache.cxf>3.0.2</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.2</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M15</version.org.apache.ds>
-        <version.org.apache.httpcomponents.httpclient>4.3.6</version.org.apache.httpcomponents.httpclient>
+        <version.org.apache.httpcomponents.httpclient>4.3.2</version.org.apache.httpcomponents.httpclient>
         <version.org.apache.httpcomponents.httpasyncclient>4.0.1</version.org.apache.httpcomponents.httpasyncclient>
         <version.org.apache.httpcomponents.httpcore>4.3.2</version.org.apache.httpcomponents.httpcore>
         <version.org.apache.james.apache-mime4j>0.6</version.org.apache.james.apache-mime4j>


### PR DESCRIPTION
Reverts wildfly/wildfly#6968

I'm reverting this because since it went in, CfgFileTestCase has continually failed.

http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WF&testNameId=4543717080903920957&tab=testDetails

Caused by: com.ctc.wstx.exc.WstxParsingException: (was java.io.FileNotFoundException) http://hibernate.org/dtd/hibernate-configuration-3.0.dtd
at [row,col {unknown-source}]: [4,63]
which I'm guessing involves trying to find the DTD at that URL
