### PR TITLE
WFLY-3384: fixing group caches jndi names, were children of the related ...

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheGroupBuilderProvider.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheGroupBuilderProvider.java
@@ -49,7 +49,7 @@ public class CacheGroupBuilderProvider implements org.wildfly.clustering.spi.Cac
     @Override
     public Collection<Builder<?>> getBuilders(String containerName, String cacheName) {
         Builder<Group> builder = this.factory.createBuilder(containerName, cacheName);
-        ContextNames.BindInfo binding = ContextNames.bindInfoFor(JndiNameFactory.createJndiName(JndiNameFactory.DEFAULT_JNDI_NAMESPACE, GroupServiceNameFactory.BASE_NAME, GroupServiceName.GROUP.toString(), containerName, cacheName).getAbsoluteName());
+        ContextNames.BindInfo binding = ContextNames.bindInfoFor(JndiNameFactory.createJndiName(JndiNameFactory.DEFAULT_JNDI_NAMESPACE, GroupServiceNameFactory.BASE_NAME, GroupServiceName.GROUP_CACHE.toString(), containerName, cacheName).getAbsoluteName());
         Builder<ManagedReferenceFactory> bindingBuilder = new BinderServiceBuilder<>(binding, builder.getServiceName(), Group.class);
         return Arrays.asList(builder, bindingBuilder);
     }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheGroupServiceNameProvider.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/CacheGroupServiceNameProvider.java
