### PR TITLE
[WFLY-3174] Create deployment resources to represent batch jobs.

### DIFF
--- a/batch/extension/src/main/java/org/wildfly/extension/batch/BatchResourceDescriptionResolver.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/BatchResourceDescriptionResolver.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch;
+
+import static org.wildfly.extension.batch.BatchSubsystemDefinition.NAME;
+
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+
+/**
+ * A description resolver for the batch subsystem.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchResourceDescriptionResolver {
+    private static final String RESOURCE_NAME = BatchSubsystemExtension.class.getPackage().getName() + ".LocalDescriptions";
+
+    public static StandardResourceDescriptionResolver getResourceDescriptionResolver() {
+        return new StandardResourceDescriptionResolver(NAME, RESOURCE_NAME, BatchSubsystemExtension.class.getClassLoader(), true, false);
+    }
+
+    public static StandardResourceDescriptionResolver getResourceDescriptionResolver(final String keyPrefix) {
+        String prefix = NAME + (keyPrefix == null ? "" : "." + keyPrefix);
+        return new StandardResourceDescriptionResolver(prefix, RESOURCE_NAME, BatchSubsystemExtension.class.getClassLoader(), true, false);
+    }
+
+    public static StandardResourceDescriptionResolver getResourceDescriptionResolver(final String... prefixes) {
+        final StringBuilder prefix = new StringBuilder(NAME);
+        for (String p : prefixes) {
+            prefix.append('.').append(p);
+        }
+        return new StandardResourceDescriptionResolver(prefix.toString(), RESOURCE_NAME, BatchSubsystemExtension.class.getClassLoader(), true, false);
+    }
+}

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/BatchServiceNames.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/BatchServiceNames.java
@@ -1,8 +1,13 @@
 package org.wildfly.extension.batch;
 
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.Services;
 import org.jboss.as.threads.ThreadsServices;
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.extension.batch._private.BatchLogger;
 
 /**
  * Service names for the batch subsystem.
@@ -22,14 +27,25 @@ public class BatchServiceNames {
     public static final ServiceName BATCH_THREAD_POOL_NAME = BASE_BATCH_THREAD_POOL_NAME.append("batch");
 
     /**
+     * Creates a service name for the batch environment service.
+     *
+     * @param deploymentUnit the deployment unit to create the service name for
+     *
+     * @return the service name
+     */
+    public static ServiceName batchEnvironmentServiceName(final DeploymentUnit deploymentUnit) {
+        return deploymentUnit.getServiceName().append("batch").append("environment");
+    }
+
+    /**
      * Creates a service name for the deployment unit to define the service.
      *
      * @param deploymentUnit the deployment unit to create the service name for
      *
      * @return the service name
      */
-    public static ServiceName batchDeploymentServiceName(final DeploymentUnit deploymentUnit) {
-        return deploymentUnit.getServiceName().append("batch");
+    public static ServiceName jobXmlResolverServiceName(final DeploymentUnit deploymentUnit) {
+        return deploymentUnit.getServiceName().append("batch").append("job-xml");
     }
 
     /**
@@ -41,5 +57,45 @@ public class BatchServiceNames {
      */
     public static ServiceName beanManagerServiceName(final DeploymentUnit deploymentUnit) {
         return deploymentUnit.getServiceName().append("beanmanager");
+    }
+
+    /**
+     * Creates the service name used for the job operator registered for the deployment.
+     *
+     * @param deploymentUnit the deployment unit where the operator is to be registered
+     *
+     * @return the service name
+     */
+    public static ServiceName jobOperatorServiceName(final DeploymentUnit deploymentUnit) {
+        return deploymentUnit.getServiceName().append("batch").append("job-operator");
+    }
+
+    /**
+     * Creates the service name used for the job operator registered for the deployment.
+     *
+     * @param address the address to resolve the deployment name from
+     *
+     * @return the service name
+     */
+    public static ServiceName jobOperatorServiceName(final PathAddress address) {
+        String deploymentName = null;
+        String subdeploymentName = null;
+        for (PathElement element : address) {
+            if (ModelDescriptionConstants.DEPLOYMENT.equals(element.getKey())) {
+                deploymentName = element.getValue();
+            } else if (ModelDescriptionConstants.SUBDEPLOYMENT.endsWith(element.getKey())) {
+                subdeploymentName = element.getValue();
+            }
+        }
+        if (deploymentName == null) {
+            throw BatchLogger.LOGGER.couldNotFindDeploymentName(address.toString());
+        }
+        final ServiceName result;
+        if (subdeploymentName == null) {
+            result = Services.deploymentUnitName(deploymentName);
+        } else {
+            result = Services.deploymentUnitName(deploymentName, subdeploymentName);
+        }
+        return result.append("batch").append("job-operator");
     }
 }

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemExtension.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemExtension.java
@@ -25,8 +25,12 @@ package org.wildfly.extension.batch;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.wildfly.extension.batch.deployment.BatchJobExecutionResourceDefinition;
+import org.wildfly.extension.batch.deployment.BatchJobResourceDefinition;
 
 public class BatchSubsystemExtension implements Extension {
 
@@ -50,5 +54,14 @@ public class BatchSubsystemExtension implements Extension {
         final SubsystemRegistration subsystem = context.registerSubsystem(BatchSubsystemDefinition.NAME, CURRENT_MODEL_VERSION);
         subsystem.registerSubsystemModel(BatchSubsystemDefinition.INSTANCE);
         subsystem.registerXMLElementWriter(BatchSubsystemParser.INSTANCE);
+        // Register the deployment resources
+        if (context.isRuntimeOnlyRegistrationValid()) {
+            final SimpleResourceDefinition deploymentResource = new SimpleResourceDefinition(
+                    BatchSubsystemDefinition.SUBSYSTEM_PATH,
+                    BatchResourceDescriptionResolver.getResourceDescriptionResolver("deployment"));
+            final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(deploymentResource);
+            final ManagementResourceRegistration jobRegistration = deployments.registerSubModel(BatchJobResourceDefinition.INSTANCE);
+            jobRegistration.registerSubModel(new BatchJobExecutionResourceDefinition()).setRuntimeOnly(true);
+        }
     }
 }

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/JobRepositoryDefinition.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/JobRepositoryDefinition.java
@@ -66,7 +66,7 @@ class JobRepositoryDefinition extends SimpleResourceDefinition {
     public static final JobRepositoryDefinition JDBC = new JobRepositoryDefinition(JobRepositoryType.JDBC.toString(), JNDI_NAME);
 
     private JobRepositoryDefinition(final String name, final AttributeDefinition... attributes) {
-        super(PathElement.pathElement(NAME, name), BatchSubsystemDefinition.getResourceDescriptionResolver(NAME, name),
+        super(PathElement.pathElement(NAME, name), BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME, name),
                 new JobRepositoryAdd(attributes), ReloadRequiredRemoveStepHandler.INSTANCE);
     }
 

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/_private/BatchLogger.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/_private/BatchLogger.java
@@ -22,18 +22,91 @@
 
 package org.wildfly.extension.batch._private;
 
+import javax.batch.operations.JobStartException;
+import javax.batch.operations.NoSuchJobException;
+
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
+import org.jboss.logging.Logger.Level;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
+import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
 /**
  * Log messages for WildFly batch module
  */
-@MessageLogger(projectCode = "<<none>>")
+@MessageLogger(projectCode = "WFLYBATCH")
 public interface BatchLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.wildfly.extension.batch}.
      */
     BatchLogger LOGGER = Logger.getMessageLogger(BatchLogger.class, "org.wildfly.extension.batch");
