### PR TITLE
[WFLY-4075] Setting "org.jboss.as.jaxrs.enableSpringIntegration" to

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
@@ -98,7 +98,7 @@ public class JaxrsSpringProcessor implements DeploymentUnitProcessor {
             if (fileUrl == null) {
                 throw JaxrsLogger.JAXRS_LOGGER.noSpringIntegrationJar();
             }
-            File dir = new File(fileUrl.getFile());
+            File dir = new File(fileUrl.toURI());
             File file = null;
             for (String jar : dir.list()) {
                 if (jar.endsWith(".jar")) {


### PR DESCRIPTION
"true" causes JaxrsSpringProcessor to throw NullPointerException

Issue: https://issues.jboss.org/browse/WFLY-4075
