### PR TITLE
[WFLY-4310] synchronize deploymentResource to avoid race condition.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/AbstractResourceAdapterDeploymentServiceListener.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/processors/AbstractResourceAdapterDeploymentServiceListener.java
@@ -139,11 +139,14 @@ public abstract class AbstractResourceAdapterDeploymentServiceListener extends A
                                     }
                                     Resource subsystemResource;
 
-                                    if (!deploymentResource.hasChild(pe)) {
-                                        subsystemResource = new IronJacamarResource.IronJacamarRuntimeResource();
-                                        deploymentResource.registerChild(pe, subsystemResource);
-                                    } else {
-                                        subsystemResource = deploymentResource.getChild(pe);
+                                    // Instances of Resoure is not thread-safe and need to be synchronized externally
+                                    synchronized (deploymentResource) {
+                                        if (!deploymentResource.hasChild(pe)) {
+                                            subsystemResource = new IronJacamarResource.IronJacamarRuntimeResource();
+                                            deploymentResource.registerChild(pe, subsystemResource);
+                                        } else {
+                                            subsystemResource = deploymentResource.getChild(pe);
+                                        }
                                     }
 
                                     ManagementResourceRegistration statsRegistration;


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4310
instances of Resoure is not thread-safe and need to be synchronized externally to avoid race condition.

Stefano told me that he will do refactoring to remove all listeners, however, it's not going to happen soon.
