### PR TITLE
WFLY-4343, WFLY-4344 Upgrade JGroups to 3.6.2.Final, Infinispan to 7.1.1.Final

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.clustering.infinispan;
 
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -83,6 +82,11 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
     }
 
     @Override
+    public Configuration getDefaultCacheConfiguration() {
+        return this.cm.getCacheConfiguration(this.defaultCacheName);
+    }
+
+    @Override
     public Configuration getCacheConfiguration(String name) {
         return this.cm.getCacheConfiguration(this.getCacheName(name));
     }
@@ -113,15 +117,6 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
     public <K, V> Cache<K, V> getCache(String cacheName, boolean createIfAbsent) {
         Cache<K, V> cache = this.cm.<K, V>getCache(this.getCacheName(cacheName), createIfAbsent);
         return (cache != null) ? new DelegatingCache<>(this, this.batcherFactory, cache) : null;
-    }
-
-    /**
-     * {@inheritDoc}
-     * @see org.infinispan.manager.EmbeddedCacheManager#getCacheNames()
-     */
-    @Override
-    public Set<String> getCacheNames() {
-        return new HashSet<>(this.cm.getCacheNames());
     }
 
     /**
@@ -168,6 +163,11 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
         }
         this.cm.startCaches(cacheNames.toArray(new String[cacheNames.size()]));
         return this;
+    }
+
+    @Override
+    public void addCacheDependency(String from, String to) {
+        this.cm.addCacheDependency(this.getCacheName(from), this.getCacheName(to));
     }
 
     private String getCacheName(String name) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AddAliasHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/AddAliasHandler.java
@@ -73,7 +73,6 @@ public class AddAliasHandler implements OperationStepHandler {
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.stepCompleted();
     }
 
     /**

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupSiteOperationHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupSiteOperationHandler.java
@@ -74,7 +74,6 @@ public class BackupSiteOperationHandler extends AbstractRuntimeOnlyHandler {
             if (result != null) {
                 context.getResult().set(result);
             }
-            context.stepCompleted();
         } catch(Exception e) {
             throw InfinispanLogger.ROOT_LOGGER.failedToInvokeOperation(e.getCause(), this.operation.getDefinition().getName());
         }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
@@ -128,7 +128,7 @@ public class CacheContainerConfigurationBuilder implements Builder<GlobalConfigu
         if (transport != null) {
             org.infinispan.configuration.global.TransportConfigurationBuilder transportBuilder = builder.transport()
                     .clusterName(this.name)
-                    .transport(new ChannelTransport(transport.getChannel()))
+                    .transport(new ChannelTransport(transport.getChannel(), transport.getChannelFactory()))
                     .distributedSyncTimeout(transport.getLockTimeout())
             ;
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
@@ -232,7 +232,6 @@ public class DistributedCacheResourceDefinition extends SharedStateCacheResource
                         }, OperationContext.Stage.RUNTIME);
                     }
                 }
-                context.stepCompleted();
             }
 
             protected boolean requiresRuntime(OperationContext context) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoveAliasHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoveAliasHandler.java
@@ -75,7 +75,6 @@ public class RemoveAliasHandler implements OperationStepHandler {
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-        context.stepCompleted();
     }
 
     /**

--- a/clustering/infinispan/extension/src/main/resources/infinispan-defaults.xml
+++ b/clustering/infinispan/extension/src/main/resources/infinispan-defaults.xml
@@ -22,7 +22,7 @@
   -->
 <!-- N.B. This is *not* meant to be a usable cache configuration -->
 <!-- This file supplies the internal configuration defaults per cache mode -->
-<infinispan xmlns="urn:infinispan:config:7.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:7.0 http://infinispan.org/schemas/infinispan-config-7.0.xsd">
+<infinispan xmlns="urn:infinispan:config:7.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:7.1 http://infinispan.org/schemas/infinispan-config-7.1.xsd">
     <cache-container default-cache="LOCAL">
         <local-cache name="LOCAL">
             <locking isolation="REPEATABLE_READ" acquire-timeout="15000" concurrency-level="1000"/>

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/DefaultCacheContainerTest.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/DefaultCacheContainerTest.java
@@ -300,7 +300,7 @@ public class DefaultCacheContainerTest {
     public void getDefaultCacheConfiguration() {
         Configuration config = new ConfigurationBuilder().build();
         
-        when(this.manager.getDefaultCacheConfiguration()).thenReturn(config);
+        when(this.manager.getCacheConfiguration("default")).thenReturn(config);
         
         Configuration result = this.subject.getDefaultCacheConfiguration();
         

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkChannelFactoryBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkChannelFactoryBuilder.java
@@ -77,7 +77,7 @@ public class ForkChannelFactoryBuilder implements Builder<ChannelFactory>, Value
         for (Value<ProtocolConfiguration> protocol : this.protocols) {
             protocols.add(protocol.getValue());
         }
-        return new ForkChannelFactory(this.parentChannel.getValue(), this.parentFactory.getValue().getProtocolStackConfiguration(), protocols);
+        return new ForkChannelFactory(this.parentChannel.getValue(), this.parentFactory.getValue(), protocols);
     }
 
     public ProtocolConfigurationBuilder addProtocol(String type) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkProtocolResourceRegistrationHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkProtocolResourceRegistrationHandler.java
@@ -125,7 +125,5 @@ public class ForkProtocolResourceRegistrationHandler implements OperationStepHan
             FieldType type = FieldType.valueOf(attribute.getType());
             protocolRegistration.registerMetric(new SimpleAttributeDefinitionBuilder(name, type.getModelType()).setStorageRuntime().build(), handler);
         }
-
-        context.stepCompleted();
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceRegistrationHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceRegistrationHandler.java
@@ -143,7 +143,6 @@ public class ProtocolResourceRegistrationHandler implements OperationStepHandler
             registration.registerSubModel(this.createProtocolResourceDefinition(RelayConfiguration.PROTOCOL_NAME, RELAY2.class)).setRuntimeOnly(true);
             resource.registerChild(ProtocolResourceDefinition.pathElement(RelayConfiguration.PROTOCOL_NAME), PlaceholderResource.INSTANCE);
         }
-        context.stepCompleted();
     }
 
     private ResourceDefinition createProtocolResourceDefinition(String protocolName, Class<? extends Protocol> protocolClass) {

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/ChannelFactory.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/ChannelFactory.java
@@ -21,6 +21,8 @@
  */
 package org.wildfly.clustering.jgroups.spi;
 
