### PR TITLE
WFLY-4110 - EJBClientClusterConfigurationTestCase fails on JDK1.8 once Dnode0 and -Dnode1 are used

### DIFF
--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -33,6 +33,13 @@
         <!-- Configure all standalone-ha.xml profiles not to be chatty by setting ip_ttl=0 -->
         <ts.config-as.configure-multicast-ttl name="jbossas" mcast.ttl="${mcast.ttl}"/>
 
+        <ts.config-as.add-interface name="jbossas"
+                                    interface="multicast"
+                                    inet-address="${node0}"/>
+        <ts.config-as.change-jgroups-multicast-interface name="jbossas"
+                                                         interface="multicast"/>
+
+
         <echo message="Copying and configuring instance jbossas-with-remote-outbound-connection"/>
         <copy todir="target/jbossas-with-remote-outbound-connection">
             <fileset dir="target/jbossas"/>


### PR DESCRIPTION
This is a follow-up of  https://github.com/wildfly/wildfly/pull/6829.

The same issue affects also manualmode TS module.
