### PR TITLE
[WFLY-4533] Port jboss-as-messaging_1_5.xsd

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging14SubsystemParser.java
@@ -51,6 +51,11 @@ public class Messaging14SubsystemParser extends Messaging13SubsystemParser {
             case MAX_SAVED_REPLICATED_JOURNAL_SIZE:
                 handleElementText(reader, element, operation);
                 break;
+            case OVERRIDE_IN_VM_SECURITY:
+                // this element was added to 1.4 XSD in EAP by error but is
+                // not actually handled by WildFly before its 3.0 schema
+                handleElementText(reader, element, operation);
+                break;
             default: {
                 super.handleUnknownConfigurationAttribute(reader, element, operation);
             }
@@ -66,6 +71,21 @@ public class Messaging14SubsystemParser extends Messaging13SubsystemParser {
                 break;
             default:
                 super.handleUnknownGroupingHandlerAttribute(reader, element, operation);
+        }
+    }
+
+    @Override
+    protected void handleUnknownAddressSetting(XMLExtendedStreamReader reader, Element element, ModelNode addressSettingsAdd) throws XMLStreamException {
+        switch (element) {
+            case SLOW_CONSUMER_CHECK_PERIOD:
+            case SLOW_CONSUMER_POLICY:
+            case SLOW_CONSUMER_THRESHOLD:
+                // these elements were added to 1.4 XSD in EAP by error but are
+                // not actually handled by WildFly before its 3.0 schema
+                handleElementText(reader, element, addressSettingsAdd);
+                break;
+            default:
+                super.handleUnknownAddressSetting(reader, element, addressSettingsAdd);
         }
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/Messaging30SubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Messaging30SubsystemParser.java
@@ -45,25 +45,10 @@ public class Messaging30SubsystemParser extends Messaging20SubsystemParser {
     }
 
     @Override
-    protected void handleUnknownConfigurationAttribute(XMLExtendedStreamReader reader, Element element, ModelNode operation) throws XMLStreamException {
-        switch (element) {
-            case OVERRIDE_IN_VM_SECURITY:
-                handleElementText(reader, element, operation);
-                break;
-            default: {
-                super.handleUnknownConfigurationAttribute(reader, element, operation);
-            }
-        }
-    }
-
-    @Override
     protected void handleUnknownAddressSetting(XMLExtendedStreamReader reader, Element element, ModelNode addressSettingsAdd) throws XMLStreamException {
         switch (element) {
             case MAX_REDELIVERY_DELAY:
             case REDELIVERY_MULTIPLIER:
-            case SLOW_CONSUMER_CHECK_PERIOD:
-            case SLOW_CONSUMER_POLICY:
-            case SLOW_CONSUMER_THRESHOLD:
                 handleElementText(reader, element, addressSettingsAdd);
                 break;
             default:

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingExtension.java
@@ -29,6 +29,7 @@ import static org.jboss.as.messaging.Namespace.MESSAGING_1_1;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_2;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_3;
 import static org.jboss.as.messaging.Namespace.MESSAGING_1_4;
+import static org.jboss.as.messaging.Namespace.MESSAGING_1_5;
 import static org.jboss.as.messaging.Namespace.MESSAGING_2_0;
 import static org.jboss.as.messaging.Namespace.MESSAGING_3_0;
 
@@ -76,6 +77,13 @@ import org.jboss.as.messaging.jms.bridge.JMSBridgeDefinition;
  *     <ul>
  *       <li>XML namespace: urn:jboss:domain:messaging:2.0
  *       <li>Management model: 2.0.0
+ *     </ul>
+ *   </dd>
+ *   <dt>EAP 6.4</dt>
+ *   <dd>
+ *     <ul>
+ *       <li>XML namespace: urn:jboss:domain:messaging:1.5
+ *       <li>Management model: 1.4.0
  *     </ul>
  *   </dd>
  *   <dt>AS 7.3.0</dt>
@@ -266,6 +274,11 @@ public class MessagingExtension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_2.getUriString(), Messaging12SubsystemParser.getInstance());
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_3.getUriString(), Messaging13SubsystemParser.getInstance());
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_4.getUriString(), Messaging14SubsystemParser.getInstance());
+        // the 1.5 schema is port forwarded from EAP 6.4.
+        // The 1.4 schema was updated by mistake in EAP 6.4. The 1.4 parser in WildFly is updated to be able to parse these
+        // elements. There are no other changes in the 1.5 schema apart from these elements so we use the 1.4 parser to parse
+        // the 1.5 schema too.
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_1_5.getUriString(), Messaging14SubsystemParser.getInstance());
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_2_0.getUriString(), Messaging20SubsystemParser.getInstance());
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, MESSAGING_3_0.getUriString(), Messaging30SubsystemParser.getInstance());
     }

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemParser.java
@@ -129,6 +129,7 @@ public class MessagingSubsystemParser implements XMLStreamConstants, XMLElementR
             case MESSAGING_1_2:
             case MESSAGING_1_3:
             case MESSAGING_1_4:
+            case MESSAGING_1_5:
             case MESSAGING_2_0:
             case MESSAGING_3_0:
                 processHornetQServers(reader, address, list);

