### PR TITLE
WFLY-3723: setting the local to english in CLI commands on non-english systems does not produce english output

### DIFF
--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -438,6 +438,10 @@ public class GlobalOperationHandlers {
         }
         String unparsed = normalizeLocale(operation.get(GlobalOperationAttributes.LOCALE.getName()).asString());
         int len = unparsed.length();
+        if ( len < 1 || len > 7 ) {
+            throw new IllegalArgumentException(unparsed);
+        }
+
         if (len != 2 && len != 5 && len < 7) {
             reportInvalidLocaleFormat(context, unparsed);
             return null;

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -469,14 +469,20 @@ public class GlobalOperationHandlers {
             return null;
         }
         if (len == 5) {
-            return new Locale(unparsed.substring(0, 2), unparsed.substring(3));
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3)));
         }
 
         if (!isLocaleSeparator(unparsed.charAt(5))) {
             reportInvalidLocaleFormat(context, unparsed);
             return null;
         }
-        return new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6));
+        return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6)));
+    }
+
+    private static final String ENGLISH = new Locale("en").getLanguage();
+
+    static Locale replaceByRootLocaleIfLanguageIsEnglish(Locale locale) {
+        return (locale.getLanguage().equals(ENGLISH) ? Locale.ROOT : locale);
     }
 
     static boolean getRecursive(OperationContext context, ModelNode op) throws OperationFailedException

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -438,61 +438,11 @@ public class GlobalOperationHandlers {
         }
         String unparsed = normalizeLocale(operation.get(GlobalOperationAttributes.LOCALE.getName()).asString());
         try {
-            return resolveLocale(unparsed);
+            return LocaleResolver.resolveLocale(unparsed);
         } catch (IllegalArgumentException e) {
             reportInvalidLocaleFormat(context, e.getMessage());
             return null;
         }
-    }
-
-    static Locale resolveLocale(String unparsed) throws IllegalArgumentException {
-        int len = unparsed.length();
-        if ( len < 1 || len > 7 ) {
-            throw new IllegalArgumentException(unparsed);
-        }
-
-        if (len != 2 && len != 5 && len < 7) {
-            throw new IllegalArgumentException(unparsed);
-        }
-
-        char char0 = unparsed.charAt(0);
-        char char1 = unparsed.charAt(1);
-        if (char0 < 'a' || char0 > 'z' || char1 < 'a' || char1 > 'z') {
-            throw new IllegalArgumentException(unparsed);
-        }
-        if (len == 2) {
-            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed, ""));
-        }
-
-        if (!isLocaleSeparator(unparsed.charAt(2))) {
-            throw new IllegalArgumentException(unparsed);
-        }
-
-        char char3 = unparsed.charAt(3);
-        if (isLocaleSeparator(char3)) {
-            // no country
-            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), "", unparsed.substring(4)));
-        }
-
-        char char4 = unparsed.charAt(4);
-        if (char3 < 'A' || char3 > 'Z' || char4 < 'A' || char4 > 'Z') {
-            throw new IllegalArgumentException(unparsed);
-        }
-
-        if (len == 5) {
-            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3)));
-        }
-
-        if (!isLocaleSeparator(unparsed.charAt(5))) {
-            throw new IllegalArgumentException(unparsed);
-        }
-        return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6)));
-    }
-
-    private static final String ENGLISH = new Locale("en").getLanguage();
-
-    static Locale replaceByRootLocaleIfLanguageIsEnglish(Locale locale) {
-        return (locale.getLanguage().equals(ENGLISH) ? Locale.ROOT : locale);
     }
 
     static boolean getRecursive(OperationContext context, ModelNode op) throws OperationFailedException