+
+    /**
+     * Creates an exception indicating there was an error processing the batch jobs directory.
+     *
+     * @param cause the cause of the error
+     *
+     * @return a {@link org.jboss.as.server.deployment.DeploymentUnitProcessingException} for the error
+     */
+    @Message(id = 1, value = "Error processing META-INF/batch-jobs directory.")
+    DeploymentUnitProcessingException errorProcessingBatchJobsDir(@Cause Throwable cause);
+
+    /**
+     * Creates an exception indicating that the resource of given type can not be removed.
+     *
+     * @return an {@link UnsupportedOperationException} for the error
+     */
+    @Message(id = 2, value = "Resources of type %s cannot be removed")
+    UnsupportedOperationException cannotRemoveResourceOfType(String childType);
+
+    /**
+     * Creates an exception indicating the deployment name could not be found on the address.
+     *
+     * @return an {@link java.lang.IllegalArgumentException} for the error
+     */
+    @Message(id = 3, value = "Could not find deployment name: %s")
+    IllegalArgumentException couldNotFindDeploymentName(String address);
+
+    /**
+     * Creates an exception indicating the {@link org.wildfly.extension.batch.deployment.JobOperatorService
+     * JobOperatorService} has stopped.
+     *
+     * @return an {@link java.lang.IllegalStateException} for the error
+     */
+    @Message(id = 4, value = "The service JobOperatorService has been stopped and cannot execute operations.")
+    IllegalStateException jobOperatorServiceStopped();
+
+    /**
+     * Creates an exception indicating the job name was not found for the deployment.
+     *
+     * @param jobName the invalid job name
+     *
+     * @return a {@link javax.batch.operations.NoSuchJobException} for the error
+     */
+    @Message(id = 5, value = "The job name '%s' was not found for the deployment.")
+    NoSuchJobException noSuchJobException(String jobName);
+
+    /**
+     * Creates an exception indicating the job XML file could not be found in the deployment.
+     *
+     * @param xmlFile the invalid XML file
+     *
+     * @return a {@link javax.batch.operations.JobStartException} for the error
+     */
+    @Message(id = 6, value = "Could not find the job XML file in the deployment: %s")
+    JobStartException couldNotFindJobXml(String xmlFile);
+
+    /**
+     * Logs a warning message indicating the job XML file failed to be processed and attempting the run the job may
+     * result in errors.
+     *
+     * @param jobXmlFile the invalid job XML file name
+     */
+    @LogMessage(level = Level.WARN)
+    @Message(id = 7, value = "Failed processing the job XML file %s. Attempting to execute this job may result in errors.")
+    void invalidJobXmlFile(String jobXmlFile);
 
 }

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchDeploymentResourceProcessor.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchDeploymentResourceProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.deployment;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.ee.structure.DeploymentType;
+import org.jboss.as.ee.structure.DeploymentTypeMarker;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentResourceSupport;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.modules.Module;
+import org.wildfly.extension.batch.BatchServiceNames;
+import org.wildfly.extension.batch.BatchSubsystemDefinition;
+import org.wildfly.extension.batch._private.BatchLogger;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchDeploymentResourceProcessor implements DeploymentUnitProcessor {
+    @Override
+    public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        if (deploymentUnit.hasAttachment(Attachments.MODULE) && !DeploymentTypeMarker.isType(DeploymentType.EAR, deploymentUnit) && deploymentUnit.hasAttachment(Attachments.DEPLOYMENT_ROOT)) {
+            BatchLogger.LOGGER.tracef("Processing deployment '%s' for the batch deployment resources.", deploymentUnit.getName());
+            // Get the class loader
+            final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
+            final ClassLoader moduleClassLoader = module.getClassLoader();
+            final DeploymentResourceSupport deploymentResourceSupport = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT);
+            // Add the job operator service used interact with a deployments batch job
+            final JobOperatorService jobOperatorService = new JobOperatorService(moduleClassLoader);
+
+            // Get all the job XML service
+            final JobXmlResolverService jobXmlResolverService = (JobXmlResolverService) phaseContext.getServiceRegistry().getService(BatchServiceNames.jobXmlResolverServiceName(deploymentUnit)).getValue();
+            // Process each job XML file
+            for (String jobXml : jobXmlResolverService.getJobXmlNames(moduleClassLoader)) {
+                try {
+                    final String jobName = jobXmlResolverService.resolveJobName(jobXml, moduleClassLoader);
+                    // Add the job information to the service
+                    jobOperatorService.addAllowedJob(jobXml, jobName);
+                    // Register the a resource for each job found
+                    final PathAddress jobAddress = PathAddress.pathAddress(BatchJobResourceDefinition.JOB, jobName);
+                    if (!deploymentResourceSupport.hasDeploymentSubModel(BatchSubsystemDefinition.NAME, jobAddress)) {
+                        deploymentResourceSupport.registerDeploymentSubResource(BatchSubsystemDefinition.NAME,
+                                jobAddress, new BatchJobExecutionResource(jobOperatorService, jobName));
+                    }
+                } catch (Exception e) {
+                    // The deployment shouldn't fail in this case, just the specific resource registration should be skipped
+                    // Log a debug message so the error is not lost
+                    BatchLogger.LOGGER.debugf(e, "Could not parse the XML file %s. The job will not be registered for runtime views on the deployment (%s).", jobXml, deploymentUnit.getName());
+                }
+            }
+            phaseContext.getServiceTarget().addService(BatchServiceNames.jobOperatorServiceName(deploymentUnit), jobOperatorService)
+                    .addDependency(BatchServiceNames.batchEnvironmentServiceName(deploymentUnit))
+                    .install();
+        }
+    }
+
+    @Override
+    public void undeploy(final DeploymentUnit context) {
+    }
+}

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchJobExecutionResource.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchJobExecutionResource.java
@@ -1,0 +1,222 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.deployment;
+
+import static org.wildfly.extension.batch.deployment.BatchJobExecutionResourceDefinition.EXECUTION;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.JobInstance;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.registry.PlaceholderResource;
+import org.jboss.as.controller.registry.PlaceholderResource.PlaceholderResourceEntry;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.dmr.ModelNode;
+import org.wildfly.extension.batch._private.BatchLogger;
+
+/**
+ * Represents a dynamic resource for batch {@link javax.batch.runtime.JobExecution job executions}.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchJobExecutionResource implements Resource {
+
+    private final Resource delegate;
+    private final JobOperator jobOperator;
+    private final String jobName;
+    // Should be guarded by it's instance
+    private final Set<String> children = new LinkedHashSet<>();
+
+    public BatchJobExecutionResource(final JobOperator jobOperator, final String jobName) {
+        this(Factory.create(true), jobOperator, jobName);
+    }
+
+    public BatchJobExecutionResource(final Resource delegate, final JobOperator jobOperator, final String jobName) {
+        this.delegate = delegate;
+        this.jobOperator = jobOperator;
+        this.jobName = jobName;
+    }
+
+    @Override
+    public ModelNode getModel() {
+        return delegate.getModel();
+    }
+
+    @Override
+    public void writeModel(final ModelNode newModel) {
+        delegate.writeModel(newModel);
+    }
+
+    @Override
+    public boolean isModelDefined() {
+        return delegate.isModelDefined();
+    }
+
+    @Override
+    public boolean hasChild(final PathElement element) {
+        if (EXECUTION.equals(element.getKey())) {
+            return hasJobExecution(element.getValue());
+        }
+        return delegate.hasChild(element);
+    }
+
+    @Override
+    public Resource getChild(final PathElement element) {
+        if (EXECUTION.equals(element.getKey())) {
+            if (hasJobExecution(element.getValue())) {
+                return PlaceholderResource.INSTANCE;
+            }
+            return null;
+        }
+        return delegate.getChild(element);
+    }
+
+    @Override
+    public Resource requireChild(final PathElement element) {
+        if (EXECUTION.equals(element.getKey())) {
+            if (hasJobExecution(element.getValue())) {
+                return PlaceholderResource.INSTANCE;
+            }
+            throw new NoSuchResourceException(element);
+        }
+        return delegate.requireChild(element);
+    }
+
+    @Override
+    public boolean hasChildren(final String childType) {
+        if (EXECUTION.equals(childType)) {
+            return !getChildrenNames(EXECUTION).isEmpty();
+        }
+        return delegate.hasChildren(childType);
+    }
+
+    @Override
+    public Resource navigate(final PathAddress address) {
+        if (address.size() > 0 && EXECUTION.equals(address.getElement(0).getKey())) {
+            if (address.size() > 1) {
+                throw new NoSuchResourceException(address.getElement(1));
+            }
+            return PlaceholderResource.INSTANCE;
+        }
+        return delegate.navigate(address);
+    }
+
+    @Override
+    public Set<String> getChildTypes() {
+        final Set<String> result = new LinkedHashSet<>(delegate.getChildTypes());
+        result.add(EXECUTION);
+        return result;
+    }
+
+    @Override
+    public Set<String> getChildrenNames(final String childType) {
+        if (EXECUTION.equals(childType)) {
+            synchronized (children) {
+                refreshChildren();
+                return new LinkedHashSet<>(children);
+            }
+        }
+        return delegate.getChildrenNames(childType);
+    }
+
+    @Override
+    public Set<ResourceEntry> getChildren(final String childType) {
+        if (EXECUTION.equals(childType)) {
+            final Set<String> names = getChildrenNames(childType);
+            final Set<ResourceEntry> result = new LinkedHashSet<>(names.size());
+            for (String name : names) {
+                result.add(new PlaceholderResourceEntry(EXECUTION, name));
+            }
+            return result;
+        }
+        return delegate.getChildren(childType);
+    }
+
+    @Override
+    public void registerChild(final PathElement address, final Resource resource) {
+        final String type = address.getKey();
+        if (EXECUTION.equals(type)) {
+            throw BatchLogger.LOGGER.cannotRemoveResourceOfType(type);
+        }
+        delegate.registerChild(address, resource);
+    }
+
+    @Override
+    public Resource removeChild(final PathElement address) {
+        final String type = address.getKey();
+        if (EXECUTION.equals(type)) {
+            throw BatchLogger.LOGGER.cannotRemoveResourceOfType(type);
+        }
+        return delegate.removeChild(address);
+    }
+
+    @Override
+    public boolean isRuntime() {
+        return delegate.isRuntime();
+    }
+
+    @Override
+    public boolean isProxy() {
+        return delegate.isProxy();
+    }
+
+    @Override
+    public Resource clone() {
+        return new BatchJobExecutionResource(delegate.clone(), jobOperator, jobName);
+    }
+
+    private boolean hasJobExecution(final String executionName) {
+        synchronized (children) {
+            if (children.contains(executionName)) {
+                return true;
+            }
+            // Load a cache of the names
+            refreshChildren();
+            return children.contains(executionName);
+        }
+    }
+
+    /**
+     * Note the access to the {@link #children} is <strong>not</strong> guarded here and needs to be externally
+     * guarded.
+     */
+    private void refreshChildren() {
+        final List<JobExecution> executions = new ArrayList<>();
+        final List<JobInstance> instances = jobOperator.getJobInstances(jobName, 0, jobOperator.getJobInstanceCount(jobName));
+        for (JobInstance instance : instances) {
+            executions.addAll(jobOperator.getJobExecutions(instance));
+        }
+        for (JobExecution execution : executions) {
+            final String name = Long.toString(execution.getExecutionId());
+            if (!children.contains(name)) {
+                children.add(name);
+            }
+        }
+    }
+}

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchJobExecutionResourceDefinition.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchJobExecutionResourceDefinition.java
@@ -1,0 +1,160 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.deployment;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.JobInstance;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.extension.batch.BatchResourceDescriptionResolver;
+
+/**
+ * A definition representing a job execution resource.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchJobExecutionResourceDefinition extends SimpleResourceDefinition {
+    static final String EXECUTION = "execution";
+
+    static final SimpleAttributeDefinition INSTANCE_ID = SimpleAttributeDefinitionBuilder.create("instance-id", ModelType.LONG)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition BATCH_STATUS = SimpleAttributeDefinitionBuilder.create("batch-status", ModelType.STRING)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition EXIT_STATUS = SimpleAttributeDefinitionBuilder.create("exit-status", ModelType.STRING)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition CREATE_TIME = SimpleAttributeDefinitionBuilder.create("create-time", ModelType.STRING)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition START_TIME = SimpleAttributeDefinitionBuilder.create("start-time", ModelType.STRING)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition LAST_UPDATED_TIME = SimpleAttributeDefinitionBuilder.create("last-updated-time", ModelType.STRING)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition END_TIME = SimpleAttributeDefinitionBuilder.create("end-time", ModelType.STRING)
+            .setStorageRuntime()
+            .build();
+
+    static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
+
+    public BatchJobExecutionResourceDefinition() {
+        super(PathElement.pathElement(EXECUTION), BatchResourceDescriptionResolver.getResourceDescriptionResolver("deployment", "job", "execution"));
+    }
+
+    @Override
+    public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerReadOnlyAttribute(INSTANCE_ID, new JobOperationStepHandler() {
+            @Override
+            protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
+                final JobInstance jobInstance = jobOperator.getJobInstance(Long.parseLong(context.getCurrentAddressValue()));
+                model.set(jobInstance.getInstanceId());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(BATCH_STATUS, new JobExecutionOperationStepHandler() {
+            @Override
+            protected void updateModel(final ModelNode model, final JobExecution jobExecution) throws OperationFailedException {
+                final BatchStatus status = jobExecution.getBatchStatus();
+                if (status != null) {
+                    model.set(status.toString());
+                }
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(EXIT_STATUS, new JobExecutionOperationStepHandler() {
+            @Override
+            protected void updateModel(final ModelNode model, final JobExecution jobExecution) throws OperationFailedException {
+                final String exitStatus = jobExecution.getExitStatus();
+                if (exitStatus != null) {
+                    model.set(exitStatus);
+                }
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(CREATE_TIME, new DateTimeFormatterOperationStepHandler() {
+            @Override
+            protected Date getDateTime(final JobExecution jobExecution) {
+                return jobExecution.getCreateTime();
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(START_TIME, new DateTimeFormatterOperationStepHandler() {
+            @Override
+            protected Date getDateTime(final JobExecution jobExecution) {
+                return jobExecution.getStartTime();
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(LAST_UPDATED_TIME, new DateTimeFormatterOperationStepHandler() {
+            @Override
+            protected Date getDateTime(final JobExecution jobExecution) {
+                return jobExecution.getLastUpdatedTime();
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(END_TIME, new DateTimeFormatterOperationStepHandler() {
+            @Override
+            protected Date getDateTime(final JobExecution jobExecution) {
+                return jobExecution.getEndTime();
+            }
+        });
+    }
+
+    abstract static class JobExecutionOperationStepHandler extends JobOperationStepHandler {
+        @Override
+        protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
+            final JobExecution jobExecution = jobOperator.getJobExecution(Long.parseLong(context.getCurrentAddressValue()));
+            updateModel(model, jobExecution);
+        }
+
+        protected abstract void updateModel(ModelNode model, JobExecution jobExecution) throws OperationFailedException;
+    }
+
+    abstract static class DateTimeFormatterOperationStepHandler extends JobExecutionOperationStepHandler {
+
+        protected void updateModel(final ModelNode model, final JobExecution jobExecution) throws OperationFailedException {
+            final Date date = getDateTime(jobExecution);
+            if (date != null) {
+                final SimpleDateFormat formatter = new SimpleDateFormat(ISO_8601_FORMAT);
+                model.set(formatter.format(date));
+            }
+        }
+
+        protected abstract Date getDateTime(JobExecution jobExecution);
+    }
+}

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchJobResourceDefinition.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchJobResourceDefinition.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.deployment;
+
+import javax.batch.operations.JobOperator;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.extension.batch.BatchResourceDescriptionResolver;
+
+/**
+ * A definition representing a job resource.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchJobResourceDefinition extends SimpleResourceDefinition {
+    static final String JOB = "job";
+
+    static final SimpleAttributeDefinition RUNNING_EXECUTIONS = SimpleAttributeDefinitionBuilder.create("running-executions", ModelType.INT)
+            .setStorageRuntime()
+            .build();
+
+    static final SimpleAttributeDefinition INSTANCE_COUNT = SimpleAttributeDefinitionBuilder.create("instance-count", ModelType.INT)
+            .setStorageRuntime()
+            .build();
+
+    public static final BatchJobResourceDefinition INSTANCE = new BatchJobResourceDefinition();
+
+    private BatchJobResourceDefinition() {
+        super(PathElement.pathElement(JOB), BatchResourceDescriptionResolver.getResourceDescriptionResolver("deployment", "job"));
+    }
+
+    @Override
+    public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerReadOnlyAttribute(RUNNING_EXECUTIONS, new JobOperationStepHandler() {
+            @Override
+            protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
+                model.set(jobOperator.getRunningExecutions(jobName).size());
+            }
+        });
+        resourceRegistration.registerReadOnlyAttribute(INSTANCE_COUNT, new JobOperationStepHandler() {
+            @Override
+            protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
+                model.set(jobOperator.getJobInstanceCount(jobName));
+            }
+        });
+    }
+
+}

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobOperationStepHandler.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobOperationStepHandler.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.deployment;
+
+import javax.batch.operations.JobOperator;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceController;
+import org.wildfly.extension.batch.BatchServiceNames;
+
+/**
+ * A handler to assist with updating the dynamic batch job resources.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class JobOperationStepHandler implements OperationStepHandler {
+    @Override
+    public final void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
+        final PathAddress address = context.getCurrentAddress();
+        final ServiceController<?> controller = context.getServiceRegistry(false).getService(BatchServiceNames.jobOperatorServiceName(address));
+        final JobOperator jobOperator = (JobOperator) controller.getService();
+        final String jobName = getJobName(address);
+        updateModel(context, context.getResult(), jobOperator, jobName);
+    }
+
+    /**
+     * Updates the model with information from the {@link javax.batch.operations.JobOperator JobOperator}.
+     *
+     * @param context     the operation context used
+     * @param model       the model to update
+     * @param jobOperator the job operator
+     * @param jobName     the name of the job
+     *
+     * @throws OperationFailedException if an update failure occurs
+     */
+    protected abstract void updateModel(OperationContext context, ModelNode model, JobOperator jobOperator, String jobName) throws OperationFailedException;
+
+    /**
+     * Gets the job from from the address.
+     *
+     * @param address the address to get the job name from
+     *
+     * @return the job name
+     */
+    static String getJobName(final PathAddress address) {
+        return address.getLastElement().getValue();
+    }
+}

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobOperatorService.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobOperatorService.java
@@ -1,0 +1,351 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.deployment;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import javax.batch.operations.JobExecutionAlreadyCompleteException;
+import javax.batch.operations.JobExecutionIsRunningException;
+import javax.batch.operations.JobExecutionNotMostRecentException;
+import javax.batch.operations.JobExecutionNotRunningException;
+import javax.batch.operations.JobOperator;
+import javax.batch.operations.JobRestartException;
+import javax.batch.operations.JobSecurityException;
+import javax.batch.operations.JobStartException;
+import javax.batch.operations.NoSuchJobException;
+import javax.batch.operations.NoSuchJobExecutionException;
+import javax.batch.operations.NoSuchJobInstanceException;
+import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.JobExecution;
+import javax.batch.runtime.JobInstance;
+import javax.batch.runtime.StepExecution;
+
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.wildfly.extension.batch._private.BatchLogger;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * A delegating {@linkplain javax.batch.operations.JobOperator job operator} to interact with the batch environment on
+ * deployments.
+ *
+ * <p>
+ * Note that for each method the job name, or derived job name, must exist for the deployment. The allowed job names and
+ * job XML files are determined at deployment time.
+ * </p>
+ *
+ * <p>
+ * This implementation does change some of the API's contracts however it's only intended to be used by management
+ * resources and operations. Limits the interaction with the jobs to the scope of the deployments jobs. Any behavioral
+ * change will be documented.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class JobOperatorService implements JobOperator, Service<JobOperator> {
+
+    private ClassLoader classLoader;
+    private JobOperator delegate;
+    // Guarded by this
+    private final Set<String> allowedJobNames;
+    // Guarded by this
+    private final Set<String> allowedJobXmlNames;
+
+    public JobOperatorService(final ClassLoader classLoader) {
+        this.classLoader = classLoader;
+        allowedJobNames = new LinkedHashSet<>();
+        allowedJobXmlNames = new LinkedHashSet<>();
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            delegate = BatchRuntime.getJobOperator();
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        delegate = null;
+        classLoader = null;
+        allowedJobXmlNames.clear();
+        allowedJobNames.clear();
+    }
+
+    @Override
+    public JobOperator getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    @Override
+    public Set<String> getJobNames() throws JobSecurityException {
+        checkState();
+        synchronized (this) {
+            return new LinkedHashSet<>(allowedJobNames);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This does not throw a {@link javax.batch.operations.NoSuchJobException} if the repository does not contain the
+     * job, but the job is allowed. If this case is true then {@code 0} is returned.
+     * </p>
+     */
+    @Override
+    public int getJobInstanceCount(final String jobName) throws NoSuchJobException, JobSecurityException {
+        checkState(jobName);
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            try {
+                return delegate.getJobInstanceCount(jobName);
+            } catch (NoSuchJobException ignore) {
+            }
+            return 0;
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This does not throw a {@link javax.batch.operations.NoSuchJobException} if the repository does not contain the
+     * job, but the job is allowed. If this case is true an empty list is returned.
+     * </p>
+     */
+    @Override
+    public List<JobInstance> getJobInstances(final String jobName, final int start, final int count) throws NoSuchJobException, JobSecurityException {
+        checkState(jobName);
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            try {
+                return delegate.getJobInstances(jobName, start, count);
+            } catch (NoSuchJobException ignore) {
+            }
+            return Collections.emptyList();
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * This does not throw a {@link javax.batch.operations.NoSuchJobException} if the repository does not contain the
+     * job, but the job is allowed. If this case is true an empty list is returned.
+     * </p>
+     */
+    @Override
+    public List<Long> getRunningExecutions(final String jobName) throws NoSuchJobException, JobSecurityException {
+        checkState(jobName);
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            try {
+                return delegate.getRunningExecutions(jobName);
+            } catch (NoSuchJobException ignore) {
+            }
+            return Collections.emptyList();
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public Properties getParameters(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final JobInstance instance = delegate.getJobInstance(executionId);
+            validateJob(instance.getJobName());
+            return delegate.getParameters(executionId);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public long start(final String jobXMLName, final Properties jobParameters) throws JobStartException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final String jobXml;
+            if (jobXMLName.endsWith(".xml")) {
+                jobXml = jobXMLName;
+            } else {
+                jobXml = jobXMLName + ".xml";
+            }
+            final boolean valid;
+            synchronized (this) {
+                valid = allowedJobXmlNames.contains(jobXml);
+            }
+            if (valid) {
+                return delegate.start(jobXMLName, jobParameters);
+            }
+            throw BatchLogger.LOGGER.couldNotFindJobXml(jobXMLName);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public long restart(final long executionId, final Properties restartParameters) throws JobExecutionAlreadyCompleteException, NoSuchJobExecutionException, JobExecutionNotMostRecentException, JobRestartException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final JobInstance instance = delegate.getJobInstance(executionId);
+            validateJob(instance.getJobName());
+            return delegate.restart(executionId, restartParameters);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public void stop(final long executionId) throws NoSuchJobExecutionException, JobExecutionNotRunningException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final JobInstance instance = delegate.getJobInstance(executionId);
+            validateJob(instance.getJobName());
+            delegate.stop(executionId);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public void abandon(final long executionId) throws NoSuchJobExecutionException, JobExecutionIsRunningException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final JobInstance instance = delegate.getJobInstance(executionId);
+            validateJob(instance.getJobName());
+            delegate.abandon(executionId);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public JobInstance getJobInstance(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final JobInstance instance = delegate.getJobInstance(executionId);
+            validateJob(instance.getJobName());
+            return delegate.getJobInstance(executionId);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public List<JobExecution> getJobExecutions(final JobInstance instance) throws NoSuchJobInstanceException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            validateJob(instance.getJobName());
+            return delegate.getJobExecutions(instance);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public JobExecution getJobExecution(final long executionId) throws NoSuchJobExecutionException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final JobInstance instance = delegate.getJobInstance(executionId);
+            validateJob(instance.getJobName());
+            return delegate.getJobExecution(executionId);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    @Override
+    public List<StepExecution> getStepExecutions(final long jobExecutionId) throws NoSuchJobExecutionException, JobSecurityException {
+        checkState();
+        final ClassLoader current = WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(classLoader);
+            final JobInstance instance = delegate.getJobInstance(jobExecutionId);
+            validateJob(instance.getJobName());
+            return delegate.getStepExecutions(jobExecutionId);
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(current);
+        }
+    }
+
+    /**
+     * Adds the job XML and the job name to the allowed resources to use.
+     *
+     * @param jobXml  the job XML file name
+     * @param jobName the job name
+     */
+    protected synchronized void addAllowedJob(final String jobXml, final String jobName) {
+        allowedJobXmlNames.add(jobXml);
+        allowedJobNames.add(jobName);
+    }
+
+    private void checkState() {
+        checkState(null);
+    }
+
+    private void checkState(final String jobName) {
+        if (delegate == null || classLoader == null) {
+            throw BatchLogger.LOGGER.jobOperatorServiceStopped();
+        }
+        if (jobName != null) {
+            validateJob(jobName);
+        }
+    }
+
+    private synchronized void validateJob(final String name) {
+        if (!allowedJobNames.contains(name)) {
+            throw BatchLogger.LOGGER.noSuchJobException(name);
+        }
+    }
+}

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobXmlResolverService.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobXmlResolverService.java
@@ -1,0 +1,172 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.deployment;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+import javax.xml.stream.XMLStreamException;
+
+import org.jberet.job.model.Job;
+import org.jberet.job.model.JobParser;
+import org.jberet.spi.JobXmlResolver;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.vfs.VirtualFile;
+import org.wildfly.extension.batch._private.BatchLogger;
+import org.wildfly.security.manager.WildFlySecurityManager;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+class JobXmlResolverService implements Service<JobXmlResolver>, JobXmlResolver {
+    private final Set<JobXmlResolver> jobXmlResolvers;
+    private final Map<String, String> cachedJobInfo;
+    private final Map<String, VirtualFile> jobXmlFiles;
+    private final ClassLoader classLoader;
+
+    public JobXmlResolverService() {
+        classLoader = null;
+        cachedJobInfo = Collections.emptyMap();
+        jobXmlResolvers = Collections.emptySet();
+        jobXmlFiles = Collections.emptyMap();
+    }
+
+    public JobXmlResolverService(final ClassLoader classLoader, final Collection<VirtualFile> jobXmlFiles) {
+        this.classLoader = classLoader;
+        cachedJobInfo = new LinkedHashMap<>();
+        jobXmlResolvers = new LinkedHashSet<>();
+        this.jobXmlFiles = new LinkedHashMap<>(jobXmlFiles.size());
+        for (VirtualFile jobXmlFile : jobXmlFiles) {
+            this.jobXmlFiles.put(jobXmlFile.getName(), jobXmlFile);
+        }
+    }
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        if (classLoader != null) {
+            // Load the user defined resolvers
+            for (JobXmlResolver resolver : ServiceLoader.load(JobXmlResolver.class, classLoader)) {
+                jobXmlResolvers.add(resolver);
+                for (String jobXml : resolver.getJobXmlNames(classLoader)) {
+                    cachedJobInfo.put(jobXml, resolver.resolveJobName(jobXml, classLoader));
+                }
+            }
+
+            // Load the default names
+            for (Map.Entry<String, VirtualFile> entry : jobXmlFiles.entrySet()) {
+                try {
+                    // Parsing the entire job XML seems excessive to just get the job name. There are two reasons for this:
+                    //  1) If an error occurs during parsing there's no real need to register the job resource
+                    //  2) Using the implementation parser seems less error prone for future-proofing
+                    // TODO (jrp) preparing for JBeret upgrade
+                    /*final Job job = JobParser.parseJob(entry.getValue().openStream(), classLoader, new XMLResolver() {
+                        // this is essentially what JBeret does, but it's ugly. JBeret might need an API to handle this
+                        @Override
+                        public Object resolveEntity(final String publicID, final String systemID, final String baseURI, final String namespace) throws XMLStreamException {
+                            try {
+                                return (jobXmlFiles.containsKey(systemID) ? jobXmlFiles.get(systemID).openStream() : null);
+                            } catch (IOException e) {
+                                throw new XMLStreamException(e);
+                            }
+                        }
+                    });*/
+                    final Job job = JobParser.parseJob(entry.getValue().openStream(), classLoader);
+                    cachedJobInfo.put(entry.getKey(), job.getId());
+                } catch (XMLStreamException | IOException e) {
+                    // Report the possible error as we don't want to fail the deployment. The job may never be run.
+                    BatchLogger.LOGGER.invalidJobXmlFile(entry.getKey());
+                }
+            }
+        }
+    }
+
+    @Override
+    public synchronized void stop(final StopContext context) {
+        jobXmlResolvers.clear();
+        jobXmlFiles.clear();
+        cachedJobInfo.clear();
+    }
+
+    @Override
+    public JobXmlResolver getValue() throws IllegalStateException, IllegalArgumentException {
+        return this;
+    }
+
+    @Override
+    public InputStream resolveJobXml(final String jobXml, final ClassLoader classLoader) throws IOException {
+        synchronized (this) {
+            if (jobXmlFiles.isEmpty() && jobXmlResolvers.isEmpty()) {
+                return null;
+            }
+            for (JobXmlResolver resolver : jobXmlResolvers) {
+                final InputStream in = resolver.resolveJobXml(jobXml, classLoader);
+                if (in != null) {
+                    return in;
+                }
+            }
+        }
+        final VirtualFile file;
+        synchronized (this) {
+            file = jobXmlFiles.get(jobXml);
+        }
+        if (file == null) {
+            return null;
+        }
+        if (WildFlySecurityManager.isChecking()) {
+            return AccessController.doPrivileged(new PrivilegedAction<InputStream>() {
+                IOException error;
+
+                @Override
+                public InputStream run() {
+                    try {
+                        return file.openStream();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+        return file.openStream();
+    }
+
+    @Override
+    public synchronized Collection<String> getJobXmlNames(final ClassLoader classLoader) {
+        return cachedJobInfo.keySet();
+    }
+
+    @Override
+    public synchronized String resolveJobName(final String jobXml, final ClassLoader classLoader) {
+        return cachedJobInfo.get(jobXml);
+    }
+}

--- a/batch/extension/src/main/resources/org/wildfly/extension/batch/LocalDescriptions.properties
+++ b/batch/extension/src/main/resources/org/wildfly/extension/batch/LocalDescriptions.properties
@@ -42,3 +42,17 @@ batch.thread-pool=The thread pool used for batch jobs.
 
 # Thread factory
 batch.thread-factory=The thread factory used for the thread-pool.
+
+# Batch job information
+batch.deployment=Information about the batch subsystem for the deployment.
+batch.deployment.job=Information about a specific batch job.
+batch.deployment.job.running-executions=The number of currently running executions for the job.
+batch.deployment.job.instance-count=The number of instances for the job.
+batch.deployment.job.execution=The execution information for the job with the value of the path being the execution id.
+batch.deployment.job.execution.instance-id=The instance id for the execution.
+batch.deployment.job.execution.batch-status=The status of the execution.
+batch.deployment.job.execution.exit-status=The exit status of the execution.
+batch.deployment.job.execution.create-time=The time the execution was created in ISO 8601 format.
+batch.deployment.job.execution.start-time=The time the execution entered the STARTED status in ISO 8601 format.
+batch.deployment.job.execution.last-updated-time=The time the execution was last updated in ISO 8601 format.
+batch.deployment.job.execution.end-time=The time, in ISO 8601 format, the execution entered a status of: COMPLETED, STOPPED or FAILED

--- a/batch/jberet/src/main/java/org/jberet/spi/JobXmlResolver.java
+++ b/batch/jberet/src/main/java/org/jberet/spi/JobXmlResolver.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jberet.spi;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+/**
+ * An interface used to resolve job XML content.
+ *
+ * <p>
+ * Both the {@link #getJobXmlNames(ClassLoader)} and {@link #resolveJobName(String, ClassLoader)} methods are optional.
+ * The intention is implementations can use the values returned to query information about specific the job XML files.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+// TODO (jrp) remove this when JBeret is upgraded
+public interface JobXmlResolver {
+
+    /**
+     * The default {@code META-INF/batch-jobs/} path.
+     */
+    String DEFAULT_PATH = "META-INF/batch-jobs/";
+
+    /**
+     * Locates the job XML and creates a stream to the contents.
+     *
+     * @param jobXml      the name of the job XML with a {@code .xml} suffix
+     * @param classLoader the class loader for the application
+     *
+     * @return a stream of the job XML or {@code null} if the job XML content was not found
+     *
+     * @throws java.io.IOException if an error occurs creating the stream
+     */
+    InputStream resolveJobXml(String jobXml, ClassLoader classLoader) throws IOException;
+
+    /**
+     * Optionally returns a list of job XML names that are allowed to be used.
+     *
+     * <p>
+     * An empty collection should be returned if job names can not be resolved.
+     * </p>
+     *
+     * @param classLoader the class loader for the application
+     *
+     * @return the job XML names or an empty collection
+     */
+    Collection<String> getJobXmlNames(final ClassLoader classLoader);
+
+    /**
+     * Optionally resolves the job name from the job XML.
+     *
+     * <p>
+     * A {@code null} value can be returned if the name cannot be resolved.
+     * </p>
+     *
+     * @param jobXml      the name of the xml XML with a {@code .xml} suffix
+     * @param classLoader the class loader for the application
+     *
+     * @return the name of the job if found or {@code null} if not found
+     */
+    String resolveJobName(String jobXml, ClassLoader classLoader);
+}

--- a/batch/jberet/src/main/java/org/wildfly/jberet/BatchEnvironmentFactory.java
+++ b/batch/jberet/src/main/java/org/wildfly/jberet/BatchEnvironmentFactory.java
@@ -32,6 +32,7 @@ import javax.transaction.TransactionManager;
 import org.jberet.repository.JobRepository;
 import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.BatchEnvironment;
+import org.jberet.spi.JobXmlResolver;
 import org.wildfly.jberet._private.WildFlyBatchLogger;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
@@ -76,6 +77,12 @@ public class BatchEnvironmentFactory {
         @Override
         public JobRepository getJobRepository() {
             throw WildFlyBatchLogger.LOGGER.invalidBatchEnvironment();
+        }
+
+        // TODO (jrp) preparing for JBeret API changes
+        //@Override
+        public JobXmlResolver getJobXmlResolver() {
+           throw WildFlyBatchLogger.LOGGER.invalidBatchEnvironment();
         }
 
         /**

--- a/batch/jberet/src/main/java/org/wildfly/jberet/DelegatingBatchEnvironment.java
+++ b/batch/jberet/src/main/java/org/wildfly/jberet/DelegatingBatchEnvironment.java
@@ -30,6 +30,7 @@ import javax.transaction.TransactionManager;
 import org.jberet.repository.JobRepository;
 import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.BatchEnvironment;
+import org.jberet.spi.JobXmlResolver;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -75,6 +76,13 @@ public class DelegatingBatchEnvironment implements BatchEnvironment {
     @Override
     public JobRepository getJobRepository() {
         return delegate.getJobRepository();
+    }
+
+    // TODO (jrp) preparing for JBeret API changes
+    //@Override
+    public JobXmlResolver getJobXmlResolver() {
+        //return delegate.getJobXmlResolver();
+        return null;
     }
 
     /**


### PR DESCRIPTION
This adds the batch subsystem as a runtime resource on deployments, `/deployment=*/subsystem=batch`. Jobs are listed as sub-resources and registered in a DUP. 

Each job resource also contains a dynamic execution resource. The value of the execution resource is the execution id. This is an integer which does result in odd sorting when the resources are lists, though I don't suspect this will be an issue.

It should be noted that if there are a lot of batch jobs reading this resource recursively can be very expensive and result in OOME's. Using something like `/deployment=*/subsystem=batch:read-resource(recursive=true,include-runtime=true,recursive-depth=1)` to get all the job execution id's then reading the resource for each desired execution is much quicker.

There are some `TODO`'s due to some upstream changes in JBeret that I wanted to prepare for as they were created for this PR, but there's not real need to wait for a JBeret release. The batch extension is in need of a clean-up and I didn't want to wait for a new release of JBeret.
