### PR TITLE
BZ1191474 - Add jmx-remoting to classpath for jconsole.sh

### DIFF
--- a/feature-pack/src/main/resources/content/bin/jconsole.sh
+++ b/feature-pack/src/main/resources/content/bin/jconsole.sh
@@ -75,6 +75,7 @@ fi
 CLASSPATH=$JAVA_HOME/lib/jconsole.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
 CLASSPATH="$CLASSPATH:\""$JBOSS_HOME"\"/bin/client/jboss-cli-client.jar"
+CLASSPATH="$CLASSPATH:\""$JBOSS_HOME"\"/modules/system/layers/base/org/jboss/remoting-jmx/main/remoting-jmx-*.jar"
 
 echo CLASSPATH $CLASSPATH
 


### PR DESCRIPTION
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1191474

In JBOSS_HOME/bin/jconsole.sh the remoting-jmx libraries are not on the classpath. This prevents jconsole from connecting to a remote JBoss instance.
