### PR TITLE
EntityBean instances are leaked from pool on certain exceptions

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanComponent.java
@@ -158,6 +158,15 @@ public class EntityBeanComponent extends EJBComponent implements PooledComponent
         }
     }
 
+    public void discardEntityBeanInstance(final EntityBeanComponentInstance instance) {
+        if (pool!=null) {
+            pool.discard(instance);
+        } else {
+            factory.destroy(instance);
+        }
+    }
+
+
     public ReadyEntityCache getCache() {
         return cache;
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanRemoteViewInstanceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanRemoteViewInstanceFactory.java
@@ -87,7 +87,15 @@ public class EntityBeanRemoteViewInstanceFactory implements ViewInstanceFactory 
 
         //call the ejbCreate method
         final Object primaryKey;
-        primaryKey = invokeEjbCreate(contextData, ejbCreate, instance, params);
+        boolean exceptionOnCreate = true;
+        try {
+            primaryKey = invokeEjbCreate(contextData, ejbCreate, instance, params);
+            exceptionOnCreate = false;
+        } finally {
+            if (exceptionOnCreate) {
+                entityBeanComponent.releaseEntityBeanInstance(instance);
+            }
+        }
         instance.associate(primaryKey);
 
         //now add the instance to the cache, so it is usable

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/ReferenceCountingEntityCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/ReferenceCountingEntityCache.java
@@ -151,6 +151,8 @@ public class ReferenceCountingEntityCache implements ReadyEntityCache {
                 //if there is a new instance we cannot discard the entry entirely
                 cache.remove(instance.getPrimaryKey());
             }
+
+            component.discardEntityBeanInstance(instance);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/TransactionLocalEntityCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/TransactionLocalEntityCache.java
@@ -94,7 +94,9 @@ public class TransactionLocalEntityCache implements ReadyEntityCache {
             final Object key = transactionSynchronizationRegistry.getTransactionKey();
             final Map<Object, CacheEntry> map = cache.get(key);
             if (map != null) {
-                map.remove(instance.getPrimaryKey());
+                if (map.remove(instance.getPrimaryKey())!=null) {
+                    component.discardEntityBeanInstance(instance);
+                }
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/interceptors/EntityBeanEjbCreateMethodInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/interceptors/EntityBeanEjbCreateMethodInterceptor.java
@@ -76,7 +76,16 @@ public class EntityBeanEjbCreateMethodInterceptor implements Interceptor {
         final EntityBeanComponentInstance instance = entityBeanComponent.acquireUnAssociatedInstance();
 
         //call the ejbCreate method
-        final Object primaryKey = invokeEjbCreate(context, ejbCreate, instance, params);
+        Object primaryKey;
+        boolean exceptionOnCreate = true;
+        try {
+            primaryKey = invokeEjbCreate(context, ejbCreate, instance, params);
+            exceptionOnCreate = false;
+        } finally {
+            if (exceptionOnCreate) {
+                entityBeanComponent.releaseEntityBeanInstance(instance);
+            }
+        }
         instance.associate(primaryKey);
         clientInstance.setViewInstanceData(EntityBeanComponent.PRIMARY_KEY_CONTEXT_KEY, primaryKey);
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityExceptionsBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityExceptionsBase.java
@@ -1,0 +1,197 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.ejb.remote.common.EJBManagementUtil;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBException;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.UserTransaction;
+import java.rmi.RemoteException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.fail;
+
+public abstract class EntityExceptionsBase {
+    private static final String ARCHIVE_NAME = "ExceptionsBeanTest.war";
+
+    static abstract class EntityPoolSetup implements ServerSetupTask {
+
+        private final String poolName;
+        private final boolean optimisticLock;
+
+        public EntityPoolSetup(String poolName, boolean optimisticLock) {
+            this.poolName = poolName;
+            this.optimisticLock = optimisticLock;
+        }
+
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            EJBManagementUtil.createStrictMaxPool(managementClient.getControllerClient(), poolName, 1, 1, TimeUnit.MILLISECONDS);
+            EJBManagementUtil.editEntityBeanInstancePool(managementClient.getControllerClient(), poolName, optimisticLock);
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            EJBManagementUtil.undefineEntityBeanInstancePool(managementClient.getControllerClient());
+            EJBManagementUtil.removeStrictMaxPool(managementClient.getControllerClient(), poolName);
+        }
+    }
+
+    static class OptimisticEntityPoolSetup extends EntityPoolSetup {
+        public OptimisticEntityPoolSetup() {
+            super("TestEntityOptimisticPool", true);
+        }
+    }
+
+    static class PessimisticEntityPoolSetup extends EntityPoolSetup {
+        public PessimisticEntityPoolSetup() {
+            super("TestEntityPessimisticPool", false);
+        }
+    }
+
+    @Deployment
+    public static Archive deploy() {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, ARCHIVE_NAME);
+        war.addPackage(EntityOptimisticLockingExceptionsTestCase.class.getPackage());
+        war.addAsWebInfResource(EntityOptimisticLockingExceptionsTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        return war;
+    }
+
+    @ArquillianResource
+    private InitialContext ctx;
+
+    @SuppressWarnings("unchecked")
+    protected  <T> T lookup(String name) throws NamingException {
+        return (T) ctx.lookup(name);
+    }
+
+    protected ExceptionsLocalHome getLocalHome() throws NamingException {
+        return lookup("java:module/ExceptionsBean!"+ExceptionsLocalHome.class.getName());
+    }
+
+    protected ExceptionsRemoteHome getRemoteHome() throws NamingException {
+        return lookup("java:module/ExceptionsBean!"+ExceptionsRemoteHome.class.getName());
+    }
+
+    protected ExceptionsLocalInterface localFind(String key) throws Exception {
+        return getLocalHome().findByPrimaryKey(key);
+    }
+
+    protected ExceptionsLocalInterface localFind() throws Exception {
+        return localFind("find-test-local");
+    }
+
+    protected ExceptionsRemoteInterface remoteFind() throws Exception {
+        return getRemoteHome().findByPrimaryKey("find-test-remote");
+    }
+
+    protected UserTransaction getUserTransaction() throws NamingException {
+        return lookup("java:jboss/UserTransaction");
+    }
+
+    /**
+     * Sanity check - verify actual pool limitations
+     */
+    @Test
+    public void shouldNotReturnInstanceToPoolUntilTransactionEnd() throws Exception {
+        UserTransaction ut = getUserTransaction();
+        ut.begin();
+        try {
+            localFind("key1").test();
+            try {
+                localFind("key2").test();
+                fail("Only one instance of bean should be allowed by pool");
+            } catch (Exception e) {
+                // Expected exception
+            }
+        } finally {
+            ut.rollback();
+        }
+    }
+
+    @Test
+    public void shouldReleaseInstanceToPoolOnLocalCreateException() throws Exception {
+        try {
+            getLocalHome().create("create-test");
+            fail("Create should throw exception");
+        } catch (CreateException e) {
+            // Expected exception
+        } catch (EJBException e) {
+            // Expected exception
+        }
+
+        // There should be no exception here
+        localFind();
+    }
+
+    @Test
+    public void shouldReleaseInstanceToPoolOnRemoteCreateException() throws Exception {
+        try {
+            getRemoteHome().create("create-test");
+            fail("Create should throw exception");
+        } catch (CreateException e) {
+            // Expected exception
+        } catch (RemoteException e) {
+            // Expected exception
+        }
+
+        // There should be no exception here
+        remoteFind();
+    }
+
+    @Test
+    public void shouldReleaseInstanceToPoolOnLocalRuntimeException() throws Exception {
+        try {
+            localFind().throwRuntimeException();
+            fail("business method should throw exception");
+        } catch (EJBException e) {
+            // Expected exception
+        }
+
+        // There should be no exception here
+        localFind();
+    }
+
+    @Test
+    public void shouldReleaseInstanceToPoolOnRemoteRuntimeException() throws Exception {
+        try {
+            remoteFind().throwRuntimeException();
+            fail("business method should throw exception");
+        } catch (RemoteException e) {
+            // Expected exception
+        }
+
+        // There should be no exception here
+        remoteFind();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityOptimisticLockingExceptionsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityOptimisticLockingExceptionsTestCase.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@ServerSetup({EntityExceptionsBase.OptimisticEntityPoolSetup.class})
+public class EntityOptimisticLockingExceptionsTestCase extends EntityExceptionsBase {
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityPessimisticLockingExceptionsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityPessimisticLockingExceptionsTestCase.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+@ServerSetup({EntityExceptionsBase.PessimisticEntityPoolSetup.class})
+public class EntityPessimisticLockingExceptionsTestCase extends EntityExceptionsBase {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsBean.java
@@ -1,0 +1,83 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import javax.ejb.*;
+import java.rmi.RemoteException;
+
+public class ExceptionsBean implements EntityBean {
+
+    @Override
+    public void setEntityContext(EntityContext ctx) throws EJBException, RemoteException {
+
+    }
+
+    @Override
+    public void unsetEntityContext() throws EJBException, RemoteException {
+
+    }
+
+    @Override
+    public void ejbActivate() throws EJBException, RemoteException {
+
+    }
+
+    @Override
+    public void ejbPassivate() throws EJBException, RemoteException {
+
+    }
+
+    @Override
+    public void ejbLoad() throws EJBException, RemoteException {
+
+    }
+
+    @Override
+    public void ejbStore() throws EJBException, RemoteException {
+
+    }
+
+    public String ejbCreate(String key) throws CreateException {
+        throw new EJBException("Expected exception");
+    }
+
+    public void ejbPostCreate(String key) throws CreateException {
+
+    }
+
+    @Override
+    public void ejbRemove() throws RemoveException, EJBException, RemoteException {
+
+    }
+
+    public String ejbFindByPrimaryKey(String key) throws FinderException {
+        return key;
+    }
+
+    public void throwRuntimeException() {
+        throw new EJBException("Expected exception");
+    }
+
+    public void test() {
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsLocalHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsLocalHome.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBLocalHome;
+import javax.ejb.FinderException;
+
+public interface ExceptionsLocalHome extends EJBLocalHome {
+
+    ExceptionsLocalInterface create(String key) throws CreateException;
+
+    ExceptionsLocalInterface findByPrimaryKey(String key) throws FinderException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsLocalInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsLocalInterface.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import javax.ejb.EJBLocalObject;
+
+public interface ExceptionsLocalInterface extends EJBLocalObject {
+
+    void throwRuntimeException();
+
+    void test();
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsRemoteHome.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsRemoteHome.java
@@ -1,0 +1,13 @@
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import javax.ejb.CreateException;
+import javax.ejb.EJBHome;
+import javax.ejb.FinderException;
+import java.rmi.RemoteException;
+
+public interface ExceptionsRemoteHome extends EJBHome {
+
+    ExceptionsRemoteInterface create(String key) throws CreateException, RemoteException;
+
+    ExceptionsRemoteInterface findByPrimaryKey(String key) throws FinderException, RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsRemoteInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsRemoteInterface.java
@@ -1,0 +1,11 @@
+package org.jboss.as.test.integration.ejb.entity.exceptions;
+
+import javax.ejb.EJBObject;
+import java.rmi.RemoteException;
+
+public interface ExceptionsRemoteInterface extends EJBObject {
+
+    void throwRuntimeException() throws RemoteException;
+
+    void test() throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ejb-jar.xml
@@ -1,0 +1,51 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+         version="3.1">
+    <enterprise-beans>
+        <entity>
+            <ejb-name>ExceptionsBean</ejb-name>
+            <home>org.jboss.as.test.integration.ejb.entity.exceptions.ExceptionsRemoteHome</home>
+            <remote>org.jboss.as.test.integration.ejb.entity.exceptions.ExceptionsRemoteInterface</remote>
+            <local-home>org.jboss.as.test.integration.ejb.entity.exceptions.ExceptionsLocalHome</local-home>
+            <local>org.jboss.as.test.integration.ejb.entity.exceptions.ExceptionsLocalInterface</local>
+            <ejb-class>org.jboss.as.test.integration.ejb.entity.exceptions.ExceptionsBean</ejb-class>
+            <persistence-type>Bean</persistence-type>
+            <prim-key-class>java.lang.String</prim-key-class>
+            <reentrant>true</reentrant>
+        </entity>
+    </enterprise-beans>
+
+    <assembly-descriptor>
+        <container-transaction>
+            <method>
+                <ejb-name>ExceptionsBean</ejb-name>
+                <method-name>*</method-name>
+            </method>
+            <trans-attribute>Required</trans-attribute>
+        </container-transaction>
+    </assembly-descriptor>
+</ejb-jar>
+

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
@@ -378,6 +378,70 @@ public class EJBManagementUtil {
         }
     }
 
+    public static void editEntityBeanInstancePool(final ModelControllerClient controllerClient, final String poolName, final boolean optimisticLocking) {
+        try {
+            // /subsystem=ejb3
+            final PathAddress ejb3SubsystemAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME));
+
+            // /subsystem=ejb3:write-attribute(name="default-entity-bean-instance-pool", value=<poolName>)
+            final ModelNode defaultEntityBeanInstancePool = new ModelNode();
+            // set the operation
+            defaultEntityBeanInstancePool.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            // set the address
+            defaultEntityBeanInstancePool.get(OP_ADDR).set(ejb3SubsystemAddress.toModelNode());
+            // setup the parameters for the write attribute operation
+            defaultEntityBeanInstancePool.get(NAME).set(EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_INSTANCE_POOL);
+            defaultEntityBeanInstancePool.get(VALUE).set(poolName);
+            // execute the operation
+            execute(controllerClient, defaultEntityBeanInstancePool);
+
+            // /subsystem=ejb3:write-attribute(name="default-entity-bean-optimistic-locking", value=<optimisticLocking>)
+            final ModelNode defaultEntityBeanOptimisticLocking = new ModelNode();
+            // set the operation
+            defaultEntityBeanOptimisticLocking.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
+            // set the address
+            defaultEntityBeanOptimisticLocking.get(OP_ADDR).set(ejb3SubsystemAddress.toModelNode());
+            // setup the parameters for the write attribute operation
+            defaultEntityBeanOptimisticLocking.get(NAME).set(EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING);
+            defaultEntityBeanOptimisticLocking.get(VALUE).set(optimisticLocking);
+            // execute the operation
+            execute(controllerClient, defaultEntityBeanOptimisticLocking);
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
+
+    public static void undefineEntityBeanInstancePool(final ModelControllerClient controllerClient) {
+        try {
+            // /subsystem=ejb3
+            final PathAddress ejb3SubsystemAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, EJB3Extension.SUBSYSTEM_NAME));
+
+            // /subsystem=ejb3:undefine-attribute(name="default-entity-bean-instance-pool")
+            final ModelNode defaultEntityBeanInstancePool = new ModelNode();
+            // set the operation
+            defaultEntityBeanInstancePool.get(OP).set(UNDEFINE_ATTRIBUTE_OPERATION);
+            // set the address
+            defaultEntityBeanInstancePool.get(OP_ADDR).set(ejb3SubsystemAddress.toModelNode());
+            // setup the parameters for the undefine attribute operation
+            defaultEntityBeanInstancePool.get(NAME).set(EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_INSTANCE_POOL);
+            // execute the operation
+            execute(controllerClient, defaultEntityBeanInstancePool);
+
+            // /subsystem=ejb3:undefine-attribute(name="default-entity-bean-optimistic-locking")
+            final ModelNode defaultEntityBeanOptimisticLocking = new ModelNode();
+            // set the operation
+            defaultEntityBeanOptimisticLocking.get(OP).set(UNDEFINE_ATTRIBUTE_OPERATION);
+            // set the address
+            defaultEntityBeanOptimisticLocking.get(OP_ADDR).set(ejb3SubsystemAddress.toModelNode());
+            // setup the parameters for the undefine attribute operation
+            defaultEntityBeanOptimisticLocking.get(NAME).set(EJB3SubsystemModel.DEFAULT_ENTITY_BEAN_OPTIMISTIC_LOCKING);
+            // execute the operation
+            execute(controllerClient, defaultEntityBeanOptimisticLocking);
+        } catch (IOException ioe) {
+            throw new RuntimeException(ioe);
+        }
+    }
+
     public static void enablePassByValueForRemoteInterfaceInvocations(ManagementClient managementClient) {
         editPassByValueForRemoteInterfaceInvocations(managementClient, true);
     }


### PR DESCRIPTION
Proposed fix for https://issues.jboss.org/browse/WFLY-4569 (entity beans not returning to the pool on certain exceptions).
This pull requests contains the fix itself and set of integration tests to validate its logic.
