### PR TITLE
WFLY-4505 Fix Compiler Warnings in JAX-RS Subsystem

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsCdiIntegrationProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsCdiIntegrationProcessor.java
@@ -59,7 +59,6 @@ public class JaxrsCdiIntegrationProcessor implements DeploymentUnitProcessor {
             return;
         }
 
-        final DeploymentUnit parent = deploymentUnit.getParent() == null ? deploymentUnit : deploymentUnit.getParent();
         final WarMetaData warMetaData = deploymentUnit.getAttachment(WarMetaData.ATTACHMENT_KEY);
         final JBossWebMetaData webdata = warMetaData.getMergedJBossWebMetaData();
 

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsComponentDeployer.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsComponentDeployer.java
@@ -102,7 +102,7 @@ public class JaxrsComponentDeployer implements DeploymentUnitProcessor {
                     }
                 }
 
-                Class[] jaxrsType = GetRestful.getSubResourceClasses(componentClass);
+                Class<?>[] jaxrsType = GetRestful.getSubResourceClasses(componentClass);
                 final String jndiName;
                 if (component.getViews().size() == 1) {
                     //only 1 view, just use the simple JNDI name
@@ -111,7 +111,7 @@ public class JaxrsComponentDeployer implements DeploymentUnitProcessor {
                     boolean found = false;
                     String foundType = null;
                     for (final ViewDescription view : component.getViews()) {
-                        for (Class subResource : jaxrsType) {
+                        for (Class<?> subResource : jaxrsType) {
                             if (view.getViewClassName().equals(subResource.getName())) {
                                 foundType = subResource.getName();
                                 found = true;

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsIntegrationProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsIntegrationProcessor.java
@@ -182,7 +182,7 @@ public class JaxrsIntegrationProcessor implements DeploymentUnitProcessor {
             return;
 
         // ignore any non-annotated Application class that doesn't have a servlet mapping
-        Set<Class> applicationClassSet = new HashSet<>();
+        Set<Class<? extends Application>> applicationClassSet = new HashSet<>();
         for (Class<? extends Application> clazz : resteasy.getScannedApplicationClasses()) {
             if (clazz.isAnnotationPresent(ApplicationPath.class) || servletMappingsExist(webdata, clazz.getName())) {
                 applicationClassSet.add(clazz);

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/deployment/JaxrsSpringProcessor.java
@@ -62,10 +62,6 @@ import java.util.List;
  */
 public class JaxrsSpringProcessor implements DeploymentUnitProcessor {
 
-    private static final String VERSION_KEY = "resteasy.version";
-
-    private static final String SPRING_INT_JAR_BASE = "resteasy-spring";
-
     private static final String JAR_LOCATION = "resteasy-spring-jar";
     private static final ModuleIdentifier MODULE = ModuleIdentifier.create("org.jboss.resteasy.resteasy-spring");
 

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
@@ -147,7 +147,7 @@ public interface JaxrsLogger extends BasicLogger {
      * @return
      */
     @Message(id = 10, value = "JAX-RS resource %s does not correspond to a view on the EJB %s. @Path annotations can only be placed on classes or interfaces that represent a local, remote or no-interface view of an EJB.")
-    DeploymentUnitProcessingException typeNameNotAnEjbView(List<Class> type, String ejbName);
+    DeploymentUnitProcessingException typeNameNotAnEjbView(List<Class<?>> type, String ejbName);
 
     @Message(id = 11, value = "Invalid value for parameter %s: %s")
     DeploymentUnitProcessingException invalidParamValue(String param, String value);


### PR DESCRIPTION
The jaxrs subsystem contains several compiler warnings. Some of them
(mostly related to generics and unused variables) are quite easy to
fix.

Issue: WFLY-4505
https://issues.jboss.org/browse/WFLY-4505
