### PR TITLE
WFLY-2967 Remove log and re-throw behaviour from the CMTTxInterceptor

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -2994,9 +2994,9 @@ public interface EjbLogger extends BasicLogger {
     @Message(id = 457, value = "Unexpected Error")
     String convertUnexpectedError();
 
-    @LogMessage(level = ERROR)
-    @Message(id = 458, value = "Failure in caller transaction.")
-    void failureInCallerTransaction(@Cause Throwable cause);
+    //@LogMessage(level = ERROR)
+    //@Message(id = 458, value = "Failure in caller transaction.")
+    //void failureInCallerTransaction(@Cause Throwable cause);
 
     @Message(id = 459, value = "Module %s containing bean %s is not deployed in ear but it specifies resource adapter name '%s' in a relative format.")
     DeploymentUnitProcessingException relativeResourceAdapterNameInStandaloneModule(String module, String bean, String adapterName);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/tx/CMTTxInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/tx/CMTTxInterceptor.java
@@ -156,7 +156,6 @@ public class CMTTxInterceptor implements Interceptor {
             } else if (t instanceof NoSuchEJBException || t instanceof NoSuchEntityException) {
                 // If this is an NoSuchEJBException, pass through to the caller
                 toThrow = (Exception) t;
-                // TODO WFLY-2967 even if we log-and-throw some stuff should this case be one?
             } else if (t instanceof RuntimeException) {
                 toThrow = new EJBTransactionRolledbackException(t.getMessage(), (Exception) t);
             } else {// application exception
@@ -167,8 +166,6 @@ public class CMTTxInterceptor implements Interceptor {
         }
 
         setRollbackOnly(tx);
-        // TODO WFLY-2967 remove this log-and-throw below, change msg to DEBUG or limit its scope to certain cases
-        EjbLogger.ROOT_LOGGER.failureInCallerTransaction(t); // log orig 't' not noisier wrapper created above
         throw toThrow;
     }
 


### PR DESCRIPTION
We already have the undesirable behaviour provided by the LoggingInterceptor, which means
that an exception may be logged twice for every EJB in the call stack, which is very unfriendly.
