### PR TITLE
[WFLY-4172] Enable the -secmgr parameter for tests if the security.manager property is defined.

### DIFF
--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -274,7 +274,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Declipselink.archive.factory=org.jipijapa.eclipselink.JBossArchiveFactoryImpl</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Declipselink.archive.factory=org.jipijapa.eclipselink.JBossArchiveFactoryImpl</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/compat/src/test/resources/arquillian.xml
+++ b/testsuite/compat/src/test/resources/arquillian.xml
@@ -8,6 +8,7 @@
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -116,7 +116,7 @@
                         <module.path>${jboss.dist}/modules</module.path>
                         <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                         <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
                     </systemPropertyVariables>
                     <includes>
                          <include>org/jboss/as/test/integration/autoignore/*TestCase.java</include>
@@ -174,7 +174,7 @@
                                 <module.path>${jboss.dist}/modules</module.path>
                                 <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                                 <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
-                                <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
+                                <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
                                 <jboss.test.rbac.soak.clients>${jboss.test.rbac.soak.clients}</jboss.test.rbac.soak.clients>
                                 <jboss.test.rbac.soak.iterations>${jboss.test.rbac.soak.iterations}</jboss.test.rbac.soak.iterations>
                             </systemPropertyVariables>

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
@@ -13,6 +13,7 @@
             <property name="jbossHome">${basedir}/target/wildfly-SYNC-tcp-0</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-SYNC-tcp-0 -Djboss.node.name=node-0</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -27,6 +28,7 @@
             <property name="jbossHome">${basedir}/target/wildfly-udp-jdbc-store</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-udp-jdbc-store -Djboss.node.name=node-0</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -44,6 +46,7 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-${cacheMode}-${stack}-0 -Djboss.node.name=node-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -58,6 +61,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-${cacheMode}-${stack}-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-${cacheMode}-${stack}-1 -Djboss.node.name=node-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 
@@ -72,6 +76,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-SYNC-tcp-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-SYNC-tcp-0 -Djboss.node.name=node-0</property>
                 <property name="serverConfig">standalone.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
@@ -89,6 +94,7 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-0 -Djboss.node.name=LON-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -103,6 +109,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-LON-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-1 -Djboss.node.name=LON-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 
@@ -117,6 +124,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-NYC-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-NYC-0 -Djboss.node.name=NYC-0 -Djboss.port.offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
 
@@ -131,6 +139,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-SFO-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-SFO-0 -Djboss.node.name=SFO-0 -Djboss.port.offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
 
@@ -150,6 +159,7 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-0 -Djboss.node.name=LON-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -164,6 +174,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-LON-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-1 -Djboss.node.name=LON-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 
@@ -178,6 +189,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-NYC-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-NYC-0 -Djboss.node.name=NYC-0 -Djboss.port.offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
 
@@ -192,6 +204,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-SFO-0-backupFor</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-SFO-0-backupFor -Djboss.node.name=SFO-0-backupFor -Djboss.port.offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
 

--- a/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
@@ -12,6 +12,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-iiop-client</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-iiop-client</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -27,6 +28,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-iiop-server</property>
                 <property name="javaVmArguments">${server.jvm.args}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -10,6 +10,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Djboss.node.name=default-jbossas</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
@@ -25,6 +26,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-with-remote-outbound-connection</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-with-remote-outbound-connection -Djboss.node.name=jbossas-with-remote-outbound-connection</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
@@ -40,6 +42,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-layered</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-layered -Djboss.node.name=jbossas-layered</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
@@ -56,6 +59,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-messaging-failover</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-messaging-failover -Djboss.node.name=default-jbossas-messaging-failover</property>
                 <property name="serverConfig">standalone-full.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
@@ -71,6 +75,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-messaging-failover</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.socket.binding.port-offset=100 -Djboss.inst=${basedir}/target/jbossas-messaging-failover -Djboss.node.name=default-jbossas-messaging-failover</property>
                 <property name="serverConfig">standalone-full-backup.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:10090}</property>
@@ -86,6 +91,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Djboss.node.name=default-jbossas</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -13,6 +13,7 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-client -Djboss.node.name=multinode-client</property>
                                                                                         <!-- jboss.node.name is defined in the test, not related to AS instance name! -->
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -28,6 +29,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-multinode-server</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 

--- a/testsuite/integration/picketlink/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/picketlink/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Djboss.bind.address=${node0} -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-picketlink.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -271,7 +271,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Dmcast.ttl=${mcast.ttl} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.other} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Dmcast.ttl=${mcast.ttl} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/integration/rbac/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/rbac/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/rts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/rts/src/test/config/arq/arquillian.xml
@@ -30,6 +30,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-rts.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
@@ -3,12 +3,13 @@
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <defaultProtocol type="jmx-as7" />
-    
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/web/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/web/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/xts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/xts/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dorg.jboss.byteman.verbose -Djboss.modules.system.pkgs=org.jboss.byteman -Dorg.jboss.byteman.transform.all -javaagent:${basedir}/target/lib/byteman.jar=listener:true</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-xts.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -110,11 +110,10 @@
         <jvm.args.ip.server>${jvm.args.ip}</jvm.args.ip.server>
         <jvm.args.ip.client>${jvm.args.ip}</jvm.args.ip.client>
 
-        <!-- Security. -->
-        <jvm.args.securityManager></jvm.args.securityManager>
-        <jvm.args.securityPolicy></jvm.args.securityPolicy>
-        <jvm.args.securityManagerOther></jvm.args.securityManagerOther>
-        <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy} ${jvm.args.securityManagerOther}</jvm.args.security>
+        <!-- Server arguments. Cannot have a null server argument in ARQ, set a dummy system property -->
+        <jboss.args>-Dts.wildfly.version=${project.version}</jboss.args>
+        <!-- jboss.args is used in the arquillian.xml files, but wildfly-core DomainLifecycleUtil expects jboss.domain.server.args -->
+        <jboss.domain.server.args></jboss.domain.server.args>
 
         <!-- Additional JVM args, like those for EC2. -->
         <jvm.args.other>-server</jvm.args.other>
@@ -188,7 +187,7 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
         <!-- Needed for @Resource(lookup=). -->
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -377,6 +376,8 @@
                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                            <jboss.dist>${jboss.dist}</jboss.dist>
                            <jboss.home>${basedir}/target/jbossas</jboss.home>
+                           <jboss.args>${jboss.args}</jboss.args>
+                           <jboss.domain.server.args>${jboss.domain.server.args}</jboss.domain.server.args>
                            <module.path>${jboss.dist}/modules${path.separator}${basedir}/target/modules</module.path>
                            <org.wildfly.test.kill-servers-before-test>${org.wildfly.test.kill-servers-before-test}</org.wildfly.test.kill-servers-before-test>
                        </systemPropertyVariables>
@@ -635,24 +636,17 @@
             <properties><mcast3>${mcast3}</mcast3></properties>
         </profile>
 
-
-
-        <!-- Security policy.  ARQ-690, Wildfly-2823, Wildfly-2826. -->
+        <!-- Security manager. -->
         <profile>
-            <id>ts.security.policy</id>
-            <activation><property><name>security.policy</name></property></activation>
+            <id>ts.security.manager</id>
+            <activation>
+                <property>
+                    <name>security.manager</name>
+                </property>
+            </activation>
             <properties>
-                <jvm.args.securityManager>-Djava.security.manager</jvm.args.securityManager>
-                <jvm.args.securityPolicy>-Djava.security.policy=${security.policy}</jvm.args.securityPolicy>
-            </properties>
-        </profile>
-
-        <!-- Security Manager Other -->
-        <profile>
-            <id>ts.security.manager.other</id>
-            <activation><property><name>security.manager.other</name></property></activation>
-            <properties>
-                <jvm.args.securityManagerOther>${security.manager.other}</jvm.args.securityManagerOther>
+                <jboss.args>-secmgr</jboss.args>
+                <jboss.domain.server.args>-secmgr</jboss.domain.server.args>
             </properties>
         </profile>
 

--- a/testsuite/shared/src/main/resources/secman/permitt_all.policy
+++ b/testsuite/shared/src/main/resources/secman/permitt_all.policy
@@ -1,7 +1,0 @@
-// Dummy policy used to test proper argument passing and basic AS7 functionality under Java Security Manager 
-grant {
-   permission java.security.AllPermission;
-};
-
-
-


### PR DESCRIPTION
Enables tests to be run under the security manager if `-Dsecurity.manager` is passed as a system property.
