### PR TITLE
WFLY-4497 Fix Compiler Warnings in JPA Subsystem

### DIFF
--- a/jpa/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -286,7 +286,7 @@ public class Configuration {
      * @param properties
      * @return
      */
-    public static boolean deferEntityDetachUntilClose(final Map properties) {
+    public static boolean deferEntityDetachUntilClose(final Map<String, Object> properties) {
         boolean result = false;
         if ( properties.containsKey(JPA_DEFER_DETACH))
             result = Boolean.parseBoolean((String)properties.get(JPA_DEFER_DETACH));

--- a/jpa/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/config/PersistenceUnitMetadataImpl.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -313,7 +314,7 @@ public class PersistenceUnitMetadataImpl implements PersistenceUnitMetadata {
         sb.append("\tproperties[\n");
 
         if (props != null) {
-            for (Map.Entry elt : props.entrySet()) {
+            for (Entry<Object, Object> elt : props.entrySet()) {
                 sb.append("\t\t").append(elt.getKey()).append(": ").append(elt.getValue()).append("\n");
             }
         }

--- a/jpa/src/main/java/org/jboss/as/jpa/container/AbstractEntityManager.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/container/AbstractEntityManager.java
@@ -525,9 +525,6 @@ public abstract class AbstractEntityManager implements EntityManager {
     }
 
     public boolean isOpen() {
-        long start = 0;
-        if (isTraceEnabled)
-            start = System.currentTimeMillis();
         return getEntityManager().isOpen();
     }
 
@@ -854,9 +851,9 @@ public abstract class AbstractEntityManager implements EntityManager {
 
     // for JPA 2.0 section 3.8.6
     // used by TransactionScopedEntityManager to detach entities loaded by a query in a non-jta invocation.
-    protected TypedQuery detachTypedQueryNonTxInvocation(EntityManager underlyingEntityManager, TypedQuery underLyingQuery) {
+    protected <T> TypedQuery<T> detachTypedQueryNonTxInvocation(EntityManager underlyingEntityManager, TypedQuery<T> underLyingQuery) {
         if (!this.isExtendedPersistenceContext() && !this.isInTx()) {
-            return new TypedQueryNonTxInvocationDetacher(underlyingEntityManager, underLyingQuery);
+            return new TypedQueryNonTxInvocationDetacher<>(underlyingEntityManager, underLyingQuery);
         }
         return underLyingQuery;
     }

--- a/jpa/src/main/java/org/jboss/as/jpa/container/EntityManagerUnwrappedTargetInvocationHandler.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/container/EntityManagerUnwrappedTargetInvocationHandler.java
@@ -40,14 +40,14 @@ public class EntityManagerUnwrappedTargetInvocationHandler implements Invocation
 
     private static final long serialVersionUID = 5254527687L;
 
-    private Class wrappedClass;
+    private Class<?> wrappedClass;
     private EntityManager targetEntityManager;
 
     public EntityManagerUnwrappedTargetInvocationHandler() {
 
     }
 
-    public EntityManagerUnwrappedTargetInvocationHandler(EntityManager targetEntityManager, Class wrappedClass) {
+    public EntityManagerUnwrappedTargetInvocationHandler(EntityManager targetEntityManager, Class<?> wrappedClass) {
         this.targetEntityManager = targetEntityManager;
         this.wrappedClass = wrappedClass;
     }

--- a/jpa/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.jpa.container;
 
+import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.security.AccessController;
@@ -39,8 +41,6 @@ import org.jboss.as.jpa.util.JPAServiceNames;
 import org.jboss.as.server.CurrentServiceContainer;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
-
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
 
 /**
  * Transaction scoped entity manager will be injected into SLSB or SFSB beans.  At bean invocation time, they

--- a/jpa/src/main/java/org/jboss/as/jpa/container/TypedQueryNonTxInvocationDetacher.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/container/TypedQueryNonTxInvocationDetacher.java
@@ -45,10 +45,10 @@ import javax.persistence.TypedQuery;
  */
 public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
 
-    private final TypedQuery underlyingQuery;
+    private final TypedQuery<X> underlyingQuery;
     private final EntityManager underlyingEntityManager;
 
-    TypedQueryNonTxInvocationDetacher(EntityManager underlyingEntityManager, TypedQuery underlyingQuery) {
+    TypedQueryNonTxInvocationDetacher(EntityManager underlyingEntityManager, TypedQuery<X> underlyingQuery) {
         this.underlyingQuery = underlyingQuery;
         this.underlyingEntityManager = underlyingEntityManager;
     }
@@ -81,7 +81,7 @@ public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
     }
 
     @Override
-    public TypedQuery setMaxResults(int maxResult) {
+    public TypedQuery<X> setMaxResults(int maxResult) {
         underlyingQuery.setMaxResults(maxResult);
         return this;
     }
@@ -92,7 +92,7 @@ public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
     }
 
     @Override
-    public TypedQuery setFirstResult(int startPosition) {
+    public TypedQuery<X> setFirstResult(int startPosition) {
         underlyingQuery.setFirstResult(startPosition);
         return this;
     }
@@ -103,7 +103,7 @@ public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
     }
 
     @Override
-    public TypedQuery setHint(String hintName, Object value) {
+    public TypedQuery<X> setHint(String hintName, Object value) {
         underlyingQuery.setHint(hintName, value);
         return this;
     }
@@ -131,37 +131,37 @@ public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
         return underlyingQuery.getHints();
     }
     @Override
-    public TypedQuery setParameter(String name, Object value) {
+    public TypedQuery<X> setParameter(String name, Object value) {
         underlyingQuery.setParameter(name, value);
         return this;
     }
 
     @Override
-    public TypedQuery setParameter(String name, Calendar value, TemporalType temporalType) {
+    public TypedQuery<X> setParameter(String name, Calendar value, TemporalType temporalType) {
         underlyingQuery.setParameter(name, value, temporalType);
         return this;
     }
 
     @Override
-    public TypedQuery setParameter(String name, Date value, TemporalType temporalType) {
+    public TypedQuery<X> setParameter(String name, Date value, TemporalType temporalType) {
         underlyingQuery.setParameter(name, value, temporalType);
         return this;
     }
 
     @Override
-    public TypedQuery setParameter(int position, Object value) {
+    public TypedQuery<X> setParameter(int position, Object value) {
         underlyingQuery.setParameter(position, value);
         return this;
     }
 
     @Override
-    public TypedQuery setParameter(int position, Calendar value, TemporalType temporalType) {
+    public TypedQuery<X> setParameter(int position, Calendar value, TemporalType temporalType) {
         underlyingQuery.setParameter(position, value, temporalType);
         return this;
     }
 
     @Override
-    public TypedQuery setParameter(int position, Date value, TemporalType temporalType) {
+    public TypedQuery<X> setParameter(int position, Date value, TemporalType temporalType) {
         underlyingQuery.setParameter(position, value, temporalType);
         return this;
     }
@@ -212,7 +212,7 @@ public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
     }
 
     @Override
-    public TypedQuery setFlushMode(FlushModeType flushMode) {
+    public TypedQuery<X> setFlushMode(FlushModeType flushMode) {
         underlyingQuery.setFlushMode(flushMode);
         return this;
     }
@@ -223,7 +223,7 @@ public class TypedQueryNonTxInvocationDetacher<X> implements TypedQuery<X> {
     }
 
     @Override
-    public TypedQuery setLockMode(LockModeType lockMode) {
+    public TypedQuery<X> setLockMode(LockModeType lockMode) {
         underlyingQuery.setLockMode(lockMode);
         return this;
     }

--- a/jpa/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.jpa.injectors;
 
+import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+
 import java.lang.reflect.Proxy;
 import java.util.Map;
 
@@ -53,8 +55,6 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceRegistry;
 import org.jboss.msc.value.ImmediateValue;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
-
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
 
 /**
  * Represents the PersistenceContext injected into a component.
@@ -208,7 +208,7 @@ public class PersistenceContextInjectionSource extends InjectionSource {
                  * To accomplish this, we will create an instance of the (underlying provider's) entity manager and
                  * invoke the EntityManager.unwrap(TargetInjectionClass).
                  */
-                Class extensionClass;
+                Class<?> extensionClass;
                 try {
                     // provider classes should be on application classpath
                     extensionClass = pu.getClassLoader().loadClass(injectionTypeName);
@@ -219,11 +219,11 @@ public class PersistenceContextInjectionSource extends InjectionSource {
                 Object targetValueToInject = entityManager.unwrap(extensionClass);
 
                 // build array of classes that proxy will represent.
-                Class[] targetInterfaces = targetValueToInject.getClass().getInterfaces();
-                Class[] proxyInterfaces = new Class[targetInterfaces.length + 1];  // include extra element for extensionClass
+                Class<?>[] targetInterfaces = targetValueToInject.getClass().getInterfaces();
+                Class<?>[] proxyInterfaces = new Class[targetInterfaces.length + 1];  // include extra element for extensionClass
                 boolean alreadyHasInterfaceClass = false;
                 for (int interfaceIndex = 0; interfaceIndex < targetInterfaces.length; interfaceIndex++) {
-                    Class interfaceClass =  targetInterfaces[interfaceIndex];
+                    Class<?> interfaceClass =  targetInterfaces[interfaceIndex];
                     if (interfaceClass.equals(extensionClass)) {
                         proxyInterfaces = targetInterfaces;                     // targetInterfaces already has all interfaces
                         alreadyHasInterfaceClass = true;

--- a/jpa/src/main/java/org/jboss/as/jpa/injectors/PersistenceUnitInjectionSource.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/injectors/PersistenceUnitInjectionSource.java
@@ -54,13 +54,11 @@ public class PersistenceUnitInjectionSource extends InjectionSource {
 
     private final PersistenceUnitJndiInjectable injectable;
     private final ServiceName puServiceName;
-    private final PersistenceUnitMetadata pu;
 
     public PersistenceUnitInjectionSource(final ServiceName puServiceName, final ServiceRegistry serviceRegistry, final String injectionTypeName, final PersistenceUnitMetadata pu) {
 
         injectable = new PersistenceUnitJndiInjectable(puServiceName, serviceRegistry, injectionTypeName, pu);
         this.puServiceName = puServiceName;
-        this.pu = pu;
     }
 
     public void getResourceValue(final ResolutionContext resolutionContext, final ServiceBuilder<?> serviceBuilder, final DeploymentPhaseContext phaseContext, final Injector<ManagedReferenceFactory> injector) throws
@@ -107,7 +105,7 @@ public class PersistenceUnitInjectionSource extends InjectionSource {
             EntityManagerFactory emf = service.getEntityManagerFactory();
 
             if (!ENTITY_MANAGER_FACTORY_CLASS.equals(injectionTypeName)) { // inject non-standard wrapped class (e.g. org.hibernate.SessionFactory)
-                Class extensionClass;
+                Class<?> extensionClass;
                 try {
                     // make sure we can access the target class type
                     extensionClass = pu.getClassLoader().loadClass(injectionTypeName);

--- a/jpa/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
@@ -169,7 +169,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
             JPA_LOGGER.unexpectedStatisticsProblem(e);
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 
@@ -190,7 +190,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
             JPA_LOGGER.unexpectedStatisticsProblem(e);
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
     }
 
@@ -211,7 +211,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
             JPA_LOGGER.unexpectedStatisticsProblem(e);
-            return Collections.EMPTY_SET;
+            return Collections.emptySet();
         }
 
     }

--- a/jpa/src/main/java/org/jboss/as/jpa/management/ManagementResourceDefinition.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/management/ManagementResourceDefinition.java
@@ -73,7 +73,7 @@ public class ManagementResourceDefinition extends SimpleResourceDefinition {
         this.descriptionResolver = descriptionResolver;
     }
 
-    private ModelType getModelType(Class type) {
+    private ModelType getModelType(Class<?> type) {
 
         if(Integer.class.equals(type)) {
             return ModelType.INT;

--- a/jpa/src/main/java/org/jboss/as/jpa/persistenceprovider/PersistenceProviderResolverImpl.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/persistenceprovider/PersistenceProviderResolverImpl.java
@@ -45,10 +45,9 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 public class PersistenceProviderResolverImpl implements PersistenceProviderResolver {
 
-    private Map<ClassLoader, List<Class>> persistenceProviderPerClassLoader =
-            new HashMap<ClassLoader, List<Class>>();
+    private Map<ClassLoader, List<Class<? extends PersistenceProvider>>> persistenceProviderPerClassLoader = new HashMap<>();
 
-    private List<Class> providers = new CopyOnWriteArrayList<Class>();
+    private List<Class<? extends PersistenceProvider>> providers = new CopyOnWriteArrayList<>();
 
     private static final PersistenceProviderResolverImpl INSTANCE = new PersistenceProviderResolverImpl();
 
@@ -66,7 +65,7 @@ public class PersistenceProviderResolverImpl implements PersistenceProviderResol
      */
     @Override
     public List<PersistenceProvider> getPersistenceProviders() {
-        List<PersistenceProvider> providersCopy = new ArrayList<PersistenceProvider>(providers.size());
+        List<PersistenceProvider> providersCopy = new ArrayList<>(providers.size());
 
         /**
          * Add the application specified providers first so they are found before the global providers
@@ -77,14 +76,14 @@ public class PersistenceProviderResolverImpl implements PersistenceProviderResol
                 ClassLoader deploymentClassLoader = findParentModuleCl(WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
                 ROOT_LOGGER.tracef("get application level Persistence Provider for classloader %s" , deploymentClassLoader);
                 // collect persistence providers associated with deployment/each sub-deployment
-                List<Class> deploymentSpecificPersistenceProviders = persistenceProviderPerClassLoader.get(deploymentClassLoader);
+                List<Class<? extends PersistenceProvider>> deploymentSpecificPersistenceProviders = persistenceProviderPerClassLoader.get(deploymentClassLoader);
                 ROOT_LOGGER.tracef("got application level Persistence Provider list %s" , deploymentSpecificPersistenceProviders);
                 if (deploymentSpecificPersistenceProviders != null) {
 
-                    for (Class providerClass : deploymentSpecificPersistenceProviders) {
+                    for (Class<? extends PersistenceProvider> providerClass : deploymentSpecificPersistenceProviders) {
                         try {
                             ROOT_LOGGER.tracef("application has its own Persistence Provider %s", providerClass.getName());
-                            providersCopy.add((PersistenceProvider) providerClass.newInstance());
+                            providersCopy.add(providerClass.newInstance());
                         } catch (InstantiationException e) {
                             throw JpaLogger.ROOT_LOGGER.couldNotCreateInstanceProvider(e, providerClass.getName());
                         } catch (IllegalAccessException e) {
@@ -96,7 +95,7 @@ public class PersistenceProviderResolverImpl implements PersistenceProviderResol
         }
 
         // add global persistence providers last (so application packaged providers have priority)
-        for (Class providerClass : providers) {
+        for (Class<?> providerClass : providers) {
             try {
                 providersCopy.add((PersistenceProvider) providerClass.newInstance());
                 ROOT_LOGGER.tracef("returning global (module) Persistence Provider %s", providerClass.getName());
@@ -139,10 +138,10 @@ public class PersistenceProviderResolverImpl implements PersistenceProviderResol
         synchronized(persistenceProviderPerClassLoader) {
 
             for (ClassLoader deploymentClassLoader: deploymentClassLoaders) {
-                List<Class> list = persistenceProviderPerClassLoader.get(deploymentClassLoader);
+                List<Class<? extends PersistenceProvider>> list = persistenceProviderPerClassLoader.get(deploymentClassLoader);
                 ROOT_LOGGER.tracef("getting persistence provider list (%s) for deployment (%s)", list, deploymentClassLoader );
                 if (list == null) {
-                    list = new ArrayList<Class>();
+                    list = new ArrayList<>();
                     persistenceProviderPerClassLoader.put(deploymentClassLoader, list);
                     ROOT_LOGGER.tracef("saving new persistence provider list (%s) for deployment (%s)", list, deploymentClassLoader );
                 }

--- a/jpa/src/main/java/org/jboss/as/jpa/platform/PlatformImpl.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/platform/PlatformImpl.java
@@ -44,14 +44,14 @@ public class PlatformImpl implements Platform {
 
     public PlatformImpl(Classification defaultCacheClassification, Classification... supportedClassifications) {
         this.defaultCacheClassification = defaultCacheClassification;
-        ArrayList<Classification> includedClassifications = new ArrayList();
+        ArrayList<Classification> includedClassifications = new ArrayList<>();
         for(Classification eachClassification:supportedClassifications) {
             includedClassifications.add(eachClassification);
         }
 
         this.cacheClassfications = includedClassifications.size() > 0 ?
                 EnumSet.copyOf(includedClassifications):
-                Collections.EMPTY_SET;
+                Collections.<Classification>emptySet();
     }
 
     @Override

--- a/jpa/src/main/java/org/jboss/as/jpa/processor/JPAAnnotationProcessor.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/processor/JPAAnnotationProcessor.java
@@ -313,11 +313,11 @@ public class JPAAnnotationProcessor implements DeploymentUnitProcessor {
                     (stType == null || SynchronizationType.SYNCHRONIZED.name().equals(stType.asString()))?
                             SynchronizationType.SYNCHRONIZED: SynchronizationType.UNSYNCHRONIZED;
 
-            Map properties;
+            Map<AnnotationValue, AnnotationValue> properties;
             AnnotationValue value = annotation.value("properties");
             AnnotationInstance[] props = value != null ? value.asNestedArray() : null;
             if (props != null) {
-                properties = new HashMap();
+                properties = new HashMap<>();
                 for (int source = 0; source < props.length; source++) {
                     properties.put(props[source].value("name"), props[source].value("value"));
                 }

--- a/jpa/src/main/java/org/jboss/as/jpa/processor/PersistenceRefProcessor.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/processor/PersistenceRefProcessor.java
@@ -176,7 +176,7 @@ public class PersistenceRefProcessor extends AbstractDeploymentDescriptorBinding
                         bindingConfiguration = new BindingConfiguration(name, new LookupInjectionSource(lookup));
                     } else {
                         PropertiesMetaData properties = puRef.getProperties();
-                        Map map = new HashMap();
+                        Map<String, String> map = new HashMap<>();
                         if (properties != null) {
                             for (PropertyMetaData prop : properties) {
                                 map.put(prop.getKey(), prop.getValue());

--- a/jpa/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -332,7 +332,7 @@ public class PersistenceUnitServiceHandler {
         pu.setClassLoader(classLoader);
         try {
             ValidatorFactory validatorFactory = null;
-            final HashMap<String, ValidatorFactory> properties = new HashMap();
+            final HashMap<String, ValidatorFactory> properties = new HashMap<>();
             if (!ValidationMode.NONE.equals(pu.getValidationMode())) {
                 // Get the CDI-enabled ValidatorFactory
                 validatorFactory = deploymentUnit.getAttachment(BeanValidationAttachments.VALIDATOR_FACTORY);
@@ -465,8 +465,7 @@ public class PersistenceUnitServiceHandler {
             final PersistenceProviderAdaptor adaptor) throws DeploymentUnitProcessingException {
         pu.setClassLoader(classLoader);
         try {
-            ValidatorFactory validatorFactory = null;
-            final HashMap<String, ValidatorFactory> properties = new HashMap();
+            final HashMap<String, ValidatorFactory> properties = new HashMap<>();
 
             ProxyBeanManager proxyBeanManager = null;
             // JPA 2.1 sections 3.5.1 + 9.1 require the CDI bean manager to be passed to the peristence provider
@@ -589,7 +588,7 @@ public class PersistenceUnitServiceHandler {
         pu.setClassLoader(classLoader);
         try {
             ValidatorFactory validatorFactory = null;
-            final HashMap<String, ValidatorFactory> properties = new HashMap();
+            final HashMap<String, ValidatorFactory> properties = new HashMap<>();
             if (!ValidationMode.NONE.equals(pu.getValidationMode())) {
                 // Get the CDI-enabled ValidatorFactory
                 validatorFactory = deploymentUnit.getAttachment(BeanValidationAttachments.VALIDATOR_FACTORY);
@@ -784,7 +783,7 @@ public class PersistenceUnitServiceHandler {
             final PersistenceUnitMetadataHolder puHolder,
             DeploymentUnit deploymentUnit ) {
 
-        final Map<URL, Index> annotationIndexes = new HashMap();
+        final Map<URL, Index> annotationIndexes = new HashMap<>();
 
         do {
             for (ResourceRoot root : DeploymentUtils.allResourceRoots(deploymentUnit)) {
@@ -919,7 +918,7 @@ public class PersistenceUnitServiceHandler {
         synchronized (deploymentUnit) {
             Map<String,PersistenceProviderAdaptor> map = deploymentUnit.getAttachment(providerAdaptorMapKey);
             if( map == null) {
-                map = new HashMap();
+                map = new HashMap<>();
                 deploymentUnit.putAttachment(providerAdaptorMapKey, map);
             }
             String key;

--- a/jpa/src/main/java/org/jboss/as/jpa/processor/secondLevelCache/CacheDeploymentListener.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/processor/secondLevelCache/CacheDeploymentListener.java
@@ -38,7 +38,7 @@ import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
  */
 public class CacheDeploymentListener implements EventListener {
 
-    private static final ThreadLocal<ServiceBuilder> SERVICEBUILDER_TLS = new ThreadLocal<ServiceBuilder>();
+    private static final ThreadLocal<ServiceBuilder<?>> SERVICEBUILDER_TLS = new ThreadLocal<>();
 
     HashMap<String,EventListener> delegates = new HashMap<String,EventListener>();
 
@@ -46,7 +46,7 @@ public class CacheDeploymentListener implements EventListener {
         delegates.put(Classification.INFINISPAN.getLocalName(), new InfinispanCacheDeploymentListener());
     }
 
-    public static void setInternalDeploymentServiceBuilder(ServiceBuilder serviceBuilder) {
+    public static void setInternalDeploymentServiceBuilder(ServiceBuilder<?> serviceBuilder) {
         SERVICEBUILDER_TLS.set(serviceBuilder);
     }
 
@@ -54,7 +54,7 @@ public class CacheDeploymentListener implements EventListener {
         SERVICEBUILDER_TLS.remove();
     }
 
-    public static ServiceBuilder getInternalDeploymentServiceBuilder() {
+    public static ServiceBuilder<?> getInternalDeploymentServiceBuilder() {
         return SERVICEBUILDER_TLS.get();
     }
 

--- a/jpa/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
@@ -99,7 +99,6 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
 
         final int count = reader.getAttributeCount();
         for (int i = 0; i < count; i++) {
-            final String value = reader.getAttributeValue(i);
             final String attributeNamespace = reader.getAttributeNamespace(i);
             if (attributeNamespace != null && !attributeNamespace.isEmpty()) {
                 continue;

--- a/jpa/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
+++ b/jpa/src/main/java/org/jboss/as/jpa/subsystem/JPASubSystemAdd.java
@@ -92,7 +92,7 @@ class JPASubSystemAdd extends AbstractBoottimeAddStepHandler {
                 }
 
                 processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_REGISTER_JBOSS_ALL_JPA,
-                        new JBossAllXmlParserRegisteringProcessor(JPAJarJBossAllParser.ROOT_ELEMENT, JpaAttachments.DEPLOYMENT_SETTINGS_KEY, new JPAJarJBossAllParser()));
+                        new JBossAllXmlParserRegisteringProcessor<>(JPAJarJBossAllParser.ROOT_ELEMENT, JpaAttachments.DEPLOYMENT_SETTINGS_KEY, new JPAJarJBossAllParser()));
 
                 // handles parsing of persistence.xml
                 processorTarget.addDeploymentProcessor(JPAExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_PERSISTENCE_UNIT, new PersistenceUnitParseProcessor(appclient));


### PR DESCRIPTION
The JPA subsystem contains several compiler warnings. Some of them
(mostly related to generics) are quite easy to fix.

This commit reduces the amount of compiler warnings in Eclipse by about
50%.

Issue: WFLY-4497
https://issues.jboss.org/browse/WFLY-4497
