### PR TITLE
WFLY-4107: Upgrade HAL to 2.4.9.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,7 +164,7 @@
         <version.org.jboss.aesh>0.33.11</version.org.jboss.aesh>
         <version.org.jboss.arquillian.core>1.1.2.Final-wildfly-1</version.org.jboss.arquillian.core>
         <version.org.jboss.arquillian.osgi>2.1.0.CR2</version.org.jboss.arquillian.osgi>
-        <version.org.jboss.hal.release-stream>2.4.8.Final</version.org.jboss.hal.release-stream>
+        <version.org.jboss.hal.release-stream>2.4.9.Final</version.org.jboss.hal.release-stream>
         <version.org.jboss.byteman>2.1.4</version.org.jboss.byteman>
         <version.org.jboss.classfilewriter>1.0.4.Final</version.org.jboss.classfilewriter>
         <version.org.jboss.common.jboss-common-beans>1.1.0.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
Ships with a log viewer which works with the reduced log-file resource (no streaming) built into WildFly 8.2. Requires https://github.com/wildfly/wildfly/pull/6980 to be merged first.

Related issue: https://issues.jboss.org/browse/WFLY-4107