+import java.nio.ByteBuffer;
+
 /**
  * Factory for creating JGroups channels.
  * @author Paul Ferraro
@@ -29,7 +31,15 @@ public interface ChannelFactory extends org.wildfly.clustering.jgroups.ChannelFa
 
     /**
      * Returns the protocol stack configuration of this channel factory.
-     * @return
+     * @return the protocol stack configuration of this channel factory
      */
     ProtocolStackConfiguration getProtocolStackConfiguration();
+
+    /**
+     * Determines whether or not the specified message response indicates the fork stack or fork channel
+     * required to handle a request does not exist on the recipient node.
+     * @param response a message response
+     * @return true, if the response indicates a missing fork stack or channel.
+     */
+    boolean isUnknownForkResponse(ByteBuffer response);
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
@@ -75,7 +75,7 @@ public class ChannelCommandDispatcherFactory implements CommandDispatcherFactory
         this.nodeFactory = config.getNodeFactory();
         this.marshallingContext = config.getMarshallingContext();
         this.timeout = config.getTimeout();
-        final RpcDispatcher.Marshaller marshaller = new CommandResponseMarshaller(this.marshallingContext);
+        final RpcDispatcher.Marshaller marshaller = new CommandResponseMarshaller(config);
         this.dispatcher = new MessageDispatcher() {
             @Override
             protected RequestCorrelator createRequestCorrelator(Protocol transport, RequestHandler handler, Address localAddr) {
@@ -105,7 +105,7 @@ public class ChannelCommandDispatcherFactory implements CommandDispatcherFactory
                 @SuppressWarnings("unchecked")
                 Command<Object, Object> command = (Command<Object, Object>) unmarshaller.readObject();
                 AtomicReference<Object> context = this.contexts.get(clientId);
-                if (context == null) return new NoSuchService();
+                if (context == null) return NoSuchService.INSTANCE;
                 return command.execute(context.get());
             }
         }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactoryBuilder.java
@@ -42,6 +42,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jgroups.Channel;
 import org.wildfly.clustering.dispatcher.CommandDispatcherFactory;
