### PR TITLE
[WFLY-4121] fix LDAP address in AdvancedLdap Login module test

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/AdvancedLdapLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/negotiation/AdvancedLdapLoginModuleTestCase.java
@@ -402,7 +402,7 @@ public class AdvancedLdapLoginModuleTestCase {
             final String hostname = Utils.getCannonicalHost(managementClient);
             final Map<String, String> map = new HashMap<String, String>();
             map.put("hostname", NetworkUtils.formatPossibleIpv6Address(hostname));
-            final String secondaryTestAddress = Utils.getSecondaryTestAddress(managementClient, true);
+            final String secondaryTestAddress = NetworkUtils.canonize(Utils.getSecondaryTestAddress(managementClient, true));
             map.put("ldaphost", secondaryTestAddress);
             final String ldifContent = StrSubstitutor.replace(
                     IOUtils.toString(


### PR DESCRIPTION
An update in `NetworkUtils.formatPossibleIpv6Address(address)` method canonizes IPv6 addresses now. The `AdvancedLdapLoginModuleTestCase` has to be updated to use correct format for LDAP server SPN in KDC.

JIRA: https://issues.jboss.org/browse/WFLY-4121
