### PR TITLE
Don't run MBean implementation lifecycle methods in MSC threads

### DIFF
--- a/sar/src/main/java/org/jboss/as/service/AbstractService.java
+++ b/sar/src/main/java/org/jboss/as/service/AbstractService.java
@@ -27,10 +27,12 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.concurrent.ExecutorService;
 
 import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.msc.service.LifecycleContext;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.value.InjectedValue;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -43,6 +45,8 @@ abstract class AbstractService implements Service<Object> {
     private final Object mBeanInstance;
     private final List<SetupAction> setupActions;
     private final ClassLoader mbeanContextClassLoader;
+    protected final InjectedValue<ExecutorService> executor = new InjectedValue<ExecutorService>();
+
 
     /**
      * @param mBeanInstance
@@ -81,6 +85,10 @@ abstract class AbstractService implements Service<Object> {
                 }
             }
         }
+    }
+
+    public InjectedValue<ExecutorService> getExecutorInjector() {
+        return executor;
     }
 
 }

--- a/sar/src/main/java/org/jboss/as/service/MBeanServices.java
+++ b/sar/src/main/java/org/jboss/as/service/MBeanServices.java
@@ -29,6 +29,7 @@ import javax.management.MBeanServer;
 
 import org.jboss.as.jmx.MBeanRegistrationService;
 import org.jboss.as.jmx.MBeanServerService;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
 import org.jboss.as.service.component.ServiceComponentInstantiator;
@@ -90,6 +91,7 @@ final class MBeanServices {
         createDestroyService = new CreateDestroyService(mBeanInstance, createMethod, destroyMethod,componentInstantiator, setupActions, mbeanContextClassLoader);
         createDestroyServiceName = ServiceNameFactory.newCreateDestroy(mBeanName);
         createDestroyServiceBuilder = target.addService(createDestroyServiceName, createDestroyService);
+        Services.addServerExecutorDependency(createDestroyServiceBuilder, ((CreateDestroyService) createDestroyService).getExecutorInjector(), false);
         if(componentInstantiator != null) {
             // the service that starts the EE component needs to start first
             createDestroyServiceBuilder.addDependency(componentInstantiator.getComponentStartServiceName());
@@ -101,6 +103,7 @@ final class MBeanServices {
         startStopServiceName = ServiceNameFactory.newStartStop(mBeanName);
         startStopServiceBuilder = target.addService(startStopServiceName, startStopService);
         startStopServiceBuilder.addDependency(createDestroyServiceName);
+        Services.addServerExecutorDependency(startStopServiceBuilder, ((StartStopService) startStopService).getExecutorInjector(), false);
 
         this.mBeanName = mBeanName;
         this.target = target;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingMBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingMBeanTestCase.java
@@ -1,0 +1,64 @@
+package org.jboss.as.test.integration.sar;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ContainerResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+
+/**
+ * Tests that MBean(s) binding to JNDI in their <code>start</code> lifecycle method do not hang up the deployment.
+ *
+ * @see https://developer.jboss.org/thread/251092
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JNDIBindingMBeanTestCase {
+
+    @ContainerResource
+    private ManagementClient managementClient;
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        final JavaArchive sar = ShrinkWrap.create(JavaArchive.class, "multiple-jndi-binding-mbeans.sar");
+        sar.addClasses(JNDIBindingService.class, JNDIBindingMBeanTestCase.class, JNDIBindingServiceMBean.class);
+        sar.addAsManifestResource(JNDIBindingMBeanTestCase.class.getPackage(), "multiple-jndi-binding-mbeans-jboss-service.xml", "jboss-service.xml");
+        return sar;
+    }
+
+    /**
+     * Makes sure that the MBeans that are expected to be up and running are accessible.
+     *
+     * @throws Exception
+     * @see https://developer.jboss.org/thread/251092
+     */
+    @Test
+    public void testMBeanStartup() throws Exception {
+        // get mbean server
+        final JMXConnector connector = JMXConnectorFactory.connect(managementClient.getRemoteJMXURL());
+        try {
+            final MBeanServerConnection mBeanServerConnection = connector.getMBeanServerConnection();
+            // check the deployed MBeans
+            for (int i = 1; i <= 9; i++) {
+                final String mbeanName = "jboss:name=mbean-startup-jndi-bind-" + i;
+                final Object instance = mBeanServerConnection.getObjectInstance(new ObjectName(mbeanName));
+                Assert.assertNotNull("No instance returned for MBean: " + mbeanName, instance);
+            }
+        } finally {
+            connector.close();
+        }
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingService.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingService.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.sar;
+
+import org.jboss.logging.Logger;
+
+import javax.naming.InitialContext;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * An MBean that binds to JNDI in its start method and unbinds from JNDI in its stop method
+ *
+ * @author Jaikiran Pai
+ *
+ */
+public class JNDIBindingService implements JNDIBindingServiceMBean {
+
+    private static final Logger logger = Logger.getLogger(JNDIBindingService.class);
+
+    private static final String NAME = "java:global/env/foo/legacy";
+    private static final String VALUE = "BAR";
+    private static final AtomicInteger count = new AtomicInteger(1);
+
+    private String jndiName;
+
+    public void create() throws Exception {
+        logger.info("create()");
+        this.jndiName =  NAME + count.getAndIncrement();
+    }
+
+    public void start() throws Exception {
+        logger.info("start()");
+        new InitialContext().bind(jndiName, VALUE);
+        logger.info("Bound to JNDI " + jndiName);
+    }
+
+    public void stop() throws Exception {
+        logger.info("stop()");
+        new InitialContext().unbind(jndiName);
+        logger.info("Unbound from jndi " + jndiName);
+    }
+
+    public void destroy() throws Exception {
+        logger.info("destroy()");
+    }
+
+    @Override
+    public void sayHello() {
+        logger.info("Hello from " + this);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingServiceMBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/JNDIBindingServiceMBean.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.sar;
+
+public interface JNDIBindingServiceMBean {
+    public void sayHello();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/multiple-jndi-binding-mbeans-jboss-service.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/multiple-jndi-binding-mbeans-jboss-service.xml
@@ -1,0 +1,38 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2012, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<server xmlns="urn:jboss:service:7.0"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="urn:jboss:service:7.0 jboss-service_7_0.xsd">
+
+    <!-- Intentionally listing multiple MBean services (backed by the same MBean implementation) to reproduce a deadlock noted in the
+        discussion here https://developer.jboss.org/thread/251092 -->
+    <mbean name="jboss:name=mbean-startup-jndi-bind-1" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-2" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-3" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-4" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-5" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-6" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-7" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-8" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+    <mbean name="jboss:name=mbean-startup-jndi-bind-9" code="org.jboss.as.test.integration.sar.JNDIBindingService" />
+
+</server>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/jboss-service.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/sar/servicembean/jboss-service.xml
@@ -24,5 +24,4 @@
       xsi:schemaLocation="urn:jboss:service:7.0 jboss-service_7_0.xsd">
 
     <mbean name="jboss:name=service-mbean-support-test" code="org.jboss.as.test.integration.sar.servicembean.TestService" />
-    
 </server>


### PR DESCRIPTION
MBean lifecycle methods are currently run in the MSC threads and can cause server start hangs as noted in this forum discussion https://developer.jboss.org/thread/251092. The commit here fixes that issue by running those lifecycle methods as asynchronous invocations as specified by the Service contract. This also contains a testcase which verifies the fix.
