### PR TITLE
[WFLY-4441] web.xml parser process cannot handle exception for xml file

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WebParsingDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WebParsingDeploymentProcessor.java
@@ -117,7 +117,13 @@ public class WebParsingDeploymentProcessor implements DeploymentUnitProcessor {
                 warMetaData.setWebMetaData(webMetaData);
 
             } catch (XMLStreamException e) {
-                throw new DeploymentUnitProcessingException(UndertowLogger.ROOT_LOGGER.failToParseXMLDescriptor(webXml.toString(), e.getLocation().getLineNumber(), e.getLocation().getColumnNumber()), e);
+                Integer lineNumber = null;
+                Integer columnNumber = null;
+                if (e.getLocation() != null) {
+                    lineNumber = e.getLocation().getLineNumber();
+                    columnNumber = e.getLocation().getColumnNumber();
+                }
+                throw new DeploymentUnitProcessingException(UndertowLogger.ROOT_LOGGER.failToParseXMLDescriptor(webXml.toString(), lineNumber, columnNumber), e);
             } catch (IOException e) {
                 throw new DeploymentUnitProcessingException(UndertowLogger.ROOT_LOGGER.failToParseXMLDescriptor(webXml.toString()), e);
             } finally {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -172,7 +172,7 @@ public interface UndertowLogger extends BasicLogger {
     // XMLStreamException unknownHandler(String name, @Param Location location);
 
     @Message(id = 27, value = "Failed to parse XML descriptor %s at [%s,%s]")
-    String failToParseXMLDescriptor(String xmlFile, int line, int column);
+    String failToParseXMLDescriptor(String xmlFile, Integer line, Integer column);
 
     @Message(id = 28, value = "Failed to parse XML descriptor %s")
     String failToParseXMLDescriptor(String xmlFile);


### PR DESCRIPTION
which does not have the encoding attribute

Issue: https://issues.jboss.org/browse/WFLY-4441
EAP Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1184292
