### PR TITLE
[WFLY-4423] ClassNotFoundException when restarting a jms-bridge

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
@@ -93,18 +93,20 @@ class JMSBridgeService implements Service<JMSBridge> {
     }
 
     public void startBridge() throws Exception {
-        if (moduleName == null) {
-            bridge.start();
+        final Module module;
+        if (moduleName != null) {
+            ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
+            module =  Module.getContextModuleLoader().loadModule(moduleID);
         } else {
-            ClassLoader oldTccl= WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-            try {
-                ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
-                Module module = Module.getCallerModuleLoader().loadModule(moduleID);
-                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
-                bridge.start();
-            } finally {
-                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
-            }
+            module = Module.forClass(JMSBridgeService.class);
+        }
+
+        ClassLoader oldTccl= WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
+            bridge.start();
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
         }
         MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);
     }


### PR DESCRIPTION
When the JMS bridge is started (or restarted), set the TCCL to the
module class loader which is either the user-specified module or
org.jboss.as.messaging to ensure that the creating of the remote initial
context factory succeeds.

JIRA: https://issues.jboss.org/browse/WFLY-4423
