### PR TITLE
WFLY-4179 add permissions.xml to work around test issue

### DIFF
--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -96,31 +96,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <!-- TODO (jrp) This profile needs to be removed once WFLY-4179 is resolved -->
-        <profile>
-            <id>ts.web.security.manager</id>
-            <activation>
-                <property>
-                    <name>security.manager</name>
-                </property>
-            </activation>
-            <properties>
-                <jboss.args>-secmgr</jboss.args>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <excludes>
-                                <exclude>**/CustomErrorsUnitTestCase.java</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/customerrors/CustomErrorsUnitTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/customerrors/CustomErrorsUnitTestCase.java
@@ -63,6 +63,7 @@ public class CustomErrorsUnitTestCase {
         war.addAsWebResource(tccl.getResource(resourcesLocation + "403.jsp"), "403.jsp");
         war.addAsWebResource(tccl.getResource(resourcesLocation + "404.jsp"), "404.jsp");
         war.addAsWebResource(tccl.getResource(resourcesLocation + "500.jsp"), "500.jsp");
+        war.addAsManifestResource(CustomErrorsUnitTestCase.class.getPackage(), "permissions.xml", "permissions.xml");
         war.addClass(ErrorGeneratorServlet.class);
 
         System.out.println(war.toString(true));
@@ -76,6 +77,7 @@ public class CustomErrorsUnitTestCase {
         
         WebArchive war = ShrinkWrap.create(WebArchive.class, "error-producer.war");
         war.setWebXML(tccl.getResource(resourcesLocation + "error-producer-web.xml"));
+        war.addAsManifestResource(CustomErrorsUnitTestCase.class.getPackage(), "permissions.xml", "permissions.xml");
         war.addClass(ErrorGeneratorServlet.class);
         war.addClass(ContextForwardServlet.class);
 

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/customerrors/permissions.xml
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/customerrors/permissions.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+             http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+             version="7">
+    <permission>
+        <class-name>java.io.FilePermission</class-name>
+        <name>&lt;&lt;ALL FILES&gt;&gt;</name>
+        <actions>read</actions>
+    </permission>
+</permissions>


### PR DESCRIPTION
The test involves multiple contexts and by default contexts are not given
permission to read files from a different context.
