### PR TITLE
Add optional dependency on sun.jdk to weld-core

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -50,5 +50,6 @@
         <module name="org.jboss.weld.api" />
         <module name="org.jboss.weld.spi" />
         <module name="org.jboss.logging" />
+        <module name="sun.jdk" optional="true" />
     </dependencies>
 </module>


### PR DESCRIPTION
Weld may optionally use Unsafe or ReflectionFactory to allocate instances
of proxy classes without calling their constructor and therefore relax some of the
proxyability requirements.
