### PR TITLE
WFLY-2480 Fix Infinispan XSD/Writer ordering issues 

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLWriter.java
@@ -201,15 +201,6 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
             writer.writeEndElement();
         }
 
-        if (cache.hasDefined(StateTransferResourceDefinition.PATH.getKey())) {
-            ModelNode stateTransfer = cache.get(StateTransferResourceDefinition.PATH.getKeyValuePair());
-            writer.writeStartElement(Element.STATE_TRANSFER.getLocalName());
-            StateTransferResourceDefinition.ENABLED.marshallAsAttribute(stateTransfer, writer);
-            StateTransferResourceDefinition.TIMEOUT.marshallAsAttribute(stateTransfer, writer);
-            StateTransferResourceDefinition.CHUNK_SIZE.marshallAsAttribute(stateTransfer, writer);
-            writer.writeEndElement();
-        }
-
         if (cache.hasDefined(CustomStoreResourceDefinition.PATH.getKey())) {
             ModelNode store = cache.get(CustomStoreResourceDefinition.PATH.getKeyValuePair());
             writer.writeStartElement(Element.STORE.getLocalName());
@@ -277,6 +268,15 @@ public class InfinispanSubsystemXMLWriter implements XMLElementWriter<SubsystemM
             writer.writeStartElement(Element.INDEXING.getLocalName());
             CacheResourceDefinition.INDEXING.marshallAsAttribute(cache, writer);
             CacheResourceDefinition.INDEXING_PROPERTIES.marshallAsElement(cache, writer);
+            writer.writeEndElement();
+        }
+
+        if (cache.hasDefined(StateTransferResourceDefinition.PATH.getKey())) {
+            ModelNode stateTransfer = cache.get(StateTransferResourceDefinition.PATH.getKeyValuePair());
+            writer.writeStartElement(Element.STATE_TRANSFER.getLocalName());
+            StateTransferResourceDefinition.ENABLED.marshallAsAttribute(stateTransfer, writer);
+            StateTransferResourceDefinition.TIMEOUT.marshallAsAttribute(stateTransfer, writer);
+            StateTransferResourceDefinition.CHUNK_SIZE.marshallAsAttribute(stateTransfer, writer);
             writer.writeEndElement();
         }
 

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_1_2.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_1_2.xsd
@@ -623,17 +623,17 @@
         <xs:complexContent>
             <xs:extension base="tns:store">
                 <xs:sequence>
-                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation>
-                                Defines the table used to store cache buckets.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
                     <xs:element name="string-keyed-table" type="tns:string-keyed-table" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>
                                 Defines the table used to store cache entries.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the table used to store cache buckets.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_1_3.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_1_3.xsd
@@ -603,17 +603,17 @@
         <xs:complexContent>
             <xs:extension base="tns:store">
                 <xs:sequence>
-                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation>
-                                Defines the table used to store cache buckets.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
                     <xs:element name="string-keyed-table" type="tns:string-keyed-table" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>
                                 Defines the table used to store cache entries.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the table used to store cache buckets.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_1_4.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_1_4.xsd
@@ -622,17 +622,17 @@
         <xs:complexContent>
             <xs:extension base="tns:store">
                 <xs:sequence>
-                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation>
-                                Defines the table used to store cache buckets.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
                     <xs:element name="string-keyed-table" type="tns:string-keyed-table" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>
                                 Defines the table used to store cache entries.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the table used to store cache buckets.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_2_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_2_0.xsd
@@ -406,18 +406,16 @@
                             <xs:documentation>The state transfer configuration for distribution and replicated caches.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:choice minOccurs="0">
-                        <xs:element name="backups" type="tns:backups" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation>A list of backup sites for this cache (for use with cross-site replication).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="backup-for" type="tns:backup-for" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation>Configures this cache as a backup for a cache on a remote site (for use with cross-site replication).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:choice>
+                    <xs:element name="backups" type="tns:backups" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>A list of backup sites for this cache (for use with cross-site replication).</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="backup-for" type="tns:backup-for" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>Configures this cache as a backup for a cache on a remote site (for use with cross-site replication).</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_2_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_2_0.xsd
@@ -651,17 +651,17 @@
         <xs:complexContent>
             <xs:extension base="tns:jdbc-store">
                 <xs:sequence>
-                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation>
-                                Defines the table used to store cache buckets.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
                     <xs:element name="string-keyed-table" type="tns:string-keyed-table" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>
                                 Defines the table used to store cache entries.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the table used to store cache buckets.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_3_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_3_0.xsd
