### PR TITLE
WFLY-4499 Fix Compiler Warnings in Transactions Subsystem

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/ArjunaTransactionManagerService.java
@@ -68,15 +68,13 @@ public final class ArjunaTransactionManagerService implements Service<com.arjuna
     private boolean coordinatorEnableStatistics;
     private int coordinatorDefaultTimeout;
     private final boolean jts;
-    private final String nodeIdentifier;
 
     public ArjunaTransactionManagerService(final boolean coordinatorEnableStatistics, final int coordinatorDefaultTimeout,
-                                           final boolean transactionStatusManagerEnable, final boolean jts, final String nodeIdentifier) {
+                                           final boolean transactionStatusManagerEnable, final boolean jts) {
         this.coordinatorEnableStatistics = coordinatorEnableStatistics;
         this.coordinatorDefaultTimeout = coordinatorDefaultTimeout;
         this.transactionStatusManagerEnable = transactionStatusManagerEnable;
         this.jts = jts;
-        this.nodeIdentifier = nodeIdentifier;
     }
 
     @Override

--- a/transactions/src/main/java/org/jboss/as/txn/service/JTAEnvironmentBeanService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/JTAEnvironmentBeanService.java
@@ -44,11 +44,9 @@ import java.util.Collections;
 public class JTAEnvironmentBeanService implements Service<JTAEnvironmentBean> {
 
     private final String nodeIdentifier;
-    private final boolean jts;
 
-    public JTAEnvironmentBeanService(final String nodeIdentifier, final boolean jts) {
+    public JTAEnvironmentBeanService(final String nodeIdentifier) {
         this.nodeIdentifier = nodeIdentifier;
-        this.jts = jts;
     }
 
     @Override

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/CompensationsDependenciesDeploymentProcessor.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/CompensationsDependenciesDeploymentProcessor.java
@@ -48,7 +48,7 @@ public class CompensationsDependenciesDeploymentProcessor implements DeploymentU
 
     private static final ModuleIdentifier COMPENSATIONS_MODULE = ModuleIdentifier.create("org.jboss.narayana.compensations");
 
-    private static final Class[] COMPENSATABLE_ANNOTATIONS = {
+    private static final Class<?>[] COMPENSATABLE_ANNOTATIONS = {
             Compensatable.class,
             CancelOnFailure.class,
             CompensationScoped.class,
@@ -77,7 +77,7 @@ public class CompensationsDependenciesDeploymentProcessor implements DeploymentU
     }
 
     private boolean isCompensationAnnotationPresent(final CompositeIndex compositeIndex) {
-        for (Class annotation : COMPENSATABLE_ANNOTATIONS) {
+        for (Class<?> annotation : COMPENSATABLE_ANNOTATIONS) {
             if (compositeIndex.getAnnotations(DotName.createSimple(annotation.getName())).size() > 1) {
                 return true;
             }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/ParticipantWriteAttributeHandler.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/ParticipantWriteAttributeHandler.java
@@ -22,16 +22,14 @@
 
 package org.jboss.as.txn.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
-
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
 
 
 public class ParticipantWriteAttributeHandler extends AbstractWriteAttributeHandler<Void> {
@@ -45,8 +43,6 @@ public class ParticipantWriteAttributeHandler extends AbstractWriteAttributeHand
         ModelNode subModel = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
         ModelNode onAttribute = subModel.get(LogStoreConstants.JMX_ON_ATTRIBUTE);
         String jmxName = onAttribute.asString();
-        PathAddress address = PathAddress.pathAddress(operation.require(OP_ADDR));
-        String name = address.getLastElement().getValue();
         MBeanServer mbs = TransactionExtension.getMBeanServer(context);
 
         try {

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem15Parser.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem15Parser.java
@@ -141,14 +141,14 @@ class TransactionSubsystem15Parser extends TransactionSubsystem14Parser {
         while (reader.hasNext()) {
             switch (reader.nextTag()) {
                 case END_ELEMENT: {
-                    if (Element.CM_RESPOURCE.forName(reader.getLocalName()) == Element.CM_RESPOURCE) {
+                    if (Element.forName(reader.getLocalName()) == Element.CM_RESPOURCE) {
                         cmrAddress.protect();
                         cmrOperation.get(OP_ADDR).set(cmrAddress);
 
                         operations.add(cmrOperation);
                         return;
                     } else {
-                        if (Element.CM_RESPOURCE.forName(reader.getLocalName()) == Element.UNKNOWN) {
+                        if (Element.forName(reader.getLocalName()) == Element.UNKNOWN) {
                             throw unexpectedElement(reader);
                         }
                     }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem30Parser.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystem30Parser.java
@@ -141,14 +141,14 @@ class TransactionSubsystem30Parser extends TransactionSubsystem20Parser {
         while (reader.hasNext()) {
             switch (reader.nextTag()) {
                 case END_ELEMENT: {
-                    if (Element.CM_RESPOURCE.forName(reader.getLocalName()) == Element.CM_RESPOURCE) {
+                    if (Element.forName(reader.getLocalName()) == Element.CM_RESPOURCE) {
                         cmrAddress.protect();
                         cmrOperation.get(OP_ADDR).set(cmrAddress);
 
                         operations.add(cmrOperation);
                         return;
                     } else {
-                        if (Element.CM_RESPOURCE.forName(reader.getLocalName()) == Element.UNKNOWN) {
+                        if (Element.forName(reader.getLocalName()) == Element.UNKNOWN) {
                             throw unexpectedElement(reader);
                         }
                     }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -425,12 +425,12 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final String nodeIdentifier = TransactionSubsystemRootResourceDefinition.NODE_IDENTIFIER.resolveModelAttribute(context, coordEnvModel).asString();
 
         // install JTA environment bean service
-        final JTAEnvironmentBeanService jtaEnvironmentBeanService = new JTAEnvironmentBeanService(nodeIdentifier, jts);
+        final JTAEnvironmentBeanService jtaEnvironmentBeanService = new JTAEnvironmentBeanService(nodeIdentifier);
         context.getServiceTarget().addService(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT, jtaEnvironmentBeanService)
                 .setInitialMode(Mode.ACTIVE)
                 .install();
 
-        final ArjunaTransactionManagerService transactionManagerService = new ArjunaTransactionManagerService(coordinatorEnableStatistics, coordinatorDefaultTimeout, transactionStatusManagerEnable, jts, nodeIdentifier);
+        final ArjunaTransactionManagerService transactionManagerService = new ArjunaTransactionManagerService(coordinatorEnableStatistics, coordinatorDefaultTimeout, transactionStatusManagerEnable, jts);
         final ServiceBuilder<com.arjuna.ats.jbossatx.jta.TransactionManagerService> transactionManagerServiceServiceBuilder = context.getServiceTarget().addService(TxnServices.JBOSS_TXN_ARJUNA_TRANSACTION_MANAGER, transactionManagerService);
         // add dependency on JTA environment bean service
         transactionManagerServiceServiceBuilder.addDependency(TxnServices.JBOSS_TXN_JTA_ENVIRONMENT, JTAEnvironmentBean.class, transactionManagerService.getJTAEnvironmentBeanInjector());

--- a/transactions/src/test/java/org/jboss/as/txn/TestWildFlyTSR.java
+++ b/transactions/src/test/java/org/jboss/as/txn/TestWildFlyTSR.java
@@ -14,8 +14,6 @@ import javax.transaction.TransactionSynchronizationRegistry;
 import org.jboss.as.txn.service.internal.tsr.TransactionSynchronizationRegistryWrapper;
 import org.junit.Test;
 
-import com.arjuna.ats.arjuna.common.arjPropertyManager;
-import com.arjuna.ats.jta.common.JTAEnvironmentBean;
 import com.arjuna.ats.jta.common.jtaPropertyManager;
 
 public class TestWildFlyTSR {


### PR DESCRIPTION
The transactions subsystem contains several compiler warnings. Some of
them (mostly related to generics) are quite easy to fix.

Issue: WFLY-4499
https://issues.jboss.org/browse/WFLY-4499
