### PR TITLE
Add missing Rhino main package

### DIFF
--- a/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
+++ b/build/src/main/resources/modules/system/layers/base/sun/jdk/main/module.xml
@@ -32,6 +32,7 @@
             <paths>
                 <!-- todo create new nashorn/scripting module-->
                 <path name="com/sun/script/javascript"/>
+                <path name="sun/org/mozilla/javascript/internal"/>
                 <path name="jdk/nashorn/api/scripting"/>
                 <path name="jdk/nashorn/api/scripting/resources"/>
                 <path name="jdk/nashorn/internal/codegen"/>


### PR DESCRIPTION
In order to use Rhino specific classes in scripting, it's necessary expose this package.
