### PR TITLE
[EJB 3.2] Test for MDB with a no-method message listener

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/NoMethodMessageListener.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/NoMethodMessageListener.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface;
+
+/**
+ * @author Jan Martiska
+ */
+public interface NoMethodMessageListener {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/NoMethodMessageListenerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/NoMethodMessageListenerTestCase.java
@@ -1,0 +1,98 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface;
+
+import java.util.concurrent.TimeUnit;
+import javax.ejb.EJB;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * EJB 3.2 5.4.3:
+ * A message-driven bean is permitted to implement a listener interface with no methods. A bean that
+ * implements a no-methods interface, exposes all non-static public methods of the bean class and
+ * of any superclasses except java.lang.Object as message listener methods.
+ * In this case, when requested by a resource adapter, the container provides a proxy which implements the
+ * message listener interface and all message listener methods of the bean. A resource adapter may use the
+ * Reflection API to invoke a message listener method on such a proxy.
+ *
+ * @author Jan Martiska
+ */
+@RunWith(Arquillian.class)
+public class NoMethodMessageListenerTestCase {
+
+    public static final String EAR_NAME = "no-method-message-listener-test";
+    private static final String RAR_NAME = "resource-adapter";
+    private static final String EJB_JAR_NAME = "message-driven-bean";
+    private static final String LIB_JAR_NAME = "common";
+
+    @EJB
+    private ReceivedMessageTracker tracker;
+
+
+    @Deployment
+    public static Archive createDeployment() {
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_NAME + ".ear");
+
+        final JavaArchive rar = ShrinkWrap.create(JavaArchive.class, RAR_NAME + ".rar");
+        rar.addAsManifestResource(NoMethodMessageListenerTestCase.class.getPackage(), "ra.xml", "ra.xml");
+
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, EJB_JAR_NAME + ".jar");
+        ejbJar.addClasses(SimpleMessageDrivenBean.class, NoMethodMessageListenerTestCase.class,
+                ReceivedMessageTracker.class);
+
+        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, LIB_JAR_NAME + ".jar");
+        libJar.addClasses(SimpleActivationSpec.class, SimpleResourceAdapter.class,
+                NoMethodMessageListener.class, TimeoutUtil.class);
+
+        ear.addAsModule(rar);
+        ear.addAsModule(ejbJar);
+        ear.addAsLibrary(libJar);
+
+        return ear;
+    }
+
+    /**
+     * The resource adapter is programmed to send a message to the MDB right after the MDB endpoint is activated.
+     * Therefore, no actions except deploying the EAR are needed.
+     *
+     * @throws InterruptedException
+     */
+    @Test
+    public void doTest() throws InterruptedException {
+        boolean receivedSuccessfully = tracker.getReceivedLatch()
+                .await(TimeoutUtil.adjust(30), TimeUnit.SECONDS);
+        Assert.assertTrue("Message was not received within reasonable timeout", receivedSuccessfully);
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/ReceivedMessageTracker.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/ReceivedMessageTracker.java
@@ -1,0 +1,46 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface;
+
+import java.util.concurrent.CountDownLatch;
+import javax.annotation.PostConstruct;
+import javax.ejb.Singleton;
+
+/**
+ * @author Jan Martiska
+ */
+@Singleton
+public class ReceivedMessageTracker {
+
+    private CountDownLatch received;
+
+    @PostConstruct
+    public void init() {
+        received = new CountDownLatch(1);
+    }
+
+    public CountDownLatch getReceivedLatch() {
+        return received;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/SimpleActivationSpec.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/SimpleActivationSpec.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.InvalidPropertyException;
+import javax.resource.spi.ResourceAdapter;
+
+/**
+ * @author Jan Martiska
+ */
+public class SimpleActivationSpec implements ActivationSpec {
+
+    private ResourceAdapter ra;
+
+    // The message listener method. The RA will access this method via reflection.
+    private String methodName;
+
+    @Override
+    public void validate() throws InvalidPropertyException {
+        if (methodName == null) {
+            throw new InvalidPropertyException("methodName property needs to be specified ");
+        }
+    }
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        return this.ra;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter resourceAdapter) throws ResourceException {
+        this.ra = resourceAdapter;
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public void setMethodName(String methodName) {
+        this.methodName = methodName;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/SimpleMessageDrivenBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/SimpleMessageDrivenBean.java
@@ -1,0 +1,52 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface;
+
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.EJB;
+import javax.ejb.MessageDriven;
+
+import org.jboss.ejb3.annotation.ResourceAdapter;
+import org.jboss.logging.Logger;
+
+/**
+ * @author Jan Martiska
+ */
+@MessageDriven(
+        messageListenerInterface = NoMethodMessageListener.class,
+        activationConfig = @ActivationConfigProperty(propertyName = "methodName", propertyValue = "handleMessage")
+)
+@ResourceAdapter("no-method-message-listener-test.ear#resource-adapter.rar")
+public class SimpleMessageDrivenBean implements NoMethodMessageListener {
+
+    @EJB
+    private ReceivedMessageTracker tracker;
+
+    private Logger logger = Logger.getLogger(SimpleMessageDrivenBean.class);
+
+    public void handleMessage(String message) {
+        logger.info("SimpleMessageDriven bean received message: " + message);
+        tracker.getReceivedLatch().countDown();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/SimpleResourceAdapter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/SimpleResourceAdapter.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface;
+
+import java.lang.reflect.Method;
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpoint;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.transaction.xa.XAResource;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Jan Martiska
+ */
+public class SimpleResourceAdapter implements ResourceAdapter {
+
+    private MessageEndpoint endpoint;
+
+    private Logger log = Logger.getLogger(SimpleResourceAdapter.class);
+
+    @Override
+    public void start(BootstrapContext bootstrapContext) throws ResourceAdapterInternalException {
+        log.info("SimpleResourceAdapter started");
+    }
+
+    @Override
+    public void stop() {
+        log.info("SimpleResourceAdapter stopped");
+    }
+
+    /**
+     * Send a message to the MDB right after the MDB endpoint is activated.
+     * Using reflection to pick a method to invoke - see EJB 3.2 spec section 5.4.3
+     */
+    @Override
+    public void endpointActivation(MessageEndpointFactory messageEndpointFactory,
+                                   ActivationSpec activationSpec) throws ResourceException {
+        log.info("SimpleResourceAdapter activating MDB endpoint and sending a message to it");
+        Class<?> endpointClass = messageEndpointFactory.getEndpointClass();
+        try {
+            Method methodToInvoke = endpointClass.getMethod(((SimpleActivationSpec)activationSpec).getMethodName(), String.class);
+            MessageEndpoint endpoint = messageEndpointFactory.createEndpoint(null);
+            this.endpoint = endpoint;
+            methodToInvoke.invoke(endpoint, "Hello world");
+        } catch (Exception e) {
+            throw new ResourceException(e);
+        }
+    }
+
+    @Override
+    public void endpointDeactivation(MessageEndpointFactory messageEndpointFactory,
+                                     ActivationSpec activationSpec) {
+        log.info("SimpleResourceAdapter deactivating MDB endpoint");
+        if (endpoint != null) {
+            endpoint.release();
+            endpoint = null;
+        }
+    }
+
+    @Override
+    public XAResource[] getXAResources(ActivationSpec[] activationSpecs) throws ResourceException {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SimpleResourceAdapter)) {
+            return false;
+        }
+
+        SimpleResourceAdapter that = (SimpleResourceAdapter)o;
+
+        return !(endpoint != null ? !endpoint.equals(that.endpoint) : that.endpoint != null);
+
+    }
+
+    @Override
+    public int hashCode() {
+        return endpoint != null ? endpoint.hashCode() : 0;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/ra.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/ra.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://java.sun.com/xml/ns/j2ee"
+           version="1.5">
+    <display-name>EIS Connector</display-name>
+    <vendor-name>My Component</vendor-name>
+    <eis-type>My Remote Server</eis-type>
+    <resourceadapter-version>1.0</resourceadapter-version>
+    <resourceadapter>
+        <resourceadapter-class>
+            org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface.SimpleResourceAdapter
+        </resourceadapter-class>
+        <inbound-resourceadapter>
+            <messageadapter>
+                <messagelistener>
+                    <messagelistener-type>
+                        org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface.NoMethodMessageListener
+                    </messagelistener-type>
+                    <activationspec>
+                        <activationspec-class>
+                            org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface.SimpleActivationSpec
+                        </activationspec-class>
+                    </activationspec>
+                </messagelistener>
+            </messageadapter>
+        </inbound-resourceadapter>
+    </resourceadapter>
+</connector>


### PR DESCRIPTION
EJB 3.2 section 5.4.3:
A message-driven bean is permitted to implement a listener interface with no methods. A bean that
implements a no-methods interface, exposes all non-static public methods of the bean class and
of any superclasses except java.lang.Object as message listener methods.
In this case, when requested by a resource adapter, the container provides a proxy which implements the message listener interface and all message listener methods of the bean. A resource adapter may use the Reflection API to invoke a message listener method on such a proxy.

This PR adds a testcase for this behavior.
