### PR TITLE
[WFLY-4295] Fix -ds.xml deprecation logging

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentParsingProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentParsingProcessor.java
@@ -80,7 +80,7 @@ public class DsXmlDeploymentParsingProcessor implements DeploymentUnitProcessor 
         final PropertyReplacer propertyReplacer = deploymentUnit.getAttachment(org.jboss.as.ee.metadata.property.Attachments.FINAL_PROPERTY_REPLACER);
 
         final Set<VirtualFile> files = dataSources(deploymentUnit);
-        ConnectorLogger.ROOT_LOGGER.deprecated();
+        boolean loggedDeprication = false;
         for (VirtualFile f : files) {
             InputStream xmlStream = null;
             try {
@@ -90,6 +90,10 @@ public class DsXmlDeploymentParsingProcessor implements DeploymentUnitProcessor 
                 DataSources dataSources = parser.parse(xmlStream);
 
                 if (dataSources != null) {
+                    if (!loggedDeprication) {
+                        loggedDeprication = true;
+                        ConnectorLogger.ROOT_LOGGER.deprecated();
+                    }
                     for (DataSource ds : dataSources.getDataSource()) {
                         if (ds.getDriver() == null) {
                             throw ConnectorLogger.ROOT_LOGGER.FailedDeployDriverNotSpecified(ds.getJndiName());

--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -821,7 +821,7 @@ public interface ConnectorLogger extends BasicLogger {
     OperationFailedException jndiNameShouldValidate();
 
     @LogMessage(level = WARN)
-    @Message(id = 91, value = "-ds.xml file deployment is deprecated. Support will be removed in next versions")
+    @Message(id = 91, value = "-ds.xml file deployments are deprecated. Support may be removed in a future version.")
     void deprecated();
 }
 


### PR DESCRIPTION
I found that the deprecation logging message was getting logged whether or not a deployment contains a -ds.xml. I have moved it to where I believe it would get triggered if it actually does.
