### PR TITLE
WFLY-3512 recovering services in case of datasource removal

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -100,7 +100,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
         context.stepCompleted();
     }
 
-    private void performRuntime(final OperationContext context, final ModelNode operation, final Resource resource,
+    protected void performRuntime(final OperationContext context, final ModelNode operation, final Resource resource,
                                 final ModelNode model) throws OperationFailedException {
         final ModelNode address = operation.require(OP_ADDR);
         final String dsName = PathAddress.pathAddress(address).getLastElement().getValue();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceRemove.java
@@ -29,6 +29,9 @@ package org.jboss.as.connector.subsystems.datasources;
  */
 public class DataSourceRemove extends AbstractDataSourceRemove {
 
-    static final DataSourceRemove INSTANCE = new DataSourceRemove();
+    static final DataSourceRemove INSTANCE = new DataSourceRemove(DataSourceAdd.INSTANCE);
 
+    protected DataSourceRemove(AbstractDataSourceAdd addHandler) {
+        super(addHandler);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/AbstractDsRemove.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/AbstractDsRemove.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource.remove;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.connector.subsystems.datasources.DataSourcesExtension;
+import org.jboss.as.connector.subsystems.datasources.Namespace;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
+import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
+import org.jboss.as.test.shared.FileUtils;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import java.net.URL;
+import java.util.Hashtable;
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+/**
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+public abstract class AbstractDsRemove extends ContainerResourceMgmtTestBase {
+
+    static final String DATASOURCE_NAME = "RemoveDS";
+
+    static class DataSourceSetupTask extends AbstractMgmtServerSetupTask {
+        @Override
+        protected void doSetup(ManagementClient managementClient) throws Exception {
+            String xml = FileUtils.readFile(this.getClass(), "remove-ds.xml");
+            List<ModelNode> operations = xmlToModelOperations(xml, Namespace.CURRENT.getUriString(), new DataSourcesExtension.DataSourceSubsystemParser());
+            boolean skipFirst = true;
+            for (ModelNode operation: operations) {
+                if (skipFirst) {
+                    skipFirst = false;
+                    continue;
+                }
+                executeOperation(operation);
+            }
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            remove(datasourceAddress());
+        }
+    }
+
+    protected static ModelNode datasourceAddress() {
+        final ModelNode address = new ModelNode();
+        address.add("subsystem", "datasources");
+        address.add("data-source", DATASOURCE_NAME);
+        return address;
+    }
+
+    protected String performCall(URL url,String urlPattern) throws Exception {
+        return HttpRequest.get(url.toExternalForm() + urlPattern, TimeoutUtil.adjust(2), SECONDS);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected static <T> T lookupEJB(final String moduleName, Class<? extends T> beanImplClass, Class<T> remoteInterface) throws NamingException {
+        final Hashtable<String, String> jndiProperties = new Hashtable<String, String>();
+        jndiProperties.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        final Context context = new InitialContext(jndiProperties);
+
+        return (T) context.lookup("ejb:/" + moduleName + "/" + beanImplClass.getSimpleName() + "!"
+                + remoteInterface.getName());
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/EjbAppDsRemoveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/EjbAppDsRemoveTestCase.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource.remove;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the removal of a data-source used in an ejb deployment.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(AbstractDsRemove.DataSourceSetupTask.class)
+public class EjbAppDsRemoveTestCase extends AbstractDsRemove {
+
+    private static final String MODULE_NAME = "remove-ds";
+
+    @Deployment
+    public static JavaArchive deploy() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addClasses(RemoveDsBean.class, RemoveDsBeanRemote.class, TimeoutUtil.class);
+        return jar;
+    }
+
+    @Test
+    public void testDatasourceRemove() throws Exception {
+        final RemoveDsBeanRemote bean = lookupEJB(MODULE_NAME, RemoveDsBean.class, RemoveDsBeanRemote.class);
+        bean.testDatasource();
+        try {
+            remove(datasourceAddress());
+            fail("Removal of the datasource should have failed.");
+        } catch (MgmtOperationException expected) {
+        }
+        bean.testDatasource();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/RemoveDsBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/RemoveDsBean.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,17 +20,34 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.connector.subsystems.datasources;
+package org.jboss.as.test.integration.jca.datasource.remove;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+
+import javax.annotation.Resource;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
 
 /**
- * Operation handler responsible for removing a XA data-source.
- *
- * @author John Bailey
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
  */
-public class XaDataSourceRemove extends AbstractDataSourceRemove {
-    static final XaDataSourceRemove INSTANCE = new XaDataSourceRemove(XaDataSourceAdd.INSTANCE);
+@Stateless
+@Remote(RemoveDsBeanRemote.class)
+public class RemoveDsBean implements RemoveDsBeanRemote {
 
-    protected XaDataSourceRemove(final AbstractDataSourceAdd addHandler) {
-        super(addHandler);
+    @Resource(mappedName = "java:jboss/datasources/RemoveDS")
+    private DataSource removeDS;
+
+    public void testDatasource() {
+        assert removeDS != null;
+        try (Connection connection = removeDS.getConnection()) {
+            assert connection != null;
+            assert connection.isValid(TimeoutUtil.adjust(1000));
+        } catch (SQLException e) {
+            throw new RuntimeException("Connection is not valid.", e);
+        }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/RemoveDsBeanRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/RemoveDsBeanRemote.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2011, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,17 +20,11 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.connector.subsystems.datasources;
+package org.jboss.as.test.integration.jca.datasource.remove;
 
 /**
- * Operation handler responsible for removing a XA data-source.
- *
- * @author John Bailey
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
  */
-public class XaDataSourceRemove extends AbstractDataSourceRemove {
-    static final XaDataSourceRemove INSTANCE = new XaDataSourceRemove(XaDataSourceAdd.INSTANCE);
-
-    protected XaDataSourceRemove(final AbstractDataSourceAdd addHandler) {
-        super(addHandler);
-    }
+public interface RemoveDsBeanRemote {
+    void testDatasource();
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/RemoveDsServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/RemoveDsServlet.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.datasource.remove;
+
+import org.jboss.as.test.shared.TimeoutUtil;
+
+import javax.annotation.Resource;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.SQLException;
+
+
+/**
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+@WebServlet(name = RemoveDsServlet.SERVLET_NAME, urlPatterns = {"/" + RemoveDsServlet.SERVLET_NAME})
+public class RemoveDsServlet extends HttpServlet {
+    public static final String SERVLET_NAME = "RemoveDsServlet";
+
+    @Resource(mappedName = "java:jboss/datasources/RemoveDS")
+    private DataSource removeDS;
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        String message = "ok";
+
+        if (removeDS == null) {
+            message = "bad";
+        }
+
+        try (Connection connection = removeDS.getConnection()) {
+            if (connection == null || !connection.isValid(TimeoutUtil.adjust(1000))) {
+                message = "bad";
+            }
+        } catch (SQLException e) {
+            System.out.println("Catched exception: " + e);
+            message = "bad";
+        }
+
+        resp.getWriter().write(message);
+        resp.getWriter().close();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/WebAppDsRemoveTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/WebAppDsRemoveTestCase.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource.remove;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Tests the removal of a data-source used in a web deployment.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(AbstractDsRemove.DataSourceSetupTask.class)
+public class WebAppDsRemoveTestCase extends AbstractDsRemove {
+
+    @Deployment
+    public static WebArchive deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "remove-ds.war");
+        war.addClasses(RemoveDsServlet.class, TimeoutUtil.class);
+        return war;
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void testDatasourceRemove() throws Exception {
+        final String resultBeforeRemoval = performCall(url, RemoveDsServlet.SERVLET_NAME);
+        assertEquals("ok", resultBeforeRemoval);
+        try {
+            remove(datasourceAddress());
+            fail("Removal of the datasource should have failed.");
+        } catch (MgmtOperationException expected) {
+        }
+        final String resultAfterRemoval = performCall(url, RemoveDsServlet.SERVLET_NAME);
+        assertEquals("ok", resultAfterRemoval);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/remove-ds.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/remove/remove-ds.xml
@@ -1,0 +1,14 @@
+<subsystem xmlns="urn:jboss:domain:datasources:3.0">
+            <datasources>
+                <datasource jndi-name="java:jboss/datasources/RemoveDS"
+                            pool-name="RemoveDS">
+                    <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1</connection-url>
+                    <driver>h2</driver>
+                    <security>
+                        <user-name>sa</user-name>
+                        <password>sa</password>
+                    </security>
+                </datasource>
+            </datasources>
+</subsystem>
+                

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/websocket/WebSocketTestCase.java
@@ -2,18 +2,20 @@ package org.jboss.as.test.integration.web.websocket;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
+import java.io.FilePermission;
 import java.net.SocketPermission;
 import java.net.URI;
 import java.util.PropertyPermission;
 
-import javax.naming.InitialContext;
+import javax.websocket.ContainerProvider;
 import javax.websocket.Session;
-import javax.websocket.server.ServerContainer;
+import javax.websocket.WebSocketContainer;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -27,6 +29,7 @@ public class WebSocketTestCase {
 
     @Deployment
     public static WebArchive deploy() {
+        final String jbossHome = System.getenv("JBOSS_HOME");
         return ShrinkWrap.create(WebArchive.class, "websocket.war")
                 .addPackage(WebSocketTestCase.class.getPackage())
                 .addClass(TestSuiteEnvironment.class)
@@ -37,13 +40,15 @@ public class WebSocketTestCase {
                                 new PropertyPermission("node0", "read"),
                                 // Needed for the serverContainer.connectToServer()
                                 new SocketPermission("*:8080", "connect,resolve")
-                        ), "permissions.xml");
+                        ), "permissions.xml")
+                .addAsManifestResource(new StringAsset("io.undertow.websockets.jsr.UndertowContainerProvider"),
+                        "services/javax.websocket.ContainerProvider");
     }
 
     @Test
     public void testWebSocket() throws Exception {
         AnnotatedClient endpoint = new AnnotatedClient();
-        ServerContainer serverContainer = (ServerContainer) new InitialContext().lookup("java:module/ServerContainer");
+        WebSocketContainer serverContainer = ContainerProvider.getWebSocketContainer();
         Session session = serverContainer.connectToServer(endpoint, new URI("ws", "", TestSuiteEnvironment.getServerAddress(), 8080, "/websocket/websocket/Stuart", "", ""));
         Assert.assertEquals("Hello Stuart", endpoint.getMessage());
     }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowJSRWebSocketDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowJSRWebSocketDeploymentProcessor.java
@@ -23,13 +23,7 @@
 package org.wildfly.extension.undertow.deployment;
 
 import io.undertow.websockets.jsr.JsrWebSocketLogger;
-import io.undertow.websockets.jsr.ServerWebSocketContainer;
 import io.undertow.websockets.jsr.WebSocketDeploymentInfo;
-import org.jboss.as.ee.component.EEModuleDescription;
-import org.jboss.as.naming.ImmediateManagedReferenceFactory;
-import org.jboss.as.naming.ServiceBasedNamingStore;
-import org.jboss.as.naming.deployment.ContextNames;
-import org.jboss.as.naming.service.BinderService;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -42,8 +36,6 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.modules.Module;
-import org.jboss.msc.service.ServiceName;
-import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 
 import javax.websocket.ClientEndpoint;
@@ -174,32 +166,7 @@ public class UndertowJSRWebSocketDeploymentProcessor implements DeploymentUnitPr
 
     private void installWebsockets(final DeploymentPhaseContext phaseContext, final WebSocketDeploymentInfo webSocketDeploymentInfo) {
         DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
-        final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION);
-
         deploymentUnit.putAttachment(UndertowAttachments.WEB_SOCKET_DEPLOYMENT_INFO, webSocketDeploymentInfo);
-
-        //bind the container to JNDI to make it available for resource injection
-        //this is not request by the spec, but is a convenient extension
-        if(moduleDescription != null) {
-            final ServiceName moduleContextServiceName = ContextNames.contextServiceNameOfModule(moduleDescription.getApplicationName(), moduleDescription.getModuleName());
-            bindJndiServices(deploymentUnit, phaseContext.getServiceTarget(), moduleContextServiceName, webSocketDeploymentInfo);
-        }
-    }
-
-    private void bindJndiServices(final DeploymentUnit deploymentUnit, final ServiceTarget serviceTarget, final ServiceName contextServiceName, final WebSocketDeploymentInfo webSocketInfo) {
-        final ServiceName bindingServiceName = contextServiceName.append("ServerContainer");
-        final BinderService binderService = new BinderService("ServerContainer");
-        serviceTarget.addService(bindingServiceName, binderService)
-                .addDependency(contextServiceName, ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
-                .install();
-
-        webSocketInfo.addListener(new WebSocketDeploymentInfo.ContainerReadyListener() {
-            @Override
-            public void ready(ServerWebSocketContainer container) {
-                binderService.getManagedObjectInjector().inject(new ImmediateManagedReferenceFactory(container));
-            }
-        });
-        deploymentUnit.addToAttachmentList(org.jboss.as.server.deployment.Attachments.JNDI_DEPENDENCIES, bindingServiceName);
     }
 
     private void doDeployment(final WebSocketDeploymentInfo container, final Set<Class<?>> annotatedEndpoints, final Set<Class<? extends ServerApplicationConfig>> serverApplicationConfigClasses, final Set<Class<? extends Endpoint>> endpoints) throws DeploymentUnitProcessingException {


### PR DESCRIPTION
Recovery of services for datasource removal, see the jira:
https://issues.jboss.org/browse/WFLY-3512

I am going to ask Stefano and Stuart for a review of these changes.
