### PR TITLE
WFLY-4234 restore old EJB shutdown interceptor

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentCreateService.java
@@ -45,6 +45,7 @@ import org.jboss.as.ee.component.BasicComponentCreateService;
 import org.jboss.as.ee.component.ComponentConfiguration;
 import org.jboss.as.ee.component.ViewConfiguration;
 import org.jboss.as.ee.component.ViewDescription;
+import org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory;
 import org.jboss.as.ejb3.component.messagedriven.MessageDrivenComponentDescription;
 import org.jboss.as.ejb3.deployment.ApplicationExceptions;
 import org.jboss.as.ejb3.remote.EJBRemoteTransactionsRepository;
@@ -101,6 +102,8 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
     private final InjectedValue<ServerSecurityManager> serverSecurityManagerInjectedValue = new InjectedValue<>();
     private final InjectedValue<ControlPoint> controlPoint = new InjectedValue<>();
     private final InjectedValue<AtomicBoolean> exceptionLoggingEnabled = new InjectedValue<>();
+
+    private final ShutDownInterceptorFactory shutDownInterceptorFactory;
 
     /**
      * Construct a new instance.
@@ -199,6 +202,7 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
         this.earApplicationName = componentConfiguration.getComponentDescription().getModuleDescription().getEarApplicationName();
         this.moduleName = componentConfiguration.getModuleName();
         this.distinctName = componentConfiguration.getComponentDescription().getModuleDescription().getDistinctName();
+        this.shutDownInterceptorFactory = ejbComponentDescription.getShutDownInterceptorFactory();
     }
 
     @Override
@@ -378,5 +382,9 @@ public class EJBComponentCreateService extends BasicComponentCreateService {
 
     public AtomicBoolean getExceptionLoggingEnabled() {
         return exceptionLoggingEnabled.getValue();
+    }
+
+    public ShutDownInterceptorFactory getShutDownInterceptorFactory() {
+        return shutDownInterceptorFactory;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -64,6 +64,7 @@ import org.jboss.as.ee.component.ViewService;
 import org.jboss.as.ee.component.interceptors.ComponentDispatcherInterceptor;
 import org.jboss.as.ee.component.interceptors.InterceptorOrder;
 import org.jboss.as.ee.naming.ContextInjectionSource;
+import org.jboss.as.ejb3.component.interceptors.ShutDownInterceptorFactory;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.component.interceptors.AdditionalSetupInterceptor;
 import org.jboss.as.ejb3.component.interceptors.CurrentInvocationContextInterceptor;
@@ -250,6 +251,8 @@ public abstract class EJBComponentDescription extends ComponentDescription {
 
     private String policyContextID;
 
+    private final ShutDownInterceptorFactory shutDownInterceptorFactory = new ShutDownInterceptorFactory();
+
     /**
      * Construct a new instance.
      *
@@ -305,6 +308,8 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                     if (!ejbSetupActions.isEmpty()) {
                         configuration.addTimeoutViewInterceptor(AdditionalSetupInterceptor.factory(ejbSetupActions), InterceptorOrder.View.EE_SETUP);
                     }
+                    configuration.addTimeoutViewInterceptor(shutDownInterceptorFactory, InterceptorOrder.View.SHUTDOWN_INTERCEPTOR);
+
                     final ClassLoader classLoader = configuration.getModuleClassLoader();
                     configuration.addTimeoutViewInterceptor(PrivilegedWithCombinerInterceptor.getFactory(), InterceptorOrder.View.PRIVILEGED_INTERCEPTOR);
                     configuration.addTimeoutViewInterceptor(AccessCheckingInterceptor.getFactory(), InterceptorOrder.View.CHECKING_INTERCEPTOR);
@@ -421,6 +426,8 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                     viewConfiguration.addViewInterceptor(AdditionalSetupInterceptor.factory(ejbSetupActions), InterceptorOrder.View.EE_SETUP);
                 }
                 viewConfiguration.addViewInterceptor(WaitTimeInterceptor.FACTORY, InterceptorOrder.View.EJB_WAIT_TIME_INTERCEPTOR);
+                viewConfiguration.addViewInterceptor(shutDownInterceptorFactory, InterceptorOrder.View.SHUTDOWN_INTERCEPTOR);
+
             }
         });
         this.addCurrentInvocationContextFactory(view);
@@ -1022,6 +1029,10 @@ public abstract class EJBComponentDescription extends ComponentDescription {
 
     public void setPolicyContextID(String policyContextID) {
         this.policyContextID = policyContextID;
+    }
+
+    public ShutDownInterceptorFactory getShutDownInterceptorFactory() {
+        return shutDownInterceptorFactory;
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/ShutDownInterceptorFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/ShutDownInterceptorFactory.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 2110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.ejb3.component.interceptors;
+
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
+
+import org.jboss.as.ejb3.logging.EjbLogger;
+import org.jboss.invocation.Interceptor;
+import org.jboss.invocation.InterceptorContext;
+import org.jboss.invocation.InterceptorFactory;
+import org.jboss.invocation.InterceptorFactoryContext;
+
+/**
+ * A per component interceptor that allows the EJB to shutdown gracefully.
+ *
+ * @author Stuart Douglas
+ */
+public class ShutDownInterceptorFactory implements InterceptorFactory {
+
+    private static final int SHUTDOWN_FLAG = 1 << 31;
+    private static final int INVERSE_SHUTDOWN_FLAG = ~SHUTDOWN_FLAG;
+
+    private static final AtomicIntegerFieldUpdater<ShutDownInterceptorFactory> updater = AtomicIntegerFieldUpdater.newUpdater(ShutDownInterceptorFactory.class, "invocationCount");
+
+    @SuppressWarnings("unused")
+    private volatile int invocationCount;
+
+    private final Object lock = new Object();
+
+    private Interceptor interceptor = new Interceptor() {
+        @Override
+        public Object processInvocation(InterceptorContext context) throws Exception {
+
+            int value;
+            int oldValue;
+            do {
+                oldValue = invocationCount;
+                if ((oldValue & SHUTDOWN_FLAG) != 0) {
+                    throw EjbLogger.ROOT_LOGGER.componentIsShuttingDown();
+                }
+                value = oldValue + 1;
+            } while (!updater.compareAndSet(ShutDownInterceptorFactory.this, oldValue, value));
+            try {
+                return context.proceed();
+            } finally {
+                do {
+                    oldValue = invocationCount;
+                    boolean shutDown = (oldValue & SHUTDOWN_FLAG) != 0;
+                    int oldCount = oldValue & INVERSE_SHUTDOWN_FLAG;
+                    value = oldCount - 1;
+                    if(shutDown) {
+                        value = value | SHUTDOWN_FLAG;
+                    }
+                } while (!updater.compareAndSet(ShutDownInterceptorFactory.this, oldValue, value));
+                //if the count is zero and the component is shutting down
+                if (value == SHUTDOWN_FLAG) {
+                    synchronized (lock) {
+                        lock.notifyAll();
+                    }
+                }
+            }
+        }
+    };
+
+    @Override
+    public Interceptor create(InterceptorFactoryContext context) {
+        return interceptor;
+    }
+
+    /**
+     * Upon calling this method the EJB will be set to a shutdown state, and no further invocations will be allowed.
+     * It will then wait for all active invocation to finish and then return.
+     */
+    public void shutdown() {
+        int value;
+        int oldValue;
+        //set the shutdown bit
+        do {
+            oldValue = invocationCount;
+            value = SHUTDOWN_FLAG | oldValue;
+            //the component has already been shutdown
+            if (oldValue == value) {
+                return;
+            }
+        } while (!updater.compareAndSet(this, oldValue, value));
+
+        synchronized (lock) {
+            value = invocationCount;
+            while (value != SHUTDOWN_FLAG) {
+                try {
+                    lock.wait();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                value = invocationCount;
+                if((value & SHUTDOWN_FLAG) == 0) {
+                    return; //component has been restarted
+                }
+            }
+        }
+    }
+
+    public void start() {
+        int value;
+        int oldValue;
+        //set the shutdown bit
+        do {
+            oldValue = invocationCount;
+            value = INVERSE_SHUTDOWN_FLAG & oldValue;
+            //the component has already been started
+            if (oldValue == value) {
+                return;
+            }
+        } while (!updater.compareAndSet(this, oldValue, value));
+        synchronized (lock) {
+            lock.notifyAll();
+        }
+    }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBComponentSuspendDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBComponentSuspendDeploymentUnitProcessor.java
@@ -61,7 +61,7 @@ public class EJBComponentSuspendDeploymentUnitProcessor implements DeploymentUni
                                     interceptor = new EjbSuspendInterceptor();
                                     factory = new ImmediateInterceptorFactory(interceptor);
                                 }
-                                view.addViewInterceptor(factory, InterceptorOrder.View.SHUTDOWN_INTERCEPTOR);
+                                view.addViewInterceptor(factory, InterceptorOrder.View.GRACEFUL_SHUTDOWN);
                             }
                         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -2874,9 +2874,8 @@ public interface EjbLogger extends BasicLogger {
      */
     @Message(id = 420, value = "No EjbContext available as no EJB invocation is active")
     IllegalStateException noEjbContextAvailable();
-
-    @Message(id = 421, value = "The request was rejected as the container is suspended")
-    EJBComponentUnavailableException containerSuspended();
+    @Message(id = 421, value = "Invocation cannot proceed as component is shutting down")
+    EJBComponentUnavailableException componentIsShuttingDown();
 
     @Message(id = 422, value = "Could not open message outputstream for writing to Channel")
     IOException failedToOpenMessageOutputStream(@Cause Throwable e);
@@ -3034,4 +3033,7 @@ public interface EjbLogger extends BasicLogger {
 
     @Message(id = 466, value = "Failed to process business interfaces for EJB class %s")
     DeploymentUnitProcessingException failedToProcessBusinessInterfaces(Class<?> ejbClass, @Cause Exception e);
+
+    @Message(id = 467, value = "The request was rejected as the container is suspended")
+    EJBComponentUnavailableException containerSuspended();
 }


### PR DESCRIPTION
I initially thought that this would no longer be nessesary due to graceful shutdown, however
there are still some cases where this is required as the use cases are a bit different.
