### PR TITLE
WFLY-4551 legacy cache containers need org.jboss.as.jpa.hibernate:4 module to have Infinispan access

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/4/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/hibernate/4/module.xml
@@ -38,5 +38,8 @@
     </resources>
 
     <dependencies>
+        <module name="org.infinispan" services="import"/>
+        <module name="org.hibernate.infinispan" services="import"/>
+        <module name="org.hibernate"/>
     </dependencies>
 </module>


### PR DESCRIPTION
I worked around the TCK 2lc failure but we should have this in wf9 or wf10.
