### PR TITLE
Add test case to ensure the default servlet is overridable

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/registration/DefaultReplacingServletContextListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/registration/DefaultReplacingServletContextListener.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.servlet.registration;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletRegistration;
+import javax.servlet.annotation.WebListener;
+
+@WebListener
+public class DefaultReplacingServletContextListener implements ServletContextListener {
+	public void contextInitialized(ServletContextEvent sce) {
+		ServletRegistration registration = sce.getServletContext().addServlet("ReplacementServlet", new ReplacementServlet());
+		registration.addMapping("/");
+	}
+
+	public void contextDestroyed(ServletContextEvent sce) {
+	}
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/registration/DefaultServletReplacmentTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/registration/DefaultServletReplacmentTestCase.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.servlet.registration;
+
+import java.net.URL;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DefaultServletReplacmentTestCase {
+
+    @ArquillianResource
+    private URL url;
+
+    @Deployment
+    public static WebArchive single() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "single.war");
+        war.addClasses(HttpRequest.class, ReplacementServlet.class, DefaultReplacingServletContextListener.class);
+        return war;
+    }
+
+    private String performCall(URL url,String urlPattern) throws Exception {
+        return HttpRequest.get(url.toExternalForm() + urlPattern, 1000, SECONDS);
+    }
+
+
+    @Test
+    public void testLifeCycle() throws Exception {
+        String result = performCall(url, "/");
+        assertEquals("ok", result);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/registration/ReplacementServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/servlet/registration/ReplacementServlet.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.servlet.registration;
+
+import java.io.IOException;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+
+public class ReplacementServlet extends HttpServlet {
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.getWriter().write("ok");
+    }
+}


### PR DESCRIPTION
This test does not require code changes, as it already works in WF. It has been broken in the past (in EAP 6), so would be good to ensure it isn't broken again.

Background is on https://bugzilla.redhat.com/show_bug.cgi?id=1094248
