### PR TITLE
WFLY-4507 Fix Compiler Warnings in Mail Subsystem

### DIFF
--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSessionDefinitionInjectionSource.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSessionDefinitionInjectionSource.java
@@ -79,7 +79,7 @@ class MailSessionDefinitionInjectionSource extends ResourceDefinitionInjectionSo
                                   final EEModuleDescription moduleDescription,
                                   final ResolutionContext context,
                                   final ServiceTarget serviceTarget,
-                                  final ServiceBuilder valueSourceServiceBuilder, final Injector<ManagedReferenceFactory> injector) {
+                                  final ServiceBuilder<?> valueSourceServiceBuilder, final Injector<ManagedReferenceFactory> injector) {
 
 
         final ServiceName mailSessionServiceName = MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("MailSessionDefinition", moduleDescription.getApplicationName(), moduleDescription.getModuleName(), jndiName);

--- a/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser.java
+++ b/mail/src/main/java/org/jboss/as/mail/extension/MailSubsystemParser.java
@@ -102,10 +102,7 @@ class MailSubsystemParser implements XMLStreamConstants, XMLElementReader<List<M
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             Attribute attr = Attribute.forName(reader.getAttributeLocalName(i));
             String value = reader.getAttributeValue(i);
-            String name;
-            if (attr == Attribute.NAME) {
-                name = value;
-            } else if (attr == Attribute.JNDI_NAME) {
+            if (attr == Attribute.JNDI_NAME) {
                 jndiName = value;
                 JNDI_NAME.parseAndSetParameter(value, operation, reader);
             } else if (attr == Attribute.DEBUG) {

--- a/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem10TestCase.java
+++ b/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem10TestCase.java
@@ -15,11 +15,7 @@ import java.util.List;
 
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.extension.ExtensionRegistry;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.naming.deployment.ContextNames;
-import org.jboss.as.naming.service.NamingService;
 import org.jboss.as.naming.service.NamingStoreService;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;

--- a/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem20TestCase.java
+++ b/mail/src/test/java/org/jboss/as/mail/extension/MailSubsystem20TestCase.java
@@ -128,7 +128,7 @@ public class MailSubsystem20TestCase extends AbstractSubsystemBaseTest {
         if (!mainServices.isSuccessfulBoot()) {
             Assert.fail(mainServices.getBootError().toString());
         }
-        ServiceController javaMailService = mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("defaultMail"));
+        ServiceController<?> javaMailService = mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("defaultMail"));
         javaMailService.setMode(ServiceController.Mode.ACTIVE);
         Session session = (Session) javaMailService.getValue();
         Assert.assertNotNull("session should not be null", session);
@@ -137,13 +137,13 @@ public class MailSubsystem20TestCase extends AbstractSubsystemBaseTest {
         Assert.assertNotNull("pop3 host should be set", properties.getProperty("mail.pop3.host"));
         Assert.assertNotNull("imap host should be set", properties.getProperty("mail.imap.host"));
 
-        ServiceController defaultMailService = mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("default2"));
+        ServiceController<?> defaultMailService = mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("default2"));
         session = (Session) defaultMailService.getValue();
         Assert.assertEquals("Debug should be true", true, session.getDebug());
 
 
-        ServiceController<Session> customMailService = (ServiceController<Session>) mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("custom"));
-        session = customMailService.getValue();
+        ServiceController<?> customMailService = mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("custom"));
+        session = (Session) customMailService.getValue();
         properties = session.getProperties();
         String host = properties.getProperty("mail.smtp.host");
         Assert.assertNotNull("smtp host should be set", host);
@@ -197,7 +197,7 @@ public class MailSubsystem20TestCase extends AbstractSubsystemBaseTest {
         checkResult(result);
 
 
-        ServiceController javaMailService = mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("defaultMail"));
+        ServiceController<?> javaMailService = mainServices.getContainer().getService(MailSessionAdd.MAIL_SESSION_SERVICE_NAME.append("defaultMail"));
         javaMailService.setMode(ServiceController.Mode.ACTIVE);
         Session session = (Session) javaMailService.getValue();
         Assert.assertNotNull("session should not be null", session);


### PR DESCRIPTION
The mail subsystem contains several compiler warnings. Some of them
(mostly related to generics) are quite easy to fix.

Issue: WFLY-4507
https://issues.jboss.org/browse/WFLY-4507
