### PR TITLE
Unused double in jsp wfly 4406

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.3.1</version.org.codehaus.jettison>
         <version.org.codehaus.plexus.plexus-utils>3.0.15</version.org.codehaus.plexus.plexus-utils>
-        <version.org.eclipse.jdt.core.compiler>4.4.1</version.org.eclipse.jdt.core.compiler>
+        <version.org.eclipse.jdt.core.compiler>4.4.2</version.org.eclipse.jdt.core.compiler>
         <version.org.glassfish.javax.el>3.0.1-b05-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsp/JspWithUnusedDoubleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsp/JspWithUnusedDoubleTestCase.java
@@ -1,0 +1,41 @@
+package org.jboss.as.test.integration.jsp;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JspWithUnusedDoubleTestCase {
+    private static final String DEPLOYMENT = "jsp-with-unused-double.war";
+
+    @Deployment(name = DEPLOYMENT)
+    public static WebArchive deployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT);
+        war.add(new UrlAsset(JspWithUnusedDoubleTestCase.class.getResource("jsp-with-unused-double.jsp")), "jsp-with-unused-double.jsp");
+        return war;
+    }
+
+
+    @Test
+    @OperateOnDeployment(DEPLOYMENT)
+    public void testUnusedDoubleInJsp(@ArquillianResource URL url) throws TimeoutException, ExecutionException, IOException {
+        String response = HttpRequest.get(url + "jsp-with-unused-double.jsp", 10, TimeUnit.SECONDS);
+        Assert.assertEquals("Jsp doesn't contain valid output", "1.0", response.trim());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsp/jsp-with-unused-double.jsp
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jsp/jsp-with-unused-double.jsp
@@ -1,0 +1,10 @@
+<%
+    session.setAttribute("v1", new Double(1));
+    session.setAttribute("v2", new Double(2));
+
+    double v1 = (Double) session.getAttribute("v1");
+    double v2 = (Double) session.getAttribute("v2");
+
+    out.write(String.valueOf(v1));
+//    out.write(String.valueOf(v2));
+%>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4406
- Compiler for JSPs used by undertow (ECJ 4.4.1) crashes when compiling jsp which contains unused double value.
  Created test and proposed update of eclipse compiler from 4.4.1 to 4.4.2 (4.4.2 contains fix for it)
