### PR TITLE
WFLY-4219 Use Message Format Patterns

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -446,7 +446,7 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
         } else {
             throw EjbLogger.ROOT_LOGGER.failToLookupJNDINameSpace(name);
         }
-        ROOT_LOGGER.debug("Looking up " + namespaceStrippedJndiName + " in jndi context: " + jndiContext);
+        ROOT_LOGGER.debugf("Looking up %s in jndi context: %s", namespaceStrippedJndiName, jndiContext);
         try {
             return jndiContext.lookup(namespaceStrippedJndiName);
         } catch (NamingException ne) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanComponent.java
@@ -98,11 +98,11 @@ public class EntityBeanComponent extends EJBComponent implements PooledComponent
         optimisticLocking = ejbComponentCreateService.getOptimisticLocking();
         final PoolConfig poolConfig = ejbComponentCreateService.getPoolConfig();
         if (poolConfig == null) {
-            ROOT_LOGGER.debug("Pooling is disabled for entity bean " + ejbComponentCreateService.getComponentName());
+            ROOT_LOGGER.debugf("Pooling is disabled for entity bean %s", ejbComponentCreateService.getComponentName());
             this.pool = null;
             this.poolName = null;
         } else {
-            ROOT_LOGGER.debug("Using pool config " + poolConfig + " to create pool for entity bean " + ejbComponentCreateService.getComponentName());
+            ROOT_LOGGER.debugf("Using pool config %s to create pool for entity bean %s", poolConfig, ejbComponentCreateService.getComponentName());
             this.pool = poolConfig.createPool(factory);
             this.poolName = poolConfig.getPoolName();
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
@@ -131,11 +131,11 @@ public class MessageDrivenComponent extends EJBComponent implements PooledCompon
         };
         final PoolConfig poolConfig = ejbComponentCreateService.getPoolConfig();
         if (poolConfig == null) {
-            ROOT_LOGGER.debug("Pooling is disabled for MDB " + ejbComponentCreateService.getComponentName());
+            ROOT_LOGGER.debugf("Pooling is disabled for MDB %s", ejbComponentCreateService.getComponentName());
             this.pool = null;
             this.poolName = null;
         } else {
-            ROOT_LOGGER.debug("Using pool config " + poolConfig + " to create pool for MDB " + ejbComponentCreateService.getComponentName());
+            ROOT_LOGGER.debugf("Using pool config %s to create pool for MDB %s", poolConfig, ejbComponentCreateService.getComponentName());
             this.pool = poolConfig.createPool(factory);
             this.poolName = poolConfig.getPoolName();
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/SingletonComponent.java
@@ -132,7 +132,7 @@ public class SingletonComponent extends SessionBeanComponent implements Lockable
         if (this.initOnStartup) {
             // Do not call createInstance() because we can't ever assume that the singleton instance
             // hasn't already been created.
-            ROOT_LOGGER.debug(this.getComponentName() + " bean is a @Startup (a.k.a init-on-startup) bean, creating/getting the singleton instance");
+            ROOT_LOGGER.debugf("%s bean is a @Startup (a.k.a init-on-startup) bean, creating/getting the singleton instance", this.getComponentName());
             this.getComponentInstance();
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessSessionComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessSessionComponent.java
@@ -71,11 +71,11 @@ public class StatelessSessionComponent extends SessionBeanComponent implements P
         };
         final PoolConfig poolConfig = slsbComponentCreateService.getPoolConfig();
         if (poolConfig == null) {
-            ROOT_LOGGER.debug("Pooling is disabled for Stateless EJB " + slsbComponentCreateService.getComponentName());
+            ROOT_LOGGER.debugf("Pooling is disabled for Stateless EJB %s", slsbComponentCreateService.getComponentName());
             this.pool = null;
             this.poolName = null;
         } else {
-            ROOT_LOGGER.debug("Using pool config " + poolConfig + " to create pool for Stateless EJB " + slsbComponentCreateService.getComponentName());
+            ROOT_LOGGER.debugf("Using pool config %s to create pool for Stateless EJB %s", poolConfig, slsbComponentCreateService.getComponentName());
             this.pool = poolConfig.createPool(factory);
             this.poolName = poolConfig.getPoolName();
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/concurrency/ContainerManagedConcurrencyInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/concurrency/ContainerManagedConcurrencyInterceptor.java
@@ -86,9 +86,12 @@ public class ContainerManagedConcurrencyInterceptor implements Interceptor {
                 // for any negative value of timeout, we just default to max timeout val and max timeout unit.
                 // violation of spec! But we don't want to wait indefinitely.
 
-                ROOT_LOGGER.debug("Ignoring a negative @AccessTimeout value: " + accessTimeoutOnMethod.getValue() + " and timeout unit: "
-                        + accessTimeoutOnMethod.getTimeUnit().name() + ". Will default to timeout value: " + defaultAccessTimeout.getValue()
-                        + " and timeout unit: " + defaultAccessTimeout.getTimeUnit().name());
+                if (ROOT_LOGGER.isDebugEnabled()) {
+                    ROOT_LOGGER.debug("Ignoring a negative @AccessTimeout value: " + accessTimeoutOnMethod.getValue()
+                            + " and timeout unit: " + accessTimeoutOnMethod.getTimeUnit().name()
+                            + ". Will default to timeout value: " + defaultAccessTimeout.getValue() + " and timeout unit: "
+                            + defaultAccessTimeout.getTimeUnit().name());
+                }
             } else {
                 // use the explicit access timeout values specified on the method
                 time = accessTimeoutOnMethod.getValue();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
@@ -185,7 +185,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
         for (int i = 0; i < remoteAttrs.length; i++) {
             final OperationAnalysis op = remoteAttrs[i].getAccessorAnalysis();
             if (op != null) {
-                EjbLogger.ROOT_LOGGER.debug("    " + op.getJavaName() + "\n                " + op.getIDLName());
+                EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", op.getJavaName(), op.getIDLName());
                 //translate to the deployment reflection index method
                 //TODO: this needs to be fixed so it just returns the correct method
                 final Method method = translateMethod(deploymentReflectionIndex, op);
@@ -193,7 +193,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
                 beanMethodMap.put(op.getIDLName(), new SkeletonStrategy(method));
                 final OperationAnalysis setop = remoteAttrs[i].getMutatorAnalysis();
                 if (setop != null) {
-                    EjbLogger.ROOT_LOGGER.debug("    " + setop.getJavaName() + "\n                " + setop.getIDLName());
+                    EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", setop.getJavaName(), setop.getIDLName());
                     //translate to the deployment reflection index method
                     //TODO: this needs to be fixed so it just returns the correct method
                     final Method realSetmethod = translateMethod(deploymentReflectionIndex, setop);
@@ -204,7 +204,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
 
         final OperationAnalysis[] ops = remoteInterfaceAnalysis.getOperations();
         for (int i = 0; i < ops.length; i++) {
-            EjbLogger.ROOT_LOGGER.debug("    " + ops[i].getJavaName() + "\n                " + ops[i].getIDLName());
+            EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", ops[i].getJavaName(), ops[i].getIDLName());
             beanMethodMap.put(ops[i].getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, ops[i])));
         }
 
@@ -226,11 +226,11 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
         for (int i = 0; i < attrs.length; i++) {
             final OperationAnalysis op = attrs[i].getAccessorAnalysis();
             if (op != null) {
-                EjbLogger.ROOT_LOGGER.debug("    " + op.getJavaName() + "\n                " + op.getIDLName());
+                EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", op.getJavaName(), op.getIDLName());
                 homeMethodMap.put(op.getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, op)));
                 final OperationAnalysis setop = attrs[i].getMutatorAnalysis();
                 if (setop != null) {
-                    EjbLogger.ROOT_LOGGER.debug("    " + setop.getJavaName() + "\n                " + setop.getIDLName());
+                    EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", setop.getJavaName(), setop.getIDLName());
                     homeMethodMap.put(setop.getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, setop)));
                 }
             }
@@ -238,7 +238,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
 
         final OperationAnalysis[] homeops = homeInterfaceAnalysis.getOperations();
         for (int i = 0; i < homeops.length; i++) {
-            EjbLogger.ROOT_LOGGER.debug("    " + homeops[i].getJavaName() + "\n                " + homeops[i].getIDLName());
+            EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", homeops[i].getJavaName(), homeops[i].getIDLName());
             homeMethodMap.put(homeops[i].getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, homeops[i])));
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbResourceInjectionAnnotationProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbResourceInjectionAnnotationProcessor.java
@@ -149,8 +149,11 @@ public class EjbResourceInjectionAnnotationProcessor implements DeploymentUnitPr
     private void process(final DeploymentUnit deploymentUnit, final String beanInterface, final String beanName, final String lookup, final ClassInfo classInfo, final InjectionTarget targetDescription, final String localContextName, final EEModuleDescription eeModuleDescription) {
 
         if (!isEmpty(lookup) && !isEmpty(beanName)) {
-            logger.debug("Both beanName = " + beanName + " and lookup = " + lookup + " have been specified in @EJB annotation." +
-                    " lookup will be given preference. Class: " + classInfo.name());
+            if (logger.isDebugEnabled()) {
+                logger.debug("Both beanName = " + beanName + " and lookup = " + lookup
+                        + " have been specified in @EJB annotation." + " lookup will be given preference. Class: "
+                        + classInfo.name());
+            }
         }
 
         final EEModuleClassDescription classDescription = eeModuleDescription.addOrGetLocalClassDescription(classInfo.name().toString());

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ImplicitLocalViewProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ImplicitLocalViewProcessor.java
@@ -84,7 +84,7 @@ public class ImplicitLocalViewProcessor extends AbstractComponentConfigProcessor
         }
         // check whether it's eligible for implicit no-interface view
         if (this.exposesNoInterfaceView(ejbClass)) {
-            logger.debug("Bean: " + sessionBeanComponentDescription.getEJBName() + " will be marked for (implicit) no-interface view");
+            logger.debugf("Bean: %s will be marked for (implicit) no-interface view", sessionBeanComponentDescription.getEJBName());
             sessionBeanComponentDescription.addNoInterfaceView();
             return;
         }
