### PR TITLE
[WFLY-4345] Use a lazy reference if the component view service is not UP

### DIFF
--- a/weld/src/main/java/org/jboss/as/weld/services/bootstrap/WeldEjbInjectionServices.java
+++ b/weld/src/main/java/org/jboss/as/weld/services/bootstrap/WeldEjbInjectionServices.java
@@ -146,7 +146,10 @@ public class WeldEjbInjectionServices extends AbstractResourceInjectionServices 
     }
 
     private ComponentView getComponentView(ViewDescription viewDescription) {
-        final ServiceController<?> controller = serviceRegistry.getRequiredService(viewDescription.getServiceName());
+        final ServiceController<?> controller = serviceRegistry.getService(viewDescription.getServiceName());
+        if (controller == null) {
+            return null;
+        }
         return (ComponentView) controller.getValue();
     }
 


### PR DESCRIPTION
For application clients, the view services are not actually started.
Using a lazy reference instead will ensure that the EJBs can properly
injected into the application.

JIRA: https://issues.jboss.org/browse/WFLY-4345
