### PR TITLE
Modules restructured: Infinispan and Hibernate Search mutual dependencies

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1665,6 +1665,28 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-backend-jms</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-serialization-avro</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>
             <artifactId>hibernate-jpa-2.1-api</artifactId>
             <exclusions>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -397,6 +397,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
             <exclusions>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1677,6 +1677,17 @@
 
         <dependency>
             <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-backend-jgroups</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-serialization-avro</artifactId>
             <exclusions>
                 <exclusion>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/antlr/antlr-runtime/3.4/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/antlr/antlr-runtime/3.4/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,26 +22,21 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.infinispan.query">
+<!--
+N.B.This is not the same as org.antlr:antlr, as used by Hibernate ORM.
+This more updated version is required by Infinispan and Hibernate OGM.
+Package names across the two versions are different too, so they are
+compatible if needed although no known module is requiring both.
+-->
+<module xmlns="urn:jboss:module:1.3" name="org.antlr.antlr-runtime" slot="3.4">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>
-        <artifact name="${org.infinispan:infinispan-query}"/>
-        <artifact name="${org.infinispan:infinispan-objectfilter}"/>
+        <artifact name="${org.antlr:antlr-runtime}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="org.hibernate.hql"/>
-        <module name="org.antlr.antlr-runtime" slot="3.4"/>
-        <module name="org.hibernate.search.engine"/>
-        <module name="org.infinispan" services="import"/>
-        <module name="org.infinispan.commons"/>
-        <module name="org.infinispan.lucene.directory" services="import" optional="true"/>
-        <module name="org.infinispan.query.dsl"/>
-        <module name="org.jboss.logging"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/hql/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/hql/main/module.xml
@@ -33,6 +33,11 @@
     </resources>
 
     <dependencies>
+        <module name="org.antlr.antlr-runtime" slot="3.4"/>
+        <module name="javax.persistence.api"/>
+        <module name="org.hibernate.search.engine"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.apache.lucene"/>
         <module name="javax.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/backend-jgroups/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/backend-jgroups/main/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.1" name="org.hibernate.search.backend-jgroups">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+    <resources>
+        <artifact name="${org.hibernate:hibernate-search-backend-jgroups}"/>
+    </resources>
+    <dependencies>
+        <module name="org.hibernate.search.engine"/>
+        <module name="org.jboss.logging"/>
+        <module name="org.jgroups"/>
+        <module name="org.jboss.as.naming"/>
+        <module name="javax.api"/>
+    </dependencies>
+</module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/backend-jms/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/backend-jms/main/module.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,34 +21,18 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<!-- Hibernate Search Engine: the fulltext indexing and query capabilities
-     without the ORM integration bits. This is reused by several other project
-     outside of the Hibernate group. -->
-<module xmlns="urn:jboss:module:1.3" name="org.hibernate.search.engine">
+<module xmlns="urn:jboss:module:1.1" name="org.hibernate.search.backend-jms">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <artifact name="${org.hibernate:hibernate-search-engine}"/>
+        <artifact name="${org.hibernate:hibernate-search-backend-jms}"/>
     </resources>
-
     <dependencies>
-        <module name="javax.transaction.api"/>
-        <module name="org.hibernate.commons-annotations"/>
-        <module name="org.apache.lucene" export="true"/>
+        <module name="org.hibernate.search.engine"/>
         <module name="org.jboss.logging"/>
-
-        <!-- optional JMS backend support -->
-        <module name="org.hibernate.search.backend-jms" export="true" services="import" optional="true"/>
-
-        <!-- optional Avro serialization -->
-        <module name="org.hibernate.search.serialization-avro" services="import" optional="true"/>
-
-        <!-- optional Infinispan integrations -->
-        <module name="org.infinispan.hibernate-search.directory-provider" services="import" optional="true"/>
-
-        <!-- For naming -->
-        <module name="javax.api" />
-        <module name="org.jboss.as.naming" />
+        <module name="javax.jms.api"/>
+        <module name="org.jboss.as.naming"/>
+        <module name="javax.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/engine/main/module.xml
@@ -42,6 +42,9 @@
         <!-- optional JMS backend support -->
         <module name="org.hibernate.search.backend-jms" export="true" services="import" optional="true"/>
 
