### PR TITLE
WELD-1839 Add WeldStartService dependency to all WARs

### DIFF
--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
@@ -98,8 +98,8 @@ public class WebIntegrationProcessor implements DeploymentUnitProcessor {
             return; // Skip non web deployments
         }
 
-        if (!WeldDeploymentMarker.isWeldDeployment(deploymentUnit)) {
-            return; // skip non weld deployments
+        if (!WeldDeploymentMarker.isPartOfWeldDeployment(deploymentUnit)) {
+            return; // Skip non weld deployments
         }
 
         WarMetaData warMetaData = deploymentUnit.getAttachment(WarMetaData.ATTACHMENT_KEY);


### PR DESCRIPTION
- a WAR which is not a bean archive but is a part of a CDI application
  (EAR) is missing the org.jboss.as.weld.WeldStartService dependency, the
  result is a timing issue
