### PR TITLE
WFLY-4517 Do not expose Infinispan bits to deployments importing the Hib...

### DIFF
--- a/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
+++ b/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
@@ -32,7 +32,7 @@
                     <file-store passivation="false" purge="false"/>
                 </local-cache>
             </cache-container>
-            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
+            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>
                     <eviction strategy="LRU" max-entries="10000"/>
@@ -68,7 +68,7 @@
                     <file-store/>
                 </distributed-cache>
             </cache-container>
-            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
+            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
                 <transport lock-timeout="60000"/>
                 <invalidation-cache name="entity" mode="SYNC">
                     <transaction mode="NON_XA"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,34 +22,16 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<!-- Represents the Hibernate 4.3.x module-->
-<module xmlns="urn:jboss:module:1.3" name="org.hibernate">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.infinispan">
     <resources>
-        <artifact name="${org.hibernate:hibernate-core}"/>
-        <artifact name="${org.hibernate:hibernate-envers}"/>
-        <artifact name="${org.hibernate:hibernate-entitymanager}"/>
+        <artifact name="${org.hibernate:hibernate-infinispan}"/>
     </resources>
 
     <dependencies>
-        <module name="asm.asm"/>
-        <module name="com.fasterxml.classmate"/>
+        <module name="org.hibernate"/>
         <module name="javax.api"/>
-        <module name="javax.annotation.api"/>
-        <module name="javax.enterprise.api"/>
-        <module name="javax.persistence.api"/>
         <module name="javax.transaction.api"/>
-        <module name="javax.validation.api"/>
-        <module name="javax.xml.bind.api"/>
-        <module name="org.antlr"/>
-        <module name="org.apache.commons.collections"/>
-        <module name="org.dom4j"/>
-        <module name="org.javassist"/>
-        <module name="org.jboss.as.jpa.spi"/>
-        <module name="org.jboss.jandex"/>
+        <module name="org.infinispan" services="import"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.vfs"/>
-        <module name="org.hibernate.commons-annotations"/>
-        <module name="org.hibernate.infinispan" services="import" optional="true"/>
-        <module name="org.hibernate.jipijapa-hibernate4-3" services="import"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate4-3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/jipijapa-hibernate4-3/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,15 +22,13 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<!-- Represents the Hibernate 4.3.x module-->
-<module xmlns="urn:jboss:module:1.3" name="org.hibernate">
+<module xmlns="urn:jboss:module:1.3" name="org.hibernate.jipijapa-hibernate4-3">
     <resources>
-        <artifact name="${org.hibernate:hibernate-core}"/>
-        <artifact name="${org.hibernate:hibernate-envers}"/>
-        <artifact name="${org.hibernate:hibernate-entitymanager}"/>
+        <artifact name="${org.jipijapa:jipijapa-hibernate4-3}"/>
     </resources>
 
     <dependencies>
+        <module name="org.hibernate"/>
         <module name="asm.asm"/>
         <module name="com.fasterxml.classmate"/>
         <module name="javax.api"/>
@@ -49,7 +47,7 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.vfs"/>
         <module name="org.hibernate.commons-annotations"/>
-        <module name="org.hibernate.infinispan" services="import" optional="true"/>
-        <module name="org.hibernate.jipijapa-hibernate4-3" services="import"/>
+        <module name="org.hibernate.infinispan" services="import"/>
+        <module name="org.infinispan" services="import"/>
     </dependencies>
 </module>

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -195,7 +195,7 @@
                         <file-store passivation="false" purge="false"/>
                     </local-cache>
                 </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
                     <local-cache name="entity">
                         <transaction mode="NON_XA"/>
                         <eviction strategy="LRU" max-entries="10000"/>
@@ -515,7 +515,7 @@
                         <file-store passivation="false" purge="false"/>
                     </local-cache>
                 </cache-container>
-                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
+                <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
                     <local-cache name="entity">
                         <transaction mode="NON_XA"/>
                         <eviction strategy="LRU" max-entries="10000"/>

--- a/testsuite/integration/java8/src/test/resources/standalone-java8.xml
+++ b/testsuite/integration/java8/src/test/resources/standalone-java8.xml
@@ -243,7 +243,7 @@
                     <file-store passivation="false" purge="false"/>
                 </local-cache>
             </cache-container>
-            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate">
+            <cache-container name="hibernate" default-cache="local-query" module="org.hibernate.infinispan">
                 <local-cache name="entity">
                     <transaction mode="NON_XA"/>
                     <eviction strategy="LRU" max-entries="10000"/>


### PR DESCRIPTION
...ernate main module

This should avoid leaking Infinispan and Jipijapa into the classpath of applications using Hibernate / JPA.

The main driver was that this was making it very hard for users to depend on a different version of Infinispan / JDG if they also happened to use Hibernate and/or JPA. Particularly nasty for Hibernate OGM users and Hibernate Search users.

I didn't check performance of deployments but I also expect it to speedup bootstrap of Hibernate ORM as it narrows down all of its classpath scanning, including for entities.
- https://issues.jboss.org/browse/WFLY-4517
