### PR TITLE
[WFLY-3532] Ignore clustering test RemoteFailoverTestCase.testConcurrent.Failover() until dependent failure-related issues resolved.

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -57,6 +57,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -274,6 +275,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
         }
     }
 
+    @Ignore("re-enable when WFLY-3532 resoolved")
     @Test
     public void testConcurrentFailover() throws Exception {
         ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);


### PR DESCRIPTION
Disable the test case until underlying issues resolved.
Details here: https://issues.jboss.org/browse/WFLY-3532
