### PR TITLE
[WFLY-4172] Enable the -secmgr parameter for tests if the security.manager property is defined.

### DIFF
--- a/feature-pack/src/main/resources/configuration/domain/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/domain/subsystems.xml
@@ -25,6 +25,7 @@
       <subsystem>request-controller.xml</subsystem>
       <subsystem>sar.xml</subsystem>
       <subsystem>security.xml</subsystem>
+      <subsystem>security-manager.xml</subsystem>
       <subsystem>transactions.xml</subsystem>
       <subsystem>undertow.xml</subsystem>
       <subsystem>webservices.xml</subsystem>
@@ -56,6 +57,7 @@
       <subsystem>request-controller.xml</subsystem>
       <subsystem>sar.xml</subsystem>
       <subsystem>security.xml</subsystem>
+      <subsystem>security-manager.xml</subsystem>
       <subsystem>transactions.xml</subsystem>
       <subsystem supplement="ha">undertow.xml</subsystem>
       <subsystem>webservices.xml</subsystem>
@@ -88,6 +90,7 @@
       <subsystem>request-controller.xml</subsystem>
       <subsystem>sar.xml</subsystem>
       <subsystem>security.xml</subsystem>
+      <subsystem>security-manager.xml</subsystem>
       <subsystem>transactions.xml</subsystem>
       <subsystem>undertow.xml</subsystem>
       <subsystem>webservices.xml</subsystem>
@@ -122,6 +125,7 @@
       <subsystem>request-controller.xml</subsystem>
       <subsystem>sar.xml</subsystem>
       <subsystem>security.xml</subsystem>
+      <subsystem>security-manager.xml</subsystem>
       <subsystem>transactions.xml</subsystem>
       <subsystem supplement="ha">undertow.xml</subsystem>
       <subsystem>webservices.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-genericjms.xml
@@ -26,7 +26,7 @@
         <subsystem>resource-adapters-genericjms.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem include-if-set="security.manager">security-manager.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full-ha.xml
@@ -29,7 +29,7 @@
         <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem include-if-set="security.manager">security-manager.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem supplement="ha">undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-full.xml
@@ -27,7 +27,7 @@
         <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem include-if-set="security.manager">security-manager.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem>undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems-ha.xml
@@ -26,7 +26,7 @@
         <subsystem>resource-adapters.xml</subsystem>
         <subsystem>request-controller.xml</subsystem>
         <subsystem>sar.xml</subsystem>
-        <subsystem include-if-set="security.manager">security-manager.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
         <subsystem>security.xml</subsystem>
         <subsystem>transactions.xml</subsystem>
         <subsystem supplement="ha">undertow.xml</subsystem>

--- a/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -24,7 +24,7 @@
       <subsystem>resource-adapters.xml</subsystem>
       <subsystem>request-controller.xml</subsystem>
       <subsystem>sar.xml</subsystem>
-      <subsystem include-if-set="security.manager">security-manager.xml</subsystem>
+      <subsystem>security-manager.xml</subsystem>
       <subsystem>security.xml</subsystem>
       <subsystem>transactions.xml</subsystem>
       <subsystem>undertow.xml</subsystem>

--- a/testsuite/compat/pom.xml
+++ b/testsuite/compat/pom.xml
@@ -274,7 +274,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.security} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Declipselink.archive.factory=org.jipijapa.eclipselink.JBossArchiveFactoryImpl</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Declipselink.archive.factory=org.jipijapa.eclipselink.JBossArchiveFactoryImpl</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/compat/src/test/resources/arquillian.xml
+++ b/testsuite/compat/src/test/resources/arquillian.xml
@@ -8,6 +8,7 @@
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>

