### PR TITLE
[WFLY-4130] Allow -secmgr to be used with the appclient to enable the security manager

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientLogger.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/logging/AppClientLogger.java
@@ -142,6 +142,14 @@ public interface AppClientLogger extends BasicLogger {
     String argVersion();
 
     /**
+     * Instructions for {@link org.jboss.as.process.CommandLineConstants#VERSION} command line argument.
+     *
+     * @return the instructions.
+     */
+    @Message(id = Message.NONE, value = "Runs the container with the security manager enabled.")
+    String argSecMgr();
+
+    /**
      * A message indicating that you must specify an application client to execute.
      *
      * @return the message.

--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/CommandLineArgumentUsageImpl.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/CommandLineArgumentUsageImpl.java
@@ -51,6 +51,9 @@ public class CommandLineArgumentUsageImpl extends CommandLineArgumentUsage {
 
         addArguments(CommandLineConstants.SHORT_VERSION, CommandLineConstants.VERSION);
         instructions.add(AppClientLogger.ROOT_LOGGER.argVersion());
+
+        addArguments(CommandLineConstants.SECMGR);
+        instructions.add(AppClientLogger.ROOT_LOGGER.argSecMgr());
     }
 
     public static void printUsage(final PrintStream out) {

--- a/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/subsystem/Main.java
@@ -258,6 +258,8 @@ public final class Main {
                     WildFlySecurityManager.setPropertyPrivileged(name, value);
                 } else if (arg.startsWith(CommandLineConstants.APPCLIENT_CONFIG)) {
                     appClientConfig = parseValue(arg, CommandLineConstants.APPCLIENT_CONFIG);
+                } else if (CommandLineConstants.SECMGR.equals(arg)) {
+                    // ignore the argument as it's allowed, but passed to jboss-modules and not used here
                 } else {
                     if (arg.startsWith("-")) {
                         STDOUT.println(AppClientLogger.ROOT_LOGGER.unknownOption(arg));

--- a/feature-pack/src/main/resources/content/bin/appclient.bat
+++ b/feature-pack/src/main/resources/content/bin/appclient.bat
@@ -7,12 +7,35 @@ rem $Id$
 
 @if not "%ECHO%" == ""  echo %ECHO%
 @if "%OS%" == "Windows_NT" setlocal
+rem Set to all parameters by default
+set SERVER_OPTS=%*
 
 if "%OS%" == "Windows_NT" (
   set "DIRNAME=%~dp0%"
 ) else (
   set DIRNAME=.\
 )
+
+setlocal EnableDelayedExpansion
+rem check for the security manager system property
+echo(!SERVER_OPTS! | findstr /r /c:"-Djava.security.manager" > nul
+if not errorlevel == 1 (
+    echo ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable.
+    GOTO :EOF
+)
+setlocal DisableDelayedExpansion
+
+rem Read command-line args, the ~ removes the quotes from the parameter
+:READ-ARGS
+if "%~1" == "" (
+   goto MAIN
+) else if "%~1" == "-secmgr" (
+   set SECMGR=true
+)
+shift
+goto READ-ARGS
+
+:MAIN
 
 rem Read an optional configuration file.
 if "x%APPCLIENT_CONF%" == "x" (
@@ -70,6 +93,12 @@ if not errorlevel == 1 (
   set "JAVA_OPTS=%JAVA_OPTS% -server"
 )
 
+rem If the -Djava.security.manager is found, enable the -secmgr and include a bogus security manager for JBoss Modules to replace
+echo(%JAVA_OPTS% | findstr /r /c:"-Djava.security.manager" > nul && (
+    echo ERROR: The use of -Djava.security.manager has been removed. Please use the -secmgr command line argument or SECMGR=true environment variable.
+    GOTO :EOF
+)
+
 rem Find run.jar, or we can't continue
 if exist "%JBOSS_HOME%\jboss-modules.jar" (
     set "RUNJAR=%JBOSS_HOME%\jboss-modules.jar"
@@ -86,10 +115,17 @@ if "x%JBOSS_MODULEPATH%" == "x" (
   set  "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
+rem Set the module options
+set "MODULE_OPTS="
+if "%SECMGR%" == "true" (
+    set "MODULE_OPTS=-secmgr"
+)
+
 "%JAVA%" %JAVA_OPTS% ^
  "-Dorg.jboss.boot.log.file=%JBOSS_HOME%\appclient\log\appclient.log" ^
  "-Dlogging.configuration=file:%JBOSS_HOME%/appclient/configuration/logging.properties" ^
     -jar "%JBOSS_HOME%\jboss-modules.jar" ^
+    %MODULE_OPTS% ^
     -mp "%JBOSS_MODULEPATH%" ^
      org.jboss.as.appclient ^
     "-Djboss.home.dir=%JBOSS_HOME%" ^

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
@@ -71,7 +71,7 @@
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.security"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.manager" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.metadata.common"/>


### PR DESCRIPTION
Allows `-secmgr` to be passed to the applicent scripts to enable the security manager.
