### PR TITLE
Make validation-related dependencies optional in resteasy-jaxrs's module.xml

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jaxrs/main/module.xml
@@ -42,10 +42,10 @@
         <module name="org.apache.commons.codec" />
         <module name="org.apache.httpcomponents"/>
         <module name="org.apache.log4j"/>
-        <module name="org.hibernate.validator" services="import"/>
+        <module name="org.hibernate.validator" optional="true" services="import"/>
         <module name="org.scannotation.scannotation" />
         <module name="org.slf4j" />
         <module name="javax.servlet.api"/>
-        <module name="org.jboss.resteasy.resteasy-validator-provider-11" services="export" export="true"/>
+        <module name="org.jboss.resteasy.resteasy-validator-provider-11" optional="true" services="export" export="true"/>
     </dependencies>
 </module>


### PR DESCRIPTION
For wildfly-boot (nee spawn) making these optional allows a simple JAX-RS fatjar to build and run without weld