@@ -92,7 +92,7 @@ public class ImplicitLocalViewProcessor extends AbstractComponentConfigProcessor
         // check for default local view
         Class<?> defaultLocalView = this.getDefaultLocalView(ejbClass);
         if (defaultLocalView != null) {
-            logger.debug("Bean: " + sessionBeanComponentDescription.getEJBName() + " will be marked for default local view: " + defaultLocalView.getName());
+            logger.debugf("Bean: %s will be marked for default local view: %s", sessionBeanComponentDescription.getEJBName(), defaultLocalView.getName());
             sessionBeanComponentDescription.addLocalBusinessInterfaceViews(Collections.singleton(defaultLocalView.getName()));
             return;
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/TimerServiceDeploymentProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/TimerServiceDeploymentProcessor.java
@@ -116,7 +116,7 @@ public class TimerServiceDeploymentProcessor implements DeploymentUnitProcessor 
                         deploymentName = moduleDescription.getApplicationName() + "." + moduleDescription.getModuleName() + "." + moduleDescription.getDistinctName();
                     }
 
-                    ROOT_LOGGER.debug("Installing timer service for component " + componentDescription.getComponentName());
+                    ROOT_LOGGER.debugf("Installing timer service for component %s", componentDescription.getComponentName());
                     componentDescription.getConfigurators().add(new ComponentConfigurator() {
                         @Override
                         public void configure(final DeploymentPhaseContext context, final ComponentDescription description, final ComponentConfiguration configuration) throws DeploymentUnitProcessingException {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbCorbaServant.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbCorbaServant.java
@@ -232,7 +232,7 @@ public class EjbCorbaServant extends Servant implements InvokeHandler, LocalIIOP
 
         SkeletonStrategy op = methodInvokerMap.get(opName);
         if (op == null) {
-            logger.debug("Unable to find opname '" + opName + "' valid operations:" + methodInvokerMap.keySet());
+            logger.debugf("Unable to find opname '%s' valid operations:%s", opName, methodInvokerMap.keySet());
             throw new BAD_OPERATION(opName);
         }
         final NamespaceContextSelector selector = componentView.getComponent().getNamespaceContextSelector();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbIIOPService.java
@@ -303,7 +303,7 @@ public class EjbIIOPService implements Service<EjbIIOPService> {
                 Policy sslPolicy = orb.create_policy(SSL_POLICY_TYPE.value, sslPolicyValue);
                 policyList.add(sslPolicy);
 
-                EjbLogger.ROOT_LOGGER.debug("container's SSL policy: " + sslPolicy);
+                EjbLogger.ROOT_LOGGER.debugf("container's SSL policy: %s", sslPolicy);
             }
 
             String securityDomain = "CORBA_REMOTE"; //TODO: what should this default to
@@ -374,7 +374,7 @@ public class EjbIIOPService implements Service<EjbIIOPService> {
 
             // Register bean home in local CORBA naming context
             rebind(corbaNamingContext.getValue(), name, corbaRef);
-            EjbLogger.ROOT_LOGGER.debug("Home IOR for " + component.getComponentName() + " bound to " + this.name + " in CORBA naming service");
+            EjbLogger.ROOT_LOGGER.debugf("Home IOR for %s bound to %s in CORBA naming service", component.getComponentName(), this.name);
 
             //now eagerly force stub creation, so de-serialization of stubs will work correctly
             final ClassLoader cl = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/stub/DynamicIIOPStub.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/stub/DynamicIIOPStub.java
@@ -24,6 +24,7 @@ package org.jboss.as.ejb3.iiop.stub;
 import javax.rmi.CORBA.Util;
 
 import java.security.PrivilegedAction;
+
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.iiop.LocalIIOPInvoker;
 import org.jboss.as.jacorb.rmi.marshal.strategy.StubStrategy;
@@ -72,6 +73,11 @@ public abstract class DynamicIIOPStub
             EjbLogger.EJB3_INVOCATION_LOGGER.trace(msg);
     }
 
+    private static void tracef(final String format, final Object... params) {
+        if (EjbLogger.EJB3_INVOCATION_LOGGER.isTraceEnabled())
+            EjbLogger.EJB3_INVOCATION_LOGGER.tracef(format, params);
+    }
+
     /**
      * Constructs a <code>DynamicIIOPStub</code>.
      */
@@ -110,7 +116,7 @@ public abstract class DynamicIIOPStub
                     OutputStream out =
                             (OutputStream) _request(operationName, true);
                     stubStrategy.writeParams(out, params);
-                    trace("sent request: " + operationName);
+                    tracef("sent request: %s", operationName);
                     in = (InputStream) _invoke(out);
                     if (stubStrategy.isNonVoid()) {
                         trace("received reply");

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterConfig.java
@@ -54,7 +54,7 @@ public class EJBClientClusterConfig extends EJBClientCommonConnectionConfig impl
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap channelCreationOptions = getOptionMapFromProperties(channelProps, this.getClass().getClassLoader());
-            logger.debug("Channel creation options for cluster " + clusterConfig.getClusterName() + " are " + channelCreationOptions);
+            logger.debugf("Channel creation options for cluster %s are %s", clusterConfig.getClusterName(), channelCreationOptions);
             this.setChannelCreationOptions(channelCreationOptions);
         }
 
@@ -64,7 +64,7 @@ public class EJBClientClusterConfig extends EJBClientCommonConnectionConfig impl
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap connectionCreationOptions = getOptionMapFromProperties(connectionProps, this.getClass().getClassLoader());
-            logger.debug("Connection creation options for cluster " + clusterConfig.getClusterName() + " are " + connectionCreationOptions);
+            logger.debugf("Connection creation options for cluster %s are %s", clusterConfig.getClusterName(), connectionCreationOptions);
             this.setConnectionCreationOptions(connectionCreationOptions);
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterNodeConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterNodeConfig.java
@@ -49,7 +49,7 @@ public class EJBClientClusterNodeConfig extends EJBClientCommonConnectionConfig 
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap channelOpts = getOptionMapFromProperties(channelProps, this.getClass().getClassLoader());
-            logger.debug("Channel creation options for node " + clusterNodeConfig.getNodeName() + " are " + channelOpts);
+            logger.debugf("Channel creation options for node %s are %s", clusterNodeConfig.getNodeName(), channelOpts);
             this.setChannelCreationOptions(channelOpts);
         }
 
@@ -58,7 +58,7 @@ public class EJBClientClusterNodeConfig extends EJBClientCommonConnectionConfig 
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap connectOpts = getOptionMapFromProperties(connectionProps, this.getClass().getClassLoader());
-            logger.debug("Connection creation options for node " + clusterNodeConfig.getNodeName() + " are " + connectOpts);
+            logger.debugf("Connection creation options for node %s are %s", clusterNodeConfig.getNodeName(), connectOpts);
             this.setConnectionCreationOptions(connectOpts);
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
@@ -247,8 +247,10 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
             try {
                 final byte version = dataInputStream.readByte();
                 final String clientMarshallingStrategy = dataInputStream.readUTF();
-                EjbLogger.ROOT_LOGGER.debug("Client with protocol version " + version + " and marshalling strategy " + clientMarshallingStrategy +
-                        " trying to communicate on " + channel);
+                if (EjbLogger.ROOT_LOGGER.isDebugEnabled()) {
+                    EjbLogger.ROOT_LOGGER.debug("Client with protocol version " + version + " and marshalling strategy "
+                            + clientMarshallingStrategy + " trying to communicate on " + channel);
+                }
                 if (!EJBRemoteConnectorService.this.isSupportedMarshallingStrategy(clientMarshallingStrategy)) {
                     EjbLogger.ROOT_LOGGER.unsupportedClientMarshallingStrategy(clientMarshallingStrategy, channel);
                     channel.close();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteTransactionsRepository.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteTransactionsRepository.java
@@ -76,7 +76,7 @@ public class EJBRemoteTransactionsRepository implements Service<EJBRemoteTransac
     @Override
     public void start(StartContext context) throws StartException {
         recoveryManagerService.getValue().addSerializableXAResourceDeserializer(EJBXAResourceDeserializer.INSTANCE);
-        logger.debug("Registered EJB XA resource deserializer " + EJBXAResourceDeserializer.INSTANCE);
+        logger.debugf("Registered EJB XA resource deserializer %s", EJBXAResourceDeserializer.INSTANCE);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
@@ -72,7 +72,7 @@ public class EJBTransactionRecoveryService implements Service<EJBTransactionReco
     public void start(StartContext startContext) throws StartException {
         // register ourselves to the recovery manager service
         recoveryManagerService.getValue().addXAResourceRecovery(this);
-        logger.debug("Registered " + this + " with the transaction recovery manager");
+        logger.debugf("Registered %s with the transaction recovery manager", this);
     }
 
     @Override
@@ -86,7 +86,7 @@ public class EJBTransactionRecoveryService implements Service<EJBTransactionReco
                     EJBTransactionRecoveryService.this.receiverContexts.clear();
                     // un-register ourselves from the recovery manager service
                     recoveryManagerService.getValue().removeXAResourceRecovery(EJBTransactionRecoveryService.this);
-                    logger.debug("Un-registered " + this + " from the transaction recovery manager");
+                    logger.debugf("Un-registered %s from the transaction recovery manager", this);
                 } finally {
                     stopContext.complete();
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEJBReceiverPreferringDeploymentNodeSelector.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEJBReceiverPreferringDeploymentNodeSelector.java
@@ -54,8 +54,10 @@ public class LocalEJBReceiverPreferringDeploymentNodeSelector implements Deploym
         // prefer local node if available
         for (final String eligibleNode : eligibleNodes) {
             if (localNodeName.equals(eligibleNode)) {
-                logger.debug("Selected local node " + this.localNodeName + " for [app: " + appName + ", module: "
-                        + moduleName + ",  distinctname: " + distinctName + "]");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Selected local node " + this.localNodeName + " for [app: " + appName + ", module: "
+                            + moduleName + ",  distinctname: " + distinctName + "]");
+                }
                 return eligibleNode;
             }
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingConnectionClusterNodeManager.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingConnectionClusterNodeManager.java
@@ -148,10 +148,10 @@ class RemotingConnectionClusterNodeManager implements ClusterNodeManager {
             try {
                 final IoFuture<Connection> futureConnection = NetworkUtil.connect(endpoint,"remote", destinationHost, destinationPort, null, connectionCreationOptions, callbackHandler, null);
                 connection = IoFutureHelper.get(futureConnection, connectionTimeout, TimeUnit.MILLISECONDS);
-                logger.debug("Successfully reconnected to connection " + connection);
+                logger.debugf("Successfully reconnected to connection %s", connection);
 
             } catch (Exception e) {
-                logger.debug("Failed to re-connect to " + this.destinationHost + ":" + this.destinationPort, e);
+                logger.debugf(e, "Failed to re-connect to %s:%d", this.destinationHost, this.destinationPort);
             }
             if (connection == null) {
                 return;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/TransactionRecoveryEJBClientContextInitializer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/TransactionRecoveryEJBClientContextInitializer.java
@@ -36,6 +36,6 @@ public class TransactionRecoveryEJBClientContextInitializer implements EJBClient
     @Override
     public void initialize(EJBClientContext context) {
         context.registerEJBClientContextListener(EJBTransactionRecoveryService.INSTANCE);
-        EjbLogger.ROOT_LOGGER.debug("Registered " + EJBTransactionRecoveryService.INSTANCE + " as a listener to EJB client context " + context);
+        EjbLogger.ROOT_LOGGER.debugf("Registered %s as a listener to EJB client context %s", EJBTransactionRecoveryService.INSTANCE, context);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
@@ -58,6 +58,6 @@ class InvocationCancellationMessageHandler extends AbstractMessageHandler {
         }
         // mark it as cancelled
         cancellationFlag.set(true);
-        logger.debug("Invocation with id " + invocationToCancel + " has been marked as cancelled, as requested");
+        logger.debugf("Invocation with id %s has been marked as cancelled, as requested", invocationToCancel);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -205,7 +205,7 @@ class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHandler {
                             // if the EJB is shutting down when the invocation was done, then it's as good as the EJB not being available. The client has to know about this as
                             // a "no such EJB" failure so that it can retry the invocation on a different node if possible.
                             if (throwable instanceof EJBComponentUnavailableException) {
-                                EjbLogger.EJB3_INVOCATION_LOGGER.debug("Cannot handle method invocation: " + invokedMethod + " on bean: " + beanName + " due to EJB component unavailability exception. Returning a no such EJB available message back to client");
+                                EjbLogger.EJB3_INVOCATION_LOGGER.debugf("Cannot handle method invocation: %s on bean: %s due to EJB component unavailability exception. Returning a no such EJB available message back to client", invokedMethod, beanName);
                                 MethodInvocationMessageHandler.this.writeNoSuchEJBFailureMessage(channelAssociation, invocationId, appName, moduleName, distinctName, beanName, viewClassName);
                             } else {
                                 // write out the failure

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -210,7 +210,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
         final Map<DeploymentModuleIdentifier, ModuleDeployment> availableModules = this.deploymentRepository.getStartedModules();
         if (availableModules != null && !availableModules.isEmpty()) {
             try {
-                EjbLogger.ROOT_LOGGER.debug("Sending initial module availability message, containing " + availableModules.size() + " module(s) to channel " + this.channelAssociation.getChannel());
+                EjbLogger.ROOT_LOGGER.debugf("Sending initial module availability message, containing %s module(s) to channel %s", availableModules.size(), this.channelAssociation.getChannel());
                 this.sendModuleAvailability(availableModules.keySet().toArray(new DeploymentModuleIdentifier[availableModules.size()]));
             } catch (IOException e) {
                 EjbLogger.ROOT_LOGGER.failedToSendModuleAvailabilityMessageToClient(e, this.channelAssociation.getChannel());
@@ -279,7 +279,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     @Override
     public void registryAdded(Registry<String, List<ClientMapping>> cluster) {
         try {
-            EjbLogger.ROOT_LOGGER.debug("Received new cluster formation notification for cluster " + cluster.getGroup().getName());
+            EjbLogger.ROOT_LOGGER.debugf("Received new cluster formation notification for cluster %s", cluster.getGroup().getName());
             this.sendNewClusterFormedMessage(Collections.singleton(cluster));
         } catch (IOException ioe) {
             EjbLogger.ROOT_LOGGER.failedToSendClusterFormationMessageToClient(ioe, cluster.getGroup().getName(), channelAssociation.getChannel());
@@ -296,7 +296,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     public void registryRemoved(Registry<String, List<ClientMapping>> registry) {
         // When the cluster node count reaches 0 then send a cluster removal message to clean up the ClusterContext on the client
         try {
-            EjbLogger.ROOT_LOGGER.debug("Received cluster removal notification for cluster " + registry.getGroup());
+            EjbLogger.ROOT_LOGGER.debugf("Received cluster removal notification for cluster %s", registry.getGroup());
             // when the membership of the cluster being left is 1, we are the last node
             if (registry.getEntries().keySet().size() == 1) {
                 this.sendClusterRemovedMessage(registry);
@@ -323,7 +323,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
         outputStream = new DataOutputStream(messageOutputStream);
         final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
         try {
-            EjbLogger.ROOT_LOGGER.debug("Writing out cluster formation message for " + clientMappingRegistries.size() + " clusters, to channel " + this.channelAssociation.getChannel());
+            EjbLogger.ROOT_LOGGER.debugf("Writing out cluster formation message for %d clusters, to channel %s", clientMappingRegistries.size(), this.channelAssociation.getChannel());
             clusterTopologyWriter.writeCompleteClusterTopology(outputStream, clientMappingRegistries);
         } finally {
             channelAssociation.releaseChannelMessageOutputStream(messageOutputStream);
@@ -348,7 +348,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
         outputStream = new DataOutputStream(messageOutputStream);
         final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
         try {
-            EjbLogger.ROOT_LOGGER.debug("Cluster " + registry.getGroup().getName() + " removed, writing cluster removal message to channel " + this.channelAssociation.getChannel());
+            EjbLogger.ROOT_LOGGER.debugf("Cluster Ts removed, writing cluster removal message to channel %s", registry.getGroup().getName(), this.channelAssociation.getChannel());
             clusterTopologyWriter.writeClusterRemoved(outputStream, Collections.singleton(registry));
         } finally {
             channelAssociation.releaseChannelMessageOutputStream(messageOutputStream);
@@ -374,7 +374,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
 
         @Override
         public void handleClose(Channel closedChannel, IOException exception) {
-            EjbLogger.ROOT_LOGGER.debug("Channel " + closedChannel + " closed");
+            EjbLogger.ROOT_LOGGER.debugf("Channel %s closed", closedChannel);
             VersionOneProtocolChannelReceiver.this.cleanupOnChannelDown();
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionManagementTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionManagementTask.java
@@ -100,7 +100,7 @@ abstract class XidTransactionManagementTask implements Runnable {
     protected SubordinateTransaction tryRecoveryForImportedTransaction() throws Exception {
         final XATerminator xaTerminator = SubordinationManager.getXATerminator();
         if (xaTerminator instanceof XATerminatorImple) {
-            EjbLogger.ROOT_LOGGER.debug("Trying to recover an imported transaction for Xid " + this.xidTransactionID.getXid());
+            EjbLogger.ROOT_LOGGER.debugf("Trying to recover an imported transaction for Xid %s", this.xidTransactionID.getXid());
             // We intentionally pass null for Xid since passing the specific Xid doesn't seem to work for some reason.
             // As for null for parentNodeName, we do that intentionally since we aren't aware of the parent node on which
             // the transaction originated

--- a/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/security/EJBSecurityViewConfigurator.java
@@ -70,8 +70,12 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
         // for the bean nor there's any default security domain that's configured at EJB3 subsystem level.
         // In such cases, we do *not* apply any security interceptors
         if (ejbComponentDescription.getSecurityDomain() == null || ejbComponentDescription.getSecurityDomain().isEmpty()) {
-            ROOT_LOGGER.debug("Security is *not* enabled on EJB: " + ejbComponentDescription.getEJBName() +
-                    ", since no explicit security domain is configured for the bean, nor is there any default security domain configured in the EJB3 subsystem");
+            if (ROOT_LOGGER.isDebugEnabled()) {
+                ROOT_LOGGER
+                        .debug("Security is *not* enabled on EJB: "
+                                + ejbComponentDescription.getEJBName()
+                                + ", since no explicit security domain is configured for the bean, nor is there any default security domain configured in the EJB3 subsystem");
+            }
             return;
         }
 
@@ -148,7 +152,7 @@ public class EJBSecurityViewConfigurator implements ViewConfigurator {
             }
         } else {
             // if security is not applicable for the EJB, then do *not* add the security related interceptors
-            ROOT_LOGGER.debug("Security is *not* enabled on EJB: " + ejbComponentDescription.getEJBName() + ", no security interceptors will apply");
+            ROOT_LOGGER.debugf("Security is *not* enabled on EJB: %s, no security interceptors will apply",  ejbComponentDescription.getEJBName());
 
             if (viewMethodSecurityAttributesServiceBuilder != null) {
                 // we install the service anyway since other components can depend on it

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/task/TimerTask.java
@@ -94,7 +94,7 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
         final TimerImpl timer = timerService.getTimer(timerId);
         try {
             if (cancelled) {
-                ROOT_LOGGER.debug("Timer task was cancelled for " + timer);
+                ROOT_LOGGER.debugf("Timer task was cancelled for %s", timer);
                 return;
             }
 


### PR DESCRIPTION
Most of the WildFly code uses message format patterns for debug logging
in order to avoid unnecessary allocations in normal operation. The
EJB3 subsystem client seems to be one of the few places where this is
not yet the case and debug messages are always created even if the
debug logging is disabled.
- use `#debugf` for debug logging
- use `#isDebugEnabled` for debug statements too complex for `#debugf`

Issue: WFLY-4219
https://issues.jboss.org/browse/WFLY-4219
