### PR TITLE
WFLY-4485 Don't Expose JDT Compiler to Web Applications

### DIFF
--- a/web-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/jdt/ecj/main/module.xml
+++ b/web-feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/jdt/ecj/main/module.xml
@@ -22,21 +22,9 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="io.undertow.jsp">
+<module xmlns="urn:jboss:module:1.3" name="org.eclipse.jdt.ecj">
     <resources>
-        <artifact name="${io.undertow.jastow:jastow}"/>
+        <artifact name="${org.eclipse.jdt.core.compiler:ecj}"/>
     </resources>
 
-    <dependencies>
-        <module name="javax.api"/>
-        <module name="sun.jdk"/>
-        <module name="javax.servlet.api"/>
-        <module name="javax.servlet.jsp.api"/>
-        <module name="javax.servlet.jstl.api"/>
-        <module name="org.jboss.logging"/>
-        <module name="io.undertow.core" />
-        <module name="io.undertow.servlet" />
-        <module name="org.jboss.xnio"/>
-        <module name="org.eclipse.jdt.ecj"/>
-    </dependencies>
 </module>


### PR DESCRIPTION
Move the Eclipse JDT compiler to it's own module so that it's no longer
visible to web applications.

Issue: WFLY-4485
https://issues.jboss.org/browse/WFLY-4485
