### PR TITLE
WFLY-4246 regression tests for vaulted credentials support in LDAP login modules

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLoginModuleTestCase.ldif
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLoginModuleTestCase.ldif
@@ -370,3 +370,39 @@ objectClass: referral
 objectClass: top
 ou: RefRoles
 ref: ldap://${hostname}:${ldapPort2}/ou=SharedRoles,dc=jboss,dc=com
+
+# Example6: "jduke" - "TheDuke", "Echo", "Admin"
+#baseCtxDN= o=example6,dc=jboss,dc=org
+#baseFilter= (uid={0})
+#rolesCtxDN= o=example6,dc=jboss,dc=org
+#roleFilter= (member={1})
+#roleAttributeID= cn
+
+dn: o=example6,dc=jboss,dc=org
+objectclass: top
+objectclass: organization
+o: example6
+
+dn: uid=jduke,o=example6,dc=jboss,dc=org
+uid: jduke
+userpassword: theduke
+sn: duke
+cn: Java Duke
+objectclass: top
+objectclass: person
+objectclass: inetOrgPerson
+
+dn: uid=sa,o=example6,dc=jboss,dc=org
+uid: sa
+userpassword: secretValue
+sn: SysAdmin
+cn: SysAdmin with a vaulted password
+objectclass: top
+objectclass: person
+objectclass: inetOrgPerson
+
+dn: cn=Admin,o=example6,dc=jboss,dc=org
+member: uid=jduke,o=example6,dc=jboss,dc=org
+cn: Admin
+objectclass: top
+objectclass: groupOfNames

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLoginModuleTestCase2.ldif
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/LdapExtLoginModuleTestCase2.ldif
@@ -57,7 +57,7 @@ ou: People
 dn: o=example5,dc=jboss,dc=org
 objectclass: top
 objectclass: organization
-o: example3
+o: example5
 
 dn: ou=People,o=example5,dc=jboss,dc=org
 objectclass: top


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-4246

Test coverage for vaulted `bindCredentials` in LDAP login modules:
- LdapExtLoginModule
- AdvancedLdapLoginModule
