### PR TITLE
FLY-4500 CMResourceService#stop fails to clean up

### DIFF
--- a/transactions/src/main/java/org/jboss/as/txn/service/CMResourceService.java
+++ b/transactions/src/main/java/org/jboss/as/txn/service/CMResourceService.java
@@ -82,7 +82,7 @@ public class CMResourceService implements Service<Void> {
     public void stop(StopContext context) {
         jtaEnvironmentBean.getValue().getCommitMarkableResourceJNDINames().remove(jndiName);
         jtaEnvironmentBean.getValue().getCommitMarkableResourceTableNameMap().remove(tableName);
-        jtaEnvironmentBean.getValue().getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap().remove(immediateCleanup);
+        jtaEnvironmentBean.getValue().getPerformImmediateCleanupOfCommitMarkableResourceBranchesMap().remove(jndiName);
         jtaEnvironmentBean.getValue().getCommitMarkableResourceRecordDeleteBatchSizeMap().remove(jndiName);
 
     }


### PR DESCRIPTION
CMResourceService#stop fails to clean up values that #start creates.

Issue: WFLY-4500
https://issues.jboss.org/browse/WFLY-4500
