### PR TITLE
Update Hibernate Search to version 5.0.0.Final and depending HQL Parser ...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,8 @@
         <version.org.hibernate.commons.annotations>4.0.5.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>5.1.3.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-        <version.org.hibernate.hql>1.1.0.Alpha3</version.org.hibernate.hql>
-        <version.org.hibernate.search>5.0.0.Beta2</version.org.hibernate.search>
+        <version.org.hibernate.hql>1.1.0.Final</version.org.hibernate.hql>
+        <version.org.hibernate.search>5.0.0.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.5.Final</version.org.hornetq>
         <version.org.infinispan>7.0.2.Final</version.org.infinispan>
         <version.org.jacorb>2.3.2-jbossorg-5</version.org.jacorb>


### PR DESCRIPTION
...to version 1.1.0.Final

https://issues.jboss.org/browse/WFLY-4231

The latest version of the HQL Parser depends strictly on this version of Hibernate Search, so I think it's best to keep the two updates in the same commit.