@@ -32,6 +32,6 @@ import org.wildfly.clustering.spi.CacheGroupServiceName;
 public class CacheGroupServiceNameProvider extends CacheServiceNameProvider {
 
     public CacheGroupServiceNameProvider(String containerName, String cacheName) {
-        super(CacheGroupServiceName.GROUP, containerName, cacheName);
+        super(CacheGroupServiceName.GROUP_CACHE, containerName, cacheName);
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistrationFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistrationFactoryBuilder.java
@@ -69,7 +69,7 @@ public class CacheServiceProviderRegistrationFactoryBuilder extends ServiceProvi
     public ServiceBuilder<ServiceProviderRegistrationFactory> build(ServiceTarget target) {
         return new AsynchronousServiceBuilder<>(this.getServiceName(), this).build(target)
                 .addDependency(CacheServiceName.CACHE.getServiceName(this.containerName, this.cacheName), Cache.class, this.cache)
-                .addDependency(CacheGroupServiceName.GROUP.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
+                .addDependency(CacheGroupServiceName.GROUP_CACHE.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
                 .addDependency(GroupServiceName.COMMAND_DISPATCHER.getServiceName(this.containerName), CommandDispatcherFactory.class, this.dispatcherFactory)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND);
     }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/LocalServiceProviderRegistrationFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/LocalServiceProviderRegistrationFactoryBuilder.java
@@ -52,7 +52,7 @@ public class LocalServiceProviderRegistrationFactoryBuilder extends ServiceProvi
     @Override
     public ServiceBuilder<ServiceProviderRegistrationFactory> build(ServiceTarget target) {
         return target.addService(this.getServiceName(), new ValueService<>(this))
-                .addDependency(CacheGroupServiceName.GROUP.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
+                .addDependency(CacheGroupServiceName.GROUP_CACHE.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND);
     }
 

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFactoryBuilder.java
@@ -63,7 +63,7 @@ public class CacheRegistryFactoryBuilder<K, V> extends RegistryFactoryServiceNam
     public ServiceBuilder<RegistryFactory<K, V>> build(ServiceTarget target) {
         return new AsynchronousServiceBuilder<>(this.getServiceName(), new ValueService<>(this)).build(target)
                 .addDependency(CacheGroupServiceName.NODE_FACTORY.getServiceName(this.containerName, this.cacheName), InfinispanNodeFactory.class, this.factory)
-                .addDependency(CacheGroupServiceName.GROUP.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
+                .addDependency(CacheGroupServiceName.GROUP_CACHE.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
                 .addDependency(CacheServiceName.CACHE.getServiceName(this.containerName, this.cacheName), Cache.class, this.cache)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND);
     }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/LocalRegistryFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/LocalRegistryFactoryBuilder.java
@@ -53,7 +53,7 @@ public class LocalRegistryFactoryBuilder<K, V> extends RegistryFactoryServiceNam
     @Override
     public ServiceBuilder<RegistryFactory<K, V>> build(ServiceTarget target) {
         return target.addService(this.getServiceName(), new ValueService<>(this))
-                .addDependency(CacheGroupServiceName.GROUP.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
+                .addDependency(CacheGroupServiceName.GROUP_CACHE.getServiceName(this.containerName, this.cacheName), Group.class, this.group)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND);
     }
 

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonService.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/singleton/SingletonService.java
@@ -115,7 +115,7 @@ public class SingletonService<T extends Serializable> implements Service<T>, Ser
         };
         final ServiceBuilder<T> singletonBuilder = new AsynchronousServiceBuilder<>(this.singletonServiceName, this).build(target)
                 .addAliases(this.singletonServiceName.append("singleton"))
-                .addDependency(CacheGroupServiceName.GROUP.getServiceName(containerName, cacheName), Group.class, this.group)
+                .addDependency(CacheGroupServiceName.GROUP_CACHE.getServiceName(containerName, cacheName), Group.class, this.group)
                 .addDependency(CacheGroupServiceName.SERVICE_PROVIDER_REGISTRATION.getServiceName(containerName, cacheName), ServiceProviderRegistrationFactory.class, this.registrationFactory)
                 .addDependency(GroupServiceName.COMMAND_DISPATCHER.getServiceName(containerName), CommandDispatcherFactory.class, this.dispatcherFactory)
                 .addListener(listener)

--- a/clustering/spi/src/main/java/org/wildfly/clustering/spi/CacheGroupServiceName.java
+++ b/clustering/spi/src/main/java/org/wildfly/clustering/spi/CacheGroupServiceName.java
@@ -34,10 +34,10 @@ public enum CacheGroupServiceName implements CacheGroupServiceNameFactory {
             return GroupServiceName.NODE_FACTORY.getServiceName(container).append(cache);
         }
     },
-    GROUP() {
+    GROUP_CACHE() {
         @Override
         public ServiceName getServiceName(String container, String cache) {
-            return GroupServiceName.GROUP.getServiceName(container).append(cache);
+            return GroupServiceName.GROUP_CACHE.getServiceName(container).append(cache);
         }
     },
     REGISTRY() {

--- a/clustering/spi/src/main/java/org/wildfly/clustering/spi/GroupServiceName.java
+++ b/clustering/spi/src/main/java/org/wildfly/clustering/spi/GroupServiceName.java
@@ -40,4 +40,15 @@ public enum GroupServiceName implements GroupServiceNameFactory {
             return "group";
         }
     },
+    GROUP_CACHE() {
+        @Override
+        public ServiceName getServiceName(String group) {
+            return BASE_SERVICE_NAME.append(this.toString(), group);
+        }
+
+        @Override
+        public String toString() {
+            return "group-cache";
+        }
+    },
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessComponentCreateServiceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessComponentCreateServiceFactory.java
@@ -49,7 +49,7 @@ public class StatelessComponentCreateServiceFactory extends EJBComponentCreateSe
             @Override
             public void configureDependency(ServiceBuilder<?> builder, StatelessSessionComponentCreateService service) {
                 builder.addDependency(DependencyType.OPTIONAL, RegistryInstallerService.SERVICE_NAME);
-                builder.addDependency(DependencyType.OPTIONAL, CacheGroupServiceName.GROUP.getServiceName(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME), Group.class, service.getGroupInjector());
+                builder.addDependency(DependencyType.OPTIONAL, CacheGroupServiceName.GROUP_CACHE.getServiceName(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME), Group.class, service.getGroupInjector());
                 builder.addDependency(DependencyType.OPTIONAL, EJBRemoteConnectorService.SERVICE_NAME);
             }
         });


### PR DESCRIPTION
...non-context group entry