@@ -664,17 +664,17 @@
         <xs:complexContent>
             <xs:extension base="tns:jdbc-store">
                 <xs:sequence>
-                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
-                        <xs:annotation>
-                            <xs:documentation>
-                                Defines the table used to store cache buckets.
-                            </xs:documentation>
-                        </xs:annotation>
-                    </xs:element>
                     <xs:element name="string-keyed-table" type="tns:string-keyed-table" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation>
                                 Defines the table used to store cache entries.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="binary-keyed-table" type="tns:binary-keyed-table" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Defines the table used to store cache buckets.
                             </xs:documentation>
                         </xs:annotation>
                     </xs:element>

--- a/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_3_0.xsd
+++ b/clustering/infinispan/extension/src/main/resources/schema/jboss-as-infinispan_3_0.xsd
@@ -406,18 +406,16 @@
                             <xs:documentation>The state transfer configuration for distribution and replicated caches.</xs:documentation>
                         </xs:annotation>
                     </xs:element>
-                    <xs:choice minOccurs="0">
-                        <xs:element name="backups" type="tns:backups" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation>A list of backup sites for this cache (for use with cross-site replication).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                        <xs:element name="backup-for" type="tns:backup-for" minOccurs="0">
-                            <xs:annotation>
-                                <xs:documentation>Configures this cache as a backup for a cache on a remote site (for use with cross-site replication).</xs:documentation>
-                            </xs:annotation>
-                        </xs:element>
-                    </xs:choice>
+                    <xs:element name="backups" type="tns:backups" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>A list of backup sites for this cache (for use with cross-site replication).</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="backup-for" type="tns:backup-for" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>Configures this cache as a backup for a cache on a remote site (for use with cross-site replication).</xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-backup.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-backup.xml
@@ -29,11 +29,11 @@
         <transport channel="maximal-channel" executor="transport-executor" lock-timeout="120000"/>
         <local-cache name="local" start="EAGER" module="org.infinispan" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
             </file-store>
             <indexing index="LOCAL">
             <!--
@@ -47,28 +47,28 @@
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </invalidation-cache>
         <replicated-cache name="repl" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="false" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">location</property>
             </store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
             <backups>
                 <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
                 <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>
@@ -80,12 +80,12 @@
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="12" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>
@@ -97,7 +97,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
-            <indexing index="ALL" />
+            <indexing index="ALL"/>
             <backups>
                 <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
                 <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-expressions.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-expressions.xml
@@ -29,11 +29,11 @@
         <transport channel="${test.xxx:maximal-cluster}" executor="transport-executor" lock-timeout="${test.xxx:120000}"/>
         <local-cache name="local" start="${test.xxx:EAGER}" module="${test.xxx:org.infinispan}" statistics-enabled="true">
             <locking acquire-timeout="${test.xxx:30000}" concurrency-level="${test.xxx:2000}" isolation="${test.xxx:NONE}" striping="${test.xxx:true}"/>
-            <transaction mode="FULL_XA" stop-timeout="${test.xxx:60000}"  locking="${tst.xxx:OPTIMISTIC}"/>
+            <transaction mode="FULL_XA" stop-timeout="${test.xxx:60000}" locking="${tst.xxx:OPTIMISTIC}"/>
             <eviction max-entries="${test.xxx:20000}" strategy="${test.xxx:LIRS}"/>
             <expiration interval="${test.xxx:10000}" lifespan="${test.xxx:10}" max-idle="${test.xxx:10}"/>
             <file-store fetch-state="${test.xxx:false}" passivation="${test.xxx:false}" path="${test.xxx:path}" preload="${test.xxx:true}" purge="${test.xxx:false}" relative-to="jboss.server.temp.dir" shared="${test.xxx:true}" singleton="${tst.xxx:false}">
-                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}" />
+                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}"/>
             </file-store>
             <indexing index="${test.xxx:LOCAL}">
                 <property name="hibernate.search.default.directory_provider">${test.xxx:infinispan}</property>
@@ -43,37 +43,37 @@
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="${test.xxx:10}" queue-size="${test.xxx:1000}" start="${test.xxx:LAZY}" async-marshalling="${tst.xxx:true}" statistics-enabled="true">
             <locking acquire-timeout="${test.xxx:30000}" concurrency-level="${test.xxx:2000}" isolation="${test.xxx:READ_UNCOMMITTED}" striping="${test.xxx:true}"/>