@@ -534,10 +484,6 @@ public class GlobalOperationHandlers {
 
     private static String normalizeLocale(String toNormalize) {
         return ("zh_Hans".equalsIgnoreCase(toNormalize) || "zh-Hans".equalsIgnoreCase(toNormalize)) ? "zh_CN" : toNormalize;
-    }
-
-    private static boolean isLocaleSeparator(char ch) {
-        return ch == '-' || ch == '_';
     }
 
     private static void reportInvalidLocaleFormat(OperationContext context, String format) {

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/GlobalOperationHandlers.java
@@ -437,48 +437,54 @@ public class GlobalOperationHandlers {
             return null;
         }
         String unparsed = normalizeLocale(operation.get(GlobalOperationAttributes.LOCALE.getName()).asString());
+        try {
+            return resolveLocale(unparsed);
+        } catch (IllegalArgumentException e) {
+            reportInvalidLocaleFormat(context, e.getMessage());
+            return null;
+        }
+    }
+
+    static Locale resolveLocale(String unparsed) throws IllegalArgumentException {
         int len = unparsed.length();
         if ( len < 1 || len > 7 ) {
             throw new IllegalArgumentException(unparsed);
         }
 
         if (len != 2 && len != 5 && len < 7) {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
+            throw new IllegalArgumentException(unparsed);
         }
 
         char char0 = unparsed.charAt(0);
         char char1 = unparsed.charAt(1);
         if (char0 < 'a' || char0 > 'z' || char1 < 'a' || char1 > 'z') {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
+            throw new IllegalArgumentException(unparsed);
         }
         if (len == 2) {
-            return new Locale(unparsed, "");
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed, ""));
         }
 
         if (!isLocaleSeparator(unparsed.charAt(2))) {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
+            throw new IllegalArgumentException(unparsed);
         }
+
         char char3 = unparsed.charAt(3);
         if (isLocaleSeparator(char3)) {
             // no country
-            return new Locale(unparsed.substring(0, 2), "", unparsed.substring(4));
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), "", unparsed.substring(4)));
         }
 
         char char4 = unparsed.charAt(4);
         if (char3 < 'A' || char3 > 'Z' || char4 < 'A' || char4 > 'Z') {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
+            throw new IllegalArgumentException(unparsed);
         }
+
         if (len == 5) {
             return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3)));
         }
 
         if (!isLocaleSeparator(unparsed.charAt(5))) {
-            reportInvalidLocaleFormat(context, unparsed);
-            return null;
+            throw new IllegalArgumentException(unparsed);
         }
         return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6)));
     }

--- a/controller/src/main/java/org/jboss/as/controller/operations/global/LocaleResolver.java
+++ b/controller/src/main/java/org/jboss/as/controller/operations/global/LocaleResolver.java
@@ -1,0 +1,73 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jboss.as.controller.operations.global;
+
+import java.util.Locale;
+
+/**
+ * Utility class handling low-level parsing of Locale string tag.
+ *
+ * @author Romain Pelisse - <romain@redhat.com>
+ */
+public final class LocaleResolver {
+
+    private static final String ENGLISH = new Locale("en").getLanguage();
+
+    private LocaleResolver(){};
+
+    static Locale resolveLocale(String unparsed) throws IllegalArgumentException {
+        int len = unparsed.length();
+        if ( len < 1 || len > 7 ) {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        if (len != 2 && len != 5 && len < 7) {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        char char0 = unparsed.charAt(0);
+        char char1 = unparsed.charAt(1);
+        if (char0 < 'a' || char0 > 'z' || char1 < 'a' || char1 > 'z') {
+            throw new IllegalArgumentException(unparsed);
+        }
+        if (len == 2) {
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed, ""));
+        }
+
+        if (!isLocaleSeparator(unparsed.charAt(2))) {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        char char3 = unparsed.charAt(3);
+        if (isLocaleSeparator(char3)) {
+            // no country
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), "", unparsed.substring(4)));
+        }
+
+        char char4 = unparsed.charAt(4);
+        if (char3 < 'A' || char3 > 'Z' || char4 < 'A' || char4 > 'Z') {
+            throw new IllegalArgumentException(unparsed);
+        }
+
+        if (len == 5) {
+            return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3)));
+        }
+
+        if (!isLocaleSeparator(unparsed.charAt(5))) {
+            throw new IllegalArgumentException(unparsed);
+        }
+        return replaceByRootLocaleIfLanguageIsEnglish(new Locale(unparsed.substring(0, 2), unparsed.substring(3, 5), unparsed.substring(6)));
+    }
+
+    private static boolean isLocaleSeparator(char ch) {
+        return ch == '-' || ch == '_';
+    }
+
+    static Locale replaceByRootLocaleIfLanguageIsEnglish(Locale locale) {
+        return (locale.getLanguage().equals(ENGLISH) ? Locale.ROOT : locale);
+    }
+
+}

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
@@ -6,9 +6,7 @@
 package org.jboss.as.controller.operations.global;
 
 import java.util.Locale;
