### PR TITLE
WFLY-4493 UrlScanner does not close ZipFiles

### DIFF
--- a/weld/src/main/java/org/jboss/as/weld/deployment/UrlScanner.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/UrlScanner.java
@@ -117,14 +117,14 @@ public class UrlScanner {
         try {
             WeldLogger.DEPLOYMENT_LOGGER.trace("archive: " + file);
 
-            String archiveUrl = "jar:" + file.toURI().toURL().toExternalForm() + "!/";
-            ZipFile zip = new ZipFile(file);
-            Enumeration<? extends ZipEntry> entries = zip.entries();
+            try (ZipFile zip = new ZipFile(file)) {
+                Enumeration<? extends ZipEntry> entries = zip.entries();
 
-            while (entries.hasMoreElements()) {
-                ZipEntry entry = entries.nextElement();
-                String name = entry.getName();
-                handleFile(name, discoveredClasses);
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    String name = entry.getName();
+                    handleFile(name, discoveredClasses);
+                }
             }
         } catch (ZipException e) {
             throw new RuntimeException("Error handling file " + file, e);


### PR DESCRIPTION
The UrlScanner class creates ZipFile instances without invoking #close
on them. This is not as bad as it sounds because ZipFile does have a
finalizer but it's still suboptimal.

I did use Java 7 try-with-resources. Let me know if this is an issue.

Issue: WFLY-4493
https://issues.jboss.org/browse/WFLY-4493
