### PR TITLE
[WFLY-3769] Implement graceful shutdown for batch.

### DIFF
--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchEnvironmentProcessor.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchEnvironmentProcessor.java
@@ -47,6 +47,7 @@ import org.jboss.vfs.VirtualFileFilter;
 import org.wildfly.extension.batch.BatchServiceNames;
 import org.wildfly.extension.batch._private.BatchLogger;
 import org.wildfly.extension.batch.job.repository.JobRepositoryFactory;
+import org.wildfly.extension.requestcontroller.RequestController;
 import org.wildfly.jberet.services.BatchEnvironmentService;
 
 /**
@@ -68,7 +69,7 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
             final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(org.jboss.as.ee.component.Attachments.EE_MODULE_DESCRIPTION);
 
             // Create the batch environment
-            final BatchEnvironmentService service = new BatchEnvironmentService(moduleClassLoader, JobRepositoryFactory.getInstance().getJobRepository(moduleDescription));
+            final BatchEnvironmentService service = new BatchEnvironmentService(moduleClassLoader, JobRepositoryFactory.getInstance().getJobRepository(moduleDescription), deploymentUnit.getName());
             final ServiceBuilder<BatchEnvironment> serviceBuilder = serviceTarget.addService(BatchServiceNames.batchEnvironmentServiceName(deploymentUnit), service);
             // Register the required services
             serviceBuilder.addDependency(BatchServiceNames.BATCH_THREAD_POOL_NAME, ExecutorService.class, service.getExecutorServiceInjector());
@@ -105,6 +106,8 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
             serviceTarget.addService(BatchServiceNames.jobXmlResolverServiceName(deploymentUnit), jobXmlResolverService).install();
             // Add a dependency to the job XML resolver service
             serviceBuilder.addDependency(BatchServiceNames.jobXmlResolverServiceName(deploymentUnit), JobXmlResolver.class, service.getJobXmlResolverInjector());
+
+            serviceBuilder.addDependency(RequestController.SERVICE_NAME, RequestController.class, service.getRequestControllerInjector());
 
             serviceBuilder.install();
         }

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/main/module.xml
@@ -48,6 +48,7 @@
         <module name="org.jboss.msc"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
+        <module name="org.wildfly.extension.request-controller"/>
         <module name="org.wildfly.jberet" services="import"/>
         <module name="org.wildfly.security.manager"/>
     </dependencies>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/CountingItemReader.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/CountingItemReader.java
@@ -1,0 +1,74 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.chunk;
+
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.batch.api.BatchProperty;
+import javax.batch.api.chunk.ItemReader;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Named
+public class CountingItemReader implements ItemReader {
+
+    @Inject
+    @BatchProperty(name = "reader.start")
+    private int start;
+
+    @Inject
+    @BatchProperty(name = "reader.end")
+    private int end;
+
+    private final AtomicInteger counter = new AtomicInteger();
+
+    @Override
+    public void open(final Serializable checkpoint) throws Exception {
+        if (end == 0) {
+            end = 10;
+        }
+        counter.set(start);
+    }
+
+    @Override
+    public void close() throws Exception {
+        counter.set(0);
+    }
+
+    @Override
+    public Object readItem() throws Exception {
+        final int result = counter.incrementAndGet();
+        if (result > end) {
+            return null;
+        }
+        return result;
+    }
+
+    @Override
+    public Serializable checkpointInfo() throws Exception {
+        return counter.get();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/CountingItemWriter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/CountingItemWriter.java
@@ -1,0 +1,69 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.chunk;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.batch.api.BatchProperty;
+import javax.batch.api.chunk.ItemWriter;
+import javax.inject.Inject;
+import javax.inject.Named;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@Named
+public class CountingItemWriter implements ItemWriter {
+
+    static final List<Object> WRITTEN_ITEMS = Collections.synchronizedList(new ArrayList<>());
+
+    @Inject
+    @BatchProperty(name = "writer.sleep.time")
+    private long sleep;
+
+    @Override
+    public void open(final Serializable checkpoint) throws Exception {
+    }
+
+    @Override
+    public void close() throws Exception {
+    }
+
+    @Override
+    public void writeItems(final List<Object> items) throws Exception {
+        WRITTEN_ITEMS.addAll(items);
+        if (sleep > 0) {
+            TimeUnit.MILLISECONDS.sleep(sleep);
+        }
+    }
+
+    @Override
+    public Serializable checkpointInfo() throws Exception {
+        synchronized (WRITTEN_ITEMS) {
+            return new ArrayList<>(WRITTEN_ITEMS);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/chunk-suspend.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/chunk/chunk-suspend.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,26 +22,20 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.wildfly.jberet">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
-    <resources>
-        <artifact name="${org.wildfly:wildfly-jberet}"/>
-    </resources>
-
-    <dependencies>
-        <module name="javax.api"/>
-        <module name="javaee.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="org.jberet.jberet-core" services="import"/>
-        <module name="org.jboss.as.ee"/>
-        <module name="org.jboss.as.naming"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.msc"/>
-        <module name="org.picketbox"/>
-        <module name="org.wildfly.extension.request-controller"/>
-        <module name="org.wildfly.security.manager"/>
-    </dependencies>
-</module>
+<job id="chunkPartition" xmlns="http://xmlns.jcp.org/xml/ns/javaee" version="1.0">
+    <step id="step1">
+        <chunk item-count="3">
+            <reader ref="countingItemReader">
+                <properties>
+                    <property name="reader.start" value="#{jobParameters['reader.start']}"/>
+                    <property name="reader.end" value="#{jobParameters['reader.end']}"/>
+                </properties>
+            </reader>
+            <writer ref="countingItemWriter">
+                <properties>
+                    <property name="writer.sleep.time" value="#{jobParameters['writer.sleep.time']}"/>
+                </properties>
+            </writer>
+        </chunk>
+    </step>
+</job>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
@@ -69,6 +69,22 @@ public abstract class AbstractBatchTestCase {
                                 .exportAsString()));
     }
 
+
+    public static WebArchive createDefaultWar(final String warName, final Package pkg, final String... jobXmls) {
+        final WebArchive deployment = ShrinkWrap.create(WebArchive.class, warName)
+                .addPackage(AbstractBatchTestCase.class.getPackage())
+                .addClasses(TimeoutUtil.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .setManifest(new StringAsset(
+                        Descriptors.create(ManifestDescriptor.class)
+                                .attribute("Dependencies", "org.jboss.msc,org.wildfly.security.manager")
+                                .exportAsString()));
+        for (String jobXml : jobXmls) {
+            deployment.addAsWebInfResource(pkg, jobXml, "classes/META-INF/batch-jobs/" + jobXml);
+        }
+        return deployment;
+    }
+
     protected static String performCall(final String url) throws ExecutionException, IOException, TimeoutException {
         return HttpRequest.get(url, 10, TimeUnit.MINUTES); // TODO (jrp) way to long only set for debugging
     }


### PR DESCRIPTION
The two methods in the `WildFlyBatchEnvironment` that now throw `UnsupportedOperationsException` are removed in the upstream JBeret. They're not used anywhere and neither is the `Future` result from the other `submit` method.

The `JobOperator.start()`, `JobOperator.stop()`, `JobOperator.abandon()` and `JobOperator.restart()` might need to do something if the server is suspended as it could attempt to access stuff like JDBC. The only way this should happen though is if a user uses unconventional means of launching a job. Most jobs are should be started through an endpoint like a servlet or in a scheduled EJB. 
