### PR TITLE
WFLY-4338 - JConsole script builds wrong path

### DIFF
--- a/feature-pack/src/main/resources/content/bin/jconsole.sh
+++ b/feature-pack/src/main/resources/content/bin/jconsole.sh
@@ -74,7 +74,7 @@ fi
 
 CLASSPATH=$JAVA_HOME/lib/jconsole.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
-CLASSPATH="$CLASSPATH:\""$JBOSS_HOME"\"/bin/client/jboss-cli-client.jar"
+CLASSPATH="$CLASSPATH:$JBOSS_HOME/bin/client/jboss-cli-client.jar"
 
 echo CLASSPATH $CLASSPATH
 


### PR DESCRIPTION
Fixes WFLY-4338. Pulling as per suggested by kabirkhan.
