### PR TITLE
[WFLY-4554] cd into JBOSS_HOME instead of fancy escaping.

### DIFF
--- a/feature-pack/src/main/resources/content/bin/jconsole.sh
+++ b/feature-pack/src/main/resources/content/bin/jconsole.sh
@@ -74,8 +74,9 @@ fi
 
 CLASSPATH=$JAVA_HOME/lib/jconsole.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
-CLASSPATH="$CLASSPATH:\""$JBOSS_HOME"\"/bin/client/jboss-cli-client.jar"
+CLASSPATH=$CLASSPATH:./bin/client/jboss-cli-client.jar
 
 echo CLASSPATH $CLASSPATH
 
+cd "$JBOSS_HOME"
 $JAVA_HOME/bin/jconsole -J-Djava.class.path="$CLASSPATH" "$@"


### PR DESCRIPTION
The problem with the jconsole script is the arguments get passed through the jconsole binary included with the JVM, there is not sufficient flexibility to escape the classpath so that it reaches the underlying Java process in the correct form.

On the other hand if we ensure we are in the troubled directory then the classpath can be relative.