+        <!-- optional JGroups backend support -->
+        <module name="org.hibernate.search.backend-jgroups" export="true" services="import" optional="true"/>
+
         <!-- optional Avro serialization -->
         <module name="org.hibernate.search.serialization-avro" services="import" optional="true"/>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/orm/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/orm/main/module.xml
@@ -33,10 +33,8 @@
         <module name="javax.transaction.api" />
         <module name="org.hibernate" />
         <module name="org.hibernate.commons-annotations" />
-        <module name="org.apache.lucene" export="true" />
         <module name="org.hibernate.search.engine" export="true" services="import" />
         <module name="org.jboss.logging" />
         <module name="javax.persistence.api" />
-        <module name="javax.jms.api" optional="true" />
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/serialization-avro/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/search/serialization-avro/main/module.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,34 +21,17 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<!-- Hibernate Search Engine: the fulltext indexing and query capabilities
-     without the ORM integration bits. This is reused by several other project
-     outside of the Hibernate group. -->
-<module xmlns="urn:jboss:module:1.3" name="org.hibernate.search.engine">
+<module xmlns="urn:jboss:module:1.1" name="org.hibernate.search.serialization-avro">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <artifact name="${org.hibernate:hibernate-search-engine}"/>
+        <artifact name="${org.hibernate:hibernate-search-serialization-avro}"/>
     </resources>
-
     <dependencies>
-        <module name="javax.transaction.api"/>
-        <module name="org.hibernate.commons-annotations"/>
-        <module name="org.apache.lucene" export="true"/>
+        <module name="org.hibernate.search.engine"/>
+        <module name="org.apache.lucene"/>
         <module name="org.jboss.logging"/>
-
-        <!-- optional JMS backend support -->
-        <module name="org.hibernate.search.backend-jms" export="true" services="import" optional="true"/>
-
-        <!-- optional Avro serialization -->
-        <module name="org.hibernate.search.serialization-avro" services="import" optional="true"/>
-
-        <!-- optional Infinispan integrations -->
-        <module name="org.infinispan.hibernate-search.directory-provider" services="import" optional="true"/>
-
-        <!-- For naming -->
-        <module name="javax.api" />
-        <module name="org.jboss.as.naming" />
+        <module name="org.apache.avro"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-search/directory-provider/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-search/directory-provider/main/module.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2013, Red Hat, Inc., and individual contributors
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -21,22 +20,20 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-
-<module xmlns="urn:jboss:module:1.3" name="org.infinispan.lucene.directory">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.hibernate-search.directory-provider">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
-
     <resources>
-        <artifact name="${org.infinispan:infinispan-lucene-directory}"/>
+        <artifact name="${org.hibernate:hibernate-search-infinispan}"/>
     </resources>
 
     <dependencies>
-        <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="org.apache.lucene" export="true"/>
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
+        <module name="org.hibernate.search.engine"/>
+        <module name="org.infinispan.lucene-directory"/>
         <module name="org.jboss.logging"/>
+        <module name="javax.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/lucene-directory/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/lucene-directory/main/module.xml
@@ -22,34 +22,21 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<!-- Hibernate Search Engine: the fulltext indexing and query capabilities
-     without the ORM integration bits. This is reused by several other project
-     outside of the Hibernate group. -->
-<module xmlns="urn:jboss:module:1.3" name="org.hibernate.search.engine">
+<module xmlns="urn:jboss:module:1.3" name="org.infinispan.lucene-directory">
     <properties>
         <property name="jboss.api" value="private"/>
     </properties>
+
     <resources>
-        <artifact name="${org.hibernate:hibernate-search-engine}"/>
+        <artifact name="${org.infinispan:infinispan-lucene-directory}"/>
     </resources>
 
     <dependencies>
+        <module name="javax.api"/>
         <module name="javax.transaction.api"/>
-        <module name="org.hibernate.commons-annotations"/>
         <module name="org.apache.lucene" export="true"/>
+        <module name="org.infinispan"/>
+        <module name="org.infinispan.commons"/>
         <module name="org.jboss.logging"/>