-            <transaction mode="NON_XA" stop-timeout="${test.xxx:60000}"  locking="${test.xxx:OPTIMISTIC}"/>
+            <transaction mode="NON_XA" stop-timeout="${test.xxx:60000}" locking="${test.xxx:OPTIMISTIC}"/>
             <eviction max-entries="${test.xxx:20000}" strategy="${test.xxx:LRU}"/>
             <expiration interval="${test.xxx:10000}" lifespan="${tst.xxx:10}" max-idle="${test.xxx:10}"/>
             <remote-store cache="${test.xxx:default}" socket-timeout="${test.xxx:60000}" tcp-no-delay="${test.xxx:true}" fetch-state="${test.xxx:false}" passivation="${test.xxx:false}" preload="${test.xxx:true}" purge="${test.xxx:false}" shared="${test.xxx:false}" singleton="${test.xxx:true}">
-                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}" />
+                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}"/>
                 <property name="valueSizeEstimate">${test.xxx:value}</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
-            <indexing index="${test.xxx:NONE}" />
+            <indexing index="${test.xxx:NONE}"/>
         </invalidation-cache>
-        <replicated-cache name="repl" mode="ASYNC" queue-flush-interval="${test.xxx:10}" queue-size="${test.xxx:1000}" start="${test.xxx:EAGER}"  async-marshalling="${test.xxx:false}" statistics-enabled="true">
+        <replicated-cache name="repl" mode="ASYNC" queue-flush-interval="${test.xxx:10}" queue-size="${test.xxx:1000}" start="${test.xxx:EAGER}" async-marshalling="${test.xxx:false}" statistics-enabled="true">
             <locking acquire-timeout="${test.xxx:30000}" concurrency-level="${test.xxx:2000}" isolation="${test.xxx:SERIALIZABLE}" striping="${test.xxx:true}"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="${test.xxx:60000}" locking="${test.xxx:OPTIMISTIC}"/>
             <eviction max-entries="${tst.xxx:20000}" strategy="${test.xxx:FIFO}"/>
             <expiration interval="${test.xxx:10000}" lifespan="${test.xxx:10}" max-idle="${test.xxx:10}"/>
-            <state-transfer enabled="${test.xxx:true}" timeout="${test.xxx:60000}" chunk-size="${test.xxx:10000}" />
+            <state-transfer enabled="${test.xxx:true}" timeout="${test.xxx:60000}" chunk-size="${test.xxx:10000}"/>
             <store class="${test.xxx:org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder}" fetch-state="${test.xxx:true}" passivation="${test.xxx:true}" preload="${test.xxx:false}" purge="${test.xxx:true}" shared="${test.xxx:false}" singleton="${test.xxx:false}">
-                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}" />
+                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}"/>
                 <property name="location">${test.xxx:location}</property>
             </store>
-            <indexing index="${test.xxx:NONE}" />
+            <indexing index="${test.xxx:NONE}"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" l1-lifespan="${test.xxx:1200000}" owners="${test.xxx:4}" remote-timeout="${test.xxx:35000}" start="${test.xxx:EAGER}" segments="${test.xxx:2}" async-marshalling="${test.xxx:true}" statistics-enabled="true">
             <locking acquire-timeout="${test.xxx:30000}" concurrency-level="${test.xxx:2000}" isolation="${test.xxx:READ_COMMITTED}" striping="${test.xxx:true}"/>
-            <transaction mode="FULL_XA" stop-timeout="${test.xxx:60000}"  locking="${test.xxx:OPTIMISTIC}"/>
+            <transaction mode="FULL_XA" stop-timeout="${test.xxx:60000}" locking="${test.xxx:OPTIMISTIC}"/>
             <eviction max-entries="${test.xxx:20000}" strategy="${test.xxx:UNORDERED}"/>
             <expiration interval="${test.xxx:10000}" lifespan="${test.xxx:10}" max-idle="${test.xxx:10}"/>
-            <state-transfer enabled="${test.xxx:true}" timeout="${test.xxx:60000}" chunk-size="${test.xxx:10000}" />
+            <state-transfer enabled="${test.xxx:true}" timeout="${test.xxx:60000}" chunk-size="${test.xxx:10000}"/>
             <mixed-keyed-jdbc-store datasource="${test.xxx:java:jboss/jdbc/store}" fetch-state="${test.xxx:false}" passivation="${test.xxx:false}" preload="${test.xxx:true}" purge="${test.xxx:false}" shared="${tst.xxx:true}" singleton="${test.xxx:true}">
