### PR TITLE
[WFLY-4259] add javax.api dependency to io.netty module

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -28,6 +28,7 @@
     </resources>
 
     <dependencies>
+        <module name="javax.api"/>
         <module name="sun.jdk"/>
         <module name="org.javassist" optional="true"/>
     </dependencies>


### PR DESCRIPTION
This dependency is required by Netty yo use its SSL features (depending
on javax.net.ssl classes)

JIRA: https://issues.jboss.org/browse/WFLY-4259
