### PR TITLE
[WFLY-4016][EJBCLIENT-119] disassociate EJBReceiver when unregistering f...

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DescriptorBasedEJBClientContextService.java
@@ -45,6 +45,7 @@ import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 import org.jboss.remoting3.Connection;
 import org.xnio.IoFuture;
+import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 
 /**
@@ -112,6 +113,15 @@ public class DescriptorBasedEJBClientContextService implements Service<EJBClient
 
     @Override
     public synchronized void stop(StopContext context) {
+        final RemotingProfileService profileService=profileServiceValue.getValue();
+        final LocalEjbReceiver localEjbReceiver = profileService.getLocalEjbReceiverInjector().getOptionalValue();
+        if (localEjbReceiver != null) {
+            this.ejbClientContext.unregisterEJBReceiver(localEjbReceiver);
+            logger.debugf("Removed a local EJB receiver from descriptor based EJB client context named %s", context.getController().getName());
+        }
+        if(this.ejbClientContext != null) {
+            IoUtils.safeClose(this.ejbClientContext);
+        }
         this.ejbClientContext = null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
         <version.org.jberet>1.1.0.Beta1</version.org.jberet>
         <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jboss.hal.release-stream>2.6.5.Final</version.org.jboss.hal.release-stream>
-        <version.org.jboss.ejb-client>2.0.1.Final</version.org.jboss.ejb-client>
+        <version.org.jboss.ejb-client>2.0.3.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.1.0</version.org.jboss.ejb3.ext-api>
         <version.org.jboss.genericjms>1.0.7.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>


### PR DESCRIPTION
...rom EJBClientContext to prevent memory leak on undeploy of ejb client deployment and channel leaks

https://issues.jboss.org/browse/WFLY-4016
requires EJBCLIENT-119 via jboss-ejb-client 2.0.3.Final