--- a/messaging/src/main/java/org/jboss/as/messaging/Namespace.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/Namespace.java
@@ -41,6 +41,7 @@ public enum Namespace {
    MESSAGING_1_2("urn:jboss:domain:messaging:1.2"),
    MESSAGING_1_3("urn:jboss:domain:messaging:1.3"),
    MESSAGING_1_4("urn:jboss:domain:messaging:1.4"),
+   MESSAGING_1_5("urn:jboss:domain:messaging:1.5"),
    MESSAGING_2_0("urn:jboss:domain:messaging:2.0"),
    MESSAGING_3_0("urn:jboss:domain:messaging:3.0");
 

--- a/messaging/src/main/resources/schema/jboss-as-messaging_1_5.xsd
+++ b/messaging/src/main/resources/schema/jboss-as-messaging_1_5.xsd
@@ -1,0 +1,2630 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns="urn:jboss:domain:messaging:1.5"
+           targetNamespace="urn:jboss:domain:messaging:1.5"
+           elementFormDefault="qualified"
+           attributeFormDefault="unqualified"
+           version="1.5">
+
+    <!-- The messaging subsystem root element -->
+    <xs:element name="subsystem">
+        <xs:annotation>
+            <xs:documentation>
+                <![CDATA[
+                The configuration of the messaging subsystem.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="hornetq-server" type="hornetq-serverType" />
+                <xs:element maxOccurs="unbounded" minOccurs="0" name="jms-bridge" type="jms-bridgeType" />
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="hornetq-serverType">
+      <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+                The configuration of an individual HornetQ Server.
+            ]]>
+          </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+          <xs:element maxOccurs="1" minOccurs="0" name="clustered" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Deprecated. A HornetQ server is clustered if it has at least one cluster-connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <!-- no file system deployment in AS
+          <xs:element maxOccurs="1" minOccurs="0" type="file-deployment-enabled"/>
+           -->
+          <xs:element maxOccurs="1" minOccurs="0" name="persistence-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server will use the file based journal for persistence.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <!--  TODO use thread subsystem?  -->
+          <xs:element maxOccurs="1" minOccurs="0" name="scheduled-thread-pool-max-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                     Maximum number of threads to use for the scheduled thread pool
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="thread-pool-max-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Maximum number of threads to use for the thread pool
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-domain" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The security domain to use to verify user and role information
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether security is enabled
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="security-invalidation-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long (in ms) to wait before invalidating the security cache.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="override-in-vm-security" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the HornetQ server will override security credentials for in-vm connections (true by default).
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="wild-card-routing-enabled" type="xs:boolean">
+               <xs:annotation>
+                   <xs:documentation>
+                       Whether the server supports wild card routing.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="management-address" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       Address to send management messages to.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="management-notification-address" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       The name of the address that consumers bind to  to receive management notifications.
+                   </xs:documentation>
+               </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-user" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The user used by cluster connections to communicate between the clustered nodes.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-password" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The password used by cluster connections to communicate between the clustered nodes.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <!-- no logging configuration for AS needed
+          <xs:element maxOccurs="1" minOccurs="0" name="log-delegate-factory-class-name" type="xs:string" />
+           -->
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-management-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether HornetQ should expose its internal management API via JMX. This is not recommended, as accessing these MBeans can lead to inconsistent configuration.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jmx-domain" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The JMX domain used to register internal HornetQ MBeans in the MBeanServer.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                    Whether gathering of statistics such as message counters are enabled.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-sample-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The sample period (in ms) to use for message counters.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-max-day-history" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many days to keep message counter history.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl-override" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      If set, this will override how long (in ms) to keep a connection alive without receiving a ping.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="async-connection-execution-enabled" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether incoming packets on the server should be handed off to a thread from the thread pool for processing. False if they should be handled on the remoting thread.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long (in ms) before a transaction can be removed from the resource manager after create time.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transaction-timeout-scan-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often (in ms) to scan for timeout transactions.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-scan-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often (in ms) to scan for expired messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-expiry-thread-priority" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The priority of the thread expiring messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="id-cache-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size of the cache for pre-creating message IDs.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-id-cache" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether IDs are persisted to the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Deprecated. Use remoting-incoming-interceptors instead
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-incoming-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The list of incoming interceptor classes used by this server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="remoting-outgoing-interceptors" type="remoting-interceptorsType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The list of outgoing interceptor classes used by this server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="backup" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server is a backup server.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="allow-failback" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server will automatically shutdown if the original live server comes back up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="failback-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long to wait before failback occurs on live server restart.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-shutdown" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this backup server (if it is a backup server) should come live on a normal server shutdown.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="shared-store" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether this server is using a shared store for failover.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="persist-delivery-count-before-delivery" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the delivery count is persisted before delivery. False means that this only happens after a message has been cancelled.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="live-connector-ref" type="live-connectorType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Deprecated.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-concurrent-io" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of concurrent reads allowed on paging
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="create-bindings-dir" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server should create the bindings directory on start up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="create-journal-dir" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the server should create the journal directory on start up.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-type" type="journalType">
+              <xs:annotation>
+                  <xs:documentation>
+                      The type of journal to use.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout (in nanoseconds) used to flush internal buffers on the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-buffer-size" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size of the internal buffer on the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-transactional" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to wait for transaction data to be synchronized to the journal before returning a response to the client.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-sync-non-transactional" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to wait for non transaction data to be synced to the journal before returning a response to the client.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="log-journal-write-rate" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether to periodically log the journal's write rate and flush rate.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-file-size" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The size (in bytes) of each journal file.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-min-files" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many journal files to pre-create.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-percentage" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The percentage of live data on which we consider compacting the journal.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-compact-min-files" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimal number of journal data files before we can start compacting.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-max-io" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of write requests that can be in the AIO queue at any one time.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-saved-replicated-journal-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of backup journals to keep after failback occurs.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="perf-blast-pages" type="xs:int" />
+          <xs:element maxOccurs="1" minOccurs="0" name="run-sync-speed-test" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether on startup to perform a diagnostic test on how fast your disk can sync. Useful when determining performance issues.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="server-dump-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often to dump basic runtime information to the server log. A value less than 1 disables this feature.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-warning-threshold" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Percentage of available memory which if exceeded results in a warning log
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="memory-measure-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Frequency to sample JVM memory in ms (or -1 to disable memory sampling)
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-for-live-server" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      If a replicated live server should check the current cluster to see if there is already a live server with the same node id
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="backup-group-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of a set of live/backups that should replicate with each other
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="replication-clustername" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of the cluster connection to replicate from if more than one cluster connection is configured
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+
+          <xs:element maxOccurs="1" minOccurs="0" name="paging-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="bindings-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="journal-directory" type="directoryType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="large-messages-directory" type="directoryType" />
+
+          <xs:element maxOccurs="1" minOccurs="0" name="connectors">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-connector" type="netty-connectorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-connector" type="inVM-connectorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector" type="connectorType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="acceptors">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="netty-acceptor" type="netty-acceptorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="in-vm-acceptor" type="inVM-acceptorType" />
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="acceptor" type="acceptorType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="broadcast-groups">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="broadcast-group" type="broadcast-groupType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="discovery-groups">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="discovery-group" type="discovery-groupType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="diverts">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="divert" type="divertType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="core-queues" type="queuesType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="bridges">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="bridge" type="bridgeType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="cluster-connections">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="cluster-connection" type="clusterConnectionType" />
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="grouping-handler" type="groupingHandlerType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="security-settings" type="security-settingsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="address-settings" type="address-settingsType" />
+          <xs:element maxOccurs="1" minOccurs="0" name="connector-services">
+              <xs:complexType>
+                  <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-service" type="connectorServiceType"/>
+                  </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jms-connection-factories">
+              <xs:complexType>
+                  <xs:sequence>
+                  <xs:element name="connection-factory" maxOccurs="unbounded" minOccurs="0" type="connection-factoryType" />
+                  <xs:element name="pooled-connection-factory" maxOccurs="unbounded" minOccurs="0" type="pooled-connection-factoryType" />
+                </xs:sequence>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="jms-destinations">
+              <xs:complexType>
+                <xs:sequence>
+                    <xs:element name="jms-queue" maxOccurs="unbounded" minOccurs="0" type="jmsQueueType" />
+                    <xs:element name="jms-topic" maxOccurs="unbounded" minOccurs="0" type="jmsTopicType" />
+                </xs:sequence>
+              </xs:complexType>
+          </xs:element>
+
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" use="optional" default="default">
+        <xs:annotation>
+            <xs:documentation>
+                The name to use for this HornetQ Server. Must be unique across all "hornetq-server" elements
+                in the subsystem. So, this attribute is optional with a default value, but if more than
+                one "hornetq-server" element exists, only one can leave this attribute unspecified.
+            </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    </xs:complexType>
+
+    <xs:element name="local-bind-address" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="local-bind-port" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="group-address" type="xs:string">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="group-port" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Deprecated.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="broadcast-period" type="xs:long">
+        <xs:annotation>
+            <xs:documentation>
+                The period in milliseconds between consecutive broadcasts.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:element name="initial-wait-timeout" type="xs:int">
+        <xs:annotation>
+            <xs:documentation>
+                Period, in ms, to wait for an initial broadcast to give us at least one node in the cluster.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+
+    <xs:complexType name="broadcast-groupType">
+       <xs:sequence>
+           <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-stack" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name of a stack defined in the org.jboss.as.clustering.jgroups subsystem.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name used by a JGroups channel to join a cluster.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The broadcast group socket binding.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+           </xs:choice>
+           <xs:element maxOccurs="1" minOccurs="0" ref="broadcast-period" />
+           <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       Specifies the names of connectors that will be broadcast.
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the broadcast group
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="discovery-groupType">
+        <xs:sequence>
+            <xs:choice>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-stack" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name of a stack defined in the org.jboss.as.clustering.jgroups subsystem.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" name="jgroups-channel" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The name used by a JGroups channel to join a cluster.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="1" name="socket-binding" type="xs:string">
+                      <xs:annotation>
+                          <xs:documentation>
+                              The discovery group socket binding.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+               <xs:sequence>
+                  <xs:element maxOccurs="1" minOccurs="0" ref="local-bind-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the local bind address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-address">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group address.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+                  <xs:element maxOccurs="1" minOccurs="1" ref="group-port">
+                      <xs:annotation>
+                          <xs:documentation>
+                              Deprecated. use socket-binding attribute instead to specify the group port.
+                          </xs:documentation>
+                      </xs:annotation>
+                  </xs:element>
+               </xs:sequence>
+            </xs:choice>
+            <xs:element maxOccurs="1" minOccurs="0" name="refresh-timeout" type="xs:int">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period the discovery group waits after receiving the last broadcast from a particular server before removing that server's connector pair entry from its list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element maxOccurs="1" minOccurs="0" ref="initial-wait-timeout">
+                <xs:annotation>
+                    <xs:documentation>
+                        Period, in ms, to wait for an initial broadcast to give us at least one node in the cluster.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the discovery group
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="remoting-interceptorsType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Deprecated. Use remoting-incoming-interceptors instead.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string" />
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="remoting-incoming-interceptorsType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Remoting incoming interceptors must be placed into a JBoss module and added as a dependency to org.jboss.as.messaging:main module.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                    The class name of the remoting incoming interceptor.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="remoting-outgoing-interceptorsType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Remoting outgoing interceptors must be placed into a JBoss module and added as a dependency to org.jboss.as.messaging:main module.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="1" name="class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The class name of the remoting outgoing interceptor.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="paramType">
+       <xs:attribute name="key" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The key of the parameter
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+       <xs:attribute name="value" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The value of the parameter
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="netty-connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The netty connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:attribute name="socket-binding" type="xs:string" use="required">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="inVM-connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The inVM connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:attribute name="server-id" type="xs:int" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The connector server ID.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="connectorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Generic connector type, with optional socket-binding depending on whether
+              the implementation requires a Host/Port parameter.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-connectorType">
+             <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Class name of the factory class that can instantiate the connector.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+             </xs:sequence>
+             <xs:attribute name="socket-binding" type="xs:string" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-connectorType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the connector
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="netty-acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The netty acceptor type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:attribute name="socket-binding" type="xs:string" use="required">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding reference.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="inVM-acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              The inVM connector type.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:attribute name="server-id" type="xs:int" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The server id.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="acceptorType">
+       <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+              Generic acceptor type, with optional socket-binding depending on whether
+              the implementation requires a Host/Port parameter.
+            ]]>
+            </xs:documentation>
+       </xs:annotation>
+       <xs:complexContent>
+          <xs:extension base="base-acceptorType">
+             <xs:sequence>
+                <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+                    <xs:annotation>
+                        <xs:documentation>
+                            Class name of the factory class that can instantiate the acceptor.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+             </xs:sequence>
+             <xs:attribute name="socket-binding" type="xs:string" use="optional">
+                 <xs:annotation>
+                     <xs:documentation>
+                         The socket binding that the acceptor will use to accept connections.
+                     </xs:documentation>
+                 </xs:annotation>
+             </xs:attribute>
+          </xs:extension>
+       </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="base-acceptorType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="optional">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the acceptor
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="bridgeType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="queue-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The unique name of the local queue that the bridge consumes from.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="forwarding-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The address on the target server that the message will be forwarded to. If a forwarding address is not specified then the original destination of the message will be retained.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="ha" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether or not this bridge should support high availability. True means it will connect to any available server in a cluster and support failover.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      An optional filter string. If specified then only messages which match the filter expression specified will be forwarded. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimum size (in bytes) for a message before it is considered as a large message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period (in milliseconds) between client failure check.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum time (in milliseconds) for which the connections used by the bridges are considered alive (in the absence of heartbeat).
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period in milliseconds between subsequent reconnection attempts, if the connection to the target server has failed.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double">
+              <xs:annotation>
+                  <xs:documentation>
+                      A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum interval of time used to retry connections
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="failover-on-server-shutdown" type="xs:boolean">
+             <xs:annotation>
+                <xs:documentation>
+                   Deprecated. the failover-on-server-shutdown attribute is no longer taken into account when configuring a connector-ref.
+                </xs:documentation>
+             </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the bridge will automatically insert a duplicate id property into each message that it forwards.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The confirmation-window-size to use for the connection used to forward messages to the target node.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The user name to use when creating the bridge connection to the remote server. If it is not specified the default cluster user specified by the cluster-user attribute in the root messaging subsystem resource will be used.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The password to use when creating the bridge connection to the remote server. If it is not specified the default cluster password specified by the cluster-password attribute in the root messaging subsystem resource will be used.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:choice>
+             <xs:element maxOccurs="1" minOccurs="1" name="static-connectors">
+                <xs:complexType>
+                    <xs:annotation>
+                        <xs:documentation>
+                            A list of names of statically defined connectors used by this bridge. Must be undefined (null) if 'discovery-group-name' is defined.
+                        </xs:documentation>
+                    </xs:annotation>
+                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="1" name="connector-ref" type="xs:string"/>
+                   </xs:sequence>
+                </xs:complexType>
+             </xs:element>
+             <xs:element maxOccurs="1" minOccurs="1" name="discovery-group-ref" type="discovery-group-refType" />
+          </xs:choice>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the bridge
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="clusterConnectionType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Each cluster connection only applies to messages sent to an address that starts with this value.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="connector-ref" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of connector to use for live connection
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="check-period" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period (in milliseconds) between client failure check.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="connection-ttl" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum time (in milliseconds) for which the connections used by the cluster connections are considered alive (in the absence of heartbeat).
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="min-large-message-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The minimum size (in bytes) for a message before it is considered as a large message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="call-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout (in ms) for remote calls made by the cluster connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="call-failover-timeout" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The timeout to use when fail over is in process (in ms) for remote calls made by the cluster connection.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The period in milliseconds between subsequent attempts to reconnect to a target server, if the connection to the target server has failed.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="retry-interval-multiplier" type="xs:double">
+              <xs:annotation>
+                  <xs:documentation>
+                      A multiplier to apply to the time since the last retry to compute the time to the next retry. This allows you to implement an exponential backoff between retry attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-retry-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum interval of time used to retry connections
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="reconnect-attempts" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The total number of reconnect attempts the bridge will make before giving up and shutting down. A value of -1 signifies an unlimited number of attempts.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="use-duplicate-detection" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether the bridge will automatically insert a duplicate id property into each message that it forwards.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="forward-when-no-consumers" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Whether messages will be distributed round robin between other nodes of the cluster irrespective of whether there are matching or indeed any consumers on other nodes. If this is set to false (the default) then HornetQ will only forward messages to other nodes of the cluster if the address to which they are being forwarded has queues which have consumers, and if those consumers have message filters (selectors) at least one of those selectors must match the message.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-hops" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The maximum number of times a message can be forwarded. HornetQ can be configured to also load balance messages to nodes which might be connected to it only indirectly with other HornetQ servers as intermediates in a chain.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="confirmation-window-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The confirmation-window-size to use for the connection used to forward messages to a target node.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-interval" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      How often the cluster connection will broadcast itself
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="notification-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How many times the cluster connection will broadcast itself
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:choice>
+             <xs:element maxOccurs="1" minOccurs="0" name="static-connectors">
+                <xs:complexType>
+                   <xs:sequence>
+                      <xs:element maxOccurs="unbounded" minOccurs="0" name="connector-ref" type="xs:string"/>
+                   </xs:sequence>
+                   <xs:attribute name="allow-direct-connections-only" type="xs:boolean" use="optional">
+                       <xs:annotation>
+                           <xs:documentation>
+                               Whether, if a node learns of the existence of a node that is more than 1 hop away, we do not create a bridge for direct cluster connection. Only relevant if 'static-connectors' is defined.
+                           </xs:documentation>
+                       </xs:annotation>
+                   </xs:attribute>
+                </xs:complexType>
+             </xs:element>
+             <xs:element maxOccurs="1" minOccurs="0" name="discovery-group-ref" type="discovery-group-refType" />
+          </xs:choice>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the discovery group
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+    <xs:complexType name="divertType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="0" name="routing-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Routing name of the divert
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Address to divert from
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="1" name="forwarding-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Address to divert to
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            An optional filter string. If specified then only messages which match the filter expression specified will be diverted. The filter string follows the HornetQ filter expression syntax described in the HornetQ documentation.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="transformer-class-name" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The name of a class used to transform the message's body or properties before it is diverted.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="exclusive" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   Whether the divert is exclusive, meaning that the message is diverted to the new address, and does not go to the old address at all.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="journalType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="ASYNCIO"/>
+          <xs:enumeration value="NIO"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="groupingHandlerType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="type" type="groupingHandlerTypeType"/>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      A reference to a cluster connection and the address it uses.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="timeout" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      How long to wait for a handling decision to be made; an exception will be thrown during the send if this timeout is reached, ensuring that strict ordering is kept.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="group-timeout" type="xs:long" >
+               <xs:annotation>
+                   <xs:documentation>
+                       How long a group binding will be used, -1 means for ever. Bindings are removed after this wait elapses (only valid for LOCAL handlers).
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
+           <xs:element maxOccurs="1" minOccurs="0" name="reaper-period" type="xs:long" >
+               <xs:annotation>
+                   <xs:documentation>
+                       How often the reaper will be run to check for timed out group bindings (only valid for LOCAL handlers).
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the grouping handler.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:simpleType name="groupingHandlerTypeType">
+       <xs:annotation>
+           <xs:documentation>
+               Whether the handler is the single "Local" handler for the cluster, which makes handling decisions, or a "Remote" handler which converses with the local handler.
+           </xs:documentation>
+       </xs:annotation>
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="LOCAL"/>
+          <xs:enumeration value="REMOTE"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="security-settingsType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="security-setting" type="security-settingType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="security-settingType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="permission">
+             <xs:complexType>
+                <xs:attribute name="type" type="security-permissionType" use="required"/>
+                <xs:attribute name="roles" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            <![CDATA[
+                                List of roles that are granted the permission for the given type. The roles must be separated by spaces or commas.
+                            ]]>
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+             </xs:complexType>
+          </xs:element>
+       </xs:sequence>
+       <xs:attribute name="match" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   Expression matched against a queue address.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="address-settingsType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="address-setting" type="address-settingType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="address-settingType">
+       <xs:all>
+          <xs:element maxOccurs="1" minOccurs="0" name="dead-letter-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The dead letter address
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="expiry-address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines where to send a message that has expired.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="redelivery-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how long to wait before attempting redelivery of a cancelled message
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-delivery-attempts" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how many time a cancelled message can be redelivered before sending to the dead-letter-address
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="max-size-bytes" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The max bytes size.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-size-bytes" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      The paging size.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="page-max-cache-size" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      The number of page files to keep in memory to optimize IO during paging navigation.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="address-full-policy" type="addressFullMessagePolicyType">
+              <xs:annotation>
+                  <xs:documentation>
+                      Determines what happens when an address where max-size-bytes is specified becomes full. (PAGE, DROP or BLOCK)
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="message-counter-history-day-limit" type="xs:int">
+              <xs:annotation>
+                  <xs:documentation>
+                      Day limit for the message counter history.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="last-value-queue" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines whether a queue only uses last values or not
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="redistribution-delay" type="xs:long">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines how long to wait when the last consumer is closed on a queue before redistributing any messages
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="send-to-dla-on-no-route" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      If this parameter is set to true for that address, if the message is not routed to any queues it will instead be sent to the dead letter address (DLA) for that address, if it exists.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+           <xs:element maxOccurs="1" minOccurs="0" name="slow-consumer-check-period" type="xs:long">
+               <xs:annotation>
+                   <xs:documentation>
+                       How often (in minutes) to check for slow consumers on a particular queue.
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
+           <xs:element maxOccurs="1" minOccurs="0" name="slow-consumer-policy" type="xs:string">
+               <xs:annotation>
+                   <xs:documentation>
+                       Determine what happens when a slow consumer is identified (accepted values: KILL, NOTIFY).
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
+           <xs:element maxOccurs="1" minOccurs="0" name="slow-consumer-threshold" type="xs:long">
+               <xs:annotation>
+                   <xs:documentation>
+                       The minimum rate of message consumption allowed before a consumer is considered slow.
+                   </xs:documentation>
+               </xs:annotation>
+           </xs:element>
+       </xs:all>
+       <xs:attribute name="match" type="xs:string" use="required">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the address setting.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="queuesType">
+       <xs:sequence>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="queue" type="queueType"/>
+       </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="queueType">
+       <xs:all>
+          <xs:element maxOccurs="1" minOccurs="1" name="address" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      The queue address defines what address is used for routing messages.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="filter">
+             <xs:complexType>
+                <xs:attribute name="string" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>
+                            A queue message filter definition. An undefined or empty filter will match all messages.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+             </xs:complexType>
+          </xs:element>
+          <xs:element maxOccurs="1" minOccurs="0" name="durable" type="xs:boolean">
+              <xs:annotation>
+                  <xs:documentation>
+                      Defines whether the queue is durable.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+        </xs:all>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation>
+                    The name of the queue.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="live-connectorType">
+       <xs:attribute name="connector-name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:simpleType name="addressFullMessagePolicyType">
+       <xs:restriction base="xs:token">
+          <xs:enumeration value="DROP"/>
+          <xs:enumeration value="PAGE"/>
+          <xs:enumeration value="BLOCK"/>
+       </xs:restriction>
+    </xs:simpleType>
+
+    <xs:complexType name="connectorServiceType">
+       <xs:sequence>
+          <xs:element maxOccurs="1" minOccurs="1" name="factory-class" type="xs:string">
+              <xs:annotation>
+                  <xs:documentation>
+                      Class name of the factory class that can instantiate the connector service.
+                  </xs:documentation>
+              </xs:annotation>
+          </xs:element>
+          <xs:element maxOccurs="unbounded" minOccurs="0" name="param" type="paramType" />
+       </xs:sequence>
+       <xs:attribute name="name" type="xs:string" use="optional">
+           <xs:annotation>
+               <xs:documentation>
+                   The name of the connector service.
+               </xs:documentation>
+           </xs:annotation>
+       </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="directoryType">
+        <xs:annotation>
+            <xs:documentation>
+            <![CDATA[
+                A directory location configuration.
+
+                The "path" attribute denotes a relative or absolute filesystem pathname where the directory should be
+                located.
+
+                The "relative-to" attribute references a global path configuration in the domain model, defaulting
+                to the JBoss Application Server data directory (jboss.server.data.dir). If the value of the "path" attribute
+                does not specify an absolute pathname, it will treated as relative to this path.
+            ]]>
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="relative-to" type="xs:string" default="jboss.server.data.dir" />
+        <xs:attribute name="path" type="xs:string" />
+    </xs:complexType>
+
+
+   <!-- using a xs:all does not allow to factorize connection-factoryType and pooled-connection-factoryType
+        in a common base type definition.
+        The elements/attributes common to both are copied/pasted...
+    -->
+   <xs:complexType name="connection-factoryType">
+      <xs:all>
+         <!-- start of JMS connection-factoryType specific elements          -->
+         <!-- ============================================================== -->
+         <xs:element name="factory-type" type="connectionFactoryType" minOccurs="0" maxOccurs="1"/>
+         <!-- ============================================================== -->
+         <!-- end of JMS connection-factoryType specific elements            -->
+
+         <!-- start of common elements                                       -->
+         <!--  ============================================================= -->
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0" />
+         <xs:element name="connectors" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="connector-ref" type="connector-refType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="entries" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1">
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the connection factory supports High Availability.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client failure check period.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The connection ttl.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The call time out.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The timeout to use when fail over is in process (in ms).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The confirmation window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether large messages should be compressed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to cache large messages.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The min large message size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The dups ok batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The transaction batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on non durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether or not message grouping is automatically used
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to pre-acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval multiplier.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The max retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The reconnect attempts.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to fail over on initial connection.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                <xs:documentation>
+                   Deprecated. the failover-on-server-shutdown attribute is no longer taken into account when configuring a connector-ref.
+                </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use global pools.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The scheduled thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The group id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <!-- ============================================================= -->
+         <!-- end of common elements                                        -->
+      </xs:all>
+      <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the connection factory.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:simpleType name="connectionFactoryType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="GENERIC"/>
+         <xs:enumeration value="QUEUE"/>
+         <xs:enumeration value="TOPIC"/>
+         <xs:enumeration value="XA_GENERIC"/>
+         <xs:enumeration value="XA_QUEUE"/>
+         <xs:enumeration value="XA_TOPIC"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="pooled-connection-factoryType">
+      <xs:all>
+         <!-- start of JMS pooled-connection-factoryType specific elements   -->
+         <!-- ============================================================== -->
+         <xs:element name="inbound-config" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                    <xs:element name="use-jndi" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Use JNDI to locate the destination for incoming connections
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="jndi-params" type="xs:string" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The JNDI params to use for locating the destination for incoming connections.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="use-local-tx" type="xs:boolean" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                Use a local transaction for incoming sessions
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="setup-attempts" type="xs:integer" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The number of times to set up an MDB endpoint
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+                    <xs:element name="setup-interval" type="xs:long" minOccurs="0" maxOccurs="1">
+                        <xs:annotation>
+                            <xs:documentation>
+                                The interval between attempts at setting up an MDB endpoint.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="transaction" type="transactionType" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     The type of transaction.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="user" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The default username to use with this connection factory. This is only needed when pointing the connection factory to a remote host.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="password" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The default password to use with this connection factory. This is only needed when pointing the connection factory to a remote host.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-pool-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The minimum size for the pool
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-pool-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum size for the pool
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-auto-recovery" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use auto recovery.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="initial-message-packet-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The initial size of messages created through this factory.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="initial-connect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The number of attempts to connect initially with this factory.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <!-- ============================================================== -->
+         <!-- end of JMS pooled-connection-factoryType specific elements     -->
+
+         <!-- start of common elements                                       -->
+         <!--  ============================================================= -->
+         <xs:element name="discovery-group-ref" type="discovery-group-refType" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The discovery group name.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connectors" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="connector-ref" type="connector-refType" maxOccurs="unbounded" minOccurs="1"></xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="entries" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:sequence>
+                  <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1">
+                  </xs:element>
+               </xs:sequence>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="ha" type="xs:boolean" minOccurs="0" maxOccurs="1">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the connection factory supports High Availability.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-failure-check-period" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client failure check period.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-ttl" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The connection ttl.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The call time out.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="call-failover-timeout" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The timeout to use when fail over is in process (in ms).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="compress-large-messages" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether large messages should be compressed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="consumer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The consumer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="confirmation-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The confirmation window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-window-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer window size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="producer-max-rate" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The producer max rate.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="cache-large-message-client" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to cache large messages.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="min-large-message-size" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The min large message size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="client-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The client id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="dups-ok-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The dups ok batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="transaction-batch-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The transaction batch size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-non-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on non durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="block-on-durable-send" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to set block on durable send.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="auto-group" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The autogroup.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="pre-acknowledge" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to pre-acknowledge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="retry-interval-multiplier" type="xs:float" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The retry interval multiplier.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="max-retry-interval" type="xs:long" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The max retry interval.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="reconnect-attempts" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The reconnect attempts. By default, a pooled connection factory will try to reconnect infinitely to the messaging server(s).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-initial-connection" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to fail over on initial connection.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="failover-on-server-shutdown" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                <xs:documentation>
+                   Deprecated. the failover-on-server-shutdown attribute is no longer taken into account when configuring a connector-ref.
+                </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="connection-load-balancing-policy-class-name" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Name of a class implementing a client-side load balancing policy that a client can use to load balance sessions across different nodes in a cluster.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="use-global-pools" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     True to use global pools.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="scheduled-thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The scheduled thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="thread-pool-max-size" type="xs:int" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The thread pool max size.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element name="group-id" type="xs:string" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     The group id.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <!-- ============================================================= -->
+         <!-- end of common elements                                        -->
+      </xs:all>
+      <xs:attribute name="name" type="xs:string">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the pooled connection factory.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+
+   <xs:complexType name="connector-refType">
+      <xs:attribute name="connector-name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the connector.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="backup-connector-name" type="xs:string" use="optional">
+          <xs:annotation>
+              <xs:documentation>
+                  Deprecated. the backup-connector-name attribute is no longer taken into account when configuring a connector-ref.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="entryType">
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JNDI entry.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="discovery-group-refType">
+      <xs:attribute name="discovery-group-name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the discovery group.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="jmsQueueType">
+      <xs:sequence>
+         <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
+         <xs:element name="selector" maxOccurs="1" minOccurs="0">
+            <xs:complexType>
+               <xs:attribute name="string" type="xs:string" use="required">
+                   <xs:annotation>
+                       <xs:documentation>
+                           The queue selector.
+                       </xs:documentation>
+                   </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element name="durable" type="xs:boolean" maxOccurs="1" minOccurs="0">
+             <xs:annotation>
+                 <xs:documentation>
+                     Whether the queue is durable or not.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JMS queue.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="jmsTopicType">
+      <xs:sequence>
+         <xs:element name="entry" type="entryType" maxOccurs="unbounded" minOccurs="1" />
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  The name of the JMS Topic.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+    <xs:complexType name="transactionType">
+        <xs:attribute name="mode" use="required" type="modeType"/>
+    </xs:complexType>
+
+    <xs:simpleType name="modeType">
+        <xs:restriction base="xs:token">
+            <xs:enumeration value="xa">
+                <xs:annotation>
+                    <xs:documentation>
+                        Use XA transaction.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="local">
+                <xs:annotation>
+                    <xs:documentation>
+                        Use local transaction.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="none">
+                <xs:annotation>
+                    <xs:documentation>
+                        Do not use transaction.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+   <xs:complexType name="jms-bridgeType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge.
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="source" type="jms-bridgeResourceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The source of the JMS bridge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="destination" type="jms-bridgeResourceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The destination of the JMS bridge.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="quality-of-service" type="quality-of-serviceType">
+             <xs:annotation>
+                 <xs:documentation>
+                     The desired quality of service mode (AT_MOST_ONCE, DUPLICATES_OK or ONCE_AND_ONLY_ONCE).
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="failure-retry-interval" type="xs:long">
+             <xs:annotation>
+                 <xs:documentation>
+                     The amount of time in milliseconds to wait between trying to recreate connections to the source or target servers when the bridge has detected they have failed.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-retries" type="xs:int">
+             <xs:annotation>
+                 <xs:documentation>
+                     The number of times to attempt to recreate connections to the source or target servers when the bridge has detected they have failed. The bridge will give up after trying this number of times. -1 represents 'try forever'.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-size" type="xs:int">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum number of messages to consume from the source destination before sending them in a batch to the target destination. Its value must >= 1.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="max-batch-time" type="xs:long">
+             <xs:annotation>
+                 <xs:documentation>
+                     The maximum number of milliseconds to wait before sending a batch to target, even if the number of messages consumed has not reached max-batch-size. Its value must be -1 to represent 'wait forever', or >= 1 to specify an actual time.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="selector" type="selectorType" />
+         <xs:element maxOccurs="1" minOccurs="0" name="subscription-name" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The name of the subscription if it is durable and the source destination is a topic.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="client-id" type="xs:string">
+             <xs:annotation>
+                 <xs:documentation>
+                     The JMS client ID to use when creating/looking up the subscription if it is durable and the source destination is a topic.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="add-messageID-in-header" type="xs:boolean">
+             <xs:annotation>
+                 <xs:documentation>
+                     If true, then the original message's message ID will be appended in the message sent to the destination in the header HORNETQ_BRIDGE_MSG_ID_LIST. If the message is bridged more than once, each message ID will be appended.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:element>
+      </xs:all>
+      <xs:attribute name="name" type="xs:string" use="optional" default="default">
+         <xs:annotation>
+            <xs:documentation>
+               The name to use for this JMS bridge. Must be unique across all "jms-bridge" elements
+               in the subsystem. So, this attribute is optional with a default value, but if more than
+               one "jms-bridge" element exists, only one can leave this attribute unspecified.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="module" type="xs:string" use="optional">
+         <xs:annotation>
+            <xs:documentation>
+               The name of the module that contains resources required to lookup source or target JMS resources from another messaging broker than AS7.
+               This does not need to be specified if the bridge uses AS7 instances for both source and target.
+            </xs:documentation>
+         </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:complexType name="jms-bridgeResourceType">
+      <xs:annotation>
+         <xs:documentation>
+            <![CDATA[
+               The configuration of a JMS bridge resource which serves either of the source (from which the messages are consumed)
+               or the destination (to which messages are produced).
+            ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:all>
+         <xs:element maxOccurs="1" minOccurs="1" name="connection-factory">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the connection factory.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="1" name="destination">
+            <xs:complexType>
+               <xs:attribute name="name" type="xs:string" use="required">
+                  <xs:annotation>
+                      <xs:documentation>
+                         The JNDI name to lookup the destination.
+                      </xs:documentation>
+                  </xs:annotation>
+               </xs:attribute>
+            </xs:complexType>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="user" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The name of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="password" type="xs:string">
+            <xs:annotation>
+               <xs:documentation>
+                  The password of the user for creating the connection.
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+         <xs:element maxOccurs="1" minOccurs="0" name="context" type="contextType" />
+      </xs:all>
+   </xs:complexType>
+
+   <xs:complexType name="selectorType">
+      <xs:attribute name="string" type="xs:string" use="required">
+          <xs:annotation>
+              <xs:documentation>
+                  A message selector.
+              </xs:documentation>
+          </xs:annotation>
+      </xs:attribute>
+   </xs:complexType>
+
+   <xs:simpleType name="quality-of-serviceType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="AT_MOST_ONCE"/>
+         <xs:enumeration value="DUPLICATES_OK"/>
+         <xs:enumeration value="ONCE_AND_ONLY_ONCE"/>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="security-permissionType">
+      <xs:restriction base="xs:token">
+         <xs:enumeration value="send"/>
+         <xs:enumeration value="consume"/>
+         <xs:enumeration value="createDurableQueue"/>
+         <xs:enumeration value="deleteDurableQueue"/>
+         <xs:enumeration value="createNonDurableQueue"/>
+         <xs:enumeration value="deleteNonDurableQueue"/>
+         <xs:enumeration value="manage"/>
+         <xs:enumeration value="createTempQueue">
+             <xs:annotation>
+                 <xs:documentation>
+                     Deprecated. use createNonDurableQueue instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:enumeration>
+         <xs:enumeration value="deleteTempQueue">
+             <xs:annotation>
+                 <xs:documentation>
+                     Deprecated. use deleteNonDurableQueue instead.
+                 </xs:documentation>
+             </xs:annotation>
+         </xs:enumeration>
+      </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="contextType">
+      <xs:annotation>
+         <xs:documentation>
+             The properties set on the JNDI Context used to lookup the JMS bridge resources.
+             In the absence of a context element, the JMS bridge will lookup resources locally on its own AS7 instance.
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="paramType" />
+      </xs:sequence>
+   </xs:complexType>
+</xs:schema>

--- a/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem15TestCase.java
+++ b/messaging/src/test/java/org/jboss/as/messaging/test/MessagingSubsystem15TestCase.java
@@ -1,0 +1,56 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.test;
+
+import java.io.IOException;
+
+import org.jboss.as.messaging.MessagingExtension;
+import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
+import org.junit.Test;
+
+/**
+ *  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2013 Red Hat inc
+ */
+public class MessagingSubsystem15TestCase extends AbstractSubsystemBaseTest {
+
+    public MessagingSubsystem15TestCase() {
+        super(MessagingExtension.SUBSYSTEM_NAME, new MessagingExtension());
+    }
+
+    @Override
+    protected String getSubsystemXml() throws IOException {
+        return readResource("subsystem_1_5.xml");
+    }
+
+    @Test
+    public void testExpressions() throws Exception {
+        standardSubsystemTest("subsystem_1_5_expressions.xml");
+    }
+
+    @Override
+    protected void compareXml(String configId, String original, String marshalled) throws Exception {
+        // XML from messaging 1.5 does not have the same output than 2.0
+        return;
+    }
+
+}

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_5.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_5.xml
@@ -1,0 +1,416 @@
+
+    <subsystem xmlns="urn:jboss:domain:messaging:1.5">
+        <hornetq-server>
+            <clustered>true</clustered>
+            <!-- disable messaging persistence -->
+            <persistence-enabled>false</persistence-enabled>
+            <scheduled-thread-pool-max-size>${messaging.scheduled.thread.pool.max.size:6}</scheduled-thread-pool-max-size>
+            <thread-pool-max-size>${messaging.thread.pool.max.size:5}</thread-pool-max-size>
+            <security-domain>someDomain</security-domain>
+            <security-enabled>false</security-enabled>
+            <security-invalidation-interval>1234</security-invalidation-interval>
+            <wild-card-routing-enabled>false</wild-card-routing-enabled>
+            <management-address>my.management.address</management-address>
+            <management-notification-address>my.management.notif.address</management-notification-address>
+            <cluster-user>${messaging.cluster.user.name}</cluster-user>
+            <cluster-password>${messaging.cluster.user.password}</cluster-password>
+            <jmx-management-enabled>false</jmx-management-enabled>
+            <jmx-domain>my.jmx.domain</jmx-domain>
+            <message-counter-enabled>true</message-counter-enabled>
+            <message-counter-sample-period>7654</message-counter-sample-period>
+            <message-counter-max-day-history>23</message-counter-max-day-history>
+            <connection-ttl-override>5432</connection-ttl-override>
+            <async-connection-execution-enabled>false</async-connection-execution-enabled>
+            <transaction-timeout>4321</transaction-timeout>
+            <transaction-timeout-scan-period>5432</transaction-timeout-scan-period>
+            <message-expiry-scan-period>7654</message-expiry-scan-period>
+            <message-expiry-thread-priority>7</message-expiry-thread-priority>
+            <id-cache-size>102030</id-cache-size>
+            <persist-id-cache>false</persist-id-cache>
+            <remoting-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-interceptors>
+            <backup>false</backup>
+            <allow-failback>false</allow-failback>
+            <failback-delay>9876</failback-delay>
+            <failover-on-shutdown>true</failover-on-shutdown>
+            <shared-store>true</shared-store>
+            <persist-delivery-count-before-delivery>true</persist-delivery-count-before-delivery>
+            <page-max-concurrent-io>10</page-max-concurrent-io>
+            <create-bindings-dir>false</create-bindings-dir>
+            <create-journal-dir>true</create-journal-dir>
+            <journal-type>NIO</journal-type>
+            <journal-buffer-timeout>1357</journal-buffer-timeout>
+            <journal-buffer-size>2468</journal-buffer-size>
+            <journal-sync-transactional>false</journal-sync-transactional>
+            <journal-sync-non-transactional>true</journal-sync-non-transactional>
+            <log-journal-write-rate>true</log-journal-write-rate>
+            <!-- Default journal file size is 10Mb, reduced here to 100k for faster first boot -->
+            <journal-file-size>102400</journal-file-size>
+            <journal-min-files>2</journal-min-files>
+            <journal-compact-percentage>83</journal-compact-percentage>
+            <journal-compact-min-files>2</journal-compact-min-files>
+            <journal-max-io>50</journal-max-io>
+            <max-saved-replicated-journal-size>2</max-saved-replicated-journal-size>
+            <perf-blast-pages>70</perf-blast-pages>
+            <run-sync-speed-test>false</run-sync-speed-test>
+            <server-dump-interval>8642</server-dump-interval>
+            <memory-warning-threshold>1024</memory-warning-threshold>
+            <memory-measure-interval>2048</memory-measure-interval>
+            <paging-directory path="test" relative-to="test" />
+            <bindings-directory path="test" relative-to="test" />
+            <journal-directory path="test" relative-to="test" />
+            <large-messages-directory path="test" relative-to="test" />
+            <connectors>
+               <netty-connector name="netty" socket-binding="messaging" />
+               <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+               </netty-connector>
+               <in-vm-connector name="in-vm" server-id="0" />
+               <connector name="myconnector">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+                  <param key="host" value="192.168.1.2"/>
+                  <param key="port" value="5445"/>
+               </connector>
+            </connectors>
+            <acceptors>
+               <netty-acceptor name="netty" socket-binding="messaging" />
+               <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+                  <param key="direct-deliver" value="false"/>
+               </netty-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="0" />
+               <acceptor name="myacceptor">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
+                  <param key="batch-delay" value="50"/>
+               </acceptor>
+            </acceptors>
+            <broadcast-groups>
+                <broadcast-group name="groupA">
+                    <local-bind-address>localhost</local-bind-address>
+                    <local-bind-port>12345</local-bind-port>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>23456</group-port>
+                    <broadcast-period>2500</broadcast-period>
+                    <connector-ref>netty</connector-ref>
+                    <connector-ref>netty-throughput</connector-ref>
+                </broadcast-group>
+                <broadcast-group name="groupB">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>34567</group-port>
+                </broadcast-group>
+                <broadcast-group name="groupS">
+                    <socket-binding>group-s-binding</socket-binding>
+                </broadcast-group>
+            </broadcast-groups>
+            <discovery-groups>
+                <discovery-group name="groupC">
+                    <local-bind-address>localhost</local-bind-address>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>45678</group-port>
+                    <refresh-timeout>3500</refresh-timeout>
+                    <initial-wait-timeout>7500</initial-wait-timeout>
+                </discovery-group>
+                <discovery-group name="groupD">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>56789</group-port>
+                </discovery-group>
+                <discovery-group name="groupT">
+                    <socket-binding>group-t-binding</socket-binding>
+                </discovery-group>
+            </discovery-groups>
+            <diverts>
+                <divert name="testDivert1">
+                    <routing-name>routing</routing-name>
+                    <address>address1</address>
+                    <forwarding-address>forwardingaddress1</forwarding-address>
+                    <filter string="afilter"/>
+                    <transformer-class-name>org.jboss.test.Transformer</transformer-class-name>
+                    <exclusive>true</exclusive>
+                </divert>
+                <divert name="testDivert2">
+                    <address>address2</address>
+                    <forwarding-address>forwardingaddress2</forwarding-address>
+                </divert>
+            </diverts>
+            <core-queues>
+                <queue name="coreQueueA">
+                    <address>addressA</address>
+                    <filter string="afilter"/>
+                    <durable>true</durable>
+                </queue>
+                <queue name="coreQueueB">
+                    <address>addressB</address>
+                </queue>
+            </core-queues>
+            <bridges>
+                <bridge name="bridge1">
+                    <queue-name>coreQueueA</queue-name>
+                    <forwarding-address>forwardingaddress1</forwarding-address>
+                    <ha>true</ha>
+                    <filter string="afilter"/>
+                    <transformer-class-name>foo.bar</transformer-class-name>
+                    <min-large-message-size>10240</min-large-message-size>
+                    <check-period>666</check-period>
+                    <connection-ttl>36000</connection-ttl>
+                    <retry-interval>750</retry-interval>
+                    <retry-interval-multiplier>2</retry-interval-multiplier>
+                    <max-retry-interval>3000</max-retry-interval>
+                    <reconnect-attempts>3</reconnect-attempts>
+                    <failover-on-server-shutdown>true</failover-on-server-shutdown>
+                    <use-duplicate-detection>true</use-duplicate-detection>
+                    <confirmation-window-size>350</confirmation-window-size>
+                    <user>${user:Brian}</user>
+                    <password>${password:secret}</password>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </bridge>
+                <bridge name="bridge2">
+                    <queue-name>coreQueueB</queue-name>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </bridge>
+            </bridges>
+            <cluster-connections>
+                <cluster-connection name="cc1">
+                    <address>cc1-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <check-period>2345</check-period>
+                    <connection-ttl>1234</connection-ttl>
+                    <min-large-message-size>10245</min-large-message-size>
+                    <call-timeout>3456</call-timeout>
+                    <retry-interval>987</retry-interval>
+                    <retry-interval-multiplier>3.0</retry-interval-multiplier>
+                    <max-retry-interval>3600</max-retry-interval>
+                    <reconnect-attempts>-1</reconnect-attempts>
+                    <use-duplicate-detection>true</use-duplicate-detection>
+                    <forward-when-no-consumers>true</forward-when-no-consumers>
+                    <max-hops>7</max-hops>
+                    <confirmation-window-size>459</confirmation-window-size>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc2">
+                    <address>cc2-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <static-connectors allow-direct-connections-only="true">
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc3">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </cluster-connection>
+                <cluster-connection name="cc4">
+                    <address>cc4-address</address>
+                    <connector-ref>netty-throughput</connector-ref>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <!--  it is valid to have a cluster connection without
+                      a static-connector or discovery-group-ref when the node
+                      must accept connections from other cluster nodes but
+                      not connect to any other nodes.
+                 -->
+                <cluster-connection name="cc5">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                </cluster-connection>
+            </cluster-connections>
+            <grouping-handler name="grouping-handler">
+                <type>LOCAL</type>
+                <address>handler-address</address>
+                <timeout>5000</timeout>
+                <group-timeout>-1</group-timeout>
+                <reaper-period>30000</reaper-period>
+            </grouping-handler>
+            <security-settings>
+               <security-setting match="#">
+                   <permission roles="guest" type="send"/>
+                   <permission roles="guest" type="consume"/>
+                   <permission roles="guest" type="createNonDurableQueue"/>
+                   <permission roles="guest" type="deleteNonDurableQueue"/>
+                   <permission roles="adming" type="manage"/>
+               </security-setting>
+            </security-settings>
+            <address-settings>
+               <!--default for catch all-->
+               <address-setting match="#">
+                  <dead-letter-address>jms.queue.DLQ</dead-letter-address>
+                  <expiry-address>jms.queue.ExpiryQueue</expiry-address>
+                  <redelivery-delay>0</redelivery-delay>
+                  <max-delivery-attempts>5</max-delivery-attempts>
+                  <max-size-bytes>10485760</max-size-bytes>
+                  <page-size-bytes>10485760</page-size-bytes>
+                  <page-max-cache-size>7</page-max-cache-size>
+                  <address-full-policy>BLOCK</address-full-policy>
+                  <message-counter-history-day-limit>10</message-counter-history-day-limit>
+                  <last-value-queue>false</last-value-queue>
+                  <redistribution-delay>0</redistribution-delay>
+                  <send-to-dla-on-no-route>false</send-to-dla-on-no-route>
+               </address-setting>
+            </address-settings>
+
+            <connector-services>
+                <connector-service name="a">
+                    <factory-class>foo.bar</factory-class>
+                </connector-service>
+                <connector-service name="b">
+                    <factory-class>bar.foo</factory-class>
+                    <param key="foo" value="bar"/>
+                    <param key="bar" value="2"/>
+                </connector-service>
+            </connector-services>
+
+            <!--JMS Stuff-->
+            <jms-connection-factories>
+              <connection-factory name="InVmConnectionFactory">
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/ConnectionFactory"/>
+                 </entries>
+              </connection-factory>
+              <connection-factory name="RemoteConnectionFactory">
+                 <factory-type>XA_QUEUE</factory-type>
+                 <connectors>
+                    <connector-ref connector-name="netty"/>
+                 </connectors>
+                 <entries>
+                    <entry name="RemoteConnectionFactory"/>
+                 </entries>
+                 <client-id>testClient</client-id>
+              </connection-factory>
+              <connection-factory name="otherConnectionFactory">
+                 <discovery-group-ref discovery-group-name="groupC"/>
+                 <entries>
+                    <entry name="otherConnectionFactory"/>
+                 </entries>
+                 <ha>true</ha>
+                 <client-failure-check-period>12345</client-failure-check-period>
+                 <connection-ttl>56789</connection-ttl>
+                 <call-timeout>123</call-timeout>
+                 <consumer-window-size>456</consumer-window-size>
+                 <consumer-max-rate>789</consumer-max-rate>
+                 <confirmation-window-size>-1</confirmation-window-size>
+			     <producer-window-size>-1</producer-window-size>
+			     <producer-max-rate>1024</producer-max-rate>
+			     <cache-large-message-client>false</cache-large-message-client>
+			     <min-large-message-size>2048</min-large-message-size>
+			     <client-id>myClientID</client-id>
+			     <dups-ok-batch-size>256</dups-ok-batch-size>
+			     <transaction-batch-size>512</transaction-batch-size>
+			     <block-on-acknowledge>false</block-on-acknowledge>
+			     <block-on-non-durable-send>false</block-on-non-durable-send>
+			     <block-on-durable-send>false</block-on-durable-send>
+			     <auto-group>true</auto-group>
+			     <pre-acknowledge>true</pre-acknowledge>
+			     <retry-interval>500</retry-interval>
+			     <retry-interval-multiplier>2.5</retry-interval-multiplier>
+			     <max-retry-interval>10000</max-retry-interval>
+			     <reconnect-attempts>2</reconnect-attempts>
+			     <failover-on-initial-connection>true</failover-on-initial-connection>
+			     <failover-on-server-shutdown>true</failover-on-server-shutdown>
+				 <connection-load-balancing-policy-class-name>not.a.real.Class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>true</use-global-pools>
+				 <scheduled-thread-pool-max-size>24</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>48</thread-pool-max-size>
+				 <group-id>myGroup</group-id>
+              </connection-factory>
+              <pooled-connection-factory name="hornetq-ra">
+                 <inbound-config>
+                     <use-jndi>false</use-jndi>
+                     <jndi-params>whatever</jndi-params>
+                     <use-local-tx>true</use-local-tx>
+                     <setup-attempts>123</setup-attempts>
+                     <setup-interval>456</setup-interval>
+                 </inbound-config>
+                 <transaction mode="xa"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <min-pool-size>42</min-pool-size>
+                 <max-pool-size>242</max-pool-size>
+				 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsXA"/>
+                 </entries>
+                 <ha>true</ha>
+                 <client-failure-check-period>12345</client-failure-check-period>
+                 <connection-ttl>56789</connection-ttl>
+                 <call-timeout>123</call-timeout>
+                 <consumer-window-size>456</consumer-window-size>
+                 <consumer-max-rate>789</consumer-max-rate>
+                 <confirmation-window-size>-1</confirmation-window-size>
+			     <producer-window-size>-1</producer-window-size>
+			     <producer-max-rate>1024</producer-max-rate>
+                 <cache-large-message-client>false</cache-large-message-client>
+			     <min-large-message-size>2048</min-large-message-size>
+			     <client-id>myClientID</client-id>
+			     <dups-ok-batch-size>256</dups-ok-batch-size>
+			     <transaction-batch-size>512</transaction-batch-size>
+			     <block-on-acknowledge>false</block-on-acknowledge>
+			     <block-on-non-durable-send>false</block-on-non-durable-send>
+			     <block-on-durable-send>false</block-on-durable-send>
+			     <auto-group>true</auto-group>
+			     <pre-acknowledge>true</pre-acknowledge>
+			     <retry-interval>500</retry-interval>
+			     <retry-interval-multiplier>2.5</retry-interval-multiplier>
+			     <max-retry-interval>10000</max-retry-interval>
+			     <reconnect-attempts>2</reconnect-attempts>
+			     <failover-on-initial-connection>true</failover-on-initial-connection>
+			     <failover-on-server-shutdown>true</failover-on-server-shutdown>
+				 <connection-load-balancing-policy-class-name>not.a.real.Class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>true</use-global-pools>
+				 <scheduled-thread-pool-max-size>24</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>48</thread-pool-max-size>
+				 <group-id>myGroup</group-id>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-local">
+                 <transaction mode="local"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsLocal"/>
+                 </entries>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-none">
+                 <transaction mode="none"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsNone"/>
+                 </entries>
+              </pooled-connection-factory>
+           </jms-connection-factories>
+
+           <jms-destinations>
+              <jms-queue name="testQueue">
+                 <entry name="queue/test"/>
+                 <selector string="color='red'"/>
+                 <durable>true</durable>
+              </jms-queue>
+              <jms-topic name="testTopic">
+                 <entry name="topic/test"/>
+              </jms-topic>
+           </jms-destinations>
+        </hornetq-server>
+
+        <hornetq-server name="empty"/>
+    </subsystem>

--- a/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_5_expressions.xml
+++ b/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_1_5_expressions.xml
@@ -1,0 +1,456 @@
+
+    <subsystem xmlns="urn:jboss:domain:messaging:1.5">
+        <hornetq-server>
+            <clustered>true</clustered>
+            <!-- disable messaging persistence -->
+            <persistence-enabled>${persistence.enabled:false}</persistence-enabled>
+            <scheduled-thread-pool-max-size>${messaging.scheduled.thread.pool.max.size:6}</scheduled-thread-pool-max-size>
+            <thread-pool-max-size>${messaging.thread.pool.max.size:5}</thread-pool-max-size>
+            <security-domain>someDomain</security-domain>
+            <security-enabled>${security.enabled:false}</security-enabled>
+            <security-invalidation-interval>${security.invalidation.interval:1234}</security-invalidation-interval>
+            <override-in-vm-security>${override.in-vm.security:false}</override-in-vm-security>
+            <wild-card-routing-enabled>${wild.card.routing.enabled:false}</wild-card-routing-enabled>
+            <management-address>${management.address:my.management.address}</management-address>
+            <management-notification-address>${management.notification.address:my.management.notif.address}</management-notification-address>
+            <cluster-user>${messaging.cluster.user.name}</cluster-user>
+            <cluster-password>${messaging.cluster.user.password}</cluster-password>
+            <jmx-management-enabled>${jmx.management.enabled:false}</jmx-management-enabled>
+            <jmx-domain>${jmx.domain:my.jmx.domain}</jmx-domain>
+            <message-counter-enabled>${message.counter.enabled:true}</message-counter-enabled>
+            <message-counter-sample-period>${message.counter.sample.period:7654}</message-counter-sample-period>
+            <message-counter-max-day-history>${message.counter.max.day.history:23}</message-counter-max-day-history>
+            <connection-ttl-override>${connection.ttl.override:5432}</connection-ttl-override>
+            <async-connection-execution-enabled>${async.connection.execution.enabled:false}</async-connection-execution-enabled>
+            <transaction-timeout>${transaction.timeout:4321}</transaction-timeout>
+            <transaction-timeout-scan-period>${transaction.timeout.scan.period:5432}</transaction-timeout-scan-period>
+            <message-expiry-scan-period>${message.expiry.scan.period:7654}</message-expiry-scan-period>
+            <message-expiry-thread-priority>${message.expiry.thread.priority:7}</message-expiry-thread-priority>
+            <id-cache-size>${id.cache.size:102030}</id-cache-size>
+            <persist-id-cache>${persist.id.cache:false}</persist-id-cache>
+            <remoting-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-interceptors>
+            <remoting-incoming-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-incoming-interceptors>
+            <remoting-outgoing-interceptors>
+                <class-name>foo.bar</class-name>
+                <class-name>bar.foo</class-name>
+            </remoting-outgoing-interceptors>
+            <backup>${backup:false}</backup>
+            <allow-failback>${allow.failback:false}</allow-failback>
+            <failback-delay>${failback.delay:9876}</failback-delay>
+            <failover-on-shutdown>${failover.on.shutdown:true}</failover-on-shutdown>
+            <shared-store>${shared.store:true}</shared-store>
+            <persist-delivery-count-before-delivery>${persist.delivery.count.before.delivery:true}</persist-delivery-count-before-delivery>
+            <page-max-concurrent-io>${page.max.concurrent.io:10}</page-max-concurrent-io>
+            <create-bindings-dir>${create.bindings.dir:false}</create-bindings-dir>
+            <create-journal-dir>${create.journal.dir:true}</create-journal-dir>
+            <journal-type>${journal.type:NIO}</journal-type>
+            <journal-buffer-timeout>${journal.buffer.timeout:1357}</journal-buffer-timeout>
+            <journal-buffer-size>${journal.buffer.size:2468}</journal-buffer-size>
+            <journal-sync-transactional>${journal.sync.transactional:false}</journal-sync-transactional>
+            <journal-sync-non-transactional>${journal.sync.non.transactional:true}</journal-sync-non-transactional>
+            <log-journal-write-rate>${log.journal.write.rate:true}</log-journal-write-rate>
+            <!-- Default journal file size is 10Mb, reduced here to 100k for faster first boot -->
+            <journal-file-size>${journal.file.size:102400}</journal-file-size>
+            <journal-min-files>${journal.min.files:2}</journal-min-files>
+            <journal-compact-percentage>${journal.compact.percentage:83}</journal-compact-percentage>
+            <journal-compact-min-files>${journal.compact.min.files:2}</journal-compact-min-files>
+            <journal-max-io>${journal.max.io:50}</journal-max-io>
+            <max-saved-replicated-journal-size>${max.saved.replicated.journal.size:42}</max-saved-replicated-journal-size>
+            <perf-blast-pages>${perf.blast.pages:70}</perf-blast-pages>
+            <run-sync-speed-test>${run.sync.speed.test:false}</run-sync-speed-test>
+            <server-dump-interval>${server.dump.interval:8642}</server-dump-interval>
+            <memory-warning-threshold>1024</memory-warning-threshold>
+            <memory-measure-interval>2048</memory-measure-interval>
+            <check-for-live-server>${check.for.live.server:false}</check-for-live-server>
+            <backup-group-name>${backup.group.name:ngname}</backup-group-name>
+            <replication-clustername>${replication.clustername:repclustername}</replication-clustername>
+            <paging-directory path="${my.paging.dir:test}" relative-to="test" />
+            <bindings-directory path="${my.bindings.dir:test}" relative-to="test" />
+            <journal-directory path="${my.journal.dir:test}" relative-to="test" />
+            <large-messages-directory path="${my.largemessages.dir:test}" relative-to="test" />
+            <connectors>
+               <netty-connector name="netty" socket-binding="messaging" />
+               <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="${batch.delay:50}"/>
+               </netty-connector>
+               <in-vm-connector name="in-vm" server-id="${my.server-id:0}" />
+               <connector name="myconnector">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyConnectorFactory</factory-class>
+                  <param key="host" value="192.168.1.2"/>
+                  <param key="port" value="5445"/>
+                  <param key="key-store-path" value="path/to/server.jks"/>
+                  <param key="key-store-password" value="${VAULT::server-key::key-store-password::sharedKey}"/>
+               </connector>
+            </connectors>
+            <acceptors>
+               <netty-acceptor name="netty" socket-binding="messaging" />
+               <netty-acceptor name="netty-throughput" socket-binding="messaging-throughput">
+                  <param key="batch-delay" value="50"/>
+                  <param key="direct-deliver" value="false"/>
+               </netty-acceptor>
+               <in-vm-acceptor name="in-vm" server-id="${my.server-id:0}" />
+               <acceptor name="myacceptor">
+                  <factory-class>org.hornetq.core.remoting.impl.netty.NettyAcceptorFactory</factory-class>
+                  <param key="batch-delay" value="${batch.delay:50}"/>
+               </acceptor>
+            </acceptors>
+            <broadcast-groups>
+                <broadcast-group name="groupA">
+                    <local-bind-address>localhost</local-bind-address>
+                    <local-bind-port>12345</local-bind-port>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>23456</group-port>
+                    <broadcast-period>${broadcast.period:2500}</broadcast-period>
+                    <connector-ref>netty</connector-ref>
+                    <connector-ref>netty-throughput</connector-ref>
+                </broadcast-group>
+                <broadcast-group name="groupB">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>34567</group-port>
+                </broadcast-group>
+                <broadcast-group name="groupS">
+                    <socket-binding>group-s-binding</socket-binding>
+                </broadcast-group>
+                <broadcast-group name="groupT">
+                    <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
+                    <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
+                </broadcast-group>
+            </broadcast-groups>
+            <discovery-groups>
+                <discovery-group name="groupC">
+                    <local-bind-address>localhost</local-bind-address>
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>45678</group-port>
+                    <refresh-timeout>${refresh.timeout:3500}</refresh-timeout>
+                    <initial-wait-timeout>${initial.wait.timeout:7500}</initial-wait-timeout>
+                </discovery-group>
+                <discovery-group name="groupD">
+                    <group-address>224.0.1.105</group-address>
+                    <group-port>56789</group-port>
+                </discovery-group>
+                <discovery-group name="groupT">
+                    <socket-binding>group-t-binding</socket-binding>
+                </discovery-group>
+                <discovery-group name="groupU">
+                    <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
+                    <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
+                </discovery-group>
+            </discovery-groups>
+            <diverts>
+                <divert name="testDivert1">
+                    <routing-name>${routing.name:routing}</routing-name>
+                    <address>${address:address1}</address>
+                    <forwarding-address>${forwarding.address:forwardingaddress1}</forwarding-address>
+                    <filter string="${filter:afilter}"/>
+                    <transformer-class-name>org.jboss.test.Transformer</transformer-class-name>
+                    <exclusive>${exclusive:true}</exclusive>
+                </divert>
+                <divert name="testDivert2">
+                    <address>address2</address>
+                    <forwarding-address>forwardingaddress2</forwarding-address>
+                </divert>
+            </diverts>
+            <core-queues>
+                <queue name="coreQueueA">
+                    <address>${address:addressA}</address>
+                    <filter string="${filter:afilter}"/>
+                    <durable>${durable:true}</durable>
+                </queue>
+                <queue name="coreQueueB">
+                    <address>addressB</address>
+                </queue>
+            </core-queues>
+            <bridges>
+                <bridge name="bridge1">
+                    <queue-name>${queue.name:coreQueueA}</queue-name>
+                    <forwarding-address>${forwarding.address:forwardingaddress1}</forwarding-address>
+                    <ha>${ha:true}</ha>
+                    <filter string="${filter:afilter}"/>
+                    <transformer-class-name>foo.bar</transformer-class-name>
+                    <min-large-message-size>${min.large.message.size:10240}</min-large-message-size>
+                    <check-period>${check.period:666}</check-period>
+                    <connection-ttl>${connection.tt:36000}</connection-ttl>
+                    <retry-interval>${retry.interval:750}</retry-interval>
+                    <retry-interval-multiplier>${retry.interval.multiplier:2}</retry-interval-multiplier>
+                    <max-retry-interval>${max.retry.interval:3000}</max-retry-interval>
+                    <reconnect-attempts>${reconnect-attempts:3}</reconnect-attempts>
+                    <failover-on-server-shutdown>false</failover-on-server-shutdown>
+                    <use-duplicate-detection>${use.duplicate.detection:true}</use-duplicate-detection>
+                    <confirmation-window-size>${confirmation.window.size:350}</confirmation-window-size>
+                    <user>${user:Brian}</user>
+                    <password>${password:secret}</password>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </bridge>
+                <bridge name="bridge2">
+                    <queue-name>coreQueueB</queue-name>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </bridge>
+            </bridges>
+            <cluster-connections>
+                <cluster-connection name="cc1">
+                    <address>${address:cc1-address}</address>
+                    <connector-ref>netty</connector-ref>
+                    <check-period>${check.period:2345}</check-period>
+                    <connection-ttl>${connection.ttl:1234}</connection-ttl>
+                    <min-large-message-size>${min.large.message.size:10245}</min-large-message-size>
+                    <call-timeout>${call.timeout:3456}</call-timeout>
+                    <call-failover-timeout>${call.failover.timeout:7890}</call-failover-timeout>
+                    <retry-interval>${retry.interval:987}</retry-interval>
+                    <retry-interval-multiplier>${retry.interval.multiplier:3.0}</retry-interval-multiplier>
+                    <max-retry-interval>${max.retry.interval:3600}</max-retry-interval>
+                    <reconnect-attempts>${reconnect.attempts:-1}</reconnect-attempts>
+                    <use-duplicate-detection>${use.duplicate.detection:true}</use-duplicate-detection>
+                    <forward-when-no-consumers>${forward.when.no.consumers:true}</forward-when-no-consumers>
+                    <max-hops>${max.hops:7}</max-hops>
+                    <confirmation-window-size>${confirmation.windows.size:459}</confirmation-window-size>
+                    <notification-attempts>${notification.attempts:2}</notification-attempts>
+                    <notification-interval>${notification.interval:1}</notification-interval>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc2">
+                    <address>cc2-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <static-connectors allow-direct-connections-only="true">
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+                <cluster-connection name="cc3">
+                    <address>cc3-address</address>
+                    <connector-ref>netty</connector-ref>
+                    <discovery-group-ref discovery-group-name="groupC"/>
+                </cluster-connection>
+                <cluster-connection name="cc4">
+                    <address>cc4-address</address>
+                    <connector-ref>netty-throughput</connector-ref>
+                    <static-connectors>
+                        <connector-ref>in-vm</connector-ref>
+                        <connector-ref>netty</connector-ref>
+                    </static-connectors>
+                </cluster-connection>
+            </cluster-connections>
+            <grouping-handler name="grouping-handler">
+                <type>${grouping.type:LOCAL}</type>
+                <address>${address:handler-address}</address>
+                <timeout>${timeout:5000}</timeout>
+                <group-timeout>${group-timeout:1234}</group-timeout>
+                <reaper-period>${reaper-period:5678}</reaper-period>
+            </grouping-handler>
+            <security-settings>
+               <security-setting match="#">
+                   <permission roles="guest" type="send"/>
+                   <permission roles="guest" type="consume"/>
+                   <permission roles="guest" type="createNonDurableQueue"/>
+                   <permission roles="guest" type="deleteNonDurableQueue"/>
+                   <permission roles="adming" type="manage"/>
+               </security-setting>
+            </security-settings>
+            <address-settings>
+               <!--default for catch all-->
+               <address-setting match="#">
+                  <dead-letter-address>${dead.letter.address:jms.queue.DLQ}</dead-letter-address>
+                  <expiry-address>${expiry.address:jms.queue.ExpiryQueue}</expiry-address>
+                  <redelivery-delay>${redelivery.delay:0}</redelivery-delay>
+                  <max-delivery-attempts>${max.delivery.attempts:5}</max-delivery-attempts>
+                  <max-size-bytes>${max.size.bytes:10485760}</max-size-bytes>
+                  <page-size-bytes>${page.size.bytes:10485760}</page-size-bytes>
+                  <page-max-cache-size>${page.max.cache.size:7}</page-max-cache-size>
+                  <address-full-policy>${address.full.policy:BLOCK}</address-full-policy>
+                  <message-counter-history-day-limit>${message.counter.history.day.limit:10}</message-counter-history-day-limit>
+                  <last-value-queue>${last.value.queue:false}</last-value-queue>
+                  <redistribution-delay>${redistribution.delay:0}</redistribution-delay>
+                  <send-to-dla-on-no-route>${send.to.dla.on.no.route:false}</send-to-dla-on-no-route>
+                  <slow-consumer-check-period>${slow.consumer.check.period:123}</slow-consumer-check-period>
+                  <slow-consumer-policy>${slow.consumer.policy:KILL}</slow-consumer-policy>
+                  <slow-consumer-threshold>${slow.consumer.threshold:456}</slow-consumer-threshold>
+               </address-setting>
+            </address-settings>
+
+            <connector-services>
+                <connector-service name="a">
+                    <factory-class>foo.bar</factory-class>
+                </connector-service>
+                <connector-service name="b">
+                    <factory-class>bar.foo</factory-class>
+                    <param key="foo" value="${connector.value:bar}"/>
+                    <param key="bar" value="2"/>
+                </connector-service>
+            </connector-services>
+
+            <!--JMS Stuff-->
+            <jms-connection-factories>
+              <connection-factory name="InVmConnectionFactory">
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="${connection-factory.entries.entry:java:/ConnectionFactory}"/>
+                 </entries>
+              </connection-factory>
+              <connection-factory name="RemoteConnectionFactory">
+                 <factory-type>XA_QUEUE</factory-type>
+                 <connectors>
+                    <connector-ref connector-name="netty"/>
+                 </connectors>
+                 <entries>
+                    <entry name="RemoteConnectionFactory"/>
+                 </entries>
+                 <client-id>testClient</client-id>
+              </connection-factory>
+              <connection-factory name="otherConnectionFactory">
+                 <discovery-group-ref discovery-group-name="groupC"/>
+                 <entries>
+                    <entry name="otherConnectionFactory"/>
+                 </entries>
+                 <ha>${ha:true}</ha>
+                 <client-failure-check-period>${client.failure.check.period:12345}</client-failure-check-period>
+                 <connection-ttl>${connection.ttl:56789}</connection-ttl>
+                 <call-timeout>${call.timeout:123}</call-timeout>
+                 <call-failover-timeout>${call.failover.timeout:456}</call-failover-timeout>
+                 <consumer-window-size>${consumer.window.size:456}</consumer-window-size>
+                 <consumer-max-rate>${consumer.max.rate:789}</consumer-max-rate>
+                 <confirmation-window-size>${confirmation.window.size:-1}</confirmation-window-size>
+			     <producer-window-size>${producer.window.size:-1}</producer-window-size>
+			     <producer-max-rate>${producer.max.rate:1024}</producer-max-rate>
+			     <compress-large-messages>${compress.large.messages:true}</compress-large-messages>
+			     <cache-large-message-client>${cache.large.message.client:false}</cache-large-message-client>
+			     <min-large-message-size>${min.large.message.size:2048}</min-large-message-size>
+			     <client-id>${client.id:myClientID}</client-id>
+			     <dups-ok-batch-size>${dups.ok.batch.size:256}</dups-ok-batch-size>
+			     <transaction-batch-size>${transaction.batch.size:512}</transaction-batch-size>
+			     <block-on-acknowledge>${block.on.acknowledge:false}</block-on-acknowledge>
+			     <block-on-non-durable-send>${block.on.non.durable.send:false}</block-on-non-durable-send>
+			     <block-on-durable-send>${block.on.durable.send:false}</block-on-durable-send>
+			     <auto-group>${auto.group:true}</auto-group>
+			     <pre-acknowledge>${pre.acknowledge:true}</pre-acknowledge>
+			     <retry-interval>${retry.interval:500}</retry-interval>
+			     <retry-interval-multiplier>${retry.interval.multiplier:2.5}</retry-interval-multiplier>
+			     <max-retry-interval>${max.retry.interval:10000}</max-retry-interval>
+			     <reconnect-attempts>${reconnect.attempts:2}</reconnect-attempts>
+			     <failover-on-initial-connection>${failover.on.initial.connection:true}</failover-on-initial-connection>
+				 <connection-load-balancing-policy-class-name>connection.load.balancy.policy.class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>${use.global.pools:true}</use-global-pools>
+				 <scheduled-thread-pool-max-size>${scheduled.thread.pool.max.size:24}</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>${thread.pool.max.size:48}</thread-pool-max-size>
+				 <group-id>${group.id:myGroup}</group-id>
+              </connection-factory>
+              <pooled-connection-factory name="hornetq-ra">
+                 <inbound-config>
+                     <use-jndi>${use.jndi:false}</use-jndi>
+                     <jndi-params>${jndi.params:whatever}</jndi-params>
+                     <use-local-tx>${use.local.tx:true}</use-local-tx>
+                     <setup-attempts>${setup-attempts:123}</setup-attempts>
+                     <setup-interval>${setup-interval:456}</setup-interval>
+                 </inbound-config>
+                 <transaction mode="${transaction:xa}"/>
+                 <user>${user:alice}</user>
+                 <password>${password:alicepassword}</password>
+                 <min-pool-size>${min.pool.size:42}</min-pool-size>
+                 <max-pool-size>${max.pool.size:242}</max-pool-size>
+                 <initial-message-packet-size>${initial.message.packet.size:9876}</initial-message-packet-size>
+                 <initial-connect-attempts>${initial.connect.attempts:5432}</initial-connect-attempts>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="${pooled-connection-factory.entries.entry:java:/JmsXA}"/>
+                 </entries>
+                 <ha>${ha:true}</ha>
+                 <client-failure-check-period>${client.failure.check.period:12345}</client-failure-check-period>
+                 <connection-ttl>${connection.ttl:6789}</connection-ttl>
+                 <call-timeout>${call.timeout:123}</call-timeout>
+                 <call-failover-timeout>${call.failover.timeout:456}</call-failover-timeout>
+                 <consumer-window-size>${consumer.window.size:456}</consumer-window-size>
+                 <consumer-max-rate>${consumer.max.rate:789}</consumer-max-rate>
+                 <confirmation-window-size>${confirmation.window.size:-1}</confirmation-window-size>
+			     <producer-window-size>${producer.window.size:-1}</producer-window-size>
+			     <producer-max-rate>${producer.max.rate:1024}</producer-max-rate>
+			     <compress-large-messages>${compress.large.messages:true}</compress-large-messages>
+			     <cache-large-message-client>${cache.large.message.client:false}</cache-large-message-client>
+			     <min-large-message-size>${min.large.message.size:2048}</min-large-message-size>
+			     <client-id>${client.id:myClientID}</client-id>
+			     <dups-ok-batch-size>${dups.ok.batch.size:256}</dups-ok-batch-size>
+			     <transaction-batch-size>${transaction.batch.size:512}</transaction-batch-size>
+			     <block-on-acknowledge>${block.on.acknowledge:false}</block-on-acknowledge>
+			     <block-on-non-durable-send>${block.on.non.durable.send:false}</block-on-non-durable-send>
+			     <block-on-durable-send>${block.on.durable.send:false}</block-on-durable-send>
+			     <auto-group>${auto.group:true}</auto-group>
+			     <pre-acknowledge>${pre.acknowledge:true}</pre-acknowledge>
+			     <retry-interval>${retry.interval:500}</retry-interval>
+			     <retry-interval-multiplier>${retry.interval.multiplier:2.5}</retry-interval-multiplier>
+			     <max-retry-interval>${max.retry.interval:10000}</max-retry-interval>
+			     <reconnect-attempts>${reconnect.attempts:2}</reconnect-attempts>
+			     <failover-on-initial-connection>${failover.on.initial.connection:true}</failover-on-initial-connection>
+				 <connection-load-balancing-policy-class-name>connection.load.balancing.policy.class</connection-load-balancing-policy-class-name>
+				 <use-global-pools>${use.global.pools:true}</use-global-pools>
+				 <scheduled-thread-pool-max-size>${scheduled.thread.pool.max.size:24}</scheduled-thread-pool-max-size>
+				 <thread-pool-max-size>${thread.pool.max.size:48}</thread-pool-max-size>
+				 <group-id>${group.id:myGroup}</group-id>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-local">
+                 <transaction mode="local"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <use-auto-recovery>${use.auto.recovery:true}</use-auto-recovery>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsLocal"/>
+                 </entries>
+              </pooled-connection-factory>
+              <pooled-connection-factory name="hornetq-ra-none">
+                 <transaction mode="none"/>
+                 <user>alice</user>
+                 <password>alicepassword</password>
+                 <connectors>
+                    <connector-ref connector-name="in-vm"/>
+                 </connectors>
+                 <entries>
+                    <entry name="java:/JmsNone"/>
+                 </entries>
+              </pooled-connection-factory>
+           </jms-connection-factories>
+
+           <jms-destinations>
+              <jms-queue name="testQueue">
+                 <entry name="${jms-queue.entry:queue/test}"/>
+                 <selector string="${selector:color='red'}"/>
+                 <durable>${durable:true}</durable>
+              </jms-queue>
+              <jms-topic name="testTopic">
+                 <entry name="${jms-topic.entry:topic/test}"/>
+              </jms-topic>
+           </jms-destinations>
+        </hornetq-server>
+
+        <hornetq-server name="empty"/>
+
+        <jms-bridge>
+            <source>
+                <connection-factory name="/cf/sourceCF" />
+                <destination name="/topic/anotherSourceTopic" />
+            </source>
+            <target>
+                <connection-factory name="/cf/targetCF" />
+                <destination name="anotherMQ/jms/queue/anotherTargetQueue" />
+            </target>
+            <quality-of-service>${quality.of.service:AT_MOST_ONCE}</quality-of-service>
+            <failure-retry-interval>${failure.retry.interval:45678}</failure-retry-interval>
+            <max-retries>${max.retries:7890}</max-retries>
+            <max-batch-size>${max.batch.size:12345}</max-batch-size>
+            <max-batch-time>${max.batch.time:10000}</max-batch-time>
+        </jms-bridge>
+    </subsystem>


### PR DESCRIPTION
- port jboss-as-messaging 1.5 XML schema
- by mistake, the 1.4 XSD provided in EAP was changed after EAP was
  release. The XSD was later fixed but for compatibility sake, the
  erroneous elements (that are added in 1.5) are also handled by the 1.4
  parser:
  - hornetq-server's override-invm-security
  - address-settings's slow-consumer-*

JIRA: https://issues.jboss.org/browse/WFLY-4533
