### PR TITLE
[WFLY-4563] Update log categories and messages where needed

### DIFF
--- a/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/RetryingInvoker.java
+++ b/clustering/ee/infinispan/src/main/java/org/wildfly/clustering/ee/infinispan/RetryingInvoker.java
@@ -33,6 +33,7 @@ import org.wildfly.clustering.ee.Invoker;
  */
 public class RetryingInvoker implements Invoker {
 
+    // No logger interface for this module and no reason to create one for this class only
     private static final Logger LOGGER = Logger.getLogger(RetryingInvoker.class);
 
     private final long[] backOffIntervals;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
@@ -63,7 +63,6 @@ import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
-import org.jboss.logging.Logger;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.ServiceName;
@@ -83,7 +82,6 @@ import org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider;
  */
 public class CacheAddHandler extends AbstractAddStepHandler {
 
-    private static final Logger log = Logger.getLogger(CacheAddHandler.class.getPackage().getName());
     private static final ModuleIdentifier QUERY_MODULE = ModuleIdentifier.fromString("org.infinispan.query");
 
     final CacheMode mode;
@@ -146,7 +144,10 @@ public class CacheAddHandler extends AbstractAddStepHandler {
 
         Class<? extends CacheGroupBuilderProvider> providerClass = this.mode.isClustered() ? ClusteredCacheGroupBuilderProvider.class : LocalCacheGroupBuilderProvider.class;
         for (CacheGroupBuilderProvider provider : ServiceLoader.load(providerClass, providerClass.getClassLoader())) {
-            log.debugf("Installing %s for cache %s of container %s", provider.getClass().getSimpleName(), cacheName, containerName);
+            // Getting the class name can be expensive
+            if (InfinispanLogger.ROOT_LOGGER.isDebugEnabled()) {
+                InfinispanLogger.ROOT_LOGGER.debugf("Installing %s for cache %s of container %s", provider.getClass().getSimpleName(), cacheName, containerName);
+            }
             for (Builder<?> groupBuilder : provider.getBuilders(containerName, cacheName)) {
                 groupBuilder.build(target).install();
             }
@@ -173,7 +174,7 @@ public class CacheAddHandler extends AbstractAddStepHandler {
             }
         }
 
-        log.debugf("cache %s removed for container %s", cacheName, containerName);
+        InfinispanLogger.ROOT_LOGGER.debugf("cache %s removed for container %s", cacheName, containerName);
     }
 
     /**

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerBuilder.java
@@ -32,7 +32,6 @@ import org.infinispan.notifications.cachemanagerlistener.event.CacheStartedEvent
 import org.infinispan.notifications.cachemanagerlistener.event.CacheStoppedEvent;
 import org.jboss.as.clustering.infinispan.DefaultCacheContainer;
 import org.jboss.as.clustering.infinispan.InfinispanLogger;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
@@ -50,8 +49,6 @@ import org.wildfly.clustering.service.Builder;
  */
 @Listener
 public class CacheContainerBuilder implements Builder<CacheContainer>, Service<CacheContainer> {
-
-    private static final Logger log = Logger.getLogger(CacheContainerBuilder.class.getPackage().getName());
 
     private final InjectedValue<GlobalConfiguration> configuration = new InjectedValue<>();
     private final List<String> aliases = new LinkedList<>();
@@ -97,7 +94,7 @@ public class CacheContainerBuilder implements Builder<CacheContainer>, Service<C
         this.container = new DefaultCacheContainer(config, this.defaultCache);
         this.container.addListener(this);
         this.container.start();
-        log.debugf("%s cache container started", this.name);
+        InfinispanLogger.ROOT_LOGGER.debugf("%s cache container started", this.name);
     }
 
     @Override
@@ -105,7 +102,7 @@ public class CacheContainerBuilder implements Builder<CacheContainer>, Service<C
         if ((this.container != null) && this.container.getStatus().allowInvocations()) {
             this.container.stop();
             this.container.removeListener(this);
-            log.debugf("%s cache container stopped", this.name);
+            InfinispanLogger.ROOT_LOGGER.debugf("%s cache container stopped", this.name);
         }
     }
 

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/service/CacheBuilder.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/service/CacheBuilder.java
@@ -43,6 +43,7 @@ import org.wildfly.clustering.service.Builder;
  */
 public class CacheBuilder<K, V> implements Service<Cache<K, V>>, Builder<Cache<K, V>> {
 
+    // No logger interface for this module and no reason to create one for this class only
     private static final Logger log = Logger.getLogger(CacheBuilder.class);
 
     private final InjectedValue<EmbeddedCacheManager> container = new InjectedValue<>();

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelBuilder.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelBuilder.java
@@ -42,6 +42,7 @@ import org.wildfly.clustering.service.Builder;
  */
 public class ChannelBuilder implements Service<Channel>, Builder<Channel> {
 
+    // No logger interface for this module and no reason to create one for only two classes
     private static final Logger LOGGER = org.jboss.logging.Logger.getLogger(ChannelConnectorBuilder.class);
 
     private InjectedValue<ChannelFactory> factory = new InjectedValue<>();
@@ -81,7 +82,7 @@ public class ChannelBuilder implements Service<Channel>, Builder<Channel> {
 
         if (LOGGER.isTraceEnabled())  {
             String output = this.channel.getProtocolStack().printProtocolSpec(true);
-            LOGGER.tracef("JGroups channel %s created with configuration:\n %s", this.name, output);
+            LOGGER.tracef("JGroups channel %s created with configuration:%n %s", this.name, output);
         }
     }
 

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelConnectorBuilder.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelConnectorBuilder.java
@@ -45,6 +45,7 @@ import org.wildfly.clustering.service.Builder;
  */
 public class ChannelConnectorBuilder implements Builder<Channel>, Service<Channel> {
 
+    // No logger interface for this module and no reason to create one for only two classes
     private static final Logger LOGGER = org.jboss.logging.Logger.getLogger(ChannelConnectorBuilder.class);
 
     private final String name;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaExtension.java
@@ -59,8 +59,8 @@ import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
-import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
+import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.controller.persistence.SubsystemMarshallingContext;
 import org.jboss.as.threads.ThreadsParser;
 import org.jboss.dmr.ModelNode;
@@ -557,7 +557,7 @@ public class JcaExtension implements Extension {
                     }
 
                     if (name == null) {
-                        throw ControllerLogger.ROOT_LOGGER.missingRequiredAttributes(new StringBuilder(attributeName), reader.getLocation());
+                        throw ParseUtils.missingRequired(reader, attributeName);
                     }
 
                     final ModelNode distributedWorkManagerAddress = parentAddress.clone();

--- a/ee/src/main/java/org/jboss/as/ee/component/AbstractComponentConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/AbstractComponentConfigurator.java
@@ -20,7 +20,7 @@ import org.jboss.invocation.InterceptorFactoryContext;
 import org.jboss.invocation.Interceptors;
 import org.jboss.msc.value.InjectedValue;
 
-import static org.jboss.as.ee.logging.EeLogger.SERVER_DEPLOYMENT_LOGGER;
+import static org.jboss.as.ee.logging.EeLogger.ROOT_LOGGER;
 
 /**
  * @author Stuart Douglas
@@ -78,7 +78,7 @@ public class AbstractComponentConfigurator {
 
         for (final ResourceInjectionConfiguration injectionConfiguration : mergedInjections.values()) {
             if(!moduleDescription.isAppClient() && injectionConfiguration.getTarget().isStatic(context.getDeploymentUnit())) {
-                SERVER_DEPLOYMENT_LOGGER.debugf("Injection for a member with static modifier is only acceptable on application clients, ignoring injection for target %s",injectionConfiguration.getTarget());
+                ROOT_LOGGER.debugf("Injection for a member with static modifier is only acceptable on application clients, ignoring injection for target %s",injectionConfiguration.getTarget());
                 continue;
             }
             if(injectionConfiguration.getTarget() instanceof MethodInjectionTarget) {

--- a/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
+++ b/ee/src/main/java/org/jboss/as/ee/logging/EeLogger.java
@@ -68,11 +68,6 @@ public interface EeLogger extends BasicLogger {
     EeLogger ROOT_LOGGER = Logger.getMessageLogger(EeLogger.class, "org.jboss.as.ee");
 
     /**
-     * A logger with a category of {@code org.jboss.as.server.deployment}.
-     */
-    EeLogger SERVER_DEPLOYMENT_LOGGER = Logger.getMessageLogger(EeLogger.class, "org.jboss.as.server.deployment");
-
-    /**
      * Logs a warning message indicating the transaction datasource, represented by the {@code className} parameter,
      * could not be proxied and will not be enlisted in the transactions automatically.
      *

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponent.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.ejb3.component;
 
-import static org.jboss.as.ejb3.logging.EjbLogger.ROOT_LOGGER;
-
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.Principal;
@@ -68,7 +66,6 @@ import org.jboss.ejb.client.EJBHomeLocator;
 import org.jboss.invocation.InterceptorContext;
 import org.jboss.invocation.InterceptorFactory;
 import org.jboss.invocation.proxy.MethodIdentifier;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceContainer;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -79,7 +76,6 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 public abstract class EJBComponent extends BasicComponent implements ServerActivityCallback {
-    private static final Logger log = Logger.getLogger(EJBComponent.class);
 
     private static final ApplicationExceptionDetails APPLICATION_EXCEPTION = new ApplicationExceptionDetails("java.lang.Exception", true, false);
 
@@ -320,9 +316,7 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
             // This is counter to EJB 3.1 where an asynchronous call does not inherit the transaction context!
 
             int status = tm.getStatus();
-            if (log.isTraceEnabled()) {
-                ROOT_LOGGER.trace("Current transaction status is " + status);
-            }
+            EjbLogger.ROOT_LOGGER.tracef("Current transaction status is %d", status);
             switch (status) {
                 case Status.STATUS_COMMITTED:
                 case Status.STATUS_ROLLEDBACK:
@@ -333,7 +327,7 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
             }
             return false;
         } catch (SystemException se) {
-            ROOT_LOGGER.getTxManagerStatusFailed(se);
+            EjbLogger.ROOT_LOGGER.getTxManagerStatusFailed(se);
             return true;
         }
     }
@@ -449,7 +443,7 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
         } else {
             throw EjbLogger.ROOT_LOGGER.failToLookupJNDINameSpace(name);
         }
-        ROOT_LOGGER.debugf("Looking up %s in jndi context: %s", namespaceStrippedJndiName, jndiContext);
+        EjbLogger.ROOT_LOGGER.debugf("Looking up %s in jndi context: %s", namespaceStrippedJndiName, jndiContext);
         try {
             return jndiContext.lookup(namespaceStrippedJndiName);
         } catch (NamingException ne) {
@@ -471,7 +465,7 @@ public abstract class EJBComponent extends BasicComponent implements ServerActiv
             // set rollback
             tm.setRollbackOnly();
         } catch (SystemException se) {
-            ROOT_LOGGER.setRollbackOnlyFailed(se);
+            EjbLogger.ROOT_LOGGER.setRollbackOnlyFailed(se);
         }
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/DeploymentRepository.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/DeploymentRepository.java
@@ -80,7 +80,7 @@ public class DeploymentRepository implements Service<DeploymentRepository> {
             try {
                 listener.deploymentAvailable(identifier, deployment);
             } catch (Throwable t) {
-                EjbLogger.ROOT_LOGGER.deploymentAddListenerException(t);
+                EjbLogger.DEPLOYMENT_LOGGER.deploymentAddListenerException(t);
             }
         }
     }
@@ -97,7 +97,7 @@ public class DeploymentRepository implements Service<DeploymentRepository> {
             try {
                 listener.deploymentStarted(identifier, deployment.deployment);
             } catch (Throwable t) {
-                EjbLogger.ROOT_LOGGER.deploymentAddListenerException(t);
+                EjbLogger.DEPLOYMENT_LOGGER.deploymentAddListenerException(t);
             }
         }
     }
@@ -126,7 +126,7 @@ public class DeploymentRepository implements Service<DeploymentRepository> {
             try {
                 listener.deploymentRemoved(identifier);
             } catch (Throwable t) {
-                EjbLogger.ROOT_LOGGER.deploymentRemoveListenerException(t);
+                EjbLogger.DEPLOYMENT_LOGGER.deploymentRemoveListenerException(t);
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/AbstractDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/AbstractDeploymentUnitProcessor.java
@@ -31,6 +31,7 @@ import org.jboss.as.ee.structure.DeploymentType;
 import org.jboss.as.ee.structure.DeploymentTypeMarker;
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
 import org.jboss.as.ejb3.deployment.EjbJarDescription;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
@@ -38,7 +39,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.EjbDeploymentMarker;
 import org.jboss.as.server.deployment.annotation.CompositeIndex;
-import org.jboss.logging.Logger;
 import org.jboss.metadata.ejb.spec.EjbJarMetaData;
 import org.jboss.metadata.ejb.spec.EnterpriseBeanMetaData;
 import org.jboss.metadata.ejb.spec.EnterpriseBeansMetaData;
@@ -47,7 +47,6 @@ import org.jboss.metadata.ejb.spec.EnterpriseBeansMetaData;
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
 public abstract class AbstractDeploymentUnitProcessor implements DeploymentUnitProcessor {
-    private static final Logger logger = Logger.getLogger(AbstractDeploymentUnitProcessor.class);
 
     /**
      * If this is an appclient we want to make the components as not installable, so we can still look up which EJB's are in
@@ -69,14 +68,10 @@ public abstract class AbstractDeploymentUnitProcessor implements DeploymentUnitP
 
         final CompositeIndex compositeIndex = deploymentUnit.getAttachment(Attachments.COMPOSITE_ANNOTATION_INDEX);
         if (compositeIndex == null) {
-            if (logger.isTraceEnabled()) {
-                logger.trace("Skipping EJB annotation processing since no composite annotation index found in unit: " + deploymentUnit);
-            }
+            EjbLogger.DEPLOYMENT_LOGGER.tracef("Skipping EJB annotation processing since no composite annotation index found in unit: %s", deploymentUnit);
         } else {
             if (MetadataCompleteMarker.isMetadataComplete(deploymentUnit)) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Skipping EJB annotation processing due to deployment being metadata-complete. ");
-                }
+                EjbLogger.DEPLOYMENT_LOGGER.trace("Skipping EJB annotation processing due to deployment being metadata-complete. ");
             } else {
                 processAnnotations(deploymentUnit, compositeIndex);
             }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EJBClientDescriptorMetaDataProcessor.java
@@ -43,7 +43,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.ejb.client.DeploymentNodeSelector;
 import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -66,7 +65,6 @@ import org.xnio.OptionMap;
  */
 public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProcessor {
 
-    private static final Logger logger = Logger.getLogger(EJBClientDescriptorMetaDataProcessor.class);
     private static final String INTERNAL_REMOTING_PROFILE = "internal-remoting-profile";
 
     @Override
@@ -115,7 +113,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
         serviceBuilder.addDependency(TCCLEJBClientContextSelectorService.TCCL_BASED_EJB_CLIENT_CONTEXT_SELECTOR_SERVICE_NAME);
         // install the service
         serviceBuilder.install();
-        logger.debugf("Deployment unit %s will use %s as the EJB client context service", deploymentUnit,
+        EjbLogger.DEPLOYMENT_LOGGER.debugf("Deployment unit %s will use %s as the EJB client context service", deploymentUnit,
                 ejbClientContextServiceName);
 
         // attach the service name of this EJB client context to the deployment unit
@@ -170,7 +168,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
                 channelCreationOpts = getOptionMapFromProperties(channelCreationProps, this.getClass().getClassLoader());
             }
             profileService.addChannelCreationOption(connectionRef, channelCreationOpts);
-            logger.debugf("Channel creation options for connection %s are %s", channelCreationOpts, connectionRef,
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("Channel creation options for connection %s are %s", channelCreationOpts, connectionRef,
                     channelCreationOpts);
         }
         final boolean localReceiverExcluded = ejbClientDescriptorMetaData.isLocalReceiverExcluded() != null ? ejbClientDescriptorMetaData
@@ -200,7 +198,7 @@ public class EJBClientDescriptorMetaDataProcessor implements DeploymentUnitProce
                 final Option<?> option = Option.fromString(propertyName, classLoader);
                 optionMapBuilder.parse(option, properties.getProperty(propertyName), classLoader);
             } catch (IllegalArgumentException e) {
-                EjbLogger.ROOT_LOGGER.failedToCreateOptionForProperty(propertyName, e.getMessage());
+                EjbLogger.DEPLOYMENT_LOGGER.failedToCreateOptionForProperty(propertyName, e.getMessage());
             }
         }
         return optionMapBuilder.getMap();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbClientContextSetupProcessor.java
@@ -25,6 +25,7 @@ import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ejb3.deployment.EjbDeploymentAttachmentKeys;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.remote.DefaultEjbClientContextService;
 import org.jboss.as.ejb3.remote.TCCLEJBClientContextSelectorService;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
@@ -32,7 +33,6 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.ejb.client.EJBClientContext;
-import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -51,8 +51,6 @@ import org.jboss.msc.value.InjectedValue;
  * @author Jaikiran Pai
  */
 public class EjbClientContextSetupProcessor implements DeploymentUnitProcessor {
-
-    private static final Logger logger = Logger.getLogger(EjbClientContextSetupProcessor.class);
 
 
     @Override
@@ -119,7 +117,7 @@ public class EjbClientContextSetupProcessor implements DeploymentUnitProcessor {
             final EJBClientContext ejbClientContext = ejbClientContextInjectedValue.getValue();
             final TCCLEJBClientContextSelectorService tcclBasedEJBClientContextSelector = tcclEJBClientContextSelectorServiceController.getValue();
             // associate the EJB client context with the deployment classloader
-            logger.debugf("Registering EJB client context %s for classloader %s", ejbClientContext, module.getClassLoader());
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("Registering EJB client context %s for classloader %s", ejbClientContext, module.getClassLoader());
             tcclBasedEJBClientContextSelector.registerEJBClientContext(ejbClientContext, module.getClassLoader());
         }
 
@@ -127,7 +125,7 @@ public class EjbClientContextSetupProcessor implements DeploymentUnitProcessor {
         public void stop(StopContext context) {
             final TCCLEJBClientContextSelectorService tcclBasedEJBClientContextSelector = tcclEJBClientContextSelectorServiceController.getValue();
             // de-associate the EJB client context with the deployment classloader
-            logger.debugf("unRegistering EJB client context for classloader %s", module.getClassLoader());
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("unRegistering EJB client context for classloader %s", module.getClassLoader());
             tcclBasedEJBClientContextSelector.unRegisterEJBClientContext(module.getClassLoader());
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbIIOPDeploymentUnitProcessor.java
@@ -188,7 +188,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
         for (int i = 0; i < remoteAttrs.length; i++) {
             final OperationAnalysis op = remoteAttrs[i].getAccessorAnalysis();
             if (op != null) {
-                EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", op.getJavaName(), op.getIDLName());
+                EjbLogger.DEPLOYMENT_LOGGER.debugf("    %s%n                %s", op.getJavaName(), op.getIDLName());
                 //translate to the deployment reflection index method
                 //TODO: this needs to be fixed so it just returns the correct method
                 final Method method = translateMethod(deploymentReflectionIndex, op);
@@ -196,7 +196,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
                 beanMethodMap.put(op.getIDLName(), new SkeletonStrategy(method));
                 final OperationAnalysis setop = remoteAttrs[i].getMutatorAnalysis();
                 if (setop != null) {
-                    EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", setop.getJavaName(), setop.getIDLName());
+                    EjbLogger.DEPLOYMENT_LOGGER.debugf("    %s%n                %s", setop.getJavaName(), setop.getIDLName());
                     //translate to the deployment reflection index method
                     //TODO: this needs to be fixed so it just returns the correct method
                     final Method realSetmethod = translateMethod(deploymentReflectionIndex, setop);
@@ -207,7 +207,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
 
         final OperationAnalysis[] ops = remoteInterfaceAnalysis.getOperations();
         for (int i = 0; i < ops.length; i++) {
-            EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", ops[i].getJavaName(), ops[i].getIDLName());
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("    %s%n                %s", ops[i].getJavaName(), ops[i].getIDLName());
             beanMethodMap.put(ops[i].getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, ops[i])));
         }
 
@@ -229,11 +229,11 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
         for (int i = 0; i < attrs.length; i++) {
             final OperationAnalysis op = attrs[i].getAccessorAnalysis();
             if (op != null) {
-                EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", op.getJavaName(), op.getIDLName());
+                EjbLogger.DEPLOYMENT_LOGGER.debugf("    %s%n                %s", op.getJavaName(), op.getIDLName());
                 homeMethodMap.put(op.getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, op)));
                 final OperationAnalysis setop = attrs[i].getMutatorAnalysis();
                 if (setop != null) {
-                    EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", setop.getJavaName(), setop.getIDLName());
+                    EjbLogger.DEPLOYMENT_LOGGER.debugf("    %s%n                %s", setop.getJavaName(), setop.getIDLName());
                     homeMethodMap.put(setop.getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, setop)));
                 }
             }
@@ -241,7 +241,7 @@ public class EjbIIOPDeploymentUnitProcessor implements DeploymentUnitProcessor {
 
         final OperationAnalysis[] homeops = homeInterfaceAnalysis.getOperations();
         for (int i = 0; i < homeops.length; i++) {
-            EjbLogger.ROOT_LOGGER.debugf("    %s\n                %s", homeops[i].getJavaName(), homeops[i].getIDLName());
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("    %s%n                %s", homeops[i].getJavaName(), homeops[i].getIDLName());
             homeMethodMap.put(homeops[i].getIDLName(), new SkeletonStrategy(translateMethod(deploymentReflectionIndex, homeops[i])));
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJarParsingDeploymentUnitProcessor.java
@@ -251,7 +251,7 @@ public class EjbJarParsingDeploymentUnitProcessor implements DeploymentUnitProce
             try {
                 stream.close();
             } catch (IOException ioe) {
-                EjbLogger.ROOT_LOGGER.failToCloseFile(ioe);
+                EjbLogger.DEPLOYMENT_LOGGER.failToCloseFile(ioe);
             }
         }
     }
@@ -283,7 +283,7 @@ public class EjbJarParsingDeploymentUnitProcessor implements DeploymentUnitProce
             try {
                 stream.close();
             } catch (IOException ioe) {
-                EjbLogger.ROOT_LOGGER.failToCloseFile(ioe);
+                EjbLogger.DEPLOYMENT_LOGGER.failToCloseFile(ioe);
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJndiBindingsDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbJndiBindingsDeploymentUnitProcessor.java
@@ -48,7 +48,6 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.EjbDeploymentMarker;
-import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -66,11 +65,6 @@ import org.wildfly.extension.requestcontroller.RunResult;
  * @author <a href="mailto:ropalka@redhat.com">Richard Opalka</a>
  */
 public class EjbJndiBindingsDeploymentUnitProcessor implements DeploymentUnitProcessor {
-
-    /**
-     * Logger
-     */
-    private static final Logger logger = Logger.getLogger(EjbJndiBindingsDeploymentUnitProcessor.class);
 
     private final boolean appclient;
 
@@ -113,7 +107,7 @@ public class EjbJndiBindingsDeploymentUnitProcessor implements DeploymentUnitPro
     private void setupJNDIBindings(EJBComponentDescription sessionBean, DeploymentUnit deploymentUnit) throws DeploymentUnitProcessingException {
         final Collection<ViewDescription> views = sessionBean.getViews();
         if (views == null || views.isEmpty()) {
-            EjbLogger.ROOT_LOGGER.noJNDIBindingsForSessionBean(sessionBean.getEJBName());
+            EjbLogger.DEPLOYMENT_LOGGER.noJNDIBindingsForSessionBean(sessionBean.getEJBName());
             return;
         }
 
@@ -128,7 +122,8 @@ public class EjbJndiBindingsDeploymentUnitProcessor implements DeploymentUnitPro
 
         // the base ServiceName which will be used to create the ServiceName(s) for each of the view bindings
         final StringBuilder jndiBindingsLogMessage = new StringBuilder();
-        jndiBindingsLogMessage.append("JNDI bindings for session bean named " + sessionBean.getEJBName() + " in deployment unit " + deploymentUnit + " are as follows:\n\n");
+        jndiBindingsLogMessage.append("JNDI bindings for session bean named " + sessionBean.getEJBName() + " in deployment unit " + deploymentUnit + " are as follows:");
+        jndiBindingsLogMessage.append(System.lineSeparator()).append(System.lineSeparator());
 
         // now create the bindings for each view under the java:global, java:app and java:module namespaces
         EJBViewDescription ejbViewDescription = null;
@@ -196,7 +191,7 @@ public class EjbJndiBindingsDeploymentUnitProcessor implements DeploymentUnitPro
         }
 
         // log the jndi bindings
-        logger.info(jndiBindingsLogMessage);
+        EjbLogger.DEPLOYMENT_LOGGER.info(jndiBindingsLogMessage);
     }
 
     private void registerBinding(final EJBComponentDescription componentDescription, final ViewDescription viewDescription, final String jndiName) {
@@ -271,7 +266,7 @@ public class EjbJndiBindingsDeploymentUnitProcessor implements DeploymentUnitPro
     private void logBinding(final StringBuilder jndiBindingsLogMessage, final String jndiName) {
         jndiBindingsLogMessage.append("\t");
         jndiBindingsLogMessage.append(jndiName);
-        jndiBindingsLogMessage.append("\n");
+        jndiBindingsLogMessage.append(System.lineSeparator());
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbManagementDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbManagementDeploymentUnitProcessor.java
@@ -97,7 +97,7 @@ public class EjbManagementDeploymentUnitProcessor implements DeploymentUnitProce
             try {
                 uninstallManagementResource(configuration);
             } catch (RuntimeException e) {
-                EjbLogger.ROOT_LOGGER.failedToRemoveManagementResources(configuration, e.getLocalizedMessage());
+                EjbLogger.DEPLOYMENT_LOGGER.failedToRemoveManagementResources(configuration, e.getLocalizedMessage());
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbResourceInjectionAnnotationProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbResourceInjectionAnnotationProcessor.java
@@ -47,7 +47,6 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.MethodInfo;
-import org.jboss.logging.Logger;
 import org.jboss.metadata.property.PropertyReplacer;
 
 import javax.ejb.EJB;
@@ -68,8 +67,6 @@ public class EjbResourceInjectionAnnotationProcessor implements DeploymentUnitPr
     private static final DotName EJBS_ANNOTATION_NAME = DotName.createSimple(EJBs.class.getName());
 
     private final boolean appclient;
-
-    private static final Logger logger = Logger.getLogger(EjbResourceInjectionAnnotationProcessor.class);
 
     public EjbResourceInjectionAnnotationProcessor(final boolean appclient) {
         this.appclient = appclient;
@@ -149,11 +146,8 @@ public class EjbResourceInjectionAnnotationProcessor implements DeploymentUnitPr
     private void process(final DeploymentUnit deploymentUnit, final String beanInterface, final String beanName, final String lookup, final ClassInfo classInfo, final InjectionTarget targetDescription, final String localContextName, final EEModuleDescription eeModuleDescription) {
 
         if (!isEmpty(lookup) && !isEmpty(beanName)) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("Both beanName = " + beanName + " and lookup = " + lookup
-                        + " have been specified in @EJB annotation." + " lookup will be given preference. Class: "
-                        + classInfo.name());
-            }
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("Both beanName = %s and lookup = %s have been specified in @EJB annotation. Lookup will be given preference. Class: %s"
+                    , beanName, lookup, classInfo.name());
         }
 
         final EEModuleClassDescription classDescription = eeModuleDescription.addOrGetLocalClassDescription(classInfo.name().toString());

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ImplicitLocalViewProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/ImplicitLocalViewProcessor.java
@@ -30,7 +30,6 @@ import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.annotation.CompositeIndex;
-import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 
 import java.util.ArrayList;
@@ -51,8 +50,6 @@ import java.util.List;
  * @author Jaikiran Pai
  */
 public class ImplicitLocalViewProcessor extends AbstractComponentConfigProcessor {
-
-    private static final Logger logger = Logger.getLogger(ImplicitLocalViewProcessor.class);
 
     @Override
     protected void processComponentConfig(DeploymentUnit deploymentUnit, DeploymentPhaseContext phaseContext, CompositeIndex index, ComponentDescription componentDescription) throws DeploymentUnitProcessingException {
@@ -84,7 +81,7 @@ public class ImplicitLocalViewProcessor extends AbstractComponentConfigProcessor
         }
         // check whether it's eligible for implicit no-interface view
         if (this.exposesNoInterfaceView(ejbClass)) {
-            logger.debugf("Bean: %s will be marked for (implicit) no-interface view", sessionBeanComponentDescription.getEJBName());
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("Bean: %s will be marked for (implicit) no-interface view", sessionBeanComponentDescription.getEJBName());
             sessionBeanComponentDescription.addNoInterfaceView();
             return;
         }
@@ -92,7 +89,7 @@ public class ImplicitLocalViewProcessor extends AbstractComponentConfigProcessor
         // check for default local view
         Class<?> defaultLocalView = this.getDefaultLocalView(ejbClass);
         if (defaultLocalView != null) {
-            logger.debugf("Bean: %s will be marked for default local view: %s", sessionBeanComponentDescription.getEJBName(), defaultLocalView.getName());
+            EjbLogger.DEPLOYMENT_LOGGER.debugf("Bean: %s will be marked for default local view: %s", sessionBeanComponentDescription.getEJBName(), defaultLocalView.getName());
             sessionBeanComponentDescription.addLocalBusinessInterfaceViews(Collections.singleton(defaultLocalView.getName()));
             return;
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/MessageDrivenComponentDescriptionFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/MessageDrivenComponentDescriptionFactory.java
@@ -198,12 +198,12 @@ public class MessageDrivenComponentDescriptionFactory extends EJBComponentDescri
         final String className = mdbClass.name().toString();
         // must *not* be an interface
         if (Modifier.isInterface(flags)) {
-            EjbLogger.ROOT_LOGGER.mdbClassCannotBeAnInterface(className);
+            EjbLogger.DEPLOYMENT_LOGGER.mdbClassCannotBeAnInterface(className);
             return false;
         }
         // bean class must be public, must *not* be abstract or final
         if (!Modifier.isPublic(flags) || Modifier.isAbstract(flags) || Modifier.isFinal(flags)) {
-            EjbLogger.ROOT_LOGGER.mdbClassMustBePublicNonAbstractNonFinal(className);
+            EjbLogger.DEPLOYMENT_LOGGER.mdbClassMustBePublicNonAbstractNonFinal(className);
             return false;
         }
         // valid class

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/SessionBeanComponentDescriptionFactory.java
@@ -118,7 +118,7 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
             final AnnotationTarget target = sessionBeanAnnotation.target();
             if (!(target instanceof ClassInfo)) {
                 // Let's just WARN and move on. No need to throw an error
-                EjbLogger.ROOT_LOGGER.warn(EjbLogger.ROOT_LOGGER.annotationOnlyAllowedOnClass(sessionBeanAnnotation.name().toString(), target).getMessage());
+                EjbLogger.DEPLOYMENT_LOGGER.warn(EjbLogger.ROOT_LOGGER.annotationOnlyAllowedOnClass(sessionBeanAnnotation.name().toString(), target).getMessage());
                 continue;
             }
             final ClassInfo sessionBeanClassInfo = (ClassInfo) target;
@@ -200,12 +200,12 @@ public class SessionBeanComponentDescriptionFactory extends EJBComponentDescript
         final String className = sessionBeanClass.name().toString();
         // must *not* be an interface
         if (Modifier.isInterface(flags)) {
-            EjbLogger.ROOT_LOGGER.sessionBeanClassCannotBeAnInterface(className);
+            EjbLogger.DEPLOYMENT_LOGGER.sessionBeanClassCannotBeAnInterface(className);
             return false;
         }
         // bean class must be public, must *not* be abstract or final
         if (!Modifier.isPublic(flags) || Modifier.isAbstract(flags) || Modifier.isFinal(flags)) {
-            EjbLogger.ROOT_LOGGER.sessionBeanClassMustBePublicNonAbstractNonFinal(className);
+            EjbLogger.DEPLOYMENT_LOGGER.sessionBeanClassMustBePublicNonAbstractNonFinal(className);
             return false;
         }
         // valid class

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ClusteredAnnotationInformationFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/annotation/ClusteredAnnotationInformationFactory.java
@@ -39,7 +39,7 @@ public class ClusteredAnnotationInformationFactory extends ClassAnnotationInform
 
     @Override
     protected Void fromAnnotation(AnnotationInstance annotationInstance, PropertyReplacer propertyReplacer) {
-        EjbLogger.ROOT_LOGGER.deprecatedAnnotation(Clustered.class.getSimpleName());
+        EjbLogger.DEPLOYMENT_LOGGER.deprecatedAnnotation(Clustered.class.getSimpleName());
         return null;
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbCorbaServant.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/EjbCorbaServant.java
@@ -42,12 +42,12 @@ import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentView;
 import org.jboss.as.ejb3.component.entity.EntityBeanComponent;
 import org.jboss.as.ejb3.component.stateful.StatefulSessionComponent;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.iiop.csiv2.SASCurrent;
 import org.jboss.as.naming.context.NamespaceContextSelector;
 import org.jboss.ejb.client.SessionID;
 import org.jboss.ejb.iiop.HandleImplIIOP;
 import org.jboss.invocation.InterceptorContext;
-import org.jboss.logging.Logger;
 import org.jboss.marshalling.InputStreamByteInput;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.MarshallingConfiguration;
@@ -82,8 +82,6 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Stuart Douglas
  */
 public class EjbCorbaServant extends Servant implements InvokeHandler, LocalIIOPInvoker {
-
-    private static final Logger logger = Logger.getLogger(EjbCorbaServant.class);
 
     /**
      * The injected component view
@@ -225,14 +223,11 @@ public class EjbCorbaServant extends Servant implements InvokeHandler, LocalIIOP
      * <code>MBean</code> server.
      */
     public OutputStream _invoke(final String opName, final InputStream in, final ResponseHandler handler) {
-
-        if (logger.isTraceEnabled()) {
-            logger.trace("EJBObject invocation: " + opName);
-        }
+        EjbLogger.ROOT_LOGGER.tracef("EJBObject invocation: %s", opName);
 
         SkeletonStrategy op = methodInvokerMap.get(opName);
         if (op == null) {
-            logger.debugf("Unable to find opname '%s' valid operations:%s", opName, methodInvokerMap.keySet());
+            EjbLogger.ROOT_LOGGER.debugf("Unable to find opname '%s' valid operations:%s", opName, methodInvokerMap.keySet());
             throw new BAD_OPERATION(opName);
         }
         final NamespaceContextSelector selector = componentView.getComponent().getNamespaceContextSelector();
@@ -342,9 +337,7 @@ public class EjbCorbaServant extends Servant implements InvokeHandler, LocalIIOP
                     op.writeRetval(out, retVal);
                 }
             } catch (Exception e) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Exception in EJBObject invocation", e);
-                }
+                EjbLogger.ROOT_LOGGER.trace("Exception in EJBObject invocation", e);
                 if (e instanceof MBeanException) {
                     e = ((MBeanException) e).getTargetException();
                 }
@@ -410,9 +403,7 @@ public class EjbCorbaServant extends Servant implements InvokeHandler, LocalIIOP
                          Principal identity,
                          Object credential)
             throws Exception {
-        if (logger.isTraceEnabled()) {
-            logger.trace("EJBObject local invocation: " + opName);
-        }
+        EjbLogger.ROOT_LOGGER.tracef("EJBObject local invocation: %s", opName);
 
         SkeletonStrategy op = methodInvokerMap.get(opName);
         if (op == null) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/stub/IIOPStubCompiler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/stub/IIOPStubCompiler.java
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.rmi.RemoteException;
 
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.classfilewriter.ClassFile;
 import org.jboss.classfilewriter.ClassMethod;
 import org.jboss.classfilewriter.code.CodeAttribute;
@@ -200,9 +201,7 @@ public class IIOPStubCompiler {
                     }
                 }
             } catch (RMIIIOPViolationException e) {
-                throw new RuntimeException("Cannot obtain "
-                        + "exception repository id for "
-                        + exceptions[i].getName() + ":\n" + e);
+                throw EjbLogger.ROOT_LOGGER.exceptionRepositoryNotFound(exceptions[i].getName(), e.getLocalizedMessage());
             }
 
             // Push third argument for StubStrategy constructor:
@@ -357,7 +356,7 @@ public class IIOPStubCompiler {
         try {
             interfaceAnalysis = InterfaceAnalysis.getInterfaceAnalysis(intf);
         } catch (RMIIIOPViolationException e) {
-            throw new RuntimeException("RMI/IIOP Violation:\n" + e);
+            throw EjbLogger.ROOT_LOGGER.rmiIiopVoliation(e.getLocalizedMessage());
         }
         return makeCode(interfaceAnalysis, DynamicIIOPStub.class, stubClassName);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -24,10 +24,6 @@
 
 package org.jboss.as.ejb3.logging;
 
-import static org.jboss.logging.Logger.Level.ERROR;
-import static org.jboss.logging.Logger.Level.INFO;
-import static org.jboss.logging.Logger.Level.WARN;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -119,6 +115,10 @@ import org.jboss.msc.service.StartException;
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.MessageInputStream;
 
+import static org.jboss.logging.Logger.Level.ERROR;
+import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.WARN;
+
 /**
  * @author <a href="mailto:Flemming.Harms@gmail.com">Flemming Harms</a>
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
@@ -127,6 +127,16 @@ import org.jboss.remoting3.MessageInputStream;
 public interface EjbLogger extends BasicLogger {
 
     EjbLogger ROOT_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3");
+
+    /**
+     * A logger with the category {@code org.jboss.as.ejb3.deployment} used for deployment log messages
+     */
+    EjbLogger DEPLOYMENT_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3.deployment");
+
+    /**
+     * A logger with the category {@code org.jboss.as.ejb3.remote} used for remote log messages
+     */
+    EjbLogger REMOTE_LOGGER = Logger.getMessageLogger(EjbLogger.class, "org.jboss.as.ejb3.remote");
 
     /**
      * logger use to log EJB invocation errors
@@ -860,8 +870,8 @@ public interface EjbLogger extends BasicLogger {
     void couldNotWriteInvocationSuccessMessage(@Cause Throwable cause);
 
     @LogMessage(level = WARN)
-    @Message(id = 154, value = "Received unsupported message header 0x%s on channel %s")
-    void unsupportedMessageHeader(String header, Channel channel);
+    @Message(id = 154, value = "Received unsupported message header 0x%x on channel %s")
+    void unsupportedMessageHeader(int header, Channel channel);
 
     @LogMessage(level = ERROR)
     @Message(id = 155, value = "Error during transaction management of transaction id %s")
@@ -3043,4 +3053,14 @@ public interface EjbLogger extends BasicLogger {
 
     @Message(id = 469, value = "Indexed child resources can only be registered if the parent resource supports ordered children. The parent of '%s' is not indexed")
     IllegalStateException indexedChildResourceRegistrationNotAvailable(PathElement address);
+
+    @LogMessage(level = INFO)
+    @Message(id = 470, value = "Could not create a connection for cluster node %s in cluster %s")
+    void couldNotCreateClusterConnection(@Cause Throwable cause, String nodeName, String clusterName);
+
+    @Message(id = 471, value = "RMI/IIOP Violation: %s%n")
+    RuntimeException rmiIiopVoliation(String violation);
+
+    @Message(id = 472, value = "Cannot obtain exception repository id for %s:%n%s")
+    RuntimeException exceptionRepositoryNotFound(String name, String message);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/pool/AbstractPool.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/pool/AbstractPool.java
@@ -21,8 +21,6 @@
  */
 package org.jboss.as.ejb3.pool;
 
-import org.jboss.logging.Logger;
-
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -33,8 +31,6 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @version $Revision$
  */
 public abstract class AbstractPool<T> implements Pool<T> {
-    @SuppressWarnings("unused")
-    private static final Logger log = Logger.getLogger(AbstractPool.class);
 
     private final StatelessObjectFactory<T> factory;
     private final AtomicInteger createCount = new AtomicInteger(0);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEJBClientContextSelector.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/DefaultEJBClientContextSelector.java
@@ -27,7 +27,6 @@ import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.EJBClientContextIdentifier;
 import org.jboss.ejb.client.IdentityEJBClientContextSelector;
-import org.jboss.logging.Logger;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -35,8 +34,6 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Jaikiran Pai
  */
 class DefaultEJBClientContextSelector implements ContextSelector<EJBClientContext>, IdentityEJBClientContextSelector {
-
-    private static final Logger logger = Logger.getLogger(DefaultEJBClientContextSelector.class);
 
     static final DefaultEJBClientContextSelector INSTANCE = new DefaultEJBClientContextSelector();
 
@@ -77,8 +74,9 @@ class DefaultEJBClientContextSelector implements ContextSelector<EJBClientContex
 
         // explicit isDebugEnabled() check to ensure that the SecurityActions.getContextClassLoader() isn't
         // unnecessarily executed when debug logging is disabled
-        if (logger.isDebugEnabled()) {
-            logger.debug("Returning default EJB client context " + this.defaultEJBClientContext + " since no EJB client context could be found for TCCL " + WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
+        if (EjbLogger.REMOTE_LOGGER.isDebugEnabled()) {
+            EjbLogger.REMOTE_LOGGER.debugf("Returning default EJB client context %s since no EJB client context could be found for TCCL %s",
+                    this.defaultEJBClientContext, WildFlySecurityManager.getCurrentContextClassLoaderPrivileged());
         }
         return this.defaultEJBClientContext;
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterConfig.java
@@ -26,7 +26,6 @@ import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.ejb.client.ClusterNodeSelector;
 import org.jboss.ejb.client.EJBClientConfiguration;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceRegistry;
 import org.xnio.OptionMap;
 
@@ -38,8 +37,6 @@ import java.util.Properties;
  * @author Jaikiran Pai
  */
 public class EJBClientClusterConfig extends EJBClientCommonConnectionConfig implements EJBClientConfiguration.ClusterConfiguration {
-
-    private static final Logger logger = Logger.getLogger(EJBClientClusterConfig.class);
 
     private final EJBClientDescriptorMetaData.ClusterConfig delegate;
     private final Map<String, EJBClientConfiguration.ClusterNodeConfiguration> nodes = new HashMap<String, EJBClientConfiguration.ClusterNodeConfiguration>();
@@ -54,7 +51,7 @@ public class EJBClientClusterConfig extends EJBClientCommonConnectionConfig impl
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap channelCreationOptions = getOptionMapFromProperties(channelProps, this.getClass().getClassLoader());
-            logger.debugf("Channel creation options for cluster %s are %s", clusterConfig.getClusterName(), channelCreationOptions);
+            EjbLogger.REMOTE_LOGGER.debugf("Channel creation options for cluster %s are %s", clusterConfig.getClusterName(), channelCreationOptions);
             this.setChannelCreationOptions(channelCreationOptions);
         }
 
@@ -64,7 +61,7 @@ public class EJBClientClusterConfig extends EJBClientCommonConnectionConfig impl
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap connectionCreationOptions = getOptionMapFromProperties(connectionProps, this.getClass().getClassLoader());
-            logger.debugf("Connection creation options for cluster %s are %s", clusterConfig.getClusterName(), connectionCreationOptions);
+            EjbLogger.REMOTE_LOGGER.debugf("Connection creation options for cluster %s are %s", clusterConfig.getClusterName(), connectionCreationOptions);
             this.setConnectionCreationOptions(connectionCreationOptions);
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterNodeConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientClusterNodeConfig.java
@@ -23,8 +23,8 @@
 package org.jboss.as.ejb3.remote;
 
 import org.jboss.as.ee.metadata.EJBClientDescriptorMetaData;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.ejb.client.EJBClientConfiguration;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.ServiceRegistry;
 import org.xnio.OptionMap;
 
@@ -34,8 +34,6 @@ import java.util.Properties;
  * @author Jaikiran Pai
  */
 public class EJBClientClusterNodeConfig extends EJBClientCommonConnectionConfig implements EJBClientConfiguration.ClusterNodeConfiguration {
-
-    private static final Logger logger = Logger.getLogger(EJBClientClusterNodeConfig.class);
 
     private final EJBClientDescriptorMetaData.ClusterNodeConfig delegate;
 
@@ -49,7 +47,7 @@ public class EJBClientClusterNodeConfig extends EJBClientCommonConnectionConfig 
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap channelOpts = getOptionMapFromProperties(channelProps, this.getClass().getClassLoader());
-            logger.debugf("Channel creation options for node %s are %s", clusterNodeConfig.getNodeName(), channelOpts);
+            EjbLogger.REMOTE_LOGGER.debugf("Channel creation options for node %s are %s", clusterNodeConfig.getNodeName(), channelOpts);
             this.setChannelCreationOptions(channelOpts);
         }
 
@@ -58,7 +56,7 @@ public class EJBClientClusterNodeConfig extends EJBClientCommonConnectionConfig 
             // we don't use the deployment CL here since the XNIO project isn't necessarily added as a dep on the deployment's
             // module CL
             final OptionMap connectOpts = getOptionMapFromProperties(connectionProps, this.getClass().getClassLoader());
-            logger.debugf("Connection creation options for node %s are %s", clusterNodeConfig.getNodeName(), connectOpts);
+            EjbLogger.REMOTE_LOGGER.debugf("Connection creation options for node %s are %s", clusterNodeConfig.getNodeName(), connectOpts);
             this.setConnectionCreationOptions(connectOpts);
         }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBClientCommonConnectionConfig.java
@@ -95,7 +95,7 @@ class EJBClientCommonConnectionConfig implements EJBClientConfiguration.CommonCo
                 final Option<?> option = Option.fromString(propertyName, classLoader);
                 optionMapBuilder.parse(option, properties.getProperty(propertyName), classLoader);
             } catch (IllegalArgumentException e) {
-                EjbLogger.ROOT_LOGGER.failedToCreateOptionForProperty(propertyName, e.getMessage());
+                EjbLogger.REMOTE_LOGGER.failedToCreateOptionForProperty(propertyName, e.getMessage());
             }
         }
         return optionMapBuilder.getMap();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
@@ -178,19 +178,19 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
         public void channelOpened(Channel channel) {
             final ChannelAssociation channelAssociation = new ChannelAssociation(channel);
 
-            EjbLogger.ROOT_LOGGER.tracef("Welcome %s to the " + EJB_CHANNEL_NAME + " channel", channel);
+            EjbLogger.REMOTE_LOGGER.tracef("Welcome %s to the %s channel", channel, EJB_CHANNEL_NAME);
             channel.addCloseHandler(new CloseHandler<Channel>() {
                 @Override
                 public void handleClose(Channel closed, IOException exception) {
                     // do nothing
-                    EjbLogger.ROOT_LOGGER.tracef("channel %s closed", closed);
+                    EjbLogger.REMOTE_LOGGER.tracef("channel %s closed", closed);
                 }
             });
             // send the server version and supported marshalling types to the client
             try {
                 EJBRemoteConnectorService.this.sendVersionMessage(channelAssociation);
             } catch (IOException e) {
-                EjbLogger.ROOT_LOGGER.closingChannel(channel, e);
+                EjbLogger.REMOTE_LOGGER.closingChannel(channel, e);
                 IoUtils.safeClose(channel);
             }
 
@@ -213,7 +213,7 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
 
         @Override
         public void handleError(Channel channel, IOException error) {
-            EjbLogger.ROOT_LOGGER.closingChannel(channel, error);
+            EjbLogger.REMOTE_LOGGER.closingChannel(channel, error);
             try {
                 channel.close();
             } catch (IOException ioe) {
@@ -223,7 +223,7 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
 
         @Override
         public void handleEnd(Channel channel) {
-            EjbLogger.ROOT_LOGGER.closingChannelOnChannelEnd(channel);
+            EjbLogger.REMOTE_LOGGER.closingChannelOnChannelEnd(channel);
             try {
                 channel.close();
             } catch (IOException ioe) {
@@ -237,12 +237,10 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
             try {
                 final byte version = dataInputStream.readByte();
                 final String clientMarshallingStrategy = dataInputStream.readUTF();
-                if (EjbLogger.ROOT_LOGGER.isDebugEnabled()) {
-                    EjbLogger.ROOT_LOGGER.debug("Client with protocol version " + version + " and marshalling strategy "
-                            + clientMarshallingStrategy + " trying to communicate on " + channel);
-                }
+                EjbLogger.REMOTE_LOGGER.debugf("Client with protocol version %s and marshalling strategy %s trying to communicate on %s",
+                        version, clientMarshallingStrategy, channel);
                 if (!EJBRemoteConnectorService.this.isSupportedMarshallingStrategy(clientMarshallingStrategy)) {
-                    EjbLogger.ROOT_LOGGER.unsupportedClientMarshallingStrategy(clientMarshallingStrategy, channel);
+                    EjbLogger.REMOTE_LOGGER.unsupportedClientMarshallingStrategy(clientMarshallingStrategy, channel);
                     channel.close();
                     return;
                 }
@@ -274,7 +272,7 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
 
             } catch (IOException e) {
                 // log it
-                EjbLogger.ROOT_LOGGER.exceptionOnChannel(e, channel, messageInputStream);
+                EjbLogger.REMOTE_LOGGER.exceptionOnChannel(e, channel, messageInputStream);
                 IoUtils.safeClose(channel);
             } finally {
                 IoUtils.safeClose(messageInputStream);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteTransactionsRepository.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteTransactionsRepository.java
@@ -30,9 +30,9 @@ import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporte
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.TransactionImporterImple;
 import com.arjuna.ats.internal.jta.transaction.arjunacore.jca.XATerminatorImple;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.ejb.client.UserTransactionID;
 import org.jboss.ejb.client.XidTransactionID;
-import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -61,8 +61,6 @@ import java.util.Set;
  */
 public class EJBRemoteTransactionsRepository implements Service<EJBRemoteTransactionsRepository> {
 
-    private static final Logger logger = Logger.getLogger(EJBRemoteTransactionsRepository.class);
-
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb").append("remote-transactions-repository");
 
     private final InjectedValue<TransactionManager> transactionManagerInjectedValue = new InjectedValue<TransactionManager>();
@@ -76,7 +74,7 @@ public class EJBRemoteTransactionsRepository implements Service<EJBRemoteTransac
     @Override
     public void start(StartContext context) throws StartException {
         recoveryManagerService.getValue().addSerializableXAResourceDeserializer(EJBXAResourceDeserializer.INSTANCE);
-        logger.debugf("Registered EJB XA resource deserializer %s", EJBXAResourceDeserializer.INSTANCE);
+        EjbLogger.REMOTE_LOGGER.debugf("Registered EJB XA resource deserializer %s", EJBXAResourceDeserializer.INSTANCE);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBTransactionRecoveryService.java
@@ -33,11 +33,11 @@ import javax.transaction.xa.XAResource;
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
 
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.EJBClientContextListener;
 import org.jboss.ejb.client.EJBClientManagedTransactionContext;
 import org.jboss.ejb.client.EJBReceiverContext;
-import org.jboss.logging.Logger;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
@@ -53,8 +53,6 @@ import org.jboss.tm.XAResourceRecovery;
  * @author Jaikiran Pai
  */
 public class EJBTransactionRecoveryService implements Service<EJBTransactionRecoveryService>, XAResourceRecovery, EJBClientContextListener {
-
-    private static final Logger logger = Logger.getLogger(EJBTransactionRecoveryService.class);
 
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb").append("tx-recovery-service");
     public static final EJBTransactionRecoveryService INSTANCE = new EJBTransactionRecoveryService();
@@ -72,7 +70,7 @@ public class EJBTransactionRecoveryService implements Service<EJBTransactionReco
     public void start(StartContext startContext) throws StartException {
         // register ourselves to the recovery manager service
         recoveryManagerService.getValue().addXAResourceRecovery(this);
-        logger.debugf("Registered %s with the transaction recovery manager", this);
+        EjbLogger.REMOTE_LOGGER.debugf("Registered %s with the transaction recovery manager", this);
     }
 
     @Override
@@ -86,7 +84,7 @@ public class EJBTransactionRecoveryService implements Service<EJBTransactionReco
                     EJBTransactionRecoveryService.this.receiverContexts.clear();
                     // un-register ourselves from the recovery manager service
                     recoveryManagerService.getValue().removeXAResourceRecovery(EJBTransactionRecoveryService.this);
-                    logger.debugf("Un-registered %s from the transaction recovery manager", this);
+                    EjbLogger.REMOTE_LOGGER.debugf("Un-registered %s from the transaction recovery manager", this);
                 } finally {
                     stopContext.complete();
                 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEJBReceiverPreferringDeploymentNodeSelector.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEJBReceiverPreferringDeploymentNodeSelector.java
@@ -22,9 +22,9 @@
 
 package org.jboss.as.ejb3.remote;
 
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.ejb.client.DeploymentNodeSelector;
-import org.jboss.logging.Logger;
 
 import java.util.Random;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -36,8 +36,6 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Jaikiran Pai
  */
 public class LocalEJBReceiverPreferringDeploymentNodeSelector implements DeploymentNodeSelector {
-
-    private static final Logger logger = Logger.getLogger(LocalEJBReceiverPreferringDeploymentNodeSelector.class);
 
     private final String localNodeName;
 
@@ -54,10 +52,8 @@ public class LocalEJBReceiverPreferringDeploymentNodeSelector implements Deploym
         // prefer local node if available
         for (final String eligibleNode : eligibleNodes) {
             if (localNodeName.equals(eligibleNode)) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Selected local node " + this.localNodeName + " for [app: " + appName + ", module: "
-                            + moduleName + ",  distinctname: " + distinctName + "]");
-                }
+                EjbLogger.REMOTE_LOGGER.debugf("Selected local node %s for [app: %s, module: %s,  distinctname: %s]",
+                        this.localNodeName, appName, moduleName, distinctName);
                 return eligibleNode;
             }
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/LocalEjbReceiver.java
@@ -74,7 +74,6 @@ import org.jboss.ejb.client.StatefulEJBLocator;
 import org.jboss.ejb.client.TransactionID;
 import org.jboss.ejb.client.remoting.NetworkUtil;
 import org.jboss.invocation.InterceptorContext;
-import org.jboss.logging.Logger;
 import org.jboss.marshalling.cloner.ClassLoaderClassCloner;
 import org.jboss.marshalling.cloner.ClonerConfiguration;
 import org.jboss.marshalling.cloner.ObjectCloner;
@@ -99,7 +98,6 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  */
 public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbReceiver>, RegistryCollector.Listener<String, List<ClientMapping>> {
 
-    private static final Logger logger = Logger.getLogger(LocalEjbReceiver.class);
     public static final ServiceName DEFAULT_LOCAL_EJB_RECEIVER_SERVICE_NAME = ServiceName.JBOSS.append("ejb").append("default-local-ejb-receiver-service");
     public static final ServiceName BY_VALUE_SERVICE_NAME = ServiceName.JBOSS.append("ejb3", "localEjbReceiver", "value");
     public static final ServiceName BY_REFERENCE_SERVICE_NAME = ServiceName.JBOSS.append("ejb3", "localEjbReceiver", "reference");
@@ -504,7 +502,7 @@ public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbRec
             // which can only handle local receiver and no remote receivers (due to lack of configurations
             // to connect to them), then skip that context
             if (this.isLocalOnlyEJBClientContext(ejbClientContext)) {
-                logger.debugf("Skipping cluster node additions to EJB client context %s since it can only handle local node", ejbClientContext);
+                EjbLogger.REMOTE_LOGGER.debugf("Skipping cluster node additions to EJB client context %s since it can only handle local node", ejbClientContext);
                 continue;
             }
             // find a matching client mapping for our bind address
@@ -517,7 +515,7 @@ public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbRec
                     final boolean match = NetworkUtil.belongsToNetwork(binding.getAddress().getAddress(), sourceNetworkAddress, (byte) (netMask & 0xff));
                     if (match) {
                         resolvedClientMapping = clientMapping;
-                        logger.debugf("Client mapping %s matches client address %s", clientMapping, binding.getAddress().getAddress());
+                        EjbLogger.REMOTE_LOGGER.debugf("Client mapping %s matches client address %s", clientMapping, binding.getAddress().getAddress());
                         break;
                     }
                 }
@@ -709,7 +707,7 @@ public class LocalEjbReceiver extends EJBReceiver implements Service<LocalEjbRec
             // which can only handle local receiver and no remote receivers (due to lack of configurations
             // to connect to them), then skip that context
             if (this.isLocalOnlyEJBClientContext(ejbClientContext)) {
-                logger.debug("Skipping cluster node removal to EJB client context " + ejbClientContext + " since it can only handle local node");
+                EjbLogger.REMOTE_LOGGER.debugf("Skipping cluster node removal to EJB client context %s since it can only handle local node", ejbClientContext);
                 continue;
             }
             clusterContext.removeClusterNode(removedNodeName);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingConnectionClusterNodeManager.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RemotingConnectionClusterNodeManager.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.ejb3.remote;
 
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.ejb.client.ClusterContext;
 import org.jboss.ejb.client.ClusterNodeManager;
 import org.jboss.ejb.client.EJBClientConfiguration;
@@ -30,7 +31,6 @@ import org.jboss.ejb.client.remoting.IoFutureHelper;
 import org.jboss.ejb.client.remoting.NetworkUtil;
 import org.jboss.ejb.client.remoting.ReconnectHandler;
 import org.jboss.ejb.client.remoting.RemotingConnectionEJBReceiver;
-import org.jboss.logging.Logger;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.IoFuture;
@@ -44,8 +44,6 @@ import java.util.concurrent.TimeUnit;
  * @author Jaikiran Pai
  */
 class RemotingConnectionClusterNodeManager implements ClusterNodeManager {
-
-    private static final Logger logger = Logger.getLogger(RemotingConnectionClusterNodeManager.class);
 
     private final String nodeName;
     private final ClusterContext clusterContext;
@@ -117,7 +115,7 @@ class RemotingConnectionClusterNodeManager implements ClusterNodeManager {
 
             }
         } catch (Exception e) {
-            logger.info("Could not create a connection for cluster node " + this.nodeName + " in cluster " + clusterContext.getClusterName(), e);
+            EjbLogger.REMOTE_LOGGER.couldNotCreateClusterConnection(e, this.nodeName, clusterContext.getClusterName());
             return null;
         }
         return new RemotingConnectionEJBReceiver(connection, reconnectHandler, channelCreationOptions, destinationProtocol);
@@ -148,10 +146,10 @@ class RemotingConnectionClusterNodeManager implements ClusterNodeManager {
             try {
                 final IoFuture<Connection> futureConnection = NetworkUtil.connect(endpoint,"remote", destinationHost, destinationPort, null, connectionCreationOptions, callbackHandler, null);
                 connection = IoFutureHelper.get(futureConnection, connectionTimeout, TimeUnit.MILLISECONDS);
-                logger.debugf("Successfully reconnected to connection %s", connection);
+                EjbLogger.REMOTE_LOGGER.debugf("Successfully reconnected to connection %s", connection);
 
             } catch (Exception e) {
-                logger.debugf(e, "Failed to re-connect to %s:%d", this.destinationHost, this.destinationPort);
+                EjbLogger.REMOTE_LOGGER.debugf(e, "Failed to re-connect to %s:%d", this.destinationHost, this.destinationPort);
             }
             if (connection == null) {
                 return;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/TransactionRecoveryEJBClientContextInitializer.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/TransactionRecoveryEJBClientContextInitializer.java
@@ -36,6 +36,6 @@ public class TransactionRecoveryEJBClientContextInitializer implements EJBClient
     @Override
     public void initialize(EJBClientContext context) {
         context.registerEJBClientContextListener(EJBTransactionRecoveryService.INSTANCE);
-        EjbLogger.ROOT_LOGGER.debugf("Registered %s as a listener to EJB client context %s", EJBTransactionRecoveryService.INSTANCE, context);
+        EjbLogger.REMOTE_LOGGER.debugf("Registered %s as a listener to EJB client context %s", EJBTransactionRecoveryService.INSTANCE, context);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/InvocationCancellationMessageHandler.java
@@ -23,9 +23,9 @@
 package org.jboss.as.ejb3.remote.protocol.versionone;
 
 import org.jboss.as.ejb3.component.interceptors.CancellationFlag;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.remote.RemoteAsyncInvocationCancelStatusService;
 import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
-import org.jboss.logging.Logger;
 
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -37,8 +37,6 @@ import java.io.InputStream;
  * @author Jaikiran Pai
  */
 class InvocationCancellationMessageHandler extends AbstractMessageHandler {
-
-    private static final Logger logger = Logger.getLogger(InvocationCancellationMessageHandler.class);
 
     private final RemoteAsyncInvocationCancelStatusService remoteAsyncInvocationCancelStatus;
 
@@ -58,6 +56,6 @@ class InvocationCancellationMessageHandler extends AbstractMessageHandler {
         }
         // mark it as cancelled
         cancellationFlag.set(true);
-        logger.debugf("Invocation with id %s has been marked as cancelled, as requested", invocationToCancel);
+        EjbLogger.REMOTE_LOGGER.debugf("Invocation with id %s has been marked as cancelled, as requested", invocationToCancel);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -191,7 +191,7 @@ public class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHan
                         } catch (Throwable t) {
                             // catch Throwable, so that we don't skip invoking the method, just because we
                             // failed to send a notification to the client that the method is an async method
-                            EjbLogger.ROOT_LOGGER.failedToSendAsyncMethodIndicatorToClient(t, invokedMethod);
+                            EjbLogger.REMOTE_LOGGER.failedToSendAsyncMethodIndicatorToClient(t, invokedMethod);
                         }
                     }
 
@@ -214,9 +214,9 @@ public class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHan
                         } catch (Throwable ioe) {
                             // we couldn't write out a method invocation failure message. So let's at least log the
                             // actual method invocation exception, for debugging/reference
-                            EjbLogger.ROOT_LOGGER.errorInvokingMethod(throwable, invokedMethod, beanName, appName, moduleName, distinctName);
+                            EjbLogger.REMOTE_LOGGER.errorInvokingMethod(throwable, invokedMethod, beanName, appName, moduleName, distinctName);
                             // now log why we couldn't send back the method invocation failure message
-                            EjbLogger.ROOT_LOGGER.couldNotWriteMethodInvocation(ioe, invokedMethod, beanName, appName, moduleName, distinctName);
+                            EjbLogger.REMOTE_LOGGER.couldNotWriteMethodInvocation(ioe, invokedMethod, beanName, appName, moduleName, distinctName);
                             // close the channel unless this is a NotSerializableException
                             //as this does not represent a problem with the channel there is no
                             //need to close it (see AS7-3402)
@@ -246,7 +246,7 @@ public class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHan
                     } catch (Throwable ioe) {
                         boolean isAsyncVoid = componentView.isAsynchronous(invokedMethod) && invokedMethod.getReturnType().equals(Void.TYPE);
                         if (!isAsyncVoid)
-                            EjbLogger.ROOT_LOGGER.couldNotWriteMethodInvocation(ioe, invokedMethod, beanName, appName, moduleName, distinctName);
+                            EjbLogger.REMOTE_LOGGER.couldNotWriteMethodInvocation(ioe, invokedMethod, beanName, appName, moduleName, distinctName);
                         // close the channel unless this is a NotSerializableException
                         //as this does not represent a problem with the channel there is no
                         //need to close it (see AS7-3402)
@@ -311,7 +311,7 @@ public class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHan
         if (componentView.isAsynchronous(method)) {
             final Component component = componentView.getComponent();
             if (!(component instanceof SessionBeanComponent)) {
-                EjbLogger.ROOT_LOGGER.asyncMethodSupportedOnlyForSessionBeans(component.getComponentClass(), method);
+                EjbLogger.REMOTE_LOGGER.asyncMethodSupportedOnlyForSessionBeans(component.getComponentClass(), method);
                 // just invoke normally
                 return componentView.invoke(interceptorContext);
             }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/SessionOpenRequestHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/SessionOpenRequestHandler.java
@@ -144,7 +144,7 @@ class SessionOpenRequestHandler extends EJBIdentifierBasedMessageHandler {
                 try {
                     sessionID = statefulSessionComponent.createSessionRemote();
                 } catch (Throwable t) {
-                    EjbLogger.ROOT_LOGGER.exceptionGeneratingSessionId(t, statefulSessionComponent.getComponentName(), invocationId, channelAssociation.getChannel());
+                    EjbLogger.REMOTE_LOGGER.exceptionGeneratingSessionId(t, statefulSessionComponent.getComponentName(), invocationId, channelAssociation.getChannel());
                     SessionOpenRequestHandler.this.writeException(channelAssociation, SessionOpenRequestHandler.this.marshallerFactory, invocationId, t, null);
                     return;
                 }
@@ -152,7 +152,7 @@ class SessionOpenRequestHandler extends EJBIdentifierBasedMessageHandler {
                 final Affinity hardAffinity = statefulSessionComponent.getCache().getStrictAffinity();
                 SessionOpenRequestHandler.this.writeSessionId(channelAssociation, invocationId, sessionID, hardAffinity);
             } catch (IOException ioe) {
-                EjbLogger.ROOT_LOGGER.exceptionGeneratingSessionId(ioe, statefulSessionComponent.getComponentName(), invocationId, channelAssociation.getChannel());
+                EjbLogger.REMOTE_LOGGER.exceptionGeneratingSessionId(ioe, statefulSessionComponent.getComponentName(), invocationId, channelAssociation.getChannel());
                 // close the channel
                 IoUtils.safeClose(this.channelAssociation.getChannel());
                 return;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/UserTransactionManagementTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/UserTransactionManagementTask.java
@@ -65,7 +65,7 @@ abstract class UserTransactionManagementTask implements Runnable {
                 // the transaction operation failed
                 transactionRequestHandler.writeException(this.channelAssociation, this.marshallerFactory, this.invocationId, t, null);
             } catch (IOException e) {
-                EjbLogger.ROOT_LOGGER.couldNotWriteOutToChannel(e);
+                EjbLogger.REMOTE_LOGGER.couldNotWriteOutToChannel(e);
                 // close the channel
                 IoUtils.safeClose(this.channelAssociation.getChannel());
             }
@@ -76,7 +76,7 @@ abstract class UserTransactionManagementTask implements Runnable {
             // write out invocation success message to the channel
             transactionRequestHandler.writeTxInvocationResponseMessage(this.channelAssociation, this.invocationId);
         } catch (IOException e) {
-            EjbLogger.ROOT_LOGGER.couldNotWriteInvocationSuccessMessage(e);
+            EjbLogger.REMOTE_LOGGER.couldNotWriteInvocationSuccessMessage(e);
             // close the channel
             IoUtils.safeClose(this.channelAssociation.getChannel());
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -108,7 +108,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             }
         } catch (IOException ioe) {
             // just log and don't throw an error
-            EjbLogger.ROOT_LOGGER.failedToSendClusterFormationMessageToClient(ioe, channel);
+            EjbLogger.REMOTE_LOGGER.failedToSendClusterFormationMessageToClient(ioe, channel);
         }
         for (final Registry<String, List<ClientMapping>> cluster : clusters) {
             // add the topology update listener
@@ -152,7 +152,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
 
         } catch (Throwable e) {
             // log it
-            EjbLogger.ROOT_LOGGER.exceptionOnChannel(e, channel, messageInputStream);
+            EjbLogger.REMOTE_LOGGER.exceptionOnChannel(e, channel, messageInputStream);
             // no more messages can be sent or received on this channel
             IoUtils.safeClose(channel);
         } finally {
@@ -192,15 +192,13 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     protected void processMessage(final Channel channel, final InputStream inputStream) throws IOException {
         // read the first byte to see what type of a message it is
         final int header = inputStream.read();
-        if (EjbLogger.ROOT_LOGGER.isTraceEnabled()) {
-            EjbLogger.ROOT_LOGGER.trace("Got message with header 0x" + Integer.toHexString(header) + " on channel " + channel);
-        }
+        EjbLogger.REMOTE_LOGGER.tracef("Got message with header 0x%x on channel %s", header, channel);
         final MessageHandler messageHandler = getMessageHandler((byte) header);
         if (messageHandler == null) {
             // enroll for next message (whenever it's available)
             channel.receiveMessage(this);
             // log a message that the message wasn't identified
-            EjbLogger.ROOT_LOGGER.unsupportedMessageHeader(Integer.toHexString(header), channel);
+            EjbLogger.REMOTE_LOGGER.unsupportedMessageHeader(header, channel);
             return;
         }
         // let the message handler process the message
@@ -213,10 +211,10 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
         final Map<DeploymentModuleIdentifier, ModuleDeployment> availableModules = this.deploymentRepository.getStartedModules();
         if (availableModules != null && !availableModules.isEmpty()) {
             try {
-                EjbLogger.ROOT_LOGGER.debugf("Sending initial module availability message, containing %s module(s) to channel %s", availableModules.size(), this.channelAssociation.getChannel());
+                EjbLogger.REMOTE_LOGGER.debugf("Sending initial module availability message, containing %s module(s) to channel %s", availableModules.size(), this.channelAssociation.getChannel());
                 this.sendModuleAvailability(availableModules.keySet().toArray(new DeploymentModuleIdentifier[availableModules.size()]));
             } catch (IOException e) {
-                EjbLogger.ROOT_LOGGER.failedToSendModuleAvailabilityMessageToClient(e, this.channelAssociation.getChannel());
+                EjbLogger.REMOTE_LOGGER.failedToSendModuleAvailabilityMessageToClient(e, this.channelAssociation.getChannel());
             }
         }
     }
@@ -228,18 +226,18 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     @Override
     public void deploymentStarted(DeploymentModuleIdentifier deploymentModuleIdentifier, ModuleDeployment moduleDeployment) {
         try {
-            this.sendModuleAvailability(new DeploymentModuleIdentifier[]{deploymentModuleIdentifier});
+            this.sendModuleAvailability(new DeploymentModuleIdentifier[] {deploymentModuleIdentifier});
         } catch (IOException e) {
-            EjbLogger.ROOT_LOGGER.failedToSendModuleAvailabilityMessageToClient(e, deploymentModuleIdentifier, channelAssociation.getChannel());
+            EjbLogger.REMOTE_LOGGER.failedToSendModuleAvailabilityMessageToClient(e, deploymentModuleIdentifier, channelAssociation.getChannel());
         }
     }
 
     @Override
     public void deploymentRemoved(DeploymentModuleIdentifier deploymentModuleIdentifier) {
         try {
-            this.sendModuleUnAvailability(new DeploymentModuleIdentifier[]{deploymentModuleIdentifier});
+            this.sendModuleUnAvailability(new DeploymentModuleIdentifier[] {deploymentModuleIdentifier});
         } catch (IOException e) {
-            EjbLogger.ROOT_LOGGER.failedToSendModuleUnavailabilityMessageToClient(e, deploymentModuleIdentifier, channelAssociation.getChannel());
+            EjbLogger.REMOTE_LOGGER.failedToSendModuleUnavailabilityMessageToClient(e, deploymentModuleIdentifier, channelAssociation.getChannel());
         }
     }
 
@@ -282,10 +280,12 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     @Override
     public void registryAdded(Registry<String, List<ClientMapping>> cluster) {
         try {
-            EjbLogger.ROOT_LOGGER.debugf("Received new cluster formation notification for cluster %s", cluster.getGroup().getName());
+            if (EjbLogger.REMOTE_LOGGER.isDebugEnabled()) {
+                EjbLogger.REMOTE_LOGGER.debugf("Received new cluster formation notification for cluster %s", cluster.getGroup().getName());
+            }
             this.sendNewClusterFormedMessage(Collections.singleton(cluster));
         } catch (IOException ioe) {
-            EjbLogger.ROOT_LOGGER.failedToSendClusterFormationMessageToClient(ioe, cluster.getGroup().getName(), channelAssociation.getChannel());
+            EjbLogger.REMOTE_LOGGER.failedToSendClusterFormationMessageToClient(ioe, cluster.getGroup().getName(), channelAssociation.getChannel());
         } finally {
             // add a listener for receiving node(s) addition/removal from the cluster
             final ClusterTopologyUpdateListener clusterTopologyUpdateListener = new ClusterTopologyUpdateListener(cluster, this);
@@ -299,13 +299,15 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
     public void registryRemoved(Registry<String, List<ClientMapping>> registry) {
         // When the cluster node count reaches 0 then send a cluster removal message to clean up the ClusterContext on the client
         try {
-            EjbLogger.ROOT_LOGGER.debugf("Received cluster removal notification for cluster %s", registry.getGroup());
+            if (EjbLogger.REMOTE_LOGGER.isDebugEnabled()) {
+                EjbLogger.REMOTE_LOGGER.debugf("Received cluster removal notification for cluster %s", registry.getGroup());
+            }
             // when the membership of the cluster being left is 1, we are the last node
             if (registry.getEntries().keySet().size() == 1) {
                 this.sendClusterRemovedMessage(registry);
             }
         } catch (IOException ioe) {
-            EjbLogger.ROOT_LOGGER.warn("Could not send a cluster removal message for cluster: " + registry.getGroup() + " to the client on channel " + channelAssociation.getChannel(), ioe);
+            EjbLogger.REMOTE_LOGGER.warn("Could not send a cluster removal message for cluster: " + registry.getGroup() + " to the client on channel " + channelAssociation.getChannel(), ioe);
         }
     }
 
@@ -326,7 +328,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
         outputStream = new DataOutputStream(messageOutputStream);
         final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
         try {
-            EjbLogger.ROOT_LOGGER.debugf("Writing out cluster formation message for %d clusters, to channel %s", clientMappingRegistries.size(), this.channelAssociation.getChannel());
+            EjbLogger.REMOTE_LOGGER.debugf("Writing out cluster formation message for %d clusters, to channel %s", clientMappingRegistries.size(), this.channelAssociation.getChannel());
             clusterTopologyWriter.writeCompleteClusterTopology(outputStream, clientMappingRegistries);
         } finally {
             channelAssociation.releaseChannelMessageOutputStream(messageOutputStream);
@@ -351,7 +353,9 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
         outputStream = new DataOutputStream(messageOutputStream);
         final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
         try {
-            EjbLogger.ROOT_LOGGER.debugf("Cluster Ts removed, writing cluster removal message to channel %s", registry.getGroup().getName(), this.channelAssociation.getChannel());
+            if (EjbLogger.REMOTE_LOGGER.isDebugEnabled()) {
+                EjbLogger.REMOTE_LOGGER.debugf("Cluster Ts removed, writing cluster removal message to channel %s", registry.getGroup().getName(), this.channelAssociation.getChannel());
+            }
             clusterTopologyWriter.writeClusterRemoved(outputStream, Collections.singleton(registry));
         } finally {
             channelAssociation.releaseChannelMessageOutputStream(messageOutputStream);
@@ -377,7 +381,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
 
         @Override
         public void handleClose(Channel closedChannel, IOException exception) {
-            EjbLogger.ROOT_LOGGER.debugf("Channel %s closed", closedChannel);
+            EjbLogger.REMOTE_LOGGER.debugf("Channel %s closed", closedChannel);
             VersionOneProtocolChannelReceiver.this.cleanupOnChannelDown();
         }
     }
@@ -402,7 +406,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             try {
                 this.sendClusterNodesAdded(added);
             } catch (IOException ioe) {
-                EjbLogger.ROOT_LOGGER.failedToSendClusterNodeAdditionMessageToClient(ioe, channelAssociation.getChannel());
+                EjbLogger.REMOTE_LOGGER.failedToSendClusterNodeAdditionMessageToClient(ioe, channelAssociation.getChannel());
             }
         }
 
@@ -416,7 +420,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             try {
                 this.sendClusterNodesRemoved(removed.keySet());
             } catch (IOException ioe) {
-                EjbLogger.ROOT_LOGGER.failedToSendClusterNodeRemovalMessageToClient(ioe, channelAssociation.getChannel());
+                EjbLogger.REMOTE_LOGGER.failedToSendClusterNodeRemovalMessageToClient(ioe, channelAssociation.getChannel());
             }
         }
 
@@ -435,14 +439,14 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             outputStream = new DataOutputStream(messageOutputStream);
             final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
             try {
-                if (EjbLogger.ROOT_LOGGER.isDebugEnabled()) {
-                    EjbLogger.ROOT_LOGGER.debug("Following " + removedNodes.size() + " nodes removed from cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
-                    final StringBuffer sb = new StringBuffer();
+                if (EjbLogger.REMOTE_LOGGER.isDebugEnabled()) {
+                    EjbLogger.REMOTE_LOGGER.debug("Following " + removedNodes.size() + " nodes removed from cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
+                    final StringBuilder sb = new StringBuilder();
                     for (final String nodeName : removedNodes) {
                         sb.append(nodeName);
-                        sb.append("\n");
+                        sb.append(System.lineSeparator());
                     }
-                    EjbLogger.ROOT_LOGGER.debug(sb.toString());
+                    EjbLogger.REMOTE_LOGGER.debug(sb.toString());
                 }
                 clusterTopologyWriter.writeNodesRemoved(outputStream, clusterName, removedNodes);
             } finally {
@@ -462,14 +466,14 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             outputStream = new DataOutputStream(messageOutputStream);
             final ClusterTopologyWriter clusterTopologyWriter = new ClusterTopologyWriter();
             try {
-                if (EjbLogger.ROOT_LOGGER.isDebugEnabled()) {
-                    EjbLogger.ROOT_LOGGER.debug("Following " + addedNodes.size() + " nodes added to cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
-                    final StringBuffer sb = new StringBuffer();
+                if (EjbLogger.REMOTE_LOGGER.isDebugEnabled()) {
+                    EjbLogger.REMOTE_LOGGER.debug("Following " + addedNodes.size() + " nodes added to cluster " + clusterName + ", writing a protocol message to channel " + this.channelReceiver.channelAssociation.getChannel());
+                    final StringBuilder sb = new StringBuilder();
                     for (final String nodeName : addedNodes.keySet()) {
                         sb.append(nodeName);
-                        sb.append("\n");
+                        sb.append(System.lineSeparator());
                     }
-                    EjbLogger.ROOT_LOGGER.debug(sb.toString());
+                    EjbLogger.REMOTE_LOGGER.debug(sb.toString());
                 }
 
                 clusterTopologyWriter.writeNewNodesAdded(outputStream, clusterName, addedNodes);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionManagementTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/XidTransactionManagementTask.java
@@ -68,12 +68,12 @@ abstract class XidTransactionManagementTask implements Runnable {
             this.manageTransaction();
         } catch (Throwable t) {
             try {
-                EjbLogger.ROOT_LOGGER.errorDuringTransactionManagement(t, this.xidTransactionID);
+                EjbLogger.REMOTE_LOGGER.errorDuringTransactionManagement(t, this.xidTransactionID);
                 // write out a failure message to the channel to let the client know that
                 // the transaction operation failed
                 transactionRequestHandler.writeException(this.channelAssociation, this.marshallerFactory, this.invocationId, t, null);
             } catch (IOException e) {
-                EjbLogger.ROOT_LOGGER.couldNotWriteOutToChannel(e);
+                EjbLogger.REMOTE_LOGGER.couldNotWriteOutToChannel(e);
                 // close the channel
                 IoUtils.safeClose(this.channelAssociation.getChannel());
             }
@@ -84,7 +84,7 @@ abstract class XidTransactionManagementTask implements Runnable {
             // write out invocation success message to the channel
             transactionRequestHandler.writeTxInvocationResponseMessage(this.channelAssociation, this.invocationId);
         } catch (IOException e) {
-            EjbLogger.ROOT_LOGGER.couldNotWriteInvocationSuccessMessage(e);
+            EjbLogger.REMOTE_LOGGER.couldNotWriteInvocationSuccessMessage(e);
             // close the channel
             IoUtils.safeClose(this.channelAssociation.getChannel());
         }
@@ -100,7 +100,7 @@ abstract class XidTransactionManagementTask implements Runnable {
     protected SubordinateTransaction tryRecoveryForImportedTransaction() throws Exception {
         final XATerminator xaTerminator = SubordinationManager.getXATerminator();
         if (xaTerminator instanceof XATerminatorImple) {
-            EjbLogger.ROOT_LOGGER.debugf("Trying to recover an imported transaction for Xid %s", this.xidTransactionID.getXid());
+            EjbLogger.REMOTE_LOGGER.debugf("Trying to recover an imported transaction for Xid %s", this.xidTransactionID.getXid());
             // We intentionally pass null for Xid since passing the specific Xid doesn't seem to work for some reason.
             // As for null for parentNodeName, we do that intentionally since we aren't aware of the parent node on which
             // the transaction originated

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/TransactionRecoverMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/TransactionRecoverMessageHandler.java
@@ -37,7 +37,6 @@ import org.jboss.as.ejb3.remote.protocol.AbstractMessageHandler;
 import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
 import org.jboss.ejb.client.XidTransactionID;
 import org.jboss.ejb.client.remoting.PackedInteger;
-import org.jboss.logging.Logger;
 import org.jboss.marshalling.Marshaller;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.remoting3.MessageOutputStream;
@@ -49,8 +48,6 @@ import org.xnio.IoUtils;
  * @author Jaikiran Pai
  */
 class TransactionRecoverMessageHandler extends AbstractMessageHandler {
-
-    private static final Logger logger = Logger.getLogger(TransactionRecoverMessageHandler.class);
 
     private static final byte HEADER_TX_RECOVER_RESPONSE = 0x1A;
 
@@ -96,28 +93,28 @@ class TransactionRecoverMessageHandler extends AbstractMessageHandler {
                 xidsToRecover = transactionsRepository.getXidsToRecoverForParentNode(this.txParentNodeName, this.recoveryFlags);
             } catch (Throwable t) {
                 try {
-                    EjbLogger.ROOT_LOGGER.errorDuringTransactionRecovery(t);
+                    EjbLogger.REMOTE_LOGGER.errorDuringTransactionRecovery(t);
                     // write out a failure message to the channel to let the client know that
                     // the transaction operation failed
                     TransactionRecoverMessageHandler.this.writeException(channelAssociation, marshallerFactory, invocationId, t, null);
                 } catch (IOException e) {
-                    EjbLogger.ROOT_LOGGER.couldNotWriteOutToChannel(e);
+                    EjbLogger.REMOTE_LOGGER.couldNotWriteOutToChannel(e);
                     // close the channel
                     IoUtils.safeClose(channelAssociation.getChannel());
                 }
                 return;
             }
             try {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("Returning " + xidsToRecover.length + " Xid(s) to recover for parent node: " + txParentNodeName);
+                if (EjbLogger.REMOTE_LOGGER.isTraceEnabled()) {
+                    EjbLogger.REMOTE_LOGGER.trace("Returning " + xidsToRecover.length + " Xid(s) to recover for parent node: " + txParentNodeName);
                     for (final Xid xid : xidsToRecover) {
-                        logger.trace("EJB Xid to recover " + XAHelper.xidToString(xid));
+                        EjbLogger.REMOTE_LOGGER.trace("EJB Xid to recover " + XAHelper.xidToString(xid));
                     }
                 }
                 // write out invocation success message to the channel
                 this.writeResponse(xidsToRecover);
             } catch (IOException e) {
-                EjbLogger.ROOT_LOGGER.couldNotWriteInvocationSuccessMessage(e);
+                EjbLogger.REMOTE_LOGGER.couldNotWriteInvocationSuccessMessage(e);
                 // close the channel
                 IoUtils.safeClose(this.channelAssociation.getChannel());
             }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -66,7 +66,6 @@ import org.jboss.as.ejb3.timerservice.persistence.TimerPersistence;
 import org.jboss.as.ejb3.timerservice.spi.ScheduleTimer;
 import org.jboss.as.ejb3.timerservice.spi.TimedObjectInvoker;
 import org.jboss.invocation.InterceptorContext;
-import org.jboss.logging.Logger;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
@@ -90,11 +89,6 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
      * inactive timer states
      */
     private static final Set<TimerState> ineligibleTimerStates;
-
-    /**
-     * Logger
-     */
-    private static final Logger logger = Logger.getLogger(TimerServiceImpl.class);
 
     public static final ServiceName SERVICE_NAME = ServiceName.of("ejb3", "timerService");
 
@@ -186,8 +180,8 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
     @Override
     public synchronized void start(final StartContext context) throws StartException {
 
-        if (logger.isDebugEnabled()) {
-            logger.debug("Starting timerservice for timedObjectId: " + getInvoker().getTimedObjectId());
+        if (EjbLogger.ROOT_LOGGER.isDebugEnabled()) {
+            EjbLogger.ROOT_LOGGER.debug("Starting timerservice for timedObjectId: " + getInvoker().getTimedObjectId());
         }
         final EJBComponent component = ejbComponentInjectedValue.getValue();
         this.transactionManager = component.getTransactionManager();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerTask.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerTask.java
@@ -96,9 +96,7 @@ public class TimerTask<T extends TimerImpl> implements Runnable {
             }
 
             Date now = new Date();
-            if (ROOT_LOGGER.isDebugEnabled()) {
-                ROOT_LOGGER.debug("Timer task invoked at: " + now + " for timer " + timer);
-            }
+            ROOT_LOGGER.debugf("Timer task invoked at: %s for timer %s", now, timer);
 
             // If a retry thread is in progress, we don't want to allow another
             // interval to execute until the retry is complete. See JIRA-1926.

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/logging/JaxrsLogger.java
@@ -48,7 +48,7 @@ public interface JaxrsLogger extends BasicLogger {
     /**
      * A logger with the category {@code org.jboss.jaxrs}.
      */
-    JaxrsLogger JAXRS_LOGGER = Logger.getMessageLogger(JaxrsLogger.class, "org.jboss.jaxrs");
+    JaxrsLogger JAXRS_LOGGER = Logger.getMessageLogger(JaxrsLogger.class, "org.jboss.as.jaxrs");
 
     /**
      * Logs a warning message indicating the annotation, represented by the {@code annotation} parameter, not on Class,

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/SFSBCallStack.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/SFSBCallStack.java
@@ -90,7 +90,7 @@ public class SFSBCallStack {
     static SFSBInjectedXPCs getSFSBCreationTimeInjectedXPCs(final String puScopedName) {
         SFSBInjectedXPCs result = CURRENT.get().creationTimeInjectedXPCs;
         if (result == null) {
-            throw JpaLogger.JPA_LOGGER.xpcOnlyFromSFSB(puScopedName);
+            throw JpaLogger.ROOT_LOGGER.xpcOnlyFromSFSB(puScopedName);
         }
         return result;
     }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.jpa.container;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -146,16 +146,16 @@ public class TransactionScopedEntityManager extends AbstractEntityManager implem
         EntityManager entityManager = TransactionUtil.getTransactionScopedEntityManager(puScopedName);
         if (entityManager == null) {
             entityManager = createEntityManager(emf, properties, synchronizationType);
-            if (JPA_LOGGER.isDebugEnabled())
-                JPA_LOGGER.debugf("%s: created entity manager session %s", TransactionUtil.getEntityManagerDetails(entityManager, scopedPuName),
+            if (ROOT_LOGGER.isDebugEnabled())
+                ROOT_LOGGER.debugf("%s: created entity manager session %s", TransactionUtil.getEntityManagerDetails(entityManager, scopedPuName),
                     TransactionUtil.getTransaction().toString());
             TransactionUtil.registerSynchronization(entityManager, scopedPuName);
             TransactionUtil.putEntityManagerInTransactionRegistry(scopedPuName, entityManager);
         }
         else {
             testForMixedSynchronizationTypes(entityManager, puScopedName, synchronizationType);
-            if (JPA_LOGGER.isDebugEnabled()) {
-                JPA_LOGGER.debugf("%s: reuse entity manager session already in tx %s", TransactionUtil.getEntityManagerDetails(entityManager, scopedPuName),
+            if (ROOT_LOGGER.isDebugEnabled()) {
+                ROOT_LOGGER.debugf("%s: reuse entity manager session already in tx %s", TransactionUtil.getEntityManagerDetails(entityManager, scopedPuName),
                     TransactionUtil.getTransaction().toString());
             }
         }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.jpa.injectors;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.lang.reflect.Proxy;
 import java.util.Map;
@@ -153,8 +153,8 @@ public class PersistenceContextInjectionSource extends InjectionSource {
 
             if (type.equals(PersistenceContextType.TRANSACTION)) {
                 entityManager = new TransactionScopedEntityManager(unitName, properties, emf, synchronizationType);
-                if (JPA_LOGGER.isDebugEnabled())
-                    JPA_LOGGER.debugf("created new TransactionScopedEntityManager for unit name=%s", unitName);
+                if (ROOT_LOGGER.isDebugEnabled())
+                    ROOT_LOGGER.debugf("created new TransactionScopedEntityManager for unit name=%s", unitName);
             } else {
                 boolean useDeepInheritance = !ExtendedPersistenceInheritance.SHALLOW.equals(JPAService.getDefaultExtendedPersistenceInheritance());
                 if (jpaDeploymentSettings != null) {
@@ -174,13 +174,13 @@ public class PersistenceContextInjectionSource extends InjectionSource {
                 if (entityManager1 == null) {
                     entityManager1 = new ExtendedEntityManager(unitName, emf.createEntityManager(properties), synchronizationType);
                     createdNewExtendedPersistence = true;
-                    if (JPA_LOGGER.isDebugEnabled())
-                        JPA_LOGGER.debugf("created new ExtendedEntityManager for unit name=%s, useDeepInheritance = %b", unitName, useDeepInheritance);
+                    if (ROOT_LOGGER.isDebugEnabled())
+                        ROOT_LOGGER.debugf("created new ExtendedEntityManager for unit name=%s, useDeepInheritance = %b", unitName, useDeepInheritance);
 
                 } else {
                     entityManager1.increaseReferenceCount();
-                    if (JPA_LOGGER.isDebugEnabled())
-                        JPA_LOGGER.debugf("inherited existing ExtendedEntityManager from SFSB invocation stack, unit name=%s, " +
+                    if (ROOT_LOGGER.isDebugEnabled())
+                        ROOT_LOGGER.debugf("inherited existing ExtendedEntityManager from SFSB invocation stack, unit name=%s, " +
                                 "%d beans sharing ExtendedEntityManager, useDeepInheritance = %b", unitName, entityManager1.getReferenceCount(), useDeepInheritance);
                 }
 
@@ -243,8 +243,8 @@ public class PersistenceContextInjectionSource extends InjectionSource {
                                     entityManagerUnwrappedTargetInvocationHandler
                                 );
 
-                if (JPA_LOGGER.isDebugEnabled())
-                    JPA_LOGGER.debugf("injecting entity manager into a '%s' (unit name=%s)", extensionClass.getName(), unitName);
+                if (ROOT_LOGGER.isDebugEnabled())
+                    ROOT_LOGGER.debugf("injecting entity manager into a '%s' (unit name=%s)", extensionClass.getName(), unitName);
 
                 return new ValueManagedReference(new ImmediateValue<Object>(proxyForUnwrappedObject));
             }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.jpa.management;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -85,7 +85,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             }
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
             return false;
         }
 
@@ -104,7 +104,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             }
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
             return super.getChild(element);
         }
     }
@@ -124,7 +124,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             }
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
             return super.requireChild(element);
         }
     }
@@ -141,7 +141,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             }
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
             return false;
         }
     }
@@ -168,7 +168,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             return result;
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
             return Collections.emptySet();
         }
     }
@@ -189,7 +189,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             }
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
             return Collections.emptySet();
         }
     }
@@ -210,7 +210,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             }
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
             return Collections.emptySet();
         }
 
@@ -227,7 +227,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
             }
         }
         catch( IllegalStateException e) {  // WFLY-2436 ignore unexpected exceptions (e.g. JIPI-27 may throw an IllegalStateException)
-            JPA_LOGGER.unexpectedStatisticsProblem(e);
+            ROOT_LOGGER.unexpectedStatisticsProblem(e);
         }
     }
 

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -58,11 +58,6 @@ public interface JpaLogger extends BasicLogger {
     JpaLogger ROOT_LOGGER = Logger.getMessageLogger(JpaLogger.class, "org.jboss.as.jpa");
 
     /**
-     * A logger with the category {@code org.jboss.jpa}.
-     */
-    JpaLogger JPA_LOGGER = Logger.getMessageLogger(JpaLogger.class, "org.jboss.as.jpa");
-
-    /**
      * Logs a warning message indicating duplicate persistence.xml files were found.
      *
      * @param puName    the persistence XML file.

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPADependencyProcessor.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.jpa.processor;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
 import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.io.IOException;
@@ -175,7 +174,7 @@ public class JPADependencyProcessor implements DeploymentUnitProcessor {
             if (deployPU) {
                 final ServiceName puServiceName = PersistenceUnitServiceImpl.getPUServiceName(pu);
                 for (final ComponentDescription component : components) {
-                    JPA_LOGGER.debugf("Adding dependency on PU service %s for component %s", puServiceName, component.getComponentClassName());
+                    ROOT_LOGGER.debugf("Adding dependency on PU service %s for component %s", puServiceName, component.getComponentClassName());
                     component.addDependency(puServiceName, ServiceBuilder.DependencyType.REQUIRED);
                 }
             }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAInterceptorProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/JPAInterceptorProcessor.java
@@ -38,7 +38,7 @@ import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 /**
  * @author Stuart Douglas
@@ -51,7 +51,7 @@ public class JPAInterceptorProcessor implements DeploymentUnitProcessor {
         final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
         for (ComponentDescription component : moduleDescription.getComponentDescriptions()) {
             if (component instanceof SessionBeanComponentDescription) {
-                JPA_LOGGER.tracef("registering session bean interceptors for component '%s' in '%s'", component.getComponentName(), deploymentUnit.getName());
+                ROOT_LOGGER.tracef("registering session bean interceptors for component '%s' in '%s'", component.getComponentName(), deploymentUnit.getName());
                 registerSessionBeanInterceptors((SessionBeanComponentDescription) component, deploymentUnit);
             }
         }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderAdaptorLoader.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderAdaptorLoader.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.jpa.processor;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.util.Map;
 import java.util.ServiceLoader;
@@ -116,7 +116,7 @@ public class PersistenceProviderAdaptorLoader {
                     throw JpaLogger.ROOT_LOGGER.multipleAdapters(adapterModule);
                 }
                 persistenceProviderAdaptor = adaptor;
-                JPA_LOGGER.debugf("loaded persistence provider adapter %s", adapterModule);
+                ROOT_LOGGER.debugf("loaded persistence provider adapter %s", adapterModule);
             }
             if (persistenceProviderAdaptor != null) {
                 persistenceProviderAdaptor.injectJtaManager(JtaManagerImpl.getInstance());
@@ -146,7 +146,7 @@ public class PersistenceProviderAdaptorLoader {
                     throw JpaLogger.ROOT_LOGGER.classloaderHasMultipleAdapters(persistenceProvider.getClass().getClassLoader().toString());
                 }
                 persistenceProviderAdaptor = adaptor;
-                JPA_LOGGER.debugf("loaded persistence provider adapter %s from classloader %s",
+                ROOT_LOGGER.debugf("loaded persistence provider adapter %s from classloader %s",
                         persistenceProviderAdaptor.getClass().getName(),
                         persistenceProvider.getClass().getClassLoader().toString());
             }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceProviderHandler.java
@@ -73,7 +73,7 @@ public class PersistenceProviderHandler {
                     final Constructor<? extends PersistenceProvider> constructor = providerClass.getConstructor();
                     provider = constructor.newInstance();
                     providerList.add(provider);
-                    JpaLogger.JPA_LOGGER.tracef("deployment %s is using its own copy of %s", deploymentUnit.getName(), providerName);
+                    JpaLogger.ROOT_LOGGER.tracef("deployment %s is using its own copy of %s", deploymentUnit.getName(), providerName);
 
                 } catch (Exception e) {
                     throw JpaLogger.ROOT_LOGGER.cannotDeployApp(e, providerName);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitParseProcessor.java
@@ -54,7 +54,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 /**
  * Handle parsing of Persistence unit persistence.xml files
@@ -112,7 +112,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
             // deploymentUnit.putAttachment(PersistenceUnitMetadataHolder.PERSISTENCE_UNITS, holder);
             deploymentRoot.putAttachment(PersistenceUnitMetadataHolder.PERSISTENCE_UNITS, holder);
             markDU(holder, deploymentUnit);
-            JPA_LOGGER.tracef("parsed persistence unit definitions for jar %s", deploymentRoot.getRootName());
+            ROOT_LOGGER.tracef("parsed persistence unit definitions for jar %s", deploymentRoot.getRootName());
 
             incrementPersistenceUnitCount(deploymentUnit, holder.getPersistenceUnits().size());
             addApplicationDependenciesOnProvider( deploymentUnit, holder);
@@ -153,7 +153,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
                     puCount += holder.getPersistenceUnits().size();
                 }
             }
-            JPA_LOGGER.tracef("parsed persistence unit definitions for war %s", deploymentRoot.getRootName());
+            ROOT_LOGGER.tracef("parsed persistence unit definitions for war %s", deploymentRoot.getRootName());
 
             incrementPersistenceUnitCount(deploymentUnit, puCount);
         }
@@ -194,7 +194,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
                     puCount += holder.getPersistenceUnits().size();
                 }
             }
-            JPA_LOGGER.tracef("parsed persistence unit definitions for ear %s", deploymentRoot.getRootName());
+            ROOT_LOGGER.tracef("parsed persistence unit definitions for ear %s", deploymentRoot.getRootName());
             incrementPersistenceUnitCount(deploymentUnit, puCount);
         }
     }
@@ -205,7 +205,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
             final DeploymentUnit deploymentUnit)
         throws DeploymentUnitProcessingException {
 
-        JPA_LOGGER.tracef("parse checking if %s exists, result = %b",persistence_xml.toString(), persistence_xml.exists());
+        ROOT_LOGGER.tracef("parse checking if %s exists, result = %b",persistence_xml.toString(), persistence_xml.exists());
         if (persistence_xml.exists() && persistence_xml.isFile()) {
             InputStream is = null;
             try {
@@ -306,7 +306,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
                 } else {
                     PersistenceUnitMetadata first = flattened.get(pu.getPersistenceUnitName());
                     PersistenceUnitMetadata duplicate = pu;
-                    JPA_LOGGER.duplicatePersistenceUnitDefinition(duplicate.getPersistenceUnitName(), first.getScopedPersistenceUnitName(), duplicate.getScopedPersistenceUnitName());
+                    ROOT_LOGGER.duplicatePersistenceUnitDefinition(duplicate.getPersistenceUnitName(), first.getScopedPersistenceUnitName(), duplicate.getScopedPersistenceUnitName());
                 }
             }
         }
@@ -378,7 +378,7 @@ public class PersistenceUnitParseProcessor implements DeploymentUnitProcessor {
             PersistenceUnitsInApplication persistenceUnitsInApplication = getPersistenceUnitsInApplication(topDeploymentUnit);
             persistenceUnitsInApplication.increment(persistenceUnitCount);
         }
-        JPA_LOGGER.tracef("incrementing PU count for %s by %d", topDeploymentUnit.getName(), persistenceUnitCount);
+        ROOT_LOGGER.tracef("incrementing PU count for %s by %d", topDeploymentUnit.getName(), persistenceUnitCount);
     }
 
     private void addApplicationDependenciesOnProvider(DeploymentUnit topDeploymentUnit, PersistenceUnitMetadataHolder holder) {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -107,7 +107,6 @@ import org.jipijapa.plugin.spi.Platform;
 import org.jipijapa.plugin.spi.TwoPhaseBootstrapCapable;
 
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
 import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 import static org.jboss.as.server.Services.addServerExecutorDependency;
 
@@ -157,7 +156,7 @@ public class PersistenceUnitServiceHandler {
                 holder.getPersistenceUnits().size() > 0) {
                 ArrayList<PersistenceUnitMetadataHolder> puList = new ArrayList<PersistenceUnitMetadataHolder>(1);
                 puList.add(holder);
-                JPA_LOGGER.tracef("install persistence unit definition for jar %s", deploymentRoot.getRootName());
+                ROOT_LOGGER.tracef("install persistence unit definition for jar %s", deploymentRoot.getRootName());
                 // assemble and install the PU service
                 addPuService(phaseContext, puList, startEarly, platform);
             }
@@ -196,7 +195,7 @@ public class PersistenceUnitServiceHandler {
                 deploymentUnit.addToAttachmentList(org.jboss.as.ee.component.Attachments.WEB_SETUP_ACTIONS, new WebNonTxEmCloserAction());
             }
 
-            JPA_LOGGER.tracef("install persistence unit definitions for war %s", deploymentRoot.getRootName());
+            ROOT_LOGGER.tracef("install persistence unit definitions for war %s", deploymentRoot.getRootName());
             addPuService(phaseContext, puList, startEarly, platform);
         }
     }
@@ -218,7 +217,7 @@ public class PersistenceUnitServiceHandler {
                         puList.add(holder);
                     }
 
-                    JPA_LOGGER.tracef("install persistence unit definitions for ear %s", root.getRootName());
+                    ROOT_LOGGER.tracef("install persistence unit definitions for ear %s", root.getRootName());
                     addPuService(phaseContext, puList, startEarly, platform);
                 }
             }
@@ -274,7 +273,7 @@ public class PersistenceUnitServiceHandler {
                             }
                             else if (false == Configuration.needClassFileTransformer(pu)) {
                                 // will start later when startEarly == false
-                                JPA_LOGGER.tracef("persistence unit %s in deployment %s is configured to not need class transformer to be set, no class rewriting will be allowed",
+                                ROOT_LOGGER.tracef("persistence unit %s in deployment %s is configured to not need class transformer to be set, no class rewriting will be allowed",
                                     pu.getPersistenceUnitName(), deploymentUnit.getName());
                             }
                             else {
@@ -296,7 +295,7 @@ public class PersistenceUnitServiceHandler {
 
                     }
                     else {
-                        JPA_LOGGER.tracef("persistence unit %s in deployment %s is not container managed (%s is set to false)",
+                        ROOT_LOGGER.tracef("persistence unit %s in deployment %s is not container managed (%s is set to false)",
                                 pu.getPersistenceUnitName(), deploymentUnit.getName(), Configuration.JPA_CONTAINER_MANAGED);
                     }
                 }
@@ -399,7 +398,7 @@ public class PersistenceUnitServiceHandler {
                 if (defaultJtaDataSource != null &&
                     !defaultJtaDataSource.isEmpty()) {
                     builder.addDependency(AbstractDataSourceService.SERVICE_NAME_BASE.append(defaultJtaDataSource), new CastingInjector<>(service.getJtaDataSourceInjector(), DataSource.class));
-                    JPA_LOGGER.tracef("%s is using the default data source '%s'", puServiceName, defaultJtaDataSource);
+                    ROOT_LOGGER.tracef("%s is using the default data source '%s'", puServiceName, defaultJtaDataSource);
                 }
             }
 
@@ -436,7 +435,7 @@ public class PersistenceUnitServiceHandler {
 
             builder.install();
 
-            JPA_LOGGER.tracef("added PersistenceUnitService for '%s'.  PU is ready for injector action.", puServiceName);
+            ROOT_LOGGER.tracef("added PersistenceUnitService for '%s'.  PU is ready for injector action.", puServiceName);
             addManagementConsole(deploymentUnit, pu, adaptor);
 
         } catch (ServiceRegistryException e) {
@@ -537,7 +536,7 @@ public class PersistenceUnitServiceHandler {
                 if (defaultJtaDataSource != null &&
                     !defaultJtaDataSource.isEmpty()) {
                     builder.addDependency(AbstractDataSourceService.SERVICE_NAME_BASE.append(defaultJtaDataSource), new CastingInjector<>(service.getJtaDataSourceInjector(), DataSource.class));
-                    JPA_LOGGER.tracef("%s is using the default data source '%s'", puServiceName, defaultJtaDataSource);
+                    ROOT_LOGGER.tracef("%s is using the default data source '%s'", puServiceName, defaultJtaDataSource);
                 }
             }
 
@@ -558,7 +557,7 @@ public class PersistenceUnitServiceHandler {
 
             builder.install();
 
-            JPA_LOGGER.tracef("added PersistenceUnitService (phase 1 of 2) for '%s'.  PU is ready for injector action.", puServiceName);
+            ROOT_LOGGER.tracef("added PersistenceUnitService (phase 1 of 2) for '%s'.  PU is ready for injector action.", puServiceName);
         } catch (ServiceRegistryException e) {
             throw JpaLogger.ROOT_LOGGER.failedToAddPersistenceUnit(e, pu.getPersistenceUnitName());
         }
@@ -662,7 +661,7 @@ public class PersistenceUnitServiceHandler {
                 if (defaultJtaDataSource != null &&
                     !defaultJtaDataSource.isEmpty()) {
                     builder.addDependency(AbstractDataSourceService.SERVICE_NAME_BASE.append(defaultJtaDataSource), new CastingInjector<>(service.getJtaDataSourceInjector(), DataSource.class));
-                    JPA_LOGGER.tracef("%s is using the default data source '%s'", puServiceName, defaultJtaDataSource);
+                    ROOT_LOGGER.tracef("%s is using the default data source '%s'", puServiceName, defaultJtaDataSource);
                 }
             }
 
@@ -700,7 +699,7 @@ public class PersistenceUnitServiceHandler {
 
             builder.install();
 
-            JPA_LOGGER.tracef("added PersistenceUnitService (phase 2 of 2) for '%s'.  PU is ready for injector action.", puServiceName);
+            ROOT_LOGGER.tracef("added PersistenceUnitService (phase 2 of 2) for '%s'.  PU is ready for injector action.", puServiceName);
             addManagementConsole(deploymentUnit, pu, adaptor);
 
         } catch (ServiceRegistryException e) {
@@ -718,7 +717,7 @@ public class PersistenceUnitServiceHandler {
             else {
                 bindingInfo = ContextNames.bindInfoFor(jndiName);
             }
-            JPA_LOGGER.tracef("binding the transaction scoped entity manager to jndi name '%s'", bindingInfo.getAbsoluteJndiName());
+            ROOT_LOGGER.tracef("binding the transaction scoped entity manager to jndi name '%s'", bindingInfo.getAbsoluteJndiName());
             final BinderService binderService = new BinderService(bindingInfo.getBindName());
             serviceTarget.addService(bindingInfo.getBinderServiceName(), binderService)
                 .addDependency(bindingInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
@@ -753,7 +752,7 @@ public class PersistenceUnitServiceHandler {
             else {
                 bindingInfo = ContextNames.bindInfoFor(jndiName);
             }
-            JPA_LOGGER.tracef("binding the entity manager factory to jndi name '%s'", bindingInfo.getAbsoluteJndiName());
+            ROOT_LOGGER.tracef("binding the entity manager factory to jndi name '%s'", bindingInfo.getAbsoluteJndiName());
             final BinderService binderService = new BinderService(bindingInfo.getBindName());
             serviceTarget.addService(bindingInfo.getBinderServiceName(), binderService)
                 .addDependency(bindingInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
@@ -793,7 +792,7 @@ public class PersistenceUnitServiceHandler {
                 final Index index = root.getAttachment(Attachments.ANNOTATION_INDEX);
                 if (index != null) {
                     try {
-                        JPA_LOGGER.tracef("adding '%s' to annotation index map", root.getRoot().toURL());
+                        ROOT_LOGGER.tracef("adding '%s' to annotation index map", root.getRoot().toURL());
                         annotationIndexes.put(root.getRoot().toURL(), index);
                     } catch (MalformedURLException e) {
                         throw new RuntimeException(e);
@@ -957,7 +956,7 @@ public class PersistenceUnitServiceHandler {
         if (providerList != null) {
             for (PersistenceProvider persistenceProvider : providerList) {
                 if (persistenceProvider.getClass().getName().equals(pu.getPersistenceProviderClassName())) {
-                    JPA_LOGGER.tracef("deployment %s is using %s", deploymentUnit.getName(), pu.getPersistenceProviderClassName());
+                    ROOT_LOGGER.tracef("deployment %s is using %s", deploymentUnit.getName(), pu.getPersistenceProviderClassName());
                     return persistenceProvider;
                 }
             }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/puparser/PersistenceUnitXmlParser.java
@@ -39,7 +39,7 @@ import org.jboss.metadata.parser.util.MetaDataElementParser;
 import org.jboss.metadata.property.PropertyReplacer;
 import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 /**
  * Parse a persistence.xml into a list of persistence unit definitions.
@@ -48,7 +48,7 @@ import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
  */
 public class PersistenceUnitXmlParser extends MetaDataElementParser {
     // cache the trace enabled flag
-    private static final boolean traceEnabled = JPA_LOGGER.isTraceEnabled();
+    private static final boolean traceEnabled = ROOT_LOGGER.isTraceEnabled();
 
     public static PersistenceUnitMetadataHolder parse(final XMLStreamReader reader, final PropertyReplacer propertyReplacer) throws XMLStreamException {
 
@@ -121,7 +121,7 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
                 case PERSISTENCEUNIT:
                     PersistenceUnitMetadata pu = parsePU(reader, version, propertyReplacer);
                     PUs.add(pu);
-                    JPA_LOGGER.readingPersistenceXml(pu.getPersistenceUnitName());
+                    ROOT_LOGGER.readingPersistenceXml(pu.getPersistenceUnitName());
                     break;
 
                 default:
@@ -129,8 +129,8 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
             }
         }
         PersistenceUnitMetadataHolder result = new PersistenceUnitMetadataHolder(PUs);
-        if (JPA_LOGGER.isTraceEnabled())
-            JPA_LOGGER.trace(result.toString());
+        if (ROOT_LOGGER.isTraceEnabled())
+            ROOT_LOGGER.trace(result.toString());
 
         return result;
     }
@@ -168,7 +168,7 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
         for (int i = 0; i < count; i++) {
             final String value = reader.getAttributeValue(i);
             if (traceEnabled) {
-                JPA_LOGGER.tracef("parse persistence.xml: attribute value(%d) = %s", i, value);
+                ROOT_LOGGER.tracef("parse persistence.xml: attribute value(%d) = %s", i, value);
             }
             final String attributeNamespace = reader.getAttributeNamespace(i);
             if (attributeNamespace != null && !attributeNamespace.isEmpty()) {
@@ -192,7 +192,7 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
             final Element element = Element.forName(reader.getLocalName());
             if (traceEnabled) {
-                JPA_LOGGER.tracef("parse persistence.xml: element=%s", element.getLocalName());
+                ROOT_LOGGER.tracef("parse persistence.xml: element=%s", element.getLocalName());
             }
             switch (element) {
                 case CLASS:
@@ -255,7 +255,7 @@ public class PersistenceUnitXmlParser extends MetaDataElementParser {
             }
         }
         if (traceEnabled) {
-            JPA_LOGGER.trace("parse persistence.xml: reached ending persistence-unit tag");
+            ROOT_LOGGER.trace("parse persistence.xml: reached ending persistence-unit tag");
         }
         pu.setManagedClassNames(classes);
         pu.setJarFiles(jarFiles);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PersistenceUnitServiceImpl.java
@@ -54,7 +54,7 @@ import org.jipijapa.plugin.spi.PersistenceUnitMetadata;
 import org.wildfly.security.manager.action.GetAccessControlContextAction;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 /**
  * Persistence Unit service that is created for each deployed persistence unit that will be referenced by the
@@ -134,7 +134,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
 
                                     // handle phase 2 of 2 of bootstrapping the persistence unit
                                     if (phaseOnePersistenceUnitService != null) {
-                                        JPA_LOGGER.startingPersistenceUnitService(2, pu.getScopedPersistenceUnitName());
+                                        ROOT_LOGGER.startingPersistenceUnitService(2, pu.getScopedPersistenceUnitName());
                                         // indicate that the second phase of bootstrapping the persistence unit has started
                                         phaseOnePersistenceUnitService.setSecondPhaseStarted(true);
                                         if (beanManagerInjector.getOptionalValue() != null) {
@@ -153,7 +153,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
                                         // get the EntityManagerFactory from the second phase of the persistence unit bootstrap
                                         entityManagerFactory = emfBuilder.build();
                                     } else {
-                                        JPA_LOGGER.startingService("Persistence Unit", pu.getScopedPersistenceUnitName());
+                                        ROOT_LOGGER.startingService("Persistence Unit", pu.getScopedPersistenceUnitName());
                                         // start the persistence unit in one pass (1 of 1)
                                         pu.setTempClassLoaderFactory(new TempClassLoaderFactoryImpl(classLoader));
                                         pu.setJtaDataSource(jtaDataSource.getOptionalValue());
@@ -209,9 +209,9 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
                             public Void run() {
 
                                 if (phaseOnePersistenceUnitServiceInjectedValue.getOptionalValue() != null) {
-                                    JPA_LOGGER.stoppingPersistenceUnitService(2, pu.getScopedPersistenceUnitName());
+                                    ROOT_LOGGER.stoppingPersistenceUnitService(2, pu.getScopedPersistenceUnitName());
                                 } else {
-                                    JPA_LOGGER.stoppingService("Persistence Unit", pu.getScopedPersistenceUnitName());
+                                    ROOT_LOGGER.stoppingService("Persistence Unit", pu.getScopedPersistenceUnitName());
                                 }
                                 if (entityManagerFactory != null) {
                                     WritableServiceBasedNamingStore.pushOwner(deploymentUnitServiceName);
@@ -220,7 +220,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
                                             entityManagerFactory.close();
                                         }
                                     } catch (Throwable t) {
-                                        JPA_LOGGER.failedToStopPUService(t, pu.getScopedPersistenceUnitName());
+                                        ROOT_LOGGER.failedToStopPUService(t, pu.getScopedPersistenceUnitName());
                                     } finally {
                                         entityManagerFactory = null;
                                         pu.setTempClassLoaderFactory(null);
@@ -313,7 +313,7 @@ public class PersistenceUnitServiceImpl implements Service<PersistenceUnitServic
     private EntityManagerFactory createContainerEntityManagerFactory() {
         persistenceProviderAdaptor.beforeCreateContainerEntityManagerFactory(pu);
         try {
-            JPA_LOGGER.tracef("calling createContainerEntityManagerFactory for pu=%s with integration properties=%s, application properties=%s",
+            ROOT_LOGGER.tracef("calling createContainerEntityManagerFactory for pu=%s with integration properties=%s, application properties=%s",
                     pu.getScopedPersistenceUnitName(), properties.getValue(), pu.getProperties());
             return persistenceProvider.createContainerEntityManagerFactory(pu, properties.getValue());
         } finally {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PhaseOnePersistenceUnitServiceImpl.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/PhaseOnePersistenceUnitServiceImpl.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.jpa.service;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
 import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.security.AccessControlContext;
@@ -105,7 +104,7 @@ public class PhaseOnePersistenceUnitServiceImpl implements Service<PhaseOnePersi
                             @Override
                             public Void run() {
                                 try {
-                                    JPA_LOGGER.startingPersistenceUnitService(1, pu.getScopedPersistenceUnitName());
+                                    ROOT_LOGGER.startingPersistenceUnitService(1, pu.getScopedPersistenceUnitName());
                                     pu.setTempClassLoaderFactory(new TempClassLoaderFactoryImpl(classLoader));
                                     pu.setJtaDataSource(jtaDataSource.getOptionalValue());
                                     pu.setNonJtaDataSource(nonJtaDataSource.getOptionalValue());
@@ -156,7 +155,7 @@ public class PhaseOnePersistenceUnitServiceImpl implements Service<PhaseOnePersi
                             @Override
                             public Void run() {
 
-                                JPA_LOGGER.stoppingPersistenceUnitService(1, pu.getScopedPersistenceUnitName());
+                                ROOT_LOGGER.stoppingPersistenceUnitService(1, pu.getScopedPersistenceUnitName());
                                 if (entityManagerFactoryBuilder != null) {
                                     WritableServiceBasedNamingStore.pushOwner(deploymentUnitServiceName);
                                     try {
@@ -166,7 +165,7 @@ public class PhaseOnePersistenceUnitServiceImpl implements Service<PhaseOnePersi
                                             entityManagerFactoryBuilder.cancel();
                                         }
                                     } catch (Throwable t) {
-                                        JPA_LOGGER.failedToStopPUService(t, pu.getScopedPersistenceUnitName());
+                                        ROOT_LOGGER.failedToStopPUService(t, pu.getScopedPersistenceUnitName());
                                     } finally {
                                         entityManagerFactoryBuilder = null;
                                         pu.setTempClassLoaderFactory(null);

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPAExtension.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/subsystem/JPAExtension.java
@@ -22,7 +22,7 @@
 package org.jboss.as.jpa.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import java.util.Collections;
 import java.util.List;
@@ -95,7 +95,7 @@ public class JPAExtension implements Extension {
         try {
             PersistenceProviderLoader.loadDefaultProvider();
         } catch (ModuleLoadException e) {
-            JPA_LOGGER.errorPreloadingDefaultProvider(e);
+            ROOT_LOGGER.errorPreloadingDefaultProvider(e);
         }
 
         if (context.isRuntimeOnlyRegistrationValid()) {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.jpa.transaction;
 
-import static org.jboss.as.jpa.messages.JpaLogger.JPA_LOGGER;
+import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Status;
@@ -149,12 +149,12 @@ public class TransactionUtil {
              */
             if (safeToClose(status)) {
                 try {
-                    if (JPA_LOGGER.isDebugEnabled())
-                        JPA_LOGGER.debugf("%s: closing entity managersession", getEntityManagerDetails(manager, scopedPuName));
+                    if (ROOT_LOGGER.isDebugEnabled())
+                        ROOT_LOGGER.debugf("%s: closing entity managersession", getEntityManagerDetails(manager, scopedPuName));
                     manager.close();
                 } catch (Exception ignored) {
-                    if (JPA_LOGGER.isDebugEnabled())
-                        JPA_LOGGER.debugf(ignored, "ignoring error that occurred while closing EntityManager for %s (", scopedPuName);
+                    if (ROOT_LOGGER.isDebugEnabled())
+                        ROOT_LOGGER.debugf(ignored, "ignoring error that occurred while closing EntityManager for %s (", scopedPuName);
                 }
             }
             // The TX reference to the entity manager, should be cleared by the TM

--- a/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsValidator.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/AddressSettingsValidator.java
@@ -83,14 +83,14 @@ class AddressSettingsValidator {
     private static void checkExpiryAddress(OperationContext context, ModelNode model, Resource hornetqServer, String addressSetting) throws OperationFailedException {
         ModelNode expiryAddress = EXPIRY_ADDRESS.resolveModelAttribute(context, model);
         if (!findMatchingResource(expiryAddress, hornetqServer)) {
-            MessagingLogger.MESSAGING_LOGGER.noMatchingExpiryAddress(expiryAddress.asString(), addressSetting);
+            MessagingLogger.ROOT_LOGGER.noMatchingExpiryAddress(expiryAddress.asString(), addressSetting);
         }
     }
 
     private static void checkDeadLetterAddress(OperationContext context, ModelNode model, Resource hornetqServer, String addressSetting) throws OperationFailedException {
         ModelNode deadLetterAddress = DEAD_LETTER_ADDRESS.resolveModelAttribute(context, model);
         if (!findMatchingResource(deadLetterAddress, hornetqServer)) {
-            MessagingLogger.MESSAGING_LOGGER.noMatchingDeadLetterAddress(deadLetterAddress.asString(), addressSetting);
+            MessagingLogger.ROOT_LOGGER.noMatchingDeadLetterAddress(deadLetterAddress.asString(), addressSetting);
         }
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/DeprecatedAttributeWriteHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/DeprecatedAttributeWriteHandler.java
@@ -41,7 +41,7 @@ public final class DeprecatedAttributeWriteHandler extends AbstractWriteAttribut
     @Override
     protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation, String attributeName, ModelNode resolvedValue, ModelNode currentValue, HandbackHolder handbackHolder) throws OperationFailedException {
         PathAddress pa = PathAddress.pathAddress(operation.require(ModelDescriptionConstants.OP_ADDR));
-        MessagingLogger.MESSAGING_LOGGER.deprecatedAttribute(attributeName, pa);
+        MessagingLogger.ROOT_LOGGER.deprecatedAttribute(attributeName, pa);
         return false;
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/HTTPUpgradeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HTTPUpgradeService.java
@@ -28,7 +28,7 @@ import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_RE
 import static org.hornetq.core.remoting.impl.netty.NettyConnector.SEC_HORNETQ_REMOTING_KEY;
 import static org.hornetq.core.remoting.impl.netty.TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME;
 import static org.jboss.as.messaging.CommonAttributes.CORE;
-import static org.jboss.as.messaging.logging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 
 import java.io.IOException;
 
@@ -98,7 +98,7 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
         httpUpgradeMetadata = new ListenerRegistry.HttpUpgradeMetadata(HORNETQ_REMOTING, CORE);
         listenerInfo.addHttpUpgradeMetadata(httpUpgradeMetadata);
 
-        MESSAGING_LOGGER.registeredHTTPUpgradeHandler(HORNETQ_REMOTING, acceptorName);
+        ROOT_LOGGER.registeredHTTPUpgradeHandler(HORNETQ_REMOTING, acceptorName);
         ServiceController<?> hornetqService = context.getController().getServiceContainer().getService(MessagingServices.getHornetQServiceName(hornetQServerName));
         HornetQServer hornetQServer = HornetQServer.class.cast(hornetqService.getValue());
 
@@ -143,7 +143,7 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
         return new ChannelListener<StreamConnection>() {
             @Override
             public void handleEvent(final StreamConnection connection) {
-                MESSAGING_LOGGER.debugf("Switching to %s protocol for %s http-acceptor", HORNETQ_REMOTING, acceptorName);
+                ROOT_LOGGER.debugf("Switching to %s protocol for %s http-acceptor", HORNETQ_REMOTING, acceptorName);
                 SocketChannel channel = new WrappingXnioSocketChannel(connection);
                 RemotingService remotingService = hornetqServer.getRemotingService();
 

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerControlWriteHandler.java
@@ -196,7 +196,7 @@ public class HornetQServerControlWriteHandler extends AbstractWriteAttributeHand
                 boolean wantsClustered = CLUSTERED.resolveModelAttribute(context, mock).asBoolean();
                 if (clustered && !wantsClustered) {
                     PathAddress serverAddress = PathAddress.pathAddress(operation.get(OP_ADDR));
-                    MessagingLogger.MESSAGING_LOGGER.warn(MessagingLogger.MESSAGING_LOGGER.canNotChangeClusteredAttribute(serverAddress));
+                    MessagingLogger.ROOT_LOGGER.warn(MessagingLogger.ROOT_LOGGER.canNotChangeClusteredAttribute(serverAddress));
                 }
                 // ignore the operation
                 context.stepCompleted();

--- a/messaging/src/main/java/org/jboss/as/messaging/QueueService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/QueueService.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.messaging;
 
-import static org.jboss.as.messaging.logging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 
 import org.hornetq.api.core.SimpleString;
 import org.hornetq.core.config.CoreQueueConfiguration;
@@ -73,7 +73,7 @@ class QueueService implements Service<Void> {
             final HornetQServer hornetQService = this.hornetQService.getValue();
             hornetQService.destroyQueue(new SimpleString(queueConfiguration.getName()), null, false);
         } catch(Exception e) {
-            MESSAGING_LOGGER.failedToDestroy("queue", queueConfiguration.getName());
+            ROOT_LOGGER.failedToDestroy("queue", queueConfiguration.getName());
         }
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -235,7 +235,7 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
             if (value == null || "".equals(value)) {
                 it.remove();
             } else if (!attributeNames.contains(entry.getKey())) {
-                MessagingLogger.MESSAGING_LOGGER.unknownPooledConnectionFactoryAttribute(entry.getKey());
+                MessagingLogger.ROOT_LOGGER.unknownPooledConnectionFactoryAttribute(entry.getKey());
                 it.remove();
             }
         }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/ConnectionFactoryService.java
@@ -31,7 +31,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 
-import static org.jboss.as.messaging.logging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -88,7 +88,7 @@ class ConnectionFactoryService implements Service<Void> {
                 try {
                     jmsManager.destroyConnectionFactory(name);
                 } catch (Throwable e) {
-                    MESSAGING_LOGGER.failedToDestroy("connection-factory", name);
+                    ROOT_LOGGER.failedToDestroy("connection-factory", name);
                 }
                 context.complete();
             }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueService.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.messaging.jms;
 
-import static org.jboss.as.messaging.logging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.as.server.Services.addServerExecutorDependency;
 
 import java.util.concurrent.ExecutorService;
@@ -102,7 +102,7 @@ public class JMSQueueService implements Service<Queue> {
                     jmsManager.removeQueueFromJNDI(queueName);
                     queue = null;
                 } catch (Throwable e) {
-                    MESSAGING_LOGGER.failedToDestroy(e, "queue", queueName);
+                    ROOT_LOGGER.failedToDestroy(e, "queue", queueName);
                 }
                 context.complete();
             }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSService.java
@@ -42,7 +42,7 @@ import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
 
-import static org.jboss.as.messaging.logging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 import static org.jboss.as.server.Services.addServerExecutorDependency;
 import static org.jboss.msc.service.ServiceController.Mode.ACTIVE;
 import static org.jboss.msc.service.ServiceController.Mode.REMOVE;
@@ -182,7 +182,7 @@ public class JMSService implements Service<JMSServerManager> {
             jmsServer.stop();
             jmsServer = null;
         } catch (Exception e) {
-            MESSAGING_LOGGER.errorStoppingJmsServer(e);
+            ROOT_LOGGER.errorStoppingJmsServer(e);
         }
     }
 }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicService.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.messaging.jms;
 
-import static org.jboss.as.messaging.logging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -97,7 +97,7 @@ public class JMSTopicService implements Service<Topic> {
                     jmsManager.removeTopicFromJNDI(name);
                     topic = null;
                 } catch (Throwable e) {
-                    MESSAGING_LOGGER.failedToDestroy(e, "jms topic", name);
+                    ROOT_LOGGER.failedToDestroy(e, "jms topic", name);
                 }
                 context.complete();
             }

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/bridge/JMSBridgeService.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.messaging.jms.bridge;
 
-import static org.jboss.as.messaging.logging.MessagingLogger.MESSAGING_LOGGER;
+import static org.jboss.as.messaging.logging.MessagingLogger.ROOT_LOGGER;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -108,7 +108,7 @@ class JMSBridgeService implements Service<JMSBridge> {
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
         }
-        MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);
+        MessagingLogger.ROOT_LOGGER.startedService("JMS Bridge", bridgeName);
     }
 
     @Override
@@ -118,11 +118,11 @@ class JMSBridgeService implements Service<JMSBridge> {
             public void run() {
                 try {
                     bridge.stop();
-                    MessagingLogger.MESSAGING_LOGGER.stoppedService("JMS Bridge", bridgeName);
+                    MessagingLogger.ROOT_LOGGER.stoppedService("JMS Bridge", bridgeName);
 
                     context.complete();
                 } catch(Exception e) {
-                    MESSAGING_LOGGER.failedToDestroy("bridge", bridgeName);
+                    ROOT_LOGGER.failedToDestroy("bridge", bridgeName);
                 }
             }
         };

--- a/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -64,11 +64,6 @@ public interface MessagingLogger extends BasicLogger {
     MessagingLogger ROOT_LOGGER = Logger.getMessageLogger(MessagingLogger.class, "org.jboss.as.messaging");
 
     /**
-     * A logger with the category {@code org.jboss.messaging}.
-     */
-    MessagingLogger MESSAGING_LOGGER = Logger.getMessageLogger(MessagingLogger.class, "org.jboss.messaging");
-
-    /**
      * Logs a warning message indicating AIO was not found.
      */
     @LogMessage(level = WARN)

--- a/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapter.java
+++ b/mod_cluster/undertow/src/main/java/org/wildfly/mod_cluster/undertow/UndertowEventHandlerAdapter.java
@@ -58,7 +58,8 @@ import org.wildfly.security.manager.action.GetAccessControlContextAction;
  * @author Paul Ferraro
  */
 public class UndertowEventHandlerAdapter implements UndertowEventListener, Service<Void>, Runnable, ServerActivity {
-    private static final Logger log = Logger.getLogger(UndertowEventHandlerAdapter.class);
+    // No logger interface for this module and no reason to create one for this class only
+    private static final Logger log = Logger.getLogger("org.jboss.mod_cluster.undertow");
 
     @SuppressWarnings("rawtypes")
     private final Value<ListenerService> listener;

--- a/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
+++ b/naming/src/main/java/org/jboss/as/naming/ServiceBasedNamingStore.java
@@ -154,9 +154,7 @@ public class ServiceBasedNamingStore implements NamingStore {
             n.initCause(e);
             throw n;
         } catch (Throwable t) {
-            NamingException n = NamingLogger.ROOT_LOGGER.lookupError(name);
-            n.initCause(t);
-            throw n;
+            throw NamingLogger.ROOT_LOGGER.lookupError(t, name);
         }
     }
 

--- a/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
+++ b/naming/src/main/java/org/jboss/as/naming/logging/NamingLogger.java
@@ -575,12 +575,13 @@ public interface NamingLogger extends BasicLogger {
     /**
      * Creates an exception indicating a lookup failure.
      *
-     * @param name the bind name.
+     * @param cause the cause of the error
+     * @param name  the bind name.
      *
      * @return a {@link NamingException} for the error.
      */
     @Message(id = 62, value = "Failed to lookup %s")
-    NamingException lookupError(String name);
+    NamingException lookupError(@Cause Throwable cause, String name);
 
     /**
      * Indicates that a service is not started as expected.

--- a/pojo/src/main/java/org/jboss/as/pojo/descriptor/LegacyKernelDeploymentXmlDescriptorParser.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/descriptor/LegacyKernelDeploymentXmlDescriptorParser.java
@@ -24,7 +24,6 @@ package org.jboss.as.pojo.descriptor;
 
 import org.jboss.as.pojo.ParseResult;
 import org.jboss.as.pojo.logging.PojoLogger;
-import org.jboss.logging.Logger;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 
 import javax.xml.stream.XMLStreamException;
@@ -35,7 +34,6 @@ import javax.xml.stream.XMLStreamException;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public class LegacyKernelDeploymentXmlDescriptorParser extends KernelDeploymentXmlDescriptorParser {
-    private static final Logger log = Logger.getLogger(LegacyKernelDeploymentXmlDescriptorParser.class);
 
     public static final String MC_NAMESPACE_1_0 = "urn:jboss:bean-deployer:1.0";
     public static final String MC_NAMESPACE_2_0 = "urn:jboss:bean-deployer:2.0";

--- a/pojo/src/main/java/org/jboss/as/pojo/service/AbstractPojoPhase.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/service/AbstractPojoPhase.java
@@ -37,7 +37,6 @@ import org.jboss.as.pojo.descriptor.DefaultConfigVisitor;
 import org.jboss.as.pojo.descriptor.InstallConfig;
 import org.jboss.as.pojo.descriptor.ValueConfig;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
-import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
@@ -57,7 +56,6 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public abstract class AbstractPojoPhase implements Service<Object> {
-    protected final Logger log = Logger.getLogger(getClass());
 
     private Module module;
     private BeanMetaDataConfig beanConfig;

--- a/pojo/src/main/java/org/jboss/as/pojo/service/BeanUtils.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/service/BeanUtils.java
@@ -30,7 +30,6 @@ import org.jboss.as.pojo.descriptor.LifecycleConfig;
 import org.jboss.as.pojo.descriptor.PropertyConfig;
 import org.jboss.as.pojo.descriptor.ValueConfig;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
-import org.jboss.logging.Logger;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.value.ImmediateValue;
@@ -47,8 +46,6 @@ import java.util.Set;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public final class BeanUtils {
-
-    private static final Logger log = Logger.getLogger(BeanUtils.class);
 
     /**
      * Instantiate bean.
@@ -165,8 +162,7 @@ public final class BeanUtils {
             try {
                 method = beanInfo.getMethod(defaultMethod);
             } catch (Exception t) {
-                if (log.isTraceEnabled())
-                    log.trace("Ignoring default " + defaultMethod + " invocation.", t);
+                PojoLogger.ROOT_LOGGER.tracef(t, "Ignoring default %s invocation.", defaultMethod);
                 return null;
             }
         } else {

--- a/pojo/src/main/java/org/jboss/as/pojo/service/Configurator.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/service/Configurator.java
@@ -27,7 +27,6 @@ import org.jboss.as.pojo.descriptor.ValueConfig;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
 import org.jboss.as.server.deployment.reflect.DeploymentReflectionIndex;
 import org.jboss.common.beans.property.PropertiesValueResolver;
-import org.jboss.logging.Logger;
 
 import java.beans.PropertyEditor;
 import java.beans.PropertyEditorManager;
@@ -45,10 +44,6 @@ import java.util.Collection;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public class Configurator {
-    /**
-     * The log
-     */
-    protected static final Logger log = Logger.getLogger(Configurator.class);
 
     /**
      * No parameter types

--- a/pojo/src/main/java/org/jboss/as/pojo/service/LifecyclePojoPhase.java
+++ b/pojo/src/main/java/org/jboss/as/pojo/service/LifecyclePojoPhase.java
@@ -23,6 +23,7 @@
 package org.jboss.as.pojo.service;
 
 import org.jboss.as.pojo.descriptor.LifecycleConfig;
+import org.jboss.as.pojo.logging.PojoLogger;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
@@ -58,7 +59,7 @@ public abstract class LifecyclePojoPhase extends AbstractPojoPhase {
         try {
             dispatchJoinpoint(getDownConfig(), defaultDown());
         } catch (Throwable t) {
-            log.debug("Exception at " + defaultDown() + " phase.", t);
+            PojoLogger.ROOT_LOGGER.debugf(t, "Exception at %s phase.", defaultDown());
         }
     }
 }

--- a/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemAdd.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemAdd.java
@@ -56,9 +56,7 @@ final class RTSSubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("RTSSubsystemAdd.populateModel");
-        }
+        RTSLogger.ROOT_LOGGER.trace("RTSSubsystemAdd.populateModel");
 
         RTSSubsystemDefinition.SERVER.validateAndSet(operation, model);
         RTSSubsystemDefinition.HOST.validateAndSet(operation, model);
@@ -69,9 +67,7 @@ final class RTSSubsystemAdd extends AbstractBoottimeAddStepHandler {
     public void performBoottime(OperationContext context, ModelNode operation, ModelNode model)
             throws OperationFailedException {
 
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("RTSSubsystemAdd.performBoottime");
-        }
+        RTSLogger.ROOT_LOGGER.trace("RTSSubsystemAdd.performBoottime");
 
         registerCoordinatorService(context, model);
         registerParticipantService(context, model);

--- a/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemParser.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemParser.java
@@ -53,9 +53,7 @@ final class RTSSubsystemParser implements XMLStreamConstants, XMLElementReader<L
 
     @Override
     public void writeContent(XMLExtendedStreamWriter writer, SubsystemMarshallingContext context) throws XMLStreamException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("RTSSubsystemParser.writeContent");
-        }
+        RTSLogger.ROOT_LOGGER.trace("RTSSubsystemParser.writeContent");
 
         context.startSubsystemElement(RTSSubsystemExtension.NAMESPACE, false);
 
@@ -73,9 +71,7 @@ final class RTSSubsystemParser implements XMLStreamConstants, XMLElementReader<L
 
     @Override
     public void readElement(XMLExtendedStreamReader reader, List<ModelNode> list) throws XMLStreamException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("RTSSubsystemParser.readElement");
-        }
+        RTSLogger.ROOT_LOGGER.trace("RTSSubsystemParser.readElement");
 
         // no attributes
         if (reader.getAttributeCount() > 0) {

--- a/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemRemove.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/RTSSubsystemRemove.java
@@ -41,9 +41,7 @@ final class RTSSubsystemRemove extends AbstractRemoveStepHandler {
 
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("RTSSubsystemRemove.performRuntime");
-        }
+        RTSLogger.ROOT_LOGGER.trace("RTSSubsystemRemove.performRuntime");
 
         context.removeService(RTSSubsystemExtension.COORDINATOR);
         context.removeService(RTSSubsystemExtension.PARTICIPANT);

--- a/rts/src/main/java/org/wildfly/extension/rts/service/CoordinatorService.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/service/CoordinatorService.java
@@ -46,27 +46,21 @@ public final class CoordinatorService extends AbstractRTSService implements Serv
 
     @Override
     public CoordinatorService getValue() throws IllegalStateException, IllegalArgumentException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("CoordinatorService.getValue");
-        }
+        RTSLogger.ROOT_LOGGER.trace("CoordinatorService.getValue");
 
         return this;
     }
 
     @Override
     public void start(StartContext context) throws StartException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("CoordinatorService.start");
-        }
+        RTSLogger.ROOT_LOGGER.trace("CoordinatorService.start");
 
         deployCoordinator();
     }
 
     @Override
     public void stop(StopContext context) {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("CoordinatorService.stop");
-        }
+        RTSLogger.ROOT_LOGGER.trace("CoordinatorService.stop");
 
         undeployServlet();
     }

--- a/rts/src/main/java/org/wildfly/extension/rts/service/ParticipantService.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/service/ParticipantService.java
@@ -48,18 +48,14 @@ public final class ParticipantService extends AbstractRTSService implements Serv
 
     @Override
     public ParticipantService getValue() throws IllegalStateException, IllegalArgumentException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("ParticipantService.getValue");
-        }
+        RTSLogger.ROOT_LOGGER.trace("ParticipantService.getValue");
 
         return this;
     }
 
     @Override
     public void start(StartContext context) throws StartException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("ParticipantService.start");
-        }
+        RTSLogger.ROOT_LOGGER.trace("ParticipantService.start");
 
         deployParticipant();
         ParticipantsManagerFactory.getInstance().setBaseUrl(getBaseUrl());
@@ -67,9 +63,7 @@ public final class ParticipantService extends AbstractRTSService implements Serv
 
     @Override
     public void stop(StopContext context) {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("ParticipantService.stop");
-        }
+        RTSLogger.ROOT_LOGGER.trace("ParticipantService.stop");
 
         undeployServlet();
     }

--- a/rts/src/main/java/org/wildfly/extension/rts/service/VolatileParticipantService.java
+++ b/rts/src/main/java/org/wildfly/extension/rts/service/VolatileParticipantService.java
@@ -47,18 +47,14 @@ public final class VolatileParticipantService extends AbstractRTSService impleme
 
     @Override
     public VolatileParticipantService getValue() throws IllegalStateException, IllegalArgumentException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("VolatileParticipantService.getValue");
-        }
+        RTSLogger.ROOT_LOGGER.trace("VolatileParticipantService.getValue");
 
         return this;
     }
 
     @Override
     public void start(StartContext context) throws StartException {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("VolatileParticipantService.start");
-        }
+        RTSLogger.ROOT_LOGGER.trace("VolatileParticipantService.start");
 
         deployParticipant();
         ParticipantsManagerFactory.getInstance().setBaseUrl(getBaseUrl());
@@ -66,9 +62,7 @@ public final class VolatileParticipantService extends AbstractRTSService impleme
 
     @Override
     public void stop(StopContext context) {
-        if (RTSLogger.ROOT_LOGGER.isTraceEnabled()) {
-            RTSLogger.ROOT_LOGGER.trace("ParticipantService.stop");
-        }
+        RTSLogger.ROOT_LOGGER.trace("ParticipantService.stop");
 
         undeployServlet();
     }

--- a/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
+++ b/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
@@ -280,7 +280,7 @@ public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor
     private static Object newValue(final Class<?> type, final String value) {
         final PropertyEditor editor = PropertyEditorFinder.getInstance().find(type);
         if (editor == null) {
-            SarLogger.DEPLOYMENT_SERVICE_LOGGER.propertyNotFound(type);
+            SarLogger.ROOT_LOGGER.propertyNotFound(type);
             return null;
         }
         editor.setAsText(value);

--- a/sar/src/main/java/org/jboss/as/service/logging/SarLogger.java
+++ b/sar/src/main/java/org/jboss/as/service/logging/SarLogger.java
@@ -48,11 +48,6 @@ public interface SarLogger extends BasicLogger {
     SarLogger ROOT_LOGGER = Logger.getMessageLogger(SarLogger.class, "org.jboss.as.service");
 
     /**
-     * A logger with the category {@code org.jboss.as.deployment.service}.
-     */
-    SarLogger DEPLOYMENT_SERVICE_LOGGER = Logger.getMessageLogger(SarLogger.class, "org.jboss.as.deployment.service");
-
-    /**
      * A message indicating a failure to execute a legacy service method, represented by the {@code methodName}
      * parameter.
      *

--- a/security/subsystem/src/main/java/org/jboss/as/security/plugins/JNDIBasedSecurityManagement.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/plugins/JNDIBasedSecurityManagement.java
@@ -53,8 +53,6 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
 
     private static final long serialVersionUID = 1924631329555621041L;
 
-    protected static SecurityLogger log = SecurityLogger.ROOT_LOGGER;
-
     private transient ConcurrentHashMap<String, SecurityDomainContext> securityMgrMap = new ConcurrentHashMap<String, SecurityDomainContext>();
     private transient ConcurrentHashMap<String, AuthenticationManager> authMgrMap = new ConcurrentHashMap<String, AuthenticationManager>();
     private transient ConcurrentHashMap<String, AuthorizationManager> authzMgrMap = new ConcurrentHashMap<String, AuthorizationManager>();
@@ -91,7 +89,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
                 auditMgrMap.put(securityDomain, am);
             }
         } catch (Exception e) {
-            log.tracef("Exception getting AuditManager for domain=" + securityDomain, e);
+            SecurityLogger.ROOT_LOGGER.tracef(e, "Exception getting AuditManager for domain=%s", securityDomain);
         }
         return am;
     }
@@ -106,7 +104,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
                 authMgrMap.put(securityDomain, am);
             }
         } catch (Exception e) {
-            log.tracef("Exception getting AuthenticationManager for domain=" + securityDomain, e);
+            SecurityLogger.ROOT_LOGGER.tracef(e, "Exception getting AuthenticationManager for domain=%s", securityDomain);
         }
         return am;
     }
@@ -121,7 +119,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
                 authzMgrMap.put(securityDomain, am);
             }
         } catch (Exception e) {
-            log.tracef("Exception getting AuthorizationManager for domain=", e);
+            SecurityLogger.ROOT_LOGGER.tracef(e, "Exception getting AuthorizationManager for domain=%s", securityDomain);
         }
         return am;
     }
@@ -136,7 +134,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
                 idmMgrMap.put(securityDomain, itm);
             }
         } catch (Exception e) {
-            log.tracef("Exception getting IdentityTrustManager for domain=" + securityDomain, e);
+            SecurityLogger.ROOT_LOGGER.tracef(e, "Exception getting IdentityTrustManager for domain=%s" + securityDomain);
         }
         return itm;
     }
@@ -151,7 +149,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
                 mappingMgrMap.put(securityDomain, mm);
             }
         } catch (Exception e) {
-            log.tracef("Exception getting MappingManager for domain=" + securityDomain, e);
+            SecurityLogger.ROOT_LOGGER.tracef(e, "Exception getting MappingManager for domain=%s", securityDomain);
         }
         return mm;
     }
@@ -166,7 +164,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
                 jsseMap.put(securityDomain, jsse);
             }
         } catch (Exception e) {
-            log.tracef("Exception getting JSSESecurityDomain for domain=" + securityDomain, e);
+            SecurityLogger.ROOT_LOGGER.tracef(e, "Exception getting JSSESecurityDomain for domain=%s", securityDomain);
         }
         return jsse;
     }
@@ -257,7 +255,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
             else
                 result = ctx.lookup(SecurityConstants.JAAS_CONTEXT_ROOT + contextName);
         } catch (Exception e) {
-            log.tracef("Look up of JNDI for " + contextName + " failed with " + e.getLocalizedMessage());
+            SecurityLogger.ROOT_LOGGER.tracef("Look up of JNDI for %s failed with %s", contextName, e.getLocalizedMessage());
             return null;
         }
         return result;
@@ -272,7 +270,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
      * @throws Exception if an error occurs during creation
      */
     public SecurityDomainContext createSecurityDomainContext(String securityDomain, AuthenticationCacheFactory cacheFactory) throws Exception {
-        log.debugf("Creating SDC for domain = %s", securityDomain);
+        SecurityLogger.ROOT_LOGGER.debugf("Creating SDC for domain = %s", securityDomain);
         AuthenticationManager am = createAuthenticationManager(securityDomain);
         if (cacheFactory != null && am instanceof CacheableManager) {
             // create authentication cache
@@ -407,7 +405,7 @@ public class JNDIBasedSecurityManagement implements ISecurityManagement {
             Object[] deepCopyArgs = { Boolean.TRUE };
             m.invoke(authenticationManager, deepCopyArgs);
         } catch (Exception e) {
-            log.tracef("Optional setDeepCopySubjectMode failed: " + e.getLocalizedMessage());
+            SecurityLogger.ROOT_LOGGER.tracef("Optional setDeepCopySubjectMode failed: %s", e.getLocalizedMessage());
         }
     }
 

--- a/security/subsystem/src/main/java/org/jboss/as/security/remoting/RemotingLoginModule.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/remoting/RemotingLoginModule.java
@@ -38,7 +38,6 @@ import javax.security.auth.login.LoginException;
 
 import org.jboss.as.core.security.RealmUser;
 import org.jboss.as.core.security.SubjectUserInfo;
-import org.jboss.as.security.logging.SecurityLogger;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.security.UserInfo;
 import org.jboss.remoting3.security.UserPrincipal;
@@ -55,8 +54,6 @@ import org.jboss.security.auth.spi.AbstractServerLoginModule;
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  */
 public class RemotingLoginModule extends AbstractServerLoginModule {
-
-    private static final SecurityLogger log = SecurityLogger.ROOT_LOGGER;
 
     /**
      * If a {@link X509Certificate} is available from the client as a result of a {@link SSLSession} being established should

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/JaasConfigurationService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/JaasConfigurationService.java
@@ -41,8 +41,6 @@ public class JaasConfigurationService implements Service<Configuration> {
 
     public static final ServiceName SERVICE_NAME = SecurityExtension.JBOSS_SECURITY.append("jaas");
 
-    private static final SecurityLogger log = SecurityLogger.ROOT_LOGGER;
-
     private final Configuration configuration;
 
     public JaasConfigurationService(Configuration configuration) {
@@ -52,7 +50,7 @@ public class JaasConfigurationService implements Service<Configuration> {
     /** {@inheritDoc} */
     @Override
     public void start(StartContext context) throws StartException {
-        log.debugf("Starting JaasConfigurationService");
+        SecurityLogger.ROOT_LOGGER.debug("Starting JaasConfigurationService");
 
         // set new configuration
         Configuration.setConfiguration(configuration);

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/JaccService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/JaccService.java
@@ -45,8 +45,6 @@ import org.jboss.msc.value.InjectedValue;
  */
 public abstract class JaccService<T> implements Service<PolicyConfiguration> {
 
-    protected static final SecurityLogger log = SecurityLogger.ROOT_LOGGER;
-
     public static final ServiceName SERVICE_NAME = SecurityExtension.JBOSS_SECURITY.append("jacc");
 
     private final String contextId;
@@ -83,7 +81,7 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
                 if (metaData != null) {
                     createPermissions(metaData, policyConfiguration);
                 } else {
-                    log.debugf("Cannot create permissions with 'null' metaData for id=" + contextId);
+                    SecurityLogger.ROOT_LOGGER.debugf("Cannot create permissions with 'null' metaData for id=%s", contextId);
                 }
                 if (!standalone) {
                     PolicyConfiguration parent = parentPolicy.getValue();
@@ -93,7 +91,7 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
                         policyConfiguration.commit();
                         parent.commit();
                     } else {
-                        log.debugf("Could not retrieve parent policy for policy " + contextId);
+                        SecurityLogger.ROOT_LOGGER.debugf("Could not retrieve parent policy for policy %s", contextId);
                     }
                 } else {
                     policyConfiguration.commit();

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityDomainService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityDomainService.java
@@ -52,8 +52,6 @@ public class SecurityDomainService implements Service<SecurityDomainContext> {
 
     public static final ServiceName SERVICE_NAME = SecurityExtension.JBOSS_SECURITY.append("security-domain");
 
-    private static final SecurityLogger log = SecurityLogger.ROOT_LOGGER;
-
     private final InjectedValue<ISecurityManagement> securityManagementValue = new InjectedValue<ISecurityManagement>();
 
     private final InjectedValue<Configuration> configurationValue = new InjectedValue<Configuration>();
@@ -81,7 +79,7 @@ public class SecurityDomainService implements Service<SecurityDomainContext> {
     /** {@inheritDoc} */
     @Override
     public void start(StartContext context) throws StartException {
-        log.debugf("Starting SecurityDomainService(" + name + ")");
+        SecurityLogger.ROOT_LOGGER.debugf("Starting SecurityDomainService(%s)", name);
         if (applicationPolicy != null) {
             final ApplicationPolicyRegistration applicationPolicyRegistration = (ApplicationPolicyRegistration) configurationValue
                     .getValue();
@@ -113,7 +111,7 @@ public class SecurityDomainService implements Service<SecurityDomainContext> {
     /** {@inheritDoc} */
     @Override
     public void stop(StopContext context) {
-        log.debug("Stopping security domain service " + name);
+        SecurityLogger.ROOT_LOGGER.debugf("Stopping security domain service %s", name);
         final JNDIBasedSecurityManagement securityManagement = (JNDIBasedSecurityManagement) securityManagementValue.getValue();
         securityManagement.removeSecurityDomain(name);
         // TODO clear auth cache?

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityManagementService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SecurityManagementService.java
@@ -44,8 +44,6 @@ public class SecurityManagementService implements Service<ISecurityManagement> {
 
     public static final ServiceName SERVICE_NAME = SecurityExtension.JBOSS_SECURITY.append("security-management");
 
-    private static final SecurityLogger log = SecurityLogger.ROOT_LOGGER;
-
     private final String authenticationManagerClassName;
 
     private final boolean deepCopySubjectMode;
@@ -79,7 +77,7 @@ public class SecurityManagementService implements Service<ISecurityManagement> {
     /** {@inheritDoc} */
     @Override
     public void start(StartContext context) throws StartException {
-        log.debugf("Starting SecurityManagementService");
+        SecurityLogger.ROOT_LOGGER.debugf("Starting SecurityManagementService");
         // set properties of JNDIBasedSecurityManagement
         JNDIBasedSecurityManagement securityManagement = new JNDIBasedSecurityManagement(serviceModuleLoaderValue.getValue());
         securityManagement.setAuthenticationManagerClassName(authenticationManagerClassName);

--- a/security/subsystem/src/main/java/org/jboss/as/security/service/SubjectFactoryService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/SubjectFactoryService.java
@@ -44,8 +44,6 @@ public class SubjectFactoryService implements Service<SubjectFactory> {
 
     public static final ServiceName SERVICE_NAME = SecurityExtension.JBOSS_SECURITY.append("subject-factory");
 
-    private static final SecurityLogger log = SecurityLogger.ROOT_LOGGER;
-
     private final InjectedValue<ISecurityManagement> securityManagementValue = new InjectedValue<ISecurityManagement>();
 
     private SubjectFactory subjectFactory;
@@ -59,7 +57,7 @@ public class SubjectFactoryService implements Service<SubjectFactory> {
     /** {@inheritDoc} */
     @Override
     public synchronized void start(StartContext context) throws StartException {
-        log.debugf("Starting SubjectFactoryService");
+        SecurityLogger.ROOT_LOGGER.debugf("Starting SubjectFactoryService");
         final ISecurityManagement injectedSecurityManagement = securityManagementValue.getValue();
         int i = subjectFactoryClassName.lastIndexOf(":");
         if (i == -1)

--- a/system-jmx/src/main/java/org/jboss/system/ServiceMBeanSupport.java
+++ b/system-jmx/src/main/java/org/jboss/system/ServiceMBeanSupport.java
@@ -82,9 +82,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
     public ServiceMBeanSupport() {
         // can not call this(Class) because we need to call getClass()
         this.log = Logger.getLogger(getClass().getName());
-        if (log.isTraceEnabled()) {
-            log.trace("Constructing");
-        }
+        log.trace("Constructing");
     }
 
     /**
@@ -118,9 +116,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
      */
     public ServiceMBeanSupport(final Logger log) {
         this.log = log;
-        if (log.isTraceEnabled()) {
-            log.trace("Constructing");
-        }
+        log.trace("Constructing");
     }
 
     /**
@@ -170,7 +166,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
         try {
             jbossInternalStop();
         } catch (Throwable t) {
-            log.warn(ServiceMBeanLogger.ROOT_LOGGER.errorInStop(t, jbossInternalDescription()));
+            log.warn(ServiceMBeanLogger.ROOT_LOGGER.errorInStop(jbossInternalDescription()), t);
         }
     }
 
@@ -178,7 +174,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
         try {
             jbossInternalDestroy();
         } catch (Throwable t) {
-            log.warn(ServiceMBeanLogger.ROOT_LOGGER.errorInDestroy(t, jbossInternalDescription()));
+            log.warn(ServiceMBeanLogger.ROOT_LOGGER.errorInDestroy(jbossInternalDescription()), t);
         }
     }
 
@@ -225,7 +221,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
             createService();
             state = CREATED;
         } catch (Exception e) {
-            log.warn(ServiceMBeanLogger.ROOT_LOGGER.initializationFailed(e, jbossInternalDescription()));
+            log.warn(ServiceMBeanLogger.ROOT_LOGGER.initializationFailed(jbossInternalDescription()), e);
             throw e;
         }
 
@@ -260,7 +256,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
         } catch (Exception e) {
             state = FAILED;
             sendStateChangeNotification(STARTING, FAILED, getName() + " failed", e);
-            log.warn(ServiceMBeanLogger.ROOT_LOGGER.startingFailed(e, jbossInternalDescription()));
+            log.warn(ServiceMBeanLogger.ROOT_LOGGER.startingFailed(jbossInternalDescription()), e);
             throw e;
         }
 
@@ -296,7 +292,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
         } catch (Throwable e) {
             state = FAILED;
             sendStateChangeNotification(STOPPING, FAILED, getName() + " failed", e);
-            log.warn(ServiceMBeanLogger.ROOT_LOGGER.stoppingFailed(e, jbossInternalDescription()));
+            log.warn(ServiceMBeanLogger.ROOT_LOGGER.stoppingFailed(jbossInternalDescription()), e);
             return;
         }
 
@@ -328,7 +324,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
         try {
             destroyService();
         } catch (Throwable t) {
-            log.warn(ServiceMBeanLogger.ROOT_LOGGER.destroyingFailed(t, jbossInternalDescription()));
+            log.warn(ServiceMBeanLogger.ROOT_LOGGER.destroyingFailed(jbossInternalDescription()), t);
         }
         state = DESTROYED;
         if (log.isDebugEnabled()) {
@@ -367,9 +363,7 @@ public class ServiceMBeanSupport extends NotificationBroadcasterSupport implemen
 
     public void postRegister(Boolean registrationDone) {
         if (!registrationDone.booleanValue()) {
-            if (log.isDebugEnabled()) {
-                log.debug("Registration is not done -> stop");
-            }
+            log.debug("Registration is not done -> stop");
             stop();
         } else {
             state = REGISTERED;

--- a/system-jmx/src/main/java/org/jboss/system/logging/ServiceMBeanLogger.java
+++ b/system-jmx/src/main/java/org/jboss/system/logging/ServiceMBeanLogger.java
@@ -24,7 +24,6 @@ package org.jboss.system.logging;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
-import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 
@@ -44,22 +43,22 @@ public interface ServiceMBeanLogger extends BasicLogger {
     IllegalArgumentException unknownLifecycleMethod(String methodName);
 
     @Message(id = 3, value = "Error in destroy %s")
-    IllegalArgumentException errorInDestroy(@Cause Throwable cause, String description);
+    String errorInDestroy(String description);
 
     @Message(id = 4, value = "Error in stop %s")
-    IllegalArgumentException errorInStop(@Cause Throwable cause, String description);
+    String errorInStop(String description);
 
     @Message(id = 5, value = "Initialization failed %s")
-    IllegalArgumentException initializationFailed(@Cause Throwable cause, String description);
+    String initializationFailed(String description);
 
     @Message(id = 6, value = "Starting failed %s")
-    IllegalArgumentException startingFailed(@Cause Throwable cause, String description);
+    String startingFailed(String description);
 
     @Message(id = 7, value = "Stopping failed %s")
-    IllegalArgumentException stoppingFailed(@Cause Throwable cause, String description);
+    String stoppingFailed(String description);
 
     @Message(id = 8, value = "Destroying failed %s")
-    IllegalArgumentException destroyingFailed(@Cause Throwable cause, String description);
+    String destroyingFailed(String description);
 
     @Message(id = 9, value = "Initialization failed during postRegister")
     String postRegisterInitializationFailed();

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemAdd.java
@@ -326,9 +326,7 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         if (model.hasDefined(TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_TABLE_PREFIX.getName()))
             confiBuilder.setCommunicationTablePrefix(TransactionSubsystemRootResourceDefinition.JDBC_COMMUNICATION_STORE_TABLE_PREFIX.resolveModelAttribute(context, model).asString());
 
-        if (TransactionLogger.ROOT_LOGGER.isDebugEnabled()) {
-            TransactionLogger.ROOT_LOGGER.debugf("objectStorePathRef=%s, objectStorePath=%s%n", objectStorePathRef, objectStorePath);
-        }
+        TransactionLogger.ROOT_LOGGER.debugf("objectStorePathRef=%s, objectStorePath=%s%n", objectStorePathRef, objectStorePath);
 
         ServiceTarget target = context.getServiceTarget();
         // Configure the ObjectStoreEnvironmentBeans
@@ -356,10 +354,8 @@ class TransactionSubsystemAdd extends AbstractBoottimeAddStepHandler {
         final String nodeIdentifier = TransactionSubsystemRootResourceDefinition.NODE_IDENTIFIER.resolveModelAttribute(context, coreEnvModel).asString();
         final String varDirPathRef = TransactionSubsystemRootResourceDefinition.RELATIVE_TO.resolveModelAttribute(context, coreEnvModel).asString();
         final String varDirPath = TransactionSubsystemRootResourceDefinition.PATH.resolveModelAttribute(context, coreEnvModel).asString();
-        if (TransactionLogger.ROOT_LOGGER.isDebugEnabled()) {
-            TransactionLogger.ROOT_LOGGER.debugf("nodeIdentifier=%s%n", nodeIdentifier);
-            TransactionLogger.ROOT_LOGGER.debugf("varDirPathRef=%s, varDirPath=%s%n", varDirPathRef, varDirPath);
-        }
+        TransactionLogger.ROOT_LOGGER.debugf("nodeIdentifier=%s%n", nodeIdentifier);
+        TransactionLogger.ROOT_LOGGER.debugf("varDirPathRef=%s, varDirPath=%s%n", varDirPathRef, varDirPath);
         final CoreEnvironmentService coreEnvironmentService = new CoreEnvironmentService(nodeIdentifier, varDirPath, varDirPathRef);
 
         String socketBindingName = null;

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/TldParsingDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/TldParsingDeploymentProcessor.java
@@ -125,8 +125,7 @@ public class TldParsingDeploymentProcessor implements DeploymentUnitProcessor {
                     }
                 }
                 if (!found) {
-                    //todo: internataitonalization
-                    UndertowLogger.ROOT_LOGGER.errorf("Could not find tld %s", tld.getTaglibLocation());
+                    UndertowLogger.ROOT_LOGGER.tldNotFound(tld.getTaglibLocation());
                 }
 
             }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WarMetaDataProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/WarMetaDataProcessor.java
@@ -46,7 +46,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.module.ResourceRoot;
 import org.jboss.as.web.common.WarMetaData;
-import org.jboss.logging.Logger;
 import org.jboss.metadata.ear.spec.EarMetaData;
 import org.jboss.metadata.javaee.spec.EmptyMetaData;
 import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
@@ -221,15 +220,14 @@ public class WarMetaDataProcessor implements DeploymentUnitProcessor {
             warMetaData.setNoOrder(true);
         }
 
-        Logger log = Logger.getLogger("org.jboss.web");
-        if (log.isDebugEnabled()) {
+        if (UndertowLogger.ROOT_LOGGER.isDebugEnabled()) {
             StringBuilder builder = new StringBuilder();
             builder.append("Resolved order: [ ");
             for (String jar : order) {
                 builder.append(jar).append(' ');
             }
             builder.append(']');
-            log.debug(builder.toString());
+            UndertowLogger.ROOT_LOGGER.debug(builder.toString());
         }
 
         warMetaData.setOrder(order);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -316,4 +316,8 @@ public interface UndertowLogger extends BasicLogger {
 
     @Message(id = 73, value = "mod_cluster advertise socket binding requires multicast address to be set")
     StartException advertiseSocketBindingRequiresMulticastAddress();
+
+    @LogMessage(level = ERROR)
+    @Message(id = 74, value = "Could not find TLD %s")
+    void tldNotFound(String location);
 }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSClassVerificationProcessor.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/deployers/WSClassVerificationProcessor.java
@@ -85,7 +85,9 @@ public class WSClassVerificationProcessor implements DeploymentUnitProcessor {
 
     private void verifyEndpoint(final AbstractEndpoint pojoEndpoint, final ClassLoader moduleClassLoader,
             final DeploymentReflectionIndex deploymentReflectionIndex) throws DeploymentUnitProcessingException {
-        WSLogger.ROOT_LOGGER.tracef("Verifying web service endpoint class %s", pojoEndpoint.getClassName());
+        if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+            WSLogger.ROOT_LOGGER.tracef("Verifying web service endpoint class %s", pojoEndpoint.getClassName());
+        }
         try {
             final Class<?> endpointClass = moduleClassLoader.loadClass(pojoEndpoint.getClassName());
             final WebService webServiceAnnotation = endpointClass.getAnnotation(WebService.class);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSDeploymentActivator.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSDeploymentActivator.java
@@ -83,7 +83,9 @@ final class WSDeploymentActivator {
         int index = 1;
         List<DeploymentAspect> aspects = DeploymentAspectsProvider.getSortedDeploymentAspects();
         for (final DeploymentAspect da : aspects) {
-            WSLogger.ROOT_LOGGER.tracef("Installing aspect %s", da.getClass().getName());
+            if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+                WSLogger.ROOT_LOGGER.tracef("Installing aspect %s", da.getClass().getName());
+            }
             processorTarget.addDeploymentProcessor(WSExtension.SUBSYSTEM_NAME, phase, priority + index++, new AspectDeploymentProcessor(da));
         }
     }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/metadata/AbstractMetaDataBuilderEJB.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/metadata/AbstractMetaDataBuilderEJB.java
@@ -49,7 +49,9 @@ abstract class AbstractMetaDataBuilderEJB {
      * @return universal EJB meta data model
      */
     final EJBArchiveMetaData create(final Deployment dep) {
-        WSLogger.ROOT_LOGGER.tracef("Building JBoss agnostic meta data for EJB webservice deployment: %s", dep.getSimpleName());
+        if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+            WSLogger.ROOT_LOGGER.tracef("Building JBoss agnostic meta data for EJB webservice deployment: %s", dep.getSimpleName());
+        }
         final EJBArchiveMetaData.Builder ejbArchiveMDBuilder = new EJBArchiveMetaData.Builder();
 
         this.buildEnterpriseBeansMetaData(dep, ejbArchiveMDBuilder);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/metadata/AbstractMetaDataBuilderPOJO.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/metadata/AbstractMetaDataBuilderPOJO.java
@@ -66,7 +66,9 @@ abstract class AbstractMetaDataBuilderPOJO {
      * @return universal JSE meta data model
      */
     JSEArchiveMetaData create(final Deployment dep) {
-        WSLogger.ROOT_LOGGER.tracef("Creating JBoss agnostic meta data for POJO webservice deployment: %s", dep.getSimpleName());
+        if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+            WSLogger.ROOT_LOGGER.tracef("Creating JBoss agnostic meta data for POJO webservice deployment: %s", dep.getSimpleName());
+        }
         final JBossWebMetaData jbossWebMD = WSHelper.getRequiredAttachment(dep, JBossWebMetaData.class);
         final DeploymentUnit unit = WSHelper.getRequiredAttachment(dep, DeploymentUnit.class);
         final List<POJOEndpoint> pojoEndpoints = getPojoEndpoints(unit);

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/metadata/ContainerMetaDataDeploymentAspect.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/metadata/ContainerMetaDataDeploymentAspect.java
@@ -44,13 +44,17 @@ public final class ContainerMetaDataDeploymentAspect extends AbstractDeploymentA
     public void start(final Deployment dep) {
         if (WSHelper.isJaxwsJseDeployment(dep)) {
             if (WSHelper.hasAttachment(dep, JBossWebMetaData.class)) {
-                WSLogger.ROOT_LOGGER.tracef("Creating JBoss agnostic JAXWS POJO meta data for deployment: %s", dep.getSimpleName());
+                if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+                    WSLogger.ROOT_LOGGER.tracef("Creating JBoss agnostic JAXWS POJO meta data for deployment: %s", dep.getSimpleName());
+                }
                 final JSEArchiveMetaData jseMetaData = jaxwsPojoMDBuilder.create(dep);
                 dep.addAttachment(JSEArchiveMetaData.class, jseMetaData);
             }
         }
         if (WSHelper.isJaxwsEjbDeployment(dep)) {
-            WSLogger.ROOT_LOGGER.tracef("Creating JBoss agnostic JAXWS EJB meta data for deployment: %s", dep.getSimpleName());
+            if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+                WSLogger.ROOT_LOGGER.tracef("Creating JBoss agnostic JAXWS EJB meta data for deployment: %s", dep.getSimpleName());
+            }
             final EJBArchiveMetaData ejbMetaData = jaxwsEjbMDBuilder.create(dep);
             dep.addAttachment(EJBArchiveMetaData.class, ejbMetaData);
         }

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataCreatingDeploymentAspect.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataCreatingDeploymentAspect.java
@@ -37,8 +37,10 @@ public final class WebMetaDataCreatingDeploymentAspect extends AbstractDeploymen
     @Override
     public void start(final Deployment dep) {
         if (isEjbDeployment(dep)) {
-            WSLogger.ROOT_LOGGER.tracef("Creating web meta data for EJB webservice deployment: %s", dep.getSimpleName());
-           webMetaDataCreator.create(dep);
+            if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+                WSLogger.ROOT_LOGGER.tracef("Creating web meta data for EJB webservice deployment: %s", dep.getSimpleName());
+            }
+            webMetaDataCreator.create(dep);
         }
     }
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataModifier.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataModifier.java
@@ -109,7 +109,9 @@ final class WebMetaDataModifier {
      */
     private void modifyContextRoot(final Deployment dep, final JBossWebMetaData jbossWebMD) {
         final String contextRoot = dep.getService().getContextRoot();
-        WSLogger.ROOT_LOGGER.tracef("Setting context root: %s for deployment: %s", contextRoot, dep.getSimpleName());
+        if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+            WSLogger.ROOT_LOGGER.tracef("Setting context root: %s for deployment: %s", contextRoot, dep.getSimpleName());
+        }
         jbossWebMD.setContextRoot(contextRoot);
     }
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataModifyingDeploymentAspect.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/tomcat/WebMetaDataModifyingDeploymentAspect.java
@@ -34,7 +34,9 @@ public final class WebMetaDataModifyingDeploymentAspect extends AbstractDeployme
 
     @Override
     public void start(final Deployment dep) {
-        WSLogger.ROOT_LOGGER.tracef("Modifying web meta data for webservice deployment: %s", dep.getSimpleName());
+        if (WSLogger.ROOT_LOGGER.isTraceEnabled()) {
+            WSLogger.ROOT_LOGGER.tracef("Modifying web meta data for webservice deployment: %s", dep.getSimpleName());
+        }
         webMetaDataModifier.modify(dep);
     }
 

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/VirtualFileAdaptor.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/util/VirtualFileAdaptor.java
@@ -58,7 +58,7 @@ public final class VirtualFileAdaptor implements UnifiedVirtualFile {
             if (throwExceptionIfNotFound) {
                 throw WSLogger.ROOT_LOGGER.missingChild(child, virtualFile);
             } else {
-                if (WSLogger.ROOT_LOGGER.isTraceEnabled()) WSLogger.ROOT_LOGGER.tracef("Child '%s' not found for VirtualFile: %s", child, virtualFile);
+                WSLogger.ROOT_LOGGER.tracef("Child '%s' not found for VirtualFile: %s", child, virtualFile);
                 return null;
             }
         }

--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldBeanManagerServiceProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldBeanManagerServiceProcessor.java
@@ -83,7 +83,7 @@ public class WeldBeanManagerServiceProcessor implements DeploymentUnitProcessor 
             rootBda = topLevelDeployment.getAttachment(WeldAttachments.DEPLOYMENT_ROOT_BEAN_DEPLOYMENT_ARCHIVE);
         }
         if (rootBda == null) {
-            WeldLogger.ROOT_LOGGER.couldNotFindBeanManagerForDeployment(deploymentUnit.getName());
+            WeldLogger.DEPLOYMENT_LOGGER.couldNotFindBeanManagerForDeployment(deploymentUnit.getName());
             return;
         }
 

--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemAdd.java
@@ -205,8 +205,8 @@ class XTSSubsystemAdd extends AbstractBoottimeAddStepHandler {
             }
         }
 
-        if (coordinatorURL != null && XtsAsLogger.ROOT_LOGGER.isDebugEnabled()) {
-            XtsAsLogger.ROOT_LOGGER.debugf("nodeIdentifier=%s\n", coordinatorURL);
+        if (coordinatorURL != null) {
+            XtsAsLogger.ROOT_LOGGER.debugf("nodeIdentifier=%s%n", coordinatorURL);
         }
 
         final boolean isDefaultContextPropagation = model.hasDefined(CommonAttributes.DEFAULT_CONTEXT_PROPAGATION)


### PR DESCRIPTION
Several updates to log messages and log categories. Just some general clean up.

The EJB change could use a good look as some new categories were added to help an end user be able to configure loggers for better debugging.

I also tried to replace `\n` line feeds to `System.lineSeparator()` where I could find them for better cross platform support.

Finally some places I removed the `isLevelEnabled()` and some places I guessed at adding where I felt the value replacement arguments may be expensive to retrieve.
