### PR TITLE
[WFLY-4273] Avoid sending (empty) EJBClient cluster topology message when node is non-clustered.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -102,7 +102,10 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
         // topology changes (members added/removed events in the cluster)
         final Collection<Registry<String, List<ClientMapping>>> clusters = this.clientMappingRegistryCollector.getRegistries();
         try {
-            this.sendNewClusterFormedMessage(clusters);
+            // WFLY-4273
+            if (clusters != null && clusters.size() > 0) {
+                this.sendNewClusterFormedMessage(clusters);
+            }
         } catch (IOException ioe) {
             // just log and don't throw an error
             EjbLogger.ROOT_LOGGER.failedToSendClusterFormationMessageToClient(ioe, channel);


### PR DESCRIPTION
This PR makes a small change to the EJBClient protocol receiver on the server side, simply does not send out a cluster topology message if the server node is non-clustered. The impact of this problem was just an annoying and wierd but harmless message appearing on the EJBClient side. 

Details here:  https://issues.jboss.org/browse/WFLY-4273