+import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 import org.wildfly.clustering.jgroups.spi.service.ChannelServiceName;
 import org.wildfly.clustering.marshalling.DynamicClassTable;
 import org.wildfly.clustering.marshalling.MarshallingContext;
@@ -60,6 +61,7 @@ public class ChannelCommandDispatcherFactoryBuilder extends CommandDispatcherFac
 
     private static final int CURRENT_VERSION = 1;
 
+    private final InjectedValue<ChannelFactory> channelFactory = new InjectedValue<>();
     private final InjectedValue<Channel> channel = new InjectedValue<>();
     private final InjectedValue<JGroupsNodeFactory> nodeFactory = new InjectedValue<>();
     private final InjectedValue<ModuleLoader> loader = new InjectedValue<>();
@@ -80,6 +82,7 @@ public class ChannelCommandDispatcherFactoryBuilder extends CommandDispatcherFac
         return new AsynchronousServiceBuilder<>(this.getServiceName(), this).build(target)
                 .addDependency(GroupServiceName.NODE_FACTORY.getServiceName(this.group), JGroupsNodeFactory.class, this.nodeFactory)
                 .addDependency(ChannelServiceName.CONNECTOR.getServiceName(this.group), Channel.class, this.channel)
+                .addDependency(ChannelServiceName.FACTORY.getServiceName(this.group), ChannelFactory.class, this.channelFactory)
                 .addDependency(Services.JBOSS_SERVICE_MODULE_LOADER, ModuleLoader.class, this.loader)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
         ;
@@ -155,5 +158,10 @@ public class ChannelCommandDispatcherFactoryBuilder extends CommandDispatcherFac
     @Override
     public long getTimeout() {
         return this.timeout;
+    }
+
+    @Override
+    public ChannelFactory getChannelFactory() {
+        return this.channelFactory.getValue();
     }
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactoryConfiguration.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactoryConfiguration.java
@@ -22,6 +22,7 @@
 package org.wildfly.clustering.server.dispatcher;
 
 import org.jgroups.Channel;
+import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 import org.wildfly.clustering.marshalling.MarshallingContext;
 import org.wildfly.clustering.server.group.JGroupsNodeFactory;
 
@@ -30,6 +31,7 @@ import org.wildfly.clustering.server.group.JGroupsNodeFactory;
  * @author Paul Ferraro
  */
 public interface ChannelCommandDispatcherFactoryConfiguration {
+    ChannelFactory getChannelFactory();
     Channel getChannel();
     JGroupsNodeFactory getNodeFactory();
     MarshallingContext getMarshallingContext();

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/NoSuchService.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/NoSuchService.java
@@ -29,4 +29,10 @@ import java.io.Serializable;
  */
 public class NoSuchService implements Serializable {
     private static final long serialVersionUID = 557858072730039623L;
+
+    public static final NoSuchService INSTANCE = new NoSuchService();
+
+    private NoSuchService() {
+        // Hide
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,7 @@
         <version.org.hibernate.hql>1.1.0.Final</version.org.hibernate.hql>
         <version.org.hibernate.search>5.0.0.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.5.Final</version.org.hornetq>
-        <version.org.infinispan>7.0.2.Final</version.org.infinispan>
+        <version.org.infinispan>7.1.1.Final</version.org.infinispan>
         <version.org.jacorb>2.3.2-jbossorg-5</version.org.jacorb>
         <version.org.jasypt>1.9.1</version.org.jasypt>
         <version.org.javassist>3.18.1-GA</version.org.javassist>
@@ -204,7 +204,7 @@
         <version.org.jboss.ws.cxf>5.0.0.Beta2</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jboss.xb>2.0.3.GA</version.org.jboss.xb>
-        <version.org.jgroups>3.6.1.Final</version.org.jgroups>
+        <version.org.jgroups>3.6.2.Final</version.org.jgroups>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.kohsuke.rngom>201103.jboss-1</version.org.kohsuke.rngom>
         <version.org.opensaml.opensaml>2.6.1</version.org.opensaml.opensaml>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4344
https://issues.jboss.org/browse/WFLY-4343
https://issues.jboss.org/browse/WFLY-4285

Adds custom UnknownForkHandler to work around JGRP-1905/ISPN-5173.
Also fixes NPE if batching is used with non-transactional cache