-                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}" />
+                <write-behind flush-lock-timeout="${test.xxx:2}" modification-queue-size="${test.xxx:2048}" shutdown-timeout="${test.xxx:20000}" thread-pool-size="${test.xxx:1}"/>
                 <string-keyed-table prefix="${test.xxx:ispn_bucket}" batch-size="${tst.xxx:100}" fetch-size="${test.xxx:100}">
                     <id-column name="${test.xxx:id}" type="${test.xxx:VARCHAR}"/>
                     <data-column name="${test.xxx:datum}" type="${test.xxx:BINARY}"/>
@@ -85,7 +85,7 @@
                     <timestamp-column name="${test.xxx:version}" type="${test.xxx:BIGINT}"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
-            <indexing index="${test.xxx:ALL}" />
+            <indexing index="${test.xxx:ALL}"/>
         </distributed-cache>
     </cache-container>
 </subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
@@ -29,12 +29,12 @@
         <transport channel="maximal-channel" executor="transport-executor" lock-timeout="120000"/>
         <local-cache name="local" start="EAGER" module="org.infinispan" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="BATCH" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="BATCH" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
                 <!-- Leave out flush-lock-timeout here to test transformations of the default value (to 5 seconds) -->
-                <write-behind modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
             </file-store>
             <indexing index="LOCAL">
             <!--
@@ -48,37 +48,37 @@
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </invalidation-cache>
         <replicated-cache name="repl" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="false" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">location</property>
             </store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="12" capacity-factor="1.0" consistent-hash-strategy="INTRA_CACHE" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>
@@ -90,7 +90,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
-            <indexing index="ALL" />
+            <indexing index="ALL"/>
         </distributed-cache>
     </cache-container>
 </subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_0.xml
@@ -40,9 +40,9 @@
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
+                <property name="valueSizeEstimate">100</property>
                 <remote-server outbound-socket-binding="hotrod-server-1"/>
                 <remote-server outbound-socket-binding="hotrod-server-2"/>
-                <property name="valueSizeEstimate">100</property>
             </remote-store>
         </invalidation-cache>
         <replicated-cache name="repl" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER">
@@ -50,29 +50,29 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" flush-timeout="60000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <property name="location">${java.io.tmpdir}</property>
             </store>
+            <state-transfer enabled="true" timeout="60000" flush-timeout="60000"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <rehashing enabled="true" timeout="1200000"/>
             <jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <entry-table prefix="ispn_entry" batch-size="100" fetch-size="100">
-                    <id-column name="id" type="VARCHAR"/>
-                    <data-column name="datum" type="BINARY"/>
-                    <timestamp-column name="version" type="BIGINT"/>
-                </entry-table>
                 <bucket-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>
                     <timestamp-column name="version" type="BIGINT"/>
                 </bucket-table>
+                <entry-table prefix="ispn_entry" batch-size="100" fetch-size="100">
+                    <id-column name="id" type="VARCHAR"/>
+                    <data-column name="datum" type="BINARY"/>
+                    <timestamp-column name="version" type="BIGINT"/>
+                </entry-table>
             </jdbc-store>
+            <rehashing enabled="true" timeout="1200000"/>
         </distributed-cache>
     </cache-container>
 </subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_0.xml
@@ -1,3 +1,24 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <subsystem xmlns="urn:jboss:domain:infinispan:1.0" default-cache-container="minimal">
     <cache-container name="minimal" default-cache="local">
         <local-cache name="local"/>
@@ -19,8 +40,8 @@
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
                 <property name="valueSizeEstimate">100</property>
             </remote-store>
         </invalidation-cache>
@@ -29,7 +50,7 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" flush-timeout="60000" />
+            <state-transfer enabled="true" timeout="60000" flush-timeout="60000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <property name="location">${java.io.tmpdir}</property>
             </store>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_1.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_1.xml
@@ -48,17 +48,16 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <property name="location">${java.io.tmpdir}</property>
             </store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <bucket-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
@@ -71,6 +70,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </entry-table>
             </jdbc-store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </distributed-cache>
     </cache-container>
 </subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_1.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_1.xml
@@ -1,3 +1,24 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <subsystem xmlns="urn:jboss:domain:infinispan:1.1" default-cache-container="minimal">
     <cache-container name="minimal" default-cache="local">
         <local-cache name="local"/>
