### PR TITLE
[WFLY-4355] Added new methods to implement for the DeploymentUnit interface

### DIFF
--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/publish/WSEndpointDeploymentUnit.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/publish/WSEndpointDeploymentUnit.java
@@ -130,6 +130,18 @@ public class WSEndpointDeploymentUnit extends SimpleAttachable implements Deploy
         throw new UnsupportedOperationException();
     }
 
+    public ModelNode registerDeploymentSubsystemModel(final String subsystemName, final Resource resource) {
+        throw new UnsupportedOperationException();
+    }
+
+    public ModelNode getOrCreateDeploymentSubModel(final String subsystemName, final PathElement address) {
+        throw new UnsupportedOperationException();
+    }
+
+    public ModelNode getOrCreateDeploymentSubModel(final String subsystemName, final PathAddress address) {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public ModelNode createDeploymentSubModel(String subsystemName, PathElement address) {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
The `DeploymentUnit` interface is getting new methods as part of [WFCORE-542](https://issues.jboss.org/browse/WFCORE-542). The usage of the API should be removed as part of [WFLY-4359](https://issues.jboss.org/browse/WFLY-4359). For now we need to add the new methods though. The work for  [WFCORE-542](https://issues.jboss.org/browse/WFCORE-542) is being done on https://github.com/jamezp/wildfly-core/compare/WFCORE-542. This PR needs to be merged before a PR can be sent to WildFly Core.