--- a/testsuite/domain/pom.xml
+++ b/testsuite/domain/pom.xml
@@ -116,7 +116,7 @@
                         <module.path>${jboss.dist}/modules</module.path>
                         <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                         <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
                     </systemPropertyVariables>
                     <includes>
                          <include>org/jboss/as/test/integration/autoignore/*TestCase.java</include>
@@ -174,7 +174,7 @@
                                 <module.path>${jboss.dist}/modules</module.path>
                                 <jboss.test.host.master.address>${node0}</jboss.test.host.master.address>
                                 <jboss.test.host.slave.address>${node1}</jboss.test.host.slave.address>
-                                <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
+                                <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.other} ${jvm.args.timeouts} -Djbossas.ts.dir=${jbossas.ts.dir}</server.jvm.args>
                                 <jboss.test.rbac.soak.clients>${jboss.test.rbac.soak.clients}</jboss.test.rbac.soak.clients>
                                 <jboss.test.rbac.soak.iterations>${jboss.test.rbac.soak.iterations}</jboss.test.rbac.soak.iterations>
                             </systemPropertyVariables>

--- a/testsuite/integration/basic/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/basic/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
@@ -13,6 +13,7 @@
             <property name="jbossHome">${basedir}/target/wildfly-SYNC-tcp-0</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-SYNC-tcp-0 -Djboss.node.name=node-0</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -27,6 +28,7 @@
             <property name="jbossHome">${basedir}/target/wildfly-udp-jdbc-store</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-udp-jdbc-store -Djboss.node.name=node-0</property>
             <property name="serverConfig">${jboss.server.config.file.name}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="managementAddress">${node0}</property>
             <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -44,6 +46,7 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-${cacheMode}-${stack}-0 -Djboss.node.name=node-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -58,6 +61,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-${cacheMode}-${stack}-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-${cacheMode}-${stack}-1 -Djboss.node.name=node-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 
@@ -72,6 +76,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-SYNC-tcp-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-SYNC-tcp-0 -Djboss.node.name=node-0</property>
                 <property name="serverConfig">standalone.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
                 <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
@@ -89,6 +94,7 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-0 -Djboss.node.name=LON-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -103,6 +109,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-LON-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-1 -Djboss.node.name=LON-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 
@@ -117,6 +124,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-NYC-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-NYC-0 -Djboss.node.name=NYC-0 -Djboss.port.offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
 
@@ -131,6 +139,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-SFO-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-SFO-0 -Djboss.node.name=SFO-0 -Djboss.port.offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
 
@@ -150,6 +159,7 @@
                 <!-- AS7-2493 different jboss.node.name must be specified -->
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-0 -Djboss.node.name=LON-0</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -164,6 +174,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-LON-1</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-LON-1 -Djboss.node.name=LON-1 -Djboss.port.offset=100</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 
@@ -178,6 +189,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-NYC-0</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-NYC-0 -Djboss.node.name=NYC-0 -Djboss.port.offset=200</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node2}</property>
                 <property name="managementPort">10190</property>
 
@@ -192,6 +204,7 @@
                 <property name="jbossHome">${basedir}/target/wildfly-xsite-SFO-0-backupFor</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-xsite-SFO-0-backupFor -Djboss.node.name=SFO-0-backupFor -Djboss.port.offset=300</property>
                 <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node3}</property>
                 <property name="managementPort">10290</property>
 

--- a/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/iiop/src/test/config/arq/arquillian.xml
@@ -12,6 +12,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-iiop-client</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-iiop-client</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -27,6 +28,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-iiop-server</property>
                 <property name="javaVmArguments">${server.jvm.args}</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 

--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -10,6 +10,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Djboss.node.name=default-jbossas</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
@@ -25,6 +26,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-with-remote-outbound-connection</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-with-remote-outbound-connection -Djboss.node.name=jbossas-with-remote-outbound-connection</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
@@ -40,6 +42,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-layered</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-layered -Djboss.node.name=jbossas-layered</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
@@ -56,6 +59,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-messaging-failover</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-messaging-failover -Djboss.node.name=default-jbossas-messaging-failover</property>
                 <property name="serverConfig">standalone-full.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
@@ -71,6 +75,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-messaging-failover</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.socket.binding.port-offset=100 -Djboss.inst=${basedir}/target/jbossas-messaging-failover -Djboss.node.name=default-jbossas-messaging-failover</property>
                 <property name="serverConfig">standalone-full-backup.xml</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:10090}</property>
@@ -86,6 +91,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Djboss.node.name=default-jbossas</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone-ha.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
                 <property name="managementAddress">${node0:127.0.0.1}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/multinode/src/test/config/arq/arquillian.xml
@@ -13,6 +13,7 @@
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-client -Djboss.node.name=multinode-client</property>
                                                                                         <!-- jboss.node.name is defined in the test, not related to AS instance name! -->
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node0}</property>
                 <property name="managementPort">${as.managementPort:9990}</property>
 
@@ -28,6 +29,7 @@
                 <property name="jbossHome">${basedir}/target/jbossas-multinode-server</property>
                 <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-multinode-server -Djboss.node.name=multinode-server</property>
                 <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+                <property name="jbossArguments">${jboss.args}</property>
                 <property name="managementAddress">${node1}</property>
                 <property name="managementPort">10090</property>
 

--- a/testsuite/integration/picketlink/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/picketlink/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Djboss.bind.address=${node0} -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-picketlink.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -271,7 +271,7 @@
                             Used in arquillian.xml - arguments for all JBoss AS instances.
                             System properties are duplicated here until ARQ-647 is implemented.
                         -->
-                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.security} ${jvm.args.other} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Dmcast.ttl=${mcast.ttl} ${jvm.args.dirs}</server.jvm.args>
+                        <server.jvm.args>${surefire.system.args} ${jvm.args.ip.server} ${jvm.args.jacoco} ${jvm.args.other} ${jvm.args.timeouts} -Dnode0=${node0} -Dnode1=${node1} -Dmcast=${mcast} -Dmcast.ttl=${mcast.ttl} ${jvm.args.dirs}</server.jvm.args>
                     </systemPropertyVariables>
 
                 </configuration>

--- a/testsuite/integration/rbac/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/rbac/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/rts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/rts/src/test/config/arq/arquillian.xml
@@ -30,6 +30,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-rts.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/smoke/src/test/config/arq/arquillian.xml
@@ -3,12 +3,13 @@
 	xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <defaultProtocol type="jmx-as7" />
-    
+
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -97,4 +97,30 @@
         </plugins>
     </build>
 
+    <profiles>
+        <!-- TODO (jrp) This profile needs to be removed once WFLY-4179 is resolved -->
+        <profile>
+            <id>ts.web.security.manager</id>
+            <activation>
+                <property>
+                    <name>security.manager</name>
+                </property>
+            </activation>
+            <properties>
+                <jboss.args>-secmgr</jboss.args>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/CustomErrorsUnitTestCase.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/testsuite/integration/web/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/web/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.
                  In the future, Arquillian should capable of injecting it into @ArquillianResource File or such. -->
             <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
@@ -32,8 +32,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import java.net.URL;
+import java.security.AllPermission;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * @author Eduardo Martins
@@ -49,6 +51,14 @@ public class DefaultContextServiceServletTestCase {
     public static WebArchive deployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "war-example.war");
         war.addClasses(HttpRequest.class, DefaultContextServiceTestServlet.class, TestServletRunnable.class);
+        war.addAsManifestResource(
+                createPermissionsXmlAsset(
+                        // Needed for getting the principle and logging in in the DefaultContextServiceTestServlet
+                        new RuntimePermission("org.jboss.security.*"),
+                        // TODO (jrp) This permission needs to be removed once WFLY-4176 is resolved
+                        new RuntimePermission("getClassLoader"),
+                        new RuntimePermission("modifyThread")
+                        ), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/servlet3/WebSecurityProgrammaticLoginTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/servlet3/WebSecurityProgrammaticLoginTestCase.java
@@ -57,6 +57,7 @@ import static org.jboss.as.security.Constants.CODE;
 import static org.jboss.as.security.Constants.FLAG;
 import static org.jboss.as.security.Constants.LOGIN_MODULE;
 import static org.jboss.as.security.Constants.SECURITY_DOMAIN;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Unit Test the programmatic login feature of Servlet 3
@@ -84,6 +85,7 @@ public class WebSecurityProgrammaticLoginTestCase {
         war.addClass(SecuredServlet.class);
         war.addClass(AbstractSecurityDomainSetup.class);
         war.addPackage(CommonCriteria.class.getPackage());
+        war.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("org.jboss.security.*")), "permissions.xml");
 
         return war;
     }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/lifecycle/ServletLifecycleMethodDescriptorTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/lifecycle/ServletLifecycleMethodDescriptorTestCase.java
@@ -28,13 +28,16 @@ import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.naming.JndiPermission;
 import org.jboss.as.test.integration.common.HttpRequest;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -51,6 +54,8 @@ public class ServletLifecycleMethodDescriptorTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "single.war");
         war.addClasses(HttpRequest.class, LifeCycleMethodServlet.class);
         war.addAsWebInfResource(ServletLifecycleMethodDescriptorTestCase.class.getPackage(), "web.xml", "web.xml");
+        war.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming meta-inf\n"), "MANIFEST.MF");
+        war.addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("java:global/env/foo", "bind")), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
@@ -1,8 +1,11 @@
 package org.jboss.as.test.integration.web.websocket;
 
-import java.net.URI;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
-import javax.annotation.Resource;
+import java.net.SocketPermission;
+import java.net.URI;
+import java.util.PropertyPermission;
+
 import javax.naming.InitialContext;
 import javax.websocket.Session;
 import javax.websocket.server.ServerContainer;
@@ -26,7 +29,15 @@ public class WebSocketTestCase {
     public static WebArchive deploy() {
         return ShrinkWrap.create(WebArchive.class, "websocket.war")
                 .addPackage(WebSocketTestCase.class.getPackage())
-                .addClass(TestSuiteEnvironment.class);
+                .addClass(TestSuiteEnvironment.class)
+                .addAsManifestResource(
+                        createPermissionsXmlAsset(
+                                // Needed for the TestSuiteEnvironment.getServerAddress()
+                                new PropertyPermission("management.address", "read"),
+                                new PropertyPermission("node0", "read"),
+                                // Needed for the serverContainer.connectToServer()
+                                new SocketPermission("*:8080", "connect,resolve")
+                        ), "permissions.xml");
     }
 
     @Test

--- a/testsuite/integration/xts/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/xts/src/test/config/arq/arquillian.xml
@@ -9,6 +9,7 @@
             <property name="jbossHome">${basedir}/target/jbossas</property>
             <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dorg.jboss.byteman.verbose -Djboss.modules.system.pkgs=org.jboss.byteman -Dorg.jboss.byteman.transform.all -javaagent:${basedir}/target/lib/byteman.jar=listener:true</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone-xts.xml}</property>
+            <property name="jbossArguments">${jboss.args}</property>
             <property name="allowConnectingToRunningServer">true</property>
             <property name="managementAddress">${node0:127.0.0.1}</property>
             <property name="managementPort">${as.managementPort:9990}</property>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -110,11 +110,10 @@
         <jvm.args.ip.server>${jvm.args.ip}</jvm.args.ip.server>
         <jvm.args.ip.client>${jvm.args.ip}</jvm.args.ip.client>
 
-        <!-- Security. -->
-        <jvm.args.securityManager></jvm.args.securityManager>
-        <jvm.args.securityPolicy></jvm.args.securityPolicy>
-        <jvm.args.securityManagerOther></jvm.args.securityManagerOther>
-        <jvm.args.security>${jvm.args.securityManager} ${jvm.args.securityPolicy} ${jvm.args.securityManagerOther}</jvm.args.security>
+        <!-- Server arguments. Cannot have a null server argument in ARQ, set a dummy system property -->
+        <jboss.args>-Dts.wildfly.version=${project.version}</jboss.args>
+        <!-- jboss.args is used in the arquillian.xml files, but wildfly-core DomainLifecycleUtil expects jboss.domain.server.args -->
+        <jboss.domain.server.args></jboss.domain.server.args>
 
         <!-- Additional JVM args, like those for EC2. -->
         <jvm.args.other>-server</jvm.args.other>
@@ -180,7 +179,7 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-testsuite-shared</artifactId>
             <scope>test</scope>
-        </dependency>        
+        </dependency>
         <!-- Needed for @Resource(lookup=). -->
         <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
@@ -365,6 +364,8 @@
                            <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
                            <jboss.dist>${jboss.dist}</jboss.dist>
                            <jboss.home>${basedir}/target/jbossas</jboss.home>
+                           <jboss.args>${jboss.args}</jboss.args>
+                           <jboss.domain.server.args>${jboss.domain.server.args}</jboss.domain.server.args>
                            <module.path>${jboss.dist}/modules${path.separator}${basedir}/target/modules</module.path>
                            <org.wildfly.test.kill-servers-before-test>${org.wildfly.test.kill-servers-before-test}</org.wildfly.test.kill-servers-before-test>
                        </systemPropertyVariables>
@@ -639,24 +640,17 @@
             <properties><mcast3>${mcast3}</mcast3></properties>
         </profile>
 
-
-
-        <!-- Security policy.  ARQ-690, Wildfly-2823, Wildfly-2826. -->
+        <!-- Security manager. -->
         <profile>
-            <id>ts.security.policy</id>
-            <activation><property><name>security.policy</name></property></activation>
+            <id>ts.security.manager</id>
+            <activation>
+                <property>
+                    <name>security.manager</name>
+                </property>
+            </activation>
             <properties>
-                <jvm.args.securityManager>-Djava.security.manager</jvm.args.securityManager>
-                <jvm.args.securityPolicy>-Djava.security.policy=${security.policy}</jvm.args.securityPolicy>
-            </properties>
-        </profile>
-
-        <!-- Security Manager Other -->
-        <profile>
-            <id>ts.security.manager.other</id>
-            <activation><property><name>security.manager.other</name></property></activation>
-            <properties>
-                <jvm.args.securityManagerOther>${security.manager.other}</jvm.args.securityManagerOther>
+                <jboss.args>-secmgr</jboss.args>
+                <jboss.domain.server.args>-secmgr</jboss.domain.server.args>
             </properties>
         </profile>
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/integration/ejb/security/PermissionUtils.java
@@ -28,6 +28,7 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.security.Permission;
 
+import nu.xom.Attribute;
 import nu.xom.Document;
 import nu.xom.Element;
 import nu.xom.Serializer;
@@ -40,13 +41,15 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 public final class PermissionUtils {
     public static Asset createPermissionsXmlAsset(Permission... permissions) {
         final Element permissionsElement = new Element("permissions");
+        permissionsElement.setNamespaceURI("http://xmlns.jcp.org/xml/ns/javaee");
+        permissionsElement.addAttribute(new Attribute("version", "7"));
         for (Permission permission : permissions) {
             final Element permissionElement = new Element("permission");
 
-            final Element classNameElement = new Element("classname");
+            final Element classNameElement = new Element("class-name");
             final Element nameElement = new Element("name");
             classNameElement.appendChild(permission.getClass().getName());
-            classNameElement.appendChild(permission.getName());
+            nameElement.appendChild(permission.getName());
             permissionElement.appendChild(classNameElement);
             permissionElement.appendChild(nameElement);
 
@@ -56,6 +59,7 @@ public final class PermissionUtils {
                 actionsElement.appendChild(actions);
                 permissionElement.appendChild(actionsElement);
             }
+            permissionsElement.appendChild(permissionElement);
         }
         Document document = new Document(permissionsElement);
         try (ByteArrayOutputStream stream = new ByteArrayOutputStream()) {

--- a/testsuite/shared/src/main/resources/secman/permitt_all.policy
+++ b/testsuite/shared/src/main/resources/secman/permitt_all.policy
@@ -1,7 +1,0 @@
-// Dummy policy used to test proper argument passing and basic AS7 functionality under Java Security Manager 
-grant {
-   permission java.security.AllPermission;
-};
-
-
-

--- a/web-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
+++ b/web-feature-pack/src/main/resources/configuration/standalone/subsystems.xml
@@ -9,6 +9,7 @@
        <subsystem supplement="web-build">naming.xml</subsystem>
        <subsystem>request-controller.xml</subsystem>
        <subsystem supplement="web-build">security.xml</subsystem>
+       <subsystem>security-manager.xml</subsystem>
        <subsystem>undertow.xml</subsystem>
    </subsystems>
 </config>


### PR DESCRIPTION
I left these commits separate as they seemed to make more sense that way. I can squash them together or squash specific ones together if that seems to make more sense.
### Commit c4dbcd710c50b05e2798210bc5315120bd9a1ed0

This is the main commit for the JIRA and simply enables the testsuite to enable the security manager by passing `-Dsecurity.manager` to the build.

Note that a dummy property is passed in the `<jboss.args/>` property defined in the parent test suite pom. If left blank system property is set to `null` which in when parsed by arquillian becomes `${jboss.args}` as that's the argument in the arquillian.xml file.
### Commit 78d224959b744065dc80c15f35185054064b735c

Enables the security manager extension by default for all server types.
### Commit 2d03267e41b9acf097e0e82671d31cd68e223efe

Runs the `NamingContext.bind()` in a privileged block as the permissions have already been checked.
### Commit bf07fdae275a8fd208d483d4670324fd28c2d88f

Fixes some issue found with generating the permissions.xml for deployments.
### Commit 303689397e7e4a835ad37216bcb696a08cdf953f

Fixes a few issues found when running the web integration tests under the security manager.