@@ -6,20 +27,20 @@
         <transport executor="transport-executor" lock-timeout="120000" stack="tcp"/>
         <local-cache name="local" batching="true" indexing="LOCAL" start="EAGER">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false"/>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
         </invalidation-cache>
         <replicated-cache name="repl" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER">
@@ -27,17 +48,17 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <property name="location">${java.io.tmpdir}</property>
             </store>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <bucket-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_2.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_2.xml
@@ -1,3 +1,24 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <subsystem xmlns="urn:jboss:domain:infinispan:1.2" default-cache-container="minimal">
     <cache-container name="minimal" default-cache="local">
         <local-cache name="local"/>
@@ -6,44 +27,44 @@
         <transport cluster="maximal-cluster" executor="transport-executor" lock-timeout="120000" stack="tcp"/>
         <local-cache name="local" batching="true" indexing="LOCAL" start="EAGER">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
             </file-store>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
         </invalidation-cache>
-        <replicated-cache name="repl" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER"  async-marshalling="false">
+        <replicated-cache name="repl" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="false">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
         </replicated-cache>
-        <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2"  async-marshalling="true">
+        <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_2.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_2.xml
@@ -51,18 +51,17 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
@@ -76,6 +75,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </distributed-cache>
     </cache-container>
 </subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_3.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_3.xml
@@ -1,3 +1,24 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
 <subsystem xmlns="urn:jboss:domain:infinispan:1.3">
     <cache-container name="minimal" default-cache="local">
         <local-cache name="local"/>
@@ -6,44 +27,44 @@
         <transport cluster="maximal-cluster" executor="transport-executor" lock-timeout="120000" stack="tcp"/>
         <local-cache name="local" batching="true" indexing="LOCAL" start="EAGER" module="org.infinispan">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
             </file-store>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
         </invalidation-cache>
-        <replicated-cache name="repl" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER"  async-marshalling="false">
+        <replicated-cache name="repl" mode="ASYNC" batching="true" indexing="NONE" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="false">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
         </replicated-cache>
-        <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2"  async-marshalling="true">
+        <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" /> 
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_3.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_3.xml
@@ -51,18 +51,17 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" indexing="ALL" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" virtual-nodes="2" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
@@ -76,6 +75,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </distributed-cache>
     </cache-container>
 </subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_4.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_4.xml
@@ -29,47 +29,47 @@
         <transport cluster="maximal-cluster" executor="transport-executor" lock-timeout="120000" stack="tcp"/>
         <local-cache name="local" batching="true" start="EAGER" module="org.infinispan">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
             </file-store>
-            <indexing index="LOCAL" />
+            <indexing index="LOCAL"/>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </invalidation-cache>
-        <replicated-cache name="repl" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER"  async-marshalling="false">
+        <replicated-cache name="repl" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="false">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="2" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>
@@ -99,7 +99,7 @@
             <transaction mode="NON_XA" locking="PESSIMISTIC"/>
             <eviction strategy="NONE"/>
         </replicated-cache>
-        <distributed-cache name="default" mode="ASYNC" >
+        <distributed-cache name="default" mode="ASYNC">
             <transaction mode="NON_XA"/>
             <eviction strategy="NONE"/>
             <file-store preload="true" purge="false"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_4.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-1_4.xml
@@ -55,19 +55,18 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
             <indexing index="NONE"/>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="2" async-marshalling="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
@@ -81,6 +80,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </distributed-cache>
     </cache-container>
     <cache-container name="capedwarf" default-cache="default">

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-2_0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-2_0.xml
@@ -29,47 +29,47 @@
         <transport cluster="maximal-cluster" executor="transport-executor" lock-timeout="120000" stack="tcp"/>
         <local-cache name="local" batching="true" start="EAGER" module="org.infinispan" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
             </file-store>
-            <indexing index="LOCAL" />
+            <indexing index="LOCAL"/>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </invalidation-cache>
-        <replicated-cache name="repl" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER"  async-marshalling="false" statistics-enabled="true">
+        <replicated-cache name="repl" mode="ASYNC" batching="true" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="false" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="2" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" dialect="MYSQL" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-2_0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-2_0.xml
@@ -55,19 +55,18 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
             <indexing index="NONE"/>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" batching="true" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="2" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" dialect="MYSQL" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
@@ -81,6 +80,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <backups>
                 <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
                 <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-3_0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-3_0.xml
