### PR TITLE
WELD-1853 Add system dependency on com.sun.org.apache.bcel.internal.classfile package to weld-core

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -51,5 +51,10 @@
         <module name="org.jboss.weld.spi" />
         <module name="org.jboss.logging" />
         <module name="sun.jdk" optional="true" />
+        <system export="false">
+            <paths>
+                <path name="com/sun/org/apache/bcel/internal/classfile"/>
+            </paths>
+        </system>
     </dependencies>
 </module>


### PR DESCRIPTION
To improve some error messages Weld attempts to get the line number
associated with a particular class member. Reflection API does not
expose such an info and so Weld is analysing the bytecode using the
Apache BCEL inluded in Oracle JDK and OpenJDK.
