### PR TITLE
[WFLY-4139] Always add batch subsystem dependencies.

### DIFF
--- a/batch/jberet/src/main/java/org/wildfly/jberet/WildFlyArtifactFactory.java
+++ b/batch/jberet/src/main/java/org/wildfly/jberet/WildFlyArtifactFactory.java
@@ -55,6 +55,9 @@ public final class WildFlyArtifactFactory extends AbstractArtifactFactory {
     }
 
     private Bean<?> getBean(final String ref) {
+        if (beanManager == null) {
+            return null;
+        }
         WildFlyBatchLogger.LOGGER.tracef("Looking up bean reference for '%s'", ref);
         final Set<Bean<?>> beans = beanManager.getBeans(ref);
         final Iterator<Bean<?>> iter = beans.iterator();

--- a/batch/jberet/src/main/java/org/wildfly/jberet/_private/WildFlyBatchLogger.java
+++ b/batch/jberet/src/main/java/org/wildfly/jberet/_private/WildFlyBatchLogger.java
@@ -37,17 +37,6 @@ public interface WildFlyBatchLogger extends BasicLogger {
     WildFlyBatchLogger LOGGER = Logger.getMessageLogger(WildFlyBatchLogger.class, "org.wildfly.jberet");
 
     /**
-     * Creates an exception indicating a service was not installed.
-     *
-     * @param name a name for the service
-     *
-     * @return an {@link IllegalStateException} for the error
-     */
-    @Message(id = 1, value = "%s service was not added on the deployment. Ensure the deployment has a " +
-            "META-INF/batch.xml file or the META-INF/batch-jobs directory contains batch configuration files.")
-    IllegalStateException serviceNotInstalled(String name);
-
-    /**
      * Creates an exception indicating the job repository type was invalid.
      *
      * @param type the invalid type

--- a/batch/jberet/src/main/java/org/wildfly/jberet/services/BatchEnvironmentService.java
+++ b/batch/jberet/src/main/java/org/wildfly/jberet/services/BatchEnvironmentService.java
@@ -69,7 +69,7 @@ public class BatchEnvironmentService implements Service<BatchEnvironment> {
     public synchronized void start(final StartContext context) throws StartException {
         WildFlyBatchLogger.LOGGER.debugf("Creating batch environment; %s", classLoader);
         final BatchEnvironment batchEnvironment = new WildFlyBatchEnvironment(beanManagerInjector.getOptionalValue(),
-                executorServiceInjector.getValue(), transactionManagerInjector.getOptionalValue());
+                executorServiceInjector.getValue(), transactionManagerInjector.getValue());
         // Add the service to the factory
         BatchEnvironmentFactory.getInstance().add(classLoader, batchEnvironment);
         this.batchEnvironment = batchEnvironment;
@@ -107,7 +107,7 @@ public class BatchEnvironmentService implements Service<BatchEnvironment> {
 
         WildFlyBatchEnvironment(final BeanManager beanManager,
                                 final ExecutorService executorService, final TransactionManager transactionManager) {
-            artifactFactory = (beanManager == null ? null : new WildFlyArtifactFactory(beanManager));
+            artifactFactory = new WildFlyArtifactFactory(beanManager);
             this.executorService = executorService;
             this.transactionManager = transactionManager;
         }
@@ -119,9 +119,6 @@ public class BatchEnvironmentService implements Service<BatchEnvironment> {
 
         @Override
         public ArtifactFactory getArtifactFactory() {
-            if (artifactFactory == null) {
-                throw WildFlyBatchLogger.LOGGER.serviceNotInstalled("BeanManager");
-            }
             return artifactFactory;
         }
 
@@ -175,9 +172,6 @@ public class BatchEnvironmentService implements Service<BatchEnvironment> {
 
         @Override
         public TransactionManager getTransactionManager() {
-            if (transactionManager == null) {
-                throw WildFlyBatchLogger.LOGGER.serviceNotInstalled("TransactionManager");
-            }
             return transactionManager;
         }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/NoCdiTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/NoCdiTestCase.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
+
+/**
+ * @author <a href="mailto:brent.n.douglas@gmail.com">Brent Douglas</a>
+ * @since 9.0
+ */
+@RunWith(Arquillian.class)
+public class NoCdiTestCase extends Assert {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        return ShrinkWrap.create(JavaArchive.class, NoCdiTestCase.class.getSimpleName() + ".jar")
+                .addClass(NoCdiTestCase.class);
+    }
+
+    @Test
+    public void testJobOperatorIsAvailable() throws Exception {
+        final JobOperator operator = BatchRuntime.getJobOperator();
+        assertNotNull(operator);
+    }
+}


### PR DESCRIPTION
Also move validation that they were configured to subsystem startup
rather than when a user requests the job operator, not that it will
matter now.
