### PR TITLE
[WFLY-4133] Hanging EJB threads because of a persistent timer and failed deployment

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -23,6 +23,14 @@ package org.jboss.as.ejb3.component;
 
 import static org.jboss.as.ejb3.logging.EjbLogger.ROOT_LOGGER;
 
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.Principal;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedExceptionAction;
+import java.util.Collections;
+import java.util.Map;
+
 import javax.ejb.EJBHome;
 import javax.ejb.EJBLocalHome;
 import javax.ejb.TimerService;
@@ -37,23 +45,16 @@ import javax.transaction.TransactionManager;
 import javax.transaction.TransactionSynchronizationRegistry;
 import javax.transaction.UserTransaction;
 
-import java.lang.reflect.Method;
-import java.security.AccessController;
-import java.security.Principal;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
-import java.util.Collections;
-import java.util.Map;
-
 import org.jboss.as.core.security.ServerSecurityManager;
 import org.jboss.as.ee.component.BasicComponent;
 import org.jboss.as.ee.component.ComponentView;
-import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.component.allowedmethods.AllowedMethodsInformation;
 import org.jboss.as.ejb3.component.invocationmetrics.InvocationMetrics;
 import org.jboss.as.ejb3.context.CurrentInvocationContext;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
 import org.jboss.as.ejb3.security.EJBSecurityMetaData;
+import org.jboss.as.ejb3.timerservice.TimerServiceImpl;
 import org.jboss.as.ejb3.tx.ApplicationExceptionDetails;
 import org.jboss.as.naming.ManagedReference;
 import org.jboss.as.naming.context.NamespaceContextSelector;
@@ -539,12 +540,18 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
         if (this.controlPoint != null) {
             this.controlPoint.resume();
         }
+        if(this.timerService instanceof TimerServiceImpl) {
+            ((TimerServiceImpl) this.timerService).activate();
+        }
     }
 
     @Override
     public final void stop() {
         if (this.controlPoint != null) {
             this.controlPoint.pause(this);
+        }
+        if(this.timerService instanceof TimerServiceImpl) {
+            ((TimerServiceImpl) this.timerService).deactivate();
         }
         this.done();
     }


### PR DESCRIPTION
BZ 6.x https://bugzilla.redhat.com/show_bug.cgi?id=1147948
JIRA upstream: https://issues.jboss.org/browse/WFLY-4133
TimerServiceImpl gets a new state (active). This avoids getting stuck
during failed deployments when the TimerService starts before the 
EJBComponent, causing an unrecoverable lock in
BasicComponent.waitForComponentStart