@@ -1,25 +1,23 @@
 <!--
-  ~ /*
-  ~  * JBoss, Home of Professional Open Source.
-  ~  * Copyright 2012, Red Hat, Inc., and individual contributors
-  ~  * as indicated by the @author tags. See the copyright.txt file in the
-  ~  * distribution for a full listing of individual contributors.
-  ~  *
-  ~  * This is free software; you can redistribute it and/or modify it
-  ~  * under the terms of the GNU Lesser General Public License as
-  ~  * published by the Free Software Foundation; either version 2.1 of
-  ~  * the License, or (at your option) any later version.
-  ~  *
-  ~  * This software is distributed in the hope that it will be useful,
-  ~  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-  ~  * Lesser General Public License for more details.
-  ~  *
-  ~  * You should have received a copy of the GNU Lesser General Public
-  ~  * License along with this software; if not, write to the Free
-  ~  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
-  ~  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  ~  */
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 <subsystem xmlns="urn:jboss:domain:infinispan:3.0">
     <cache-container name="minimal" default-cache="local">
@@ -29,47 +27,47 @@
         <transport channel="maximal-channel" executor="transport-executor" lock-timeout="120000"/>
         <local-cache name="local" start="EAGER" module="org.infinispan" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="NONE" striping="true"/>
-            <transaction mode="BATCH" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="BATCH" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LIRS"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
             </file-store>
-            <indexing index="LOCAL" />
+            <indexing index="LOCAL"/>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="LAZY" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_UNCOMMITTED" striping="true"/>
-            <transaction mode="NON_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="NON_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="LRU"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <remote-store cache="default" socket-timeout="60000" tcp-no-delay="true" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="true">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="valueSizeEstimate">100</property>
-                <remote-server outbound-socket-binding="hotrod-server-1" />
-                <remote-server outbound-socket-binding="hotrod-server-2" />
+                <remote-server outbound-socket-binding="hotrod-server-1"/>
+                <remote-server outbound-socket-binding="hotrod-server-2"/>
             </remote-store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </invalidation-cache>
-        <replicated-cache name="repl" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="EAGER"  async-marshalling="false" statistics-enabled="true">
+        <replicated-cache name="repl" mode="ASYNC" queue-flush-interval="10" queue-size="1000" start="EAGER" async-marshalling="false" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
-            <indexing index="NONE" />
+            <indexing index="NONE"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="2" capacity-factor="1.0" consistent-hash-strategy="INTRA_CACHE" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
-            <transaction mode="FULL_XA" stop-timeout="60000"  locking="OPTIMISTIC"/>
+            <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000" />
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" dialect="MYSQL" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
-                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1" />
+                <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-3_0.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/subsystem-infinispan-3_0.xml
@@ -53,19 +53,18 @@
             <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="FIFO"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <property name="location">${java.io.tmpdir}</property>
             </store>
             <indexing index="NONE"/>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
         </replicated-cache>
         <distributed-cache name="dist" mode="SYNC" l1-lifespan="1200000" owners="4" remote-timeout="35000" start="EAGER" segments="2" capacity-factor="1.0" consistent-hash-strategy="INTRA_CACHE" async-marshalling="true" statistics-enabled="true">
             <locking acquire-timeout="30000" concurrency-level="2000" isolation="READ_COMMITTED" striping="true"/>
             <transaction mode="FULL_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
             <eviction max-entries="20000" strategy="UNORDERED"/>
             <expiration interval="10000" lifespan="10" max-idle="10"/>
-            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <mixed-keyed-jdbc-store datasource="java:jboss/jdbc/store" dialect="MYSQL" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <write-behind flush-lock-timeout="2" modification-queue-size="2048" shutdown-timeout="20000" thread-pool-size="1"/>
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
@@ -79,6 +78,7 @@
                     <timestamp-column name="version" type="BIGINT"/>
                 </binary-keyed-table>
             </mixed-keyed-jdbc-store>
+            <state-transfer enabled="true" timeout="60000" chunk-size="10000"/>
             <backups>
                 <backup site="NYC" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="false"/>
                 <backup site="SFO" failure-policy="WARN" strategy="SYNC" timeout="12000" enabled="true"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-2480

Note on the fix: string/binary-keyed-table ordering approach is to fix the XSD what our writer is doing so existing configurations created by the writer are correct, StateTransfer cannot be fixed in XSD reasonably, so fixing the ordering in writer.
