### PR TITLE
[WFLY-4464] JDBC driver module-slot is not persisted in domain mode

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesExtension.java
@@ -65,6 +65,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.INTERLEAVI
 import static org.jboss.as.connector.subsystems.datasources.Constants.JDBC_DRIVER_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
+import static org.jboss.as.connector.subsystems.datasources.Constants.MODULE_SLOT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.NEW_CONNECTION_SQL;
 import static org.jboss.as.connector.subsystems.datasources.Constants.NO_RECOVERY;
 import static org.jboss.as.connector.subsystems.datasources.Constants.NO_TX_SEPARATE_POOL;
@@ -225,7 +226,13 @@ public class DataSourcesExtension implements Extension {
                 for (Property driverProperty : node.get(JDBC_DRIVER_NAME).asPropertyList()) {
                     writer.writeStartElement(DataSources.Tag.DRIVER.getLocalName());
                     writer.writeAttribute(Driver.Attribute.NAME.getLocalName(), driverProperty.getValue().require(DRIVER_NAME.getName()).asString());
-                    writeAttributeIfHas(writer, driverProperty.getValue(), Driver.Attribute.MODULE, DRIVER_MODULE_NAME.getName());
+                    if (has(driverProperty.getValue(), DRIVER_MODULE_NAME.getName())) {
+                        String moduleName = driverProperty.getValue().get(DRIVER_MODULE_NAME.getName()).asString();
+                        if (has(driverProperty.getValue(), MODULE_SLOT.getName())) {
+                            moduleName = moduleName + ":" + driverProperty.getValue().get(MODULE_SLOT.getName()).asString();
+                        }
+                        writer.writeAttribute(Driver.Attribute.MODULE.getLocalName(), moduleName);
+                    }
                     writeAttributeIfHas(writer, driverProperty.getValue(), Driver.Attribute.MAJOR_VERSION, DRIVER_MAJOR_VERSION.getName());
                     writeAttributeIfHas(writer, driverProperty.getValue(), Driver.Attribute.MINOR_VERSION, DRIVER_MINOR_VERSION.getName());
                     writeElementIfHas(writer, driverProperty.getValue(), Driver.Tag.DRIVER_CLASS.getLocalName(), DRIVER_CLASS_NAME.getName());

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DsParser.java
@@ -66,6 +66,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.INTERLEAVI
 import static org.jboss.as.connector.subsystems.datasources.Constants.JDBC_DRIVER_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JTA;
+import static org.jboss.as.connector.subsystems.datasources.Constants.MODULE_SLOT;
 import static org.jboss.as.connector.subsystems.datasources.Constants.NEW_CONNECTION_SQL;
 import static org.jboss.as.connector.subsystems.datasources.Constants.NO_RECOVERY;
 import static org.jboss.as.connector.subsystems.datasources.Constants.NO_TX_SEPARATE_POOL;
@@ -669,8 +670,16 @@ public class DsParser extends AbstractParser {
                     break;
                 }
                 case MODULE: {
-                    String value = rawAttributeText(reader, DRIVER_MODULE_NAME.getXmlName());
-                    DRIVER_MODULE_NAME.parseAndSetParameter(value, operation, reader);
+                    String moduleName = rawAttributeText(reader, DRIVER_MODULE_NAME.getXmlName());
+                    String slot = null;
+                    if (moduleName.contains(":")) {
+                        slot = moduleName.substring(moduleName.indexOf(":") + 1);
+                        moduleName = moduleName.substring(0, moduleName.indexOf(":"));
+                    }
+                    DRIVER_MODULE_NAME.parseAndSetParameter(moduleName, operation, reader);
+                    if (slot != null) {
+                        MODULE_SLOT.parseAndSetParameter(slot, operation, reader);
+                    }
                     break;
                 }
                 default:

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
@@ -81,12 +81,12 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
         if (operation.get(DRIVER_NAME.getName()).isDefined() && !driverName.equals(operation.get(DRIVER_NAME.getName()).asString())) {
             throw ConnectorLogger.ROOT_LOGGER.driverNameAndResourceNameNotEquals(operation.get(DRIVER_NAME.getName()).asString(), driverName);
         }
-        String moduleName = DRIVER_MODULE_NAME.resolveModelAttribute(context, operation).asString();
-        final Integer majorVersion = operation.hasDefined(DRIVER_MAJOR_VERSION.getName()) ? DRIVER_MAJOR_VERSION.resolveModelAttribute(context, operation).asInt() : null;
-        final Integer minorVersion = operation.hasDefined(DRIVER_MINOR_VERSION.getName()) ? DRIVER_MINOR_VERSION.resolveModelAttribute(context, operation).asInt() : null;
-        final String driverClassName = operation.hasDefined(DRIVER_CLASS_NAME.getName()) ? DRIVER_CLASS_NAME.resolveModelAttribute(context, operation).asString() : null;
-        final String dataSourceClassName = operation.hasDefined(DRIVER_DATASOURCE_CLASS_NAME.getName()) ? DRIVER_DATASOURCE_CLASS_NAME.resolveModelAttribute(context, operation).asString() : null;
-        final String xaDataSourceClassName = operation.hasDefined(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()) ? DRIVER_XA_DATASOURCE_CLASS_NAME.resolveModelAttribute(context, operation).asString() : null;
+        String moduleName = DRIVER_MODULE_NAME.resolveModelAttribute(context, model).asString();
+        final Integer majorVersion = model.hasDefined(DRIVER_MAJOR_VERSION.getName()) ? DRIVER_MAJOR_VERSION.resolveModelAttribute(context, model).asInt() : null;
+        final Integer minorVersion = model.hasDefined(DRIVER_MINOR_VERSION.getName()) ? DRIVER_MINOR_VERSION.resolveModelAttribute(context, model).asInt() : null;
+        final String driverClassName = model.hasDefined(DRIVER_CLASS_NAME.getName()) ? DRIVER_CLASS_NAME.resolveModelAttribute(context, model).asString() : null;
+        final String dataSourceClassName = model.hasDefined(DRIVER_DATASOURCE_CLASS_NAME.getName()) ? DRIVER_DATASOURCE_CLASS_NAME.resolveModelAttribute(context, model).asString() : null;
+        final String xaDataSourceClassName = model.hasDefined(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()) ? DRIVER_XA_DATASOURCE_CLASS_NAME.resolveModelAttribute(context, model).asString() : null;
 
         Resource rootNode = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
         ModelNode rootModel = rootNode.getModel();
@@ -96,15 +96,7 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
 
         final ModuleIdentifier moduleId;
         final Module module;
-        String slot = operation.hasDefined(MODULE_SLOT.getName()) ? MODULE_SLOT.resolveModelAttribute(context, operation).asString() : null;
-        if (moduleName.contains(":")) {
-            slot = moduleName.substring(moduleName.indexOf(":") + 1);
-            moduleName = moduleName.substring(0, moduleName.indexOf(":"));
-        } else {
-            if (slot != null) {
-                model.get(DRIVER_MODULE_NAME.getName()).set(moduleName + ":" + slot);
-            }
-        }
+        String slot = model.hasDefined(MODULE_SLOT.getName()) ? MODULE_SLOT.resolveModelAttribute(context, model).asString() : null;
 
         try {
             moduleId = ModuleIdentifier.create(moduleName, slot);

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/ComplexDatasourceSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/complextestcases/ComplexDatasourceSubsystemTestCase.java
@@ -69,4 +69,18 @@ public class ComplexDatasourceSubsystemTestCase extends AbstractComplexSubsystem
 
 
     }
+
+    @Test
+    public void testJDBCDriver() throws Exception{
+        ModelNode model = getModel("datasource.xml",false,null);
+        ModelNode h2MainModuleDriver = model.get("subsystem", "datasources", "jdbc-driver", "h2");
+        ModelNode h2TestModuleDriver = model.get("subsystem", "datasources", "jdbc-driver", "h2test");
+        Assert.assertEquals(h2MainModuleDriver.asString(),"com.h2database.h2",h2MainModuleDriver.get("driver-module-name").asString());
+        Assert.assertEquals(h2MainModuleDriver.asString(),"org.h2.jdbcx.JdbcDataSource",h2MainModuleDriver.get("driver-xa-datasource-class-name").asString());
+        Assert.assertFalse(h2MainModuleDriver.get("module-slot").isDefined());
+
+        Assert.assertEquals(h2TestModuleDriver.asString(),"com.h2database.h2",h2TestModuleDriver.get("driver-module-name").asString());
+        Assert.assertEquals(h2TestModuleDriver.asString(),"org.h2.jdbcx.JdbcDataSource",h2TestModuleDriver.get("driver-xa-datasource-class-name").asString());
+        Assert.assertEquals(h2TestModuleDriver.asString(),"test",h2TestModuleDriver.get("module-slot").asString());
+    }
 }

--- a/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/datasource.xml
+++ b/connector/src/test/resources/org/jboss/as/connector/subsystems/complextestcases/datasource.xml
@@ -243,6 +243,11 @@
                             org.h2.jdbcx.JdbcDataSource
                         </xa-datasource-class>
                     </driver>
+                    <driver name="h2test" module="com.h2database.h2:test">
+                        <xa-datasource-class>
+                            org.h2.jdbcx.JdbcDataSource
+                        </xa-datasource-class>
+                    </driver>
                 </drivers>
             </datasources>
         </subsystem>


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-4464

Forum discussion: https://developer.jboss.org/thread/253654

Fixed by checking whether "module_slot" is defined on writing, and whether "driver_module_name" has ":" which separates the module name and module slot on reading.
