### PR TITLE
WFLY-4506 Fix Compiler Warnings in JDR Subsystem

### DIFF
--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrRunner.java
@@ -92,7 +92,7 @@ public class JdrRunner implements JdrReportCollector {
             Properties plugins = new Properties();
             plugins.load(is);
             for (String pluginName : plugins.stringPropertyNames()) {
-                Class pluginClass = Class.forName(pluginName);
+                Class<?> pluginClass = Class.forName(pluginName);
                 JdrPlugin plugin = (JdrPlugin) pluginClass.newInstance();
                 commands.addAll(plugin.getCommands());
                 versionWriter.println(plugin.getPluginId());

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/commands/SystemProperties.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/commands/SystemProperties.java
@@ -45,7 +45,7 @@ public class SystemProperties extends JdrCommand {
         PrintWriter printWriter = new PrintWriter(stringWriter);
 
         Properties properties = System.getProperties();
-        Enumeration names = properties.propertyNames();
+        Enumeration<?> names = properties.propertyNames();
         while(names.hasMoreElements()) {
             String name = (String) names.nextElement();
             if(name.matches(".*password.*")) {


### PR DESCRIPTION
The jdr subsystem contains three compiler warnings. Two of them
(related to generics) are quite easy to fix.

Issue: WFLY-4506
https://issues.jboss.org/browse/WFLY-4506
