### PR TITLE
WFLY-4470, Fix duplicate message deliveries when invoke start-delivery t...

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/messagedriven/MessageDrivenComponent.java
@@ -257,13 +257,17 @@ public class MessageDrivenComponent extends EJBComponent implements PooledCompon
     }
 
     public void startDelivery() {
-        this.deliveryActive = true;
-        activate();
+        if (!this.deliveryActive) {
+            this.deliveryActive = true;
+            activate();
+        }
     }
 
     public void stopDelivery() {
-        this.deactivate();
-        this.deliveryActive = false;
+        if (this.deliveryActive) {
+            this.deactivate();
+            this.deliveryActive = false;
+        }
     }
 
     public boolean isDeliveryActive() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/deliveryactive/MDBTestCase.java
@@ -163,6 +163,8 @@ public class MDBTestCase {
 
             executeMDBOperation(mdbName, "start-delivery");
             assertMDBDeliveryIsActive(mdbName, true);
+            // WFLY-4470 check duplicate message when start delivery twice. Last assertNull(reply) should still be valid
+            executeMDBOperation(mdbName, "start-delivery");
 
             // the message was delivered to the MDB which replied
             reply = consumer.receive(TIMEOUT);


### PR DESCRIPTION
...wice.

https://issues.jboss.org/browse/WFLY-4470
Currently, startDelivery() stopDelivery() don't check deliveryActive value, it directly sets it and calls activate() and deactivate() even they are not necessary. 