-import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
 import org.junit.Test;
 
@@ -56,7 +54,7 @@ public class LocaleResolverTest {
 
     public void invalidLanguageOrCountry(String unparsed) {
         try { 
-            GlobalOperationHandlers.resolveLocale(unparsed);
+            LocaleResolver.resolveLocale(unparsed);
         } catch ( IllegalArgumentException e) {
             assertEquals(unparsed,e.getMessage());
             return; // pass...
@@ -66,8 +64,8 @@ public class LocaleResolverTest {
     
     @Test
     public void wfly3723() {
-        assertEquals("",french, GlobalOperationHandlers.resolveLocale(french.toLanguageTag())); 
-        assertEquals("",german, GlobalOperationHandlers.resolveLocale(german.toLanguageTag())); 
-        assertEquals("",Locale.ROOT, GlobalOperationHandlers.resolveLocale(english.toLanguageTag()));         
+        assertEquals("",french, LocaleResolver.resolveLocale(french.toLanguageTag())); 
+        assertEquals("",german, LocaleResolver.resolveLocale(german.toLanguageTag())); 
+        assertEquals("",Locale.ROOT, LocaleResolver.resolveLocale(english.toLanguageTag()));         
     }
 }

--- a/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
+++ b/controller/src/test/java/org/jboss/as/controller/operations/global/LocaleResolverTest.java
@@ -1,0 +1,73 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.jboss.as.controller.operations.global;
+
+import java.util.Locale;
+import org.junit.Assert;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+import org.junit.Test;
+
+/**
+ *
+ * @author rpelisse
+ */
+public class LocaleResolverTest {
+    
+    Locale french = Locale.FRENCH;
+    Locale english = Locale.ENGLISH;
+    Locale german = Locale.GERMAN;
+
+    @Test
+    public void invalidLanguageNotUsingAlphanumericCharacters() {
+        invalidLanguageOrCountry("1#");
+    }   
+    
+    @Test
+    public void invalidCountryNotUsingAlphanumericCharacters() {
+        invalidLanguageOrCountry("en_1€");
+    }   
+
+    @Test
+    public void invalidLanguageTag() {
+        invalidLanguageOrCountry("en_EN_too_long");
+        invalidLanguageOrCountry("e"); // too short
+        invalidLanguageOrCountry("e_U"); 
+        invalidLanguageOrCountry("en_U"); 
+        invalidLanguageOrCountry("en_US_"); // incomplete
+    }   
+
+    @Test
+    public void nonExistingLanguageOrCountry() {
+        invalidLanguageOrCountry("aW");
+        invalidLanguageOrCountry("aW_AW");
+    }   
+
+    @Test
+    public void invalidLocaleSeparator() {
+        invalidLanguageOrCountry("*");
+        invalidLanguageOrCountry("de_DE8");
+        invalidLanguageOrCountry("en_#");
+    }   
+
+    public void invalidLanguageOrCountry(String unparsed) {
+        try { 
+            GlobalOperationHandlers.resolveLocale(unparsed);
+        } catch ( IllegalArgumentException e) {
+            assertEquals(unparsed,e.getMessage());
+            return; // pass...
+        }
+        fail("Format " + unparsed + " is invalid, test should have failed.");
+    }
+    
+    @Test
+    public void wfly3723() {
+        assertEquals("",french, GlobalOperationHandlers.resolveLocale(french.toLanguageTag())); 
+        assertEquals("",german, GlobalOperationHandlers.resolveLocale(german.toLanguageTag())); 
+        assertEquals("",Locale.ROOT, GlobalOperationHandlers.resolveLocale(english.toLanguageTag()));         
+    }
+}


### PR DESCRIPTION
On top of fixing the underlying issue, the PR includes some code cleaning, and addition of a test case.
