### PR TITLE
WFLY-4229 Make http status return while deploying configurable

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeAtRootTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeAtRootTestCase.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.web.response;
+
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.controller.client.helpers.Operations.CompositeOperationBuilder;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Simple test to check if server will return default code if no app is registered under path.
+ *
+ * @author baranowb
+ *
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DefaultResponseCodeAtRootTestCase extends TestBase {
+    private static final String URL_PATTERN = "/";
+    private URL url;
+    @ArquillianResource
+    Deployer deployer;
+
+    private HttpClient httpclient = null;
+
+    @Deployment(testable = false, managed = false, name = "test")
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DefaultResponseCodeAtRootTestCase.class.getSimpleName() + ".war");
+        war.addClasses(SimpleServlet.class);
+        war.addAsWebInfResource(new StringAsset(
+                "<jboss-web>"+
+                        "<context-root>/</context-root>"+
+                "</jboss-web>"),"jboss-web.xml");
+        return war;
+    }
+
+    @Before
+    public void setup() throws Exception {
+        this.httpclient = HttpClientBuilder.create().build();
+        this.url = super.getManagementClient().getWebUri().toURL();
+    }
+
+    @Test
+    public void testNormalOpMode() throws Exception {
+        deployer.deploy("test");
+        try {
+            HttpGet httpget = new HttpGet(url.toString());
+            HttpResponse response = this.httpclient.execute(httpget);
+            //403 apparently
+            Assert.assertEquals(HttpServletResponse.SC_FORBIDDEN, response.getStatusLine().getStatusCode());
+            httpget = new HttpGet(url.toString() + URL_PATTERN + "xxx");
+            response = this.httpclient.execute(httpget);
+            Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatusLine().getStatusCode());
+        } finally {
+            deployer.undeploy("test");
+        }
+    }
+
+    @Test
+    public void testDefaultResponseCode() throws Exception {
+        CompositeOperationBuilder cob = CompositeOperationBuilder.create();
+
+        ModelNode operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "write-attribute");
+        operation.get("name").set("default-response-code");
+        operation.get("value").set(506);
+        cob.addStep(operation);
+        // if location service is removed, if no deployment == no virtual host.
+//        operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "remove");
+//        operation.get("address").add("location","/");
+//        cob.addStep(operation);
+        executeOperation(cob.build().getOperation());
+        reload();
+        deployer.deploy("test");
+        try {
+            HttpGet httpget = null;
+            HttpResponse response = null;
+            httpget = new HttpGet(url.toString() + URL_PATTERN+"xxx/xxxxx");
+            response = this.httpclient.execute(httpget);
+            Assert.assertEquals(404, response.getStatusLine().getStatusCode());
+            deployer.undeploy("test");
+            httpget = new HttpGet(url.toString() + URL_PATTERN);
+            response = this.httpclient.execute(httpget);
+            Assert.assertEquals(""+httpget,506, response.getStatusLine().getStatusCode());
+        } finally {
+            cob = CompositeOperationBuilder.create();
+            operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "undefine-attribute");
+            operation.get("name").set("default-response-code");
+            cob.addStep(operation);
+//            operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "add");
+//            operation.get("address").add("location","/");
+//            operation.get("handler").set("welcome-content");
+//            cob.addStep(operation);
+            executeOperation(cob.build().getOperation());
+            reload();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultResponseCodeTestCase.java
@@ -1,0 +1,114 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.web.response;
+
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Simple test to check if server will return default code if no app is registered under path.
+ *
+ * @author baranowb
+ *
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DefaultResponseCodeTestCase extends TestBase {
+    private static final String URL_PATTERN = "simple";
+    @ArquillianResource
+    URL url;
+    private HttpClient httpclient = null;
+
+    @Deployment
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DefaultResponseCodeTestCase.class.getSimpleName() + ".war");
+        war.addClasses(SimpleServlet.class);
+        return war;
+    }
+
+    @Before
+    public void setup() {
+        this.httpclient = HttpClientBuilder.create().build();
+    }
+
+    @Test
+    public void testNormalOpMode() throws Exception {
+        HttpGet httpget = new HttpGet(url.toString() + URL_PATTERN);
+        HttpResponse response = this.httpclient.execute(httpget);
+        Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+        httpget = new HttpGet(url.toString() + URL_PATTERN+"/xxx");
+        response = this.httpclient.execute(httpget);
+        Assert.assertEquals(HttpServletResponse.SC_NOT_FOUND, response.getStatusLine().getStatusCode());
+    }
+
+    @Test
+    public void testDefaultResponseCode() throws Exception {
+        ModelNode operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "write-attribute");
+        operation.get("name").set("default-response-code");
+        operation.get("value").set(506);
+        executeOperation(operation);
+        operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "remove");
+        operation.get("address").add("location","/");
+        executeOperation(operation);
+        reload();
+        try {
+            HttpGet httpget = new HttpGet(url.toString() + URL_PATTERN);
+            HttpResponse response = this.httpclient.execute(httpget);
+            Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+            String badUrl = url.toString();
+            badUrl = badUrl.substring(0,badUrl.length()-1);
+            httpget = new HttpGet(badUrl + "xxx/xxx");
+            response = this.httpclient.execute(httpget);
+            Assert.assertEquals(506, response.getStatusLine().getStatusCode());
+        } finally {
+            operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "undefine-attribute");
+            operation.get("name").set("default-response-code");
+            executeOperation(operation);
+            operation = createOpNode("subsystem=undertow/server=default-server/host=default-host", "add");
+            operation.get("address").add("location","/");
+            operation.get("handler").set("welcome-content");
+            executeOperation(operation);
+            reload();
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/SimpleRootServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/SimpleRootServlet.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.web.response;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author baranowb
+ *
+ */
+@WebServlet(name = "SimpleServlet", urlPatterns = { "/" })
+public class SimpleRootServlet extends HttpServlet {
+    
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/SimpleServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/SimpleServlet.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.web.response;
+
+import java.io.IOException;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author baranowb
+ *
+ */
+@WebServlet(name = "SimpleServlet", urlPatterns = { "/simple" })
+public class SimpleServlet extends HttpServlet {
+    
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/TestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/TestBase.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.web.response;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+
+import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author baranowb
+ *
+ */
+public class TestBase extends ContainerResourceMgmtTestBase{
+
+    protected void reload() throws Exception {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set("reload");
+        executeOperation(operation);
+        boolean reloaded = false;
+        int i = 0;
+        while (!reloaded) {
+            try {
+                Thread.sleep(5000);
+                if (getManagementClient().isServerInRunningState())
+                    reloaded = true;
+            } catch (Throwable t) {
+                // nothing to do, just waiting
+            } finally {
+                if (!reloaded && i++ > 10)
+                    throw new Exception("Server reloading failed");
+            }
+        }
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Constants.java
@@ -70,6 +70,7 @@ public interface Constants {
     String SIMPLE_ERROR_PAGE = "simple-error-page";
     String SCHEME = "scheme";
     String MAX_POST_SIZE = "max-post-size";
+    String DEFAULT_RESPONSE_CODE = "default-response-code";
     /*JSP config */
     String CHECK_INTERVAL = "check-interval";
     String CONTAINER = "container";

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DefaultResponseCodeHandler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DefaultResponseCodeHandler.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.undertow;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+
+import org.jboss.logging.Logger;
+
+/**
+ * Simple hander to set default code
+ *
+ * @author baranowb
+ *
+ */
+public class DefaultResponseCodeHandler implements HttpHandler {
+
+    protected static final Logger log = Logger.getLogger(DefaultResponseCodeHandler.class);
+    protected static final boolean traceEnabled;
+    static {
+        traceEnabled = log.isTraceEnabled();
+    }
+
+    private int responseCode;
+
+    public DefaultResponseCodeHandler(final int defaultCode) {
+        this.responseCode = defaultCode;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        exchange.setResponseCode(this.responseCode);
+        if (traceEnabled) {
+            log.tracef("Setting response code %s for exchange %s", responseCode, exchange);
+        }
+    }
+
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
@@ -55,7 +55,7 @@ class HostAdd extends AbstractAddStepHandler {
     static final HostAdd INSTANCE = new HostAdd();
 
     private HostAdd() {
-        super(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE);
+        super(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE, HostDefinition.DEFAULT_RESPONSE_CODE);
     }
 
     @Override
@@ -76,12 +76,14 @@ class HostAdd extends AbstractAddStepHandler {
         final String defaultServerName = UndertowRootDefinition.DEFAULT_SERVER.resolveModelAttribute(context, subsystemModel).asString();
         final String defaultHostName = ServerDefinition.DEFAULT_HOST.resolveModelAttribute(context, serverModel).asString();
         final String serverName = serverAddress.getLastElement().getValue();
-
-        boolean isDefaultHost = defaultServerName.equals(serverName) && name.equals(defaultHostName);
+        final boolean isDefaultHost = defaultServerName.equals(serverName) && name.equals(defaultHostName);
+        final ModelNode defaultResponseCode = HostDefinition.DEFAULT_RESPONSE_CODE.resolveModelAttribute(context, model);
 
         final ServiceName virtualHostServiceName = UndertowService.virtualHostName(serverName, name);
         final ServiceName accessLogServiceName = UndertowService.accessLogServiceName(serverName, name);
-        final Host service = new Host(name, aliases == null ? new LinkedList<String>() : aliases, defaultWebModule);
+        final Host service = defaultResponseCode.isDefined() ? new Host(name, aliases == null ? new LinkedList<String>()
+                : aliases, defaultWebModule, defaultResponseCode.asInt()) : new Host(name,
+                aliases == null ? new LinkedList<String>() : aliases, defaultWebModule);
         final ServiceBuilder<Host> builder = context.getServiceTarget().addService(virtualHostServiceName, service)
                 .addDependency(UndertowService.SERVER.append(serverName), Server.class, service.getServerInjection())
                 .addDependency(UndertowService.UNDERTOW, UndertowService.class, service.getUndertowService())

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -91,6 +91,7 @@ class HostDefinition extends PersistentResourceDefinition {
     static final SimpleAttributeDefinition DEFAULT_RESPONSE_CODE = new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_RESPONSE_CODE, ModelType.INT, true)
     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
     .setValidator(new IntRangeValidator(400, 599, true, true))
+    .setDefaultValue(new ModelNode(404))
     .build();
 
     static final HostDefinition INSTANCE = new HostDefinition();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostDefinition.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
@@ -37,6 +38,7 @@ import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.StringListAttributeDefinition;
+import org.jboss.as.controller.operations.validation.IntRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.dmr.ModelNode;
@@ -86,8 +88,13 @@ class HostDefinition extends PersistentResourceDefinition {
             .setDefaultValue(new ModelNode("ROOT.war"))
             .build();
 
+    static final SimpleAttributeDefinition DEFAULT_RESPONSE_CODE = new SimpleAttributeDefinitionBuilder(Constants.DEFAULT_RESPONSE_CODE, ModelType.INT, true)
+    .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
+    .setValidator(new IntRangeValidator(400, 599, true, true))
+    .build();
+
     static final HostDefinition INSTANCE = new HostDefinition();
-    private static final Collection ATTRIBUTES = Collections.unmodifiableCollection(Arrays.asList(ALIAS, DEFAULT_WEB_MODULE));
+    private static final Collection ATTRIBUTES = Collections.unmodifiableCollection(Arrays.asList(ALIAS, DEFAULT_WEB_MODULE, DEFAULT_RESPONSE_CODE));
     private static final List<? extends PersistentResourceDefinition> CHILDREN = Collections.unmodifiableList(Arrays.asList(
             LocationDefinition.INSTANCE,
             AccessLogDefinition.INSTANCE,

--- a/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_2_0.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/UndertowSubsystemParser_2_0.java
@@ -102,7 +102,7 @@ public class UndertowSubsystemParser_2_0 implements XMLStreamConstants, XMLEleme
                                                 .addAttributes(ListenerResourceDefinition.BACKLOG, ListenerResourceDefinition.RECEIVE_BUFFER, ListenerResourceDefinition.SEND_BUFFER, ListenerResourceDefinition.KEEP_ALIVE, ListenerResourceDefinition.READ_TIMEOUT, ListenerResourceDefinition.WRITE_TIMEOUT)
                                 ).addChild(
                                         builder(HostDefinition.INSTANCE)
-                                                .addAttributes(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE)
+                                                .addAttributes(HostDefinition.ALIAS, HostDefinition.DEFAULT_WEB_MODULE, HostDefinition.DEFAULT_RESPONSE_CODE)
                                                 .addChild(
                                                         builder(LocationDefinition.INSTANCE)
                                                                 .addAttributes(LocationDefinition.HANDLER)

--- a/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
+++ b/undertow/src/main/resources/org/wildfly/extension/undertow/LocalDescriptions.properties
@@ -153,6 +153,7 @@ undertow.host.name=The host name
 undertow.host.alias=Aliases for the host
 undertow.host.default-web-module=Default web module
 undertow.host.setting=Settings
+undertow.host.default-response-code=If set, this will be response code sent back in case requested context does not exist on server.
 undertow.setting.jsp=JSP container configuration.
 undertow.setting.jsp.add=Adds JSP container configuration.
 undertow.setting.jsp.remove=Removes JSP container configuration.

--- a/undertow/src/main/resources/schema/wildfly-undertow_2_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_2_0.xsd
@@ -199,7 +199,12 @@
         <xs:attribute name="name" use="required" type="xs:string"/>
         <xs:attribute name="alias" use="optional" type="xs:string"/>
         <xs:attribute name="default-web-module" use="optional" type="xs:string" default="ROOT.war"/>
-        <xs:attribute name="default-response-code" use="optional" type="xs:int"/>
+        <xs:attribute name="default-response-code" use="optional" type="xs:int">
+        	<xs:annotation> 
+            	<xs:documentation>Default response code should be set in case server should respond with nonstandard code( other than 404 ) for unavailable resource.
+            	For instance, server behind load balancer might want to respond with 5xx code to avoid being dropped by it. </xs:documentation> 
+            </xs:annotation> 
+        </xs:attribute>
     </xs:complexType>
 
     <xs:complexType name="websocketsType">

--- a/undertow/src/main/resources/schema/wildfly-undertow_2_0.xsd
+++ b/undertow/src/main/resources/schema/wildfly-undertow_2_0.xsd
@@ -199,6 +199,7 @@
         <xs:attribute name="name" use="required" type="xs:string"/>
         <xs:attribute name="alias" use="optional" type="xs:string"/>
         <xs:attribute name="default-web-module" use="optional" type="xs:string" default="ROOT.war"/>
+        <xs:attribute name="default-response-code" use="optional" type="xs:int"/>
     </xs:complexType>
 
     <xs:complexType name="websocketsType">


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4229  - v2, this require change of access level in undertow -> PathHandler.pathMatcher

One that includes more hacks: https://github.com/wildfly/wildfly/pull/7144
