### PR TITLE
WFLY-436 Remove unused maven org.wildfly.core:wildfly-threads dependency

### DIFF
--- a/clustering/jgroups/extension/pom.xml
+++ b/clustering/jgroups/extension/pom.xml
@@ -103,10 +103,6 @@
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-threads</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
         </dependency>


### PR DESCRIPTION
JGroups subsystem no longer uses core threads.
