### PR TITLE
WFLY-4128 Move JAX-RS 2.0 API to JBoss Specs one

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -925,8 +925,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>jaxrs-api</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/src/license/licenses.xml
+++ b/feature-pack/src/license/licenses.xml
@@ -2932,7 +2932,7 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.ws.rs</groupId>
-      <artifactId>jboss-jaxrs-api_1.1_spec</artifactId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
       <licenses>
         <license>
           <name>GNU Lesser General Public License, Version 2.1</name>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/ws/rs/api/main/module.xml
@@ -24,7 +24,7 @@
 
 <module xmlns="urn:jboss:module:1.3" name="javax.ws.rs.api">
     <resources>
-        <artifact name="${org.jboss.resteasy:jaxrs-api}"/>
+        <artifact name="${org.jboss.spec.javax.ws.rs:jboss-jaxrs-api_2.0_spec}"/>
     </resources>
 
     <dependencies>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -97,8 +97,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>jaxrs-api</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,6 @@
         <version.javax.jws.jsr181-api>1.0-MR1</version.javax.jws.jsr181-api>
         <version.javax.mail>1.5.3</version.javax.mail>
         <version.javax.validation>1.1.0.Final</version.javax.validation>
-        <version.org.jboss.spec.javax.websockets>1.1.1.Final</version.org.jboss.spec.javax.websockets>
         <version.jaxen>1.1.6</version.jaxen>
         <version.jboss.jaxbintros>1.0.2.GA</version.jboss.jaxbintros>
         <version.joda-time>2.7</version.joda-time>
@@ -187,10 +186,12 @@
         <version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>1.0.1.Final</version.org.jboss.spec.javax.servlet.jsp.jboss-jsp-api_2.3_spec>
         <version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>1.1.2.Final</version.org.jboss.spec.javax.servlet.jstl.jboss-jstl-api_1.2_spec>
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.0.0.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
+        <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>1.0.0.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec>
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.3.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
+        <version.org.jboss.spec.javax.websockets>1.1.1.Final</version.org.jboss.spec.javax.websockets>
         <version.org.jboss.weld.weld>2.2.11.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.2.SP4</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.3.CR4</version.org.jboss.ws.api>
@@ -4841,6 +4842,10 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.resteasy</groupId>
+                        <artifactId>jaxrs-api</artifactId>
+                    </exclusion>
                 </exclusions>
              </dependency>
 
@@ -4925,12 +4930,6 @@
 
             <dependency>
                 <groupId>org.jboss.resteasy</groupId>
-                <artifactId>jaxrs-api</artifactId>
-                <version>${version.org.jboss.resteasy}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.jboss.resteasy</groupId>
                 <artifactId>jose-jwt</artifactId>
                 <version>${version.org.jboss.resteasy}</version>
                 <exclusions>
@@ -5009,6 +5008,10 @@
                     <exclusion>
                         <groupId>org.jboss.spec.javax.annotation</groupId>
                         <artifactId>jboss-annotations-api_1.1_spec</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.jboss.resteasy</groupId>
+                        <artifactId>jaxrs-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>
@@ -5480,6 +5483,12 @@
                 <groupId>org.jboss.spec.javax.transaction</groupId>
                 <artifactId>jboss-transaction-api_1.2_spec</artifactId>
                 <version>${version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.spec.javax.ws.rs</groupId>
+                <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
+                <version>${version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.0_spec}</version>
             </dependency>
 
             <dependency>

--- a/rts/pom.xml
+++ b/rts/pom.xml
@@ -53,8 +53,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>jaxrs-api</artifactId>
+            <groupId>org.jboss.spec.javax.ws.rs</groupId>
+            <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
         </dependency>
 
         <dependency>

--- a/spec-api/pom.xml
+++ b/spec-api/pom.xml
@@ -46,8 +46,8 @@
       <artifactId>javax.json</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
-      <artifactId>jaxrs-api</artifactId>
+      <groupId>org.jboss.spec.javax.ws.rs</groupId>
+      <artifactId>jboss-jaxrs-api_2.0_spec</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jboss.spec.javax.batch</groupId>


### PR DESCRIPTION
This PR moves from resteasy provided jaxrs-api to https://github.com/jboss/jboss-jaxrs-api_spec
For now it is beta1 version, with .Final released as soon as TCK passes with this. 
@scottmarlow agrees that this change should be fine. 
