### PR TITLE
[WFLY-2855] Fix description of annotation-property-replacement attribute

### DIFF
--- a/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
+++ b/ee/src/main/resources/org/jboss/as/ee/subsystem/LocalDescriptions.properties
@@ -10,7 +10,7 @@ ee.global-modules.services=If any services exposed in META-INF/services should b
 ee.ear-subdeployments-isolated=Flag indicating whether each of the subdeployments within a .ear can access classes belonging to another subdeployment within the same .ear. A value of false means the subdeployments can see classes belonging to other subdeployments within the .ear.
 ee.spec-descriptor-property-replacement=Flag indicating whether descriptors defined by the Java EE specification will have property replacements applied
 ee.jboss-descriptor-property-replacement=Flag indicating whether JBoss specific deployment descriptors will have property replacements applied
-ee.annotation-property-replacement=Flag indicating whether EJB annotations will have property replacements applied
+ee.annotation-property-replacement=Flag indicating whether Java EE annotations will have property replacements applied
 
 service=Centrally configurable services that are part of the EE subsystem.
 


### PR DESCRIPTION
This was left out when fixing https://issues.jboss.org/browse/WFLY-2855
The description still says 'EJB' but it applies to all Java EE annotations.