-
-        <!-- optional JMS backend support -->
-        <module name="org.hibernate.search.backend-jms" export="true" services="import" optional="true"/>
-
-        <!-- optional Avro serialization -->
-        <module name="org.hibernate.search.serialization-avro" services="import" optional="true"/>
-
-        <!-- optional Infinispan integrations -->
-        <module name="org.infinispan.hibernate-search.directory-provider" services="import" optional="true"/>
-
-        <!-- For naming -->
-        <module name="javax.api" />
-        <module name="org.jboss.as.naming" />
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/lucene/directory/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/lucene/directory/main/module.xml
@@ -34,7 +34,7 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.transaction.api"/>
-        <module name="org.apache.lucene"/>
+        <module name="org.apache.lucene" export="true"/>
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
         <module name="org.jboss.logging"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/main/module.xml
@@ -37,6 +37,8 @@
         <module name="org.infinispan.cachestore.remote" optional="true"/>
         <module name="org.infinispan.client.hotrod" optional="true"/>
         <module name="org.infinispan.commons"/>
+        <module name="org.infinispan.query" services="import" optional="true"/>
+        <module name="org.infinispan.lucene-directory" services="import" optional="true"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
@@ -37,10 +37,9 @@
         <module name="javax.transaction.api"/>
         <module name="org.hibernate.hql"/>
         <module name="org.antlr.antlr-runtime" slot="3.4"/>
-        <module name="org.hibernate.search.engine"/>
-        <module name="org.infinispan" services="import"/>
-        <module name="org.infinispan.commons"/>
-        <module name="org.infinispan.lucene.directory" services="import" optional="true"/>
+        <module name="org.hibernate.search.engine" export="true"/>
+        <module name="org.infinispan"/>
+        <module name="org.infinispan.lucene.directory" services="export"/>
         <module name="org.infinispan.query.dsl"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
@@ -39,7 +39,7 @@
         <module name="org.hibernate.search.engine"/>
         <module name="org.infinispan" services="import"/>
         <module name="org.infinispan.commons"/>
-        <module name="org.infinispan.lucene.directory" optional="true"/>
+        <module name="org.infinispan.lucene.directory" services="import" optional="true"/>
         <module name="org.infinispan.query.dsl"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/query/main/module.xml
@@ -39,7 +39,9 @@
         <module name="org.antlr.antlr-runtime" slot="3.4"/>
         <module name="org.hibernate.search.engine" export="true"/>
         <module name="org.infinispan"/>
-        <module name="org.infinispan.lucene.directory" services="export"/>
+        <module name="org.infinispan.commons"/>
+        <module name="org.infinispan.hibernate-search.directory-provider" />
+        <module name="org.infinispan.lucene-directory" services="import" optional="true"/>
         <module name="org.infinispan.query.dsl"/>
         <module name="org.jboss.logging"/>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
         <version.joda-time>2.7</version.joda-time>
         <version.jsoup>1.8.1</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
+        <version.org.antlr-34>3.4</version.org.antlr-34>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.0.4</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.3</version.org.apache.cxf.xjcplugins>
@@ -4028,6 +4029,18 @@
                     <exclusion>
                         <groupId>org.antlr</groupId>
                         <artifactId>antlr-runtime</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr-runtime</artifactId>
+                <version>${version.org.antlr-34}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.antlr</groupId>
+                        <artifactId>stringtemplate</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4104,6 +4104,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-search-backend-jms</artifactId>
+                <version>${version.org.hibernate.search}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-search-serialization-avro</artifactId>
+                <version>${version.org.hibernate.search}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.hornetq</groupId>
                 <artifactId>hornetq-amqp-protocol</artifactId>
                 <version>${version.org.hornetq}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -4111,6 +4111,12 @@
 
             <dependency>
                 <groupId>org.hibernate</groupId>
+                <artifactId>hibernate-search-backend-jgroups</artifactId>
+                <version>${version.org.hibernate.search}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-serialization-avro</artifactId>
                 <version>${version.org.hibernate.search}</version>
             </dependency>


### PR DESCRIPTION
This aligns the structure of the WildFly bundled modules to the ones we've been polishing (and testing) within the respective projects.

I've been running integration tests for these by pointing the existing tests of Infinispan and Hibernate Search to a WildFly snapshot build: it's not worth literally migrating those integration tests, as after WildFly 9 we'll be using the features pack format so the integration tests should still be run in the source projects which actually build those feature packs.

Please integrate as this fixes several classloading issues for layered projects.
- https://issues.jboss.org/browse/WFLY-4543
- https://issues.jboss.org/browse/WFLY-4232
