### PR TITLE
Don't fail test on std configs that use a property to specify the intra-...

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -209,6 +209,7 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         String result = line.replace("${jboss.management.native.port:9999}", "9999");
         result = result.replace("${jboss.management.http.port:9990}", "9990");
         result = result.replace("${jboss.management.https.port:9993}", "9993");
+        result = result.replace("${jboss.domain.master.protocol:remote}", "remote");
         result = result.replace("${jboss.domain.master.port:9999}", "9999");
         result = result.replace("${jboss.messaging.group.port:9876}", "9876");
         result = result.replace("${jboss.socket.binding.port-offset:0}", "0");


### PR DESCRIPTION
...domain protocol

I'm going to add such a config to core, so we need this to avoid a failure.
