### PR TITLE
WFLY-4450 Added test coverage for datasource credentials in a security domain

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase-remove.cli
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase-remove.cli
@@ -1,0 +1,3 @@
+/subsystem=datasources/data-source=SecuredDataSourceTestCase:disable
+/subsystem=datasources/data-source=SecuredDataSourceTestCase:remove
+/subsystem=security/security-domain=SecuredDataSourceTestCase:remove

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase.cli
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase.cli
@@ -1,0 +1,4 @@
+/subsystem=security/security-domain=SecuredDataSourceTestCase:add(cache-type=default)
+/subsystem=security/security-domain=SecuredDataSourceTestCase/authentication=classic:add
+/subsystem=security/security-domain=SecuredDataSourceTestCase/authentication=classic/login-module=CallerIdentity:add(code=org.picketbox.datasource.security.CallerIdentityLoginModule, flag=required, module-options=[("principal"=>"principal"), ("username"=>"username"), ("password"=>"password")])
+/subsystem=datasources/data-source=SecuredDataSourceTestCase:add(jndi-name="java:jboss/datasources/SecuredDataSourceTestCase",use-java-context=true,connection-url="jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",driver-name=h2,min-pool-size=15,max-pool-size=150,pool-prefill=true,security-domain=SecuredDataSourceTestCase)

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.manualmode.security;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.FileUtils;
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.servlets.DataSourceTestServlet;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests a DataSource which uses Credentials stored in a security domain.
+ * 
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class SecuredDataSourceTestCase extends AbstractCliTestBase {
+
+    private static final String CONTAINER = "default-jbossas";
+    private static final String DEPLOYMENT = "deployment";
+
+    private static final String TEST_NAME = SecuredDataSourceTestCase.class.getSimpleName();
+
+    private static final String BATCH_CLI_FILENAME = TEST_NAME + ".cli";
+    private static final String REMOVE_BATCH_CLI_FILENAME = TEST_NAME + "-remove.cli";
+
+    private static final File WORK_DIR = new File("secured-ds-" + System.currentTimeMillis());
+    private static final File BATCH_CLI_FILE = new File(WORK_DIR, BATCH_CLI_FILENAME);
+    private static final File REMOVE_BATCH_CLI_FILE = new File(WORK_DIR, REMOVE_BATCH_CLI_FILENAME);
+
+    @ArquillianResource
+    private static ContainerController container;
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    @Test
+    public void test() throws Exception {
+        final URI uri = new URI("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/" + TEST_NAME
+                + DataSourceTestServlet.SERVLET_PATH + "?" + DataSourceTestServlet.PARAM_DS + "=" + TEST_NAME);
+        final String body = Utils.makeCall(uri, HttpServletResponse.SC_OK);
+        assertEquals("true", body);
+    }
+
+    @Deployment(name = DEPLOYMENT, managed = false, testable = false)
+    @TargetsContainer(CONTAINER)
+    public static Archive<?> getDeployment() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, TEST_NAME + ".war");
+        war.addClass(DataSourceTestServlet.class);
+        return war;
+    }
+
+    /**
+     * Configure the AS and LDAP as the first step in this testcase.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(Integer.MIN_VALUE)
+    public void initServer() throws Exception {
+        container.start(CONTAINER);
+
+        WORK_DIR.mkdirs();
+
+        FileUtils.copyInputStreamToFile(getClass().getResourceAsStream(BATCH_CLI_FILENAME), BATCH_CLI_FILE);
+        FileUtils.copyInputStreamToFile(getClass().getResourceAsStream(REMOVE_BATCH_CLI_FILENAME), REMOVE_BATCH_CLI_FILE);
+
+        initCLI();
+        final boolean batchResult = runBatch(BATCH_CLI_FILE);
+        closeCLI();
+
+        try {
+            assertTrue("Server configuration failed", batchResult);
+        } finally {
+            container.stop(CONTAINER);
+        }
+        container.start(CONTAINER);
+
+        deployer.deploy(DEPLOYMENT);
+
+    }
+
+    /**
+     * Revert the AS configuration and stop the server as the last but one step.
+     *
+     * @throws Exception
+     */
+    @Test
+    @InSequence(Integer.MAX_VALUE)
+    public void closeServer() throws Exception {
+        assertTrue(container.isStarted(CONTAINER));
+
+        deployer.undeploy(DEPLOYMENT);
+
+        initCLI();
+        final boolean batchResult = runBatch(REMOVE_BATCH_CLI_FILE);
+        closeCLI();
+        container.stop(CONTAINER);
+
+        FileUtils.deleteQuietly(WORK_DIR);
+
+        assertTrue("Reverting server configuration failed", batchResult);
+    }
+
+    /**
+     * Runs given CLI script file as a batch. The CLI has to be initialized before calling this method.
+     *
+     * @param batchFile CLI file to run in batch
+     * @return true if CLI returns Success
+     * @throws IOException
+     */
+    protected static boolean runBatch(File batchFile) throws IOException {
+        cli.sendLine("run-batch --file=\"" + batchFile.getAbsolutePath()
+                + "\" --headers={allow-resource-service-restart=true} -v", false);
+        return cli.readAllAsOpResult().isIsOutcomeSuccess();
+    }
+}

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/servlets/DataSourceTestServlet.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/servlets/DataSourceTestServlet.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.common.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.sql.DataSource;
+
+/**
+ * Servlet which makes a simple test on the given datasource ("ExampleDS" by default, use {@value #PARAM_DS} request parameter
+ * to change the tested datasource). This servlet lookups the datasource through JNDI and follows these steps:
+ * <ol>
+ * <li>get Connection from DS</li>
+ * <li>create Statement</li>
+ * <li>create table</li>
+ * <li>insert record</li>
+ * <li>run query and check if the inserted record is returned</li>
+ * <li>drop table</li>
+ * <li>close resources</li>
+ * <ol>
+ *
+ * If everything finishes as expected then "true" is returned as the response body. If query doesn't return expected value then
+ * the response body is "false".<br>
+ * The response contains stack trace in case of SQLException or NamingException.<br>
+ * The response content type is text/plain.
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(DataSourceTestServlet.SERVLET_PATH)
+public class DataSourceTestServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/DataSourceTestServlet";
+
+    public static final String PARAM_DS = "datasource";
+    public static final String PARAM_DS_DEFAULT = "ExampleDS";
+
+    @Override
+    public void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+
+        String datasourceName = req.getParameter(PARAM_DS);
+        if (datasourceName == null || datasourceName.length() == 0) {
+            datasourceName = PARAM_DS_DEFAULT;
+        }
+        final PrintWriter writer = resp.getWriter();
+
+        Connection con = null;
+
+        try {
+            InitialContext iniCtx = new InitialContext();
+            DataSource ds = (DataSource) iniCtx.lookup("java:jboss/datasources/" + datasourceName);
+            con = ds.getConnection();
+            Statement stmt = con.createStatement();
+            stmt.executeUpdate("create table testtable(testid int)");
+            stmt.executeUpdate("insert into testtable values (1)");
+            ResultSet rs = stmt.executeQuery("select * from testtable");
+            writer.print(rs.next() && 1 == rs.getInt(1));
+            rs.close();
+            stmt.executeUpdate("drop table testtable");
+            stmt.close();
+        } catch (SQLException e) {
+            e.printStackTrace(writer);
+        } catch (NamingException e) {
+            e.printStackTrace(writer);
+        } finally {
+            if (con != null) {
+                try {
+                    con.close();
+                } catch (SQLException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
Simple test that DataSource is able to use credentials coming from a security domain.
