### PR TITLE
[WFLY-4357] Update the JDR Subsystem to Include a Type 4 UUID in its Report

### DIFF
--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
@@ -112,9 +112,11 @@ public class CommandLineMain {
             String startTime = result.get("start-time").asString();
             String endTime = result.get("end-time").asString();
             String reportLocation = result.get("report-location").asString();
+            String jdrUuid = result.get("jdr-uuid").asString();
             System.out.println("JDR started: " + startTime);
             System.out.println("JDR ended: " + endTime);
             System.out.println("JDR location: " + reportLocation);
+            System.out.println("JDR uuid: " + jdrUuid);
         } catch(IllegalStateException ise) {
             System.out.println(ise.getMessage());
 
@@ -127,6 +129,7 @@ public class CommandLineMain {
                 System.out.println("JDR started: " + response.getStartTime().toString());
                 System.out.println("JDR ended: " + response.getEndTime().toString());
                 System.out.println("JDR location: " + response.getLocation());
+                System.out.println("JDR uuid: " + response.getJdrUuid());
             } catch (OperationFailedException e) {
                 System.out.println("Failed to complete the JDR report: " + e.getMessage());
             }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommonAttributes.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommonAttributes.java
@@ -37,4 +37,5 @@ public interface CommonAttributes {
     SimpleAttributeDefinition START_TIME = new SimpleAttributeDefinitionBuilder("start-time", ModelType.STRING, false).build();
     SimpleAttributeDefinition END_TIME = new SimpleAttributeDefinitionBuilder("end-time", ModelType.STRING, false).build();
     SimpleAttributeDefinition REPORT_LOCATION = new SimpleAttributeDefinitionBuilder("report-location", ModelType.STRING, true).build();
+    SimpleAttributeDefinition JDR_UUID = new SimpleAttributeDefinitionBuilder("jdr-uuid", ModelType.STRING, true).build();
 }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportRequestHandler.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportRequestHandler.java
@@ -44,7 +44,7 @@ public class JdrReportRequestHandler implements OperationStepHandler {
     static final JdrReportRequestHandler INSTANCE = new JdrReportRequestHandler();
 
     static final SimpleOperationDefinition DEFINITION = new SimpleOperationDefinitionBuilder(OPERATION_NAME, JdrReportExtension.getResourceDescriptionResolver())
-            .setReplyParameters(CommonAttributes.START_TIME, CommonAttributes.END_TIME, CommonAttributes.REPORT_LOCATION)
+            .setReplyParameters(CommonAttributes.START_TIME, CommonAttributes.END_TIME, CommonAttributes.REPORT_LOCATION, CommonAttributes.JDR_UUID)
             .setReadOnly()
             .setRuntimeOnly()
             .addAccessConstraint(JdrReportExtension.JDR_SENSITIVITY_DEF)
@@ -78,6 +78,9 @@ public class JdrReportRequestHandler implements OperationStepHandler {
                 }
                 if (report.getEndTime() != null) {
                     response.get("end-time").set(report.getEndTime().toString());
+                }
+                if (report.getJdrUuid() != null) {
+                    response.get("jdr-uuid").set(report.getJdrUuid().toString());
                 }
                 response.get("report-location").set(report.getLocation());
 

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
@@ -22,18 +22,83 @@
 
 package org.jboss.as.jdr;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 import org.jboss.as.controller.SimpleResourceDefinition;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class JdrReportSubsystemDefinition extends SimpleResourceDefinition {
+
+    public static final String JBOSS_PROPERTY_DIR = "jboss.server.data.dir";
+
+    public static final String JDR_PROPERTY_FILE_NAME = "jdr.properties";
+
+    public static final String UUID_NAME = "UUID";
+
+    public static final String JDR_PROPERTIES_COMMENT = "JDR Properties";
+
     static final JdrReportSubsystemDefinition INSTANCE = new JdrReportSubsystemDefinition();
+
+    private String uuid;
 
     private JdrReportSubsystemDefinition() {
         super(JdrReportExtension.SUBSYSTEM_PATH, JdrReportExtension.getResourceDescriptionResolver(),
                 JdrReportSubsystemAdd.INSTANCE,
                 JdrReportSubsystemRemove.INSTANCE);
+        setUUID();
+        System.out.println("UUID: " + uuid);
     }
 
+    private void setUUID() {
+        String jbossConfig = System.getProperty(JBOSS_PROPERTY_DIR);
+        String jdrPropertiesFilePath = jbossConfig + File.separator + JdrReportExtension.SUBSYSTEM_NAME + File.separator + JDR_PROPERTY_FILE_NAME;
+        Properties jdrProperties = new Properties();
+        InputStream jdrIS = getClass().getClassLoader().getResourceAsStream(jdrPropertiesFilePath);
+        if(jdrIS != null) {
+            try {
+                jdrProperties.load(jdrIS);
+                uuid = jdrProperties.getProperty(UUID_NAME);
+                if(uuid == null) {
+                    uuid = java.util.UUID.randomUUID().toString();
+                    jdrProperties.setProperty(UUID_NAME, uuid);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+        else {
+            uuid = java.util.UUID.randomUUID().toString();
+            jdrProperties.setProperty(UUID_NAME, java.util.UUID.randomUUID().toString());
+            FileOutputStream fileOut = null;
+            try {
+                File file = new File(jdrPropertiesFilePath);
+                file.getParentFile().mkdirs();
+                fileOut = new FileOutputStream(jdrPropertiesFilePath);
+                jdrProperties.store(fileOut, JDR_PROPERTIES_COMMENT);
+            }
+            catch (IOException e) {
+                e.printStackTrace();
+            }
+            finally {
+                if(fileOut != null) {
+                    try {
+                        fileOut.close();
+                    }
+                    catch(IOException e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+    }
+
+    public String getUUID() {
+        return uuid;
+    }
 }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
@@ -28,7 +28,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
  */
 public class JdrReportSubsystemDefinition extends SimpleResourceDefinition {
-
     static final JdrReportSubsystemDefinition INSTANCE = new JdrReportSubsystemDefinition();
 
     private JdrReportSubsystemDefinition() {
@@ -36,5 +35,4 @@ public class JdrReportSubsystemDefinition extends SimpleResourceDefinition {
                 JdrReportSubsystemAdd.INSTANCE,
                 JdrReportSubsystemRemove.INSTANCE);
     }
-
 }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
@@ -22,12 +22,6 @@
 
 package org.jboss.as.jdr;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
-
 import org.jboss.as.controller.SimpleResourceDefinition;
 
 /**
@@ -35,70 +29,11 @@ import org.jboss.as.controller.SimpleResourceDefinition;
  */
 public class JdrReportSubsystemDefinition extends SimpleResourceDefinition {
 
-    public static final String JBOSS_PROPERTY_DIR = "jboss.server.data.dir";
-
-    public static final String JDR_PROPERTY_FILE_NAME = "jdr.properties";
-
-    public static final String UUID_NAME = "UUID";
-
-    public static final String JDR_PROPERTIES_COMMENT = "JDR Properties";
-
     static final JdrReportSubsystemDefinition INSTANCE = new JdrReportSubsystemDefinition();
-
-    private String uuid;
 
     private JdrReportSubsystemDefinition() {
         super(JdrReportExtension.SUBSYSTEM_PATH, JdrReportExtension.getResourceDescriptionResolver(),
                 JdrReportSubsystemAdd.INSTANCE,
                 JdrReportSubsystemRemove.INSTANCE);
-        setUUID();
-        System.out.println("UUID: " + uuid);
-    }
-
-    private void setUUID() {
-        String jbossConfig = System.getProperty(JBOSS_PROPERTY_DIR);
-        String jdrPropertiesFilePath = jbossConfig + File.separator + JdrReportExtension.SUBSYSTEM_NAME + File.separator + JDR_PROPERTY_FILE_NAME;
-        Properties jdrProperties = new Properties();
-        InputStream jdrIS = getClass().getClassLoader().getResourceAsStream(jdrPropertiesFilePath);
-        if(jdrIS != null) {
-            try {
-                jdrProperties.load(jdrIS);
-                uuid = jdrProperties.getProperty(UUID_NAME);
-                if(uuid == null) {
-                    uuid = java.util.UUID.randomUUID().toString();
-                    jdrProperties.setProperty(UUID_NAME, uuid);
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-        else {
-            uuid = java.util.UUID.randomUUID().toString();
-            jdrProperties.setProperty(UUID_NAME, java.util.UUID.randomUUID().toString());
-            FileOutputStream fileOut = null;
-            try {
-                File file = new File(jdrPropertiesFilePath);
-                file.getParentFile().mkdirs();
-                fileOut = new FileOutputStream(jdrPropertiesFilePath);
-                jdrProperties.store(fileOut, JDR_PROPERTIES_COMMENT);
-            }
-            catch (IOException e) {
-                e.printStackTrace();
-            }
-            finally {
-                if(fileOut != null) {
-                    try {
-                        fileOut.close();
-                    }
-                    catch(IOException e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
-    }
-
-    public String getUUID() {
-        return uuid;
     }
 }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportSubsystemDefinition.java
@@ -36,4 +36,5 @@ public class JdrReportSubsystemDefinition extends SimpleResourceDefinition {
                 JdrReportSubsystemAdd.INSTANCE,
                 JdrReportSubsystemRemove.INSTANCE);
     }
+
 }

--- a/jdr/jboss-as-jdr/src/main/resources/org/jboss/as/jdr/LocalDescriptions.properties
+++ b/jdr/jboss-as-jdr/src/main/resources/org/jboss/as/jdr/LocalDescriptions.properties
@@ -5,4 +5,5 @@ jdr.generate-jdr-report=Request the generation of a JDR report.
 jdr.generate-jdr-report.start-time=Time JDR report collection was initiated.
 jdr.generate-jdr-report.end-time=Time JDR report collection was initiated.
 jdr.generate-jdr-report.report-location=Location of the JDR report.
+jdr.generate-jdr-report.jdr-uuid=UUID representing the subsystem.
 jdr.report.return=Result summary of the JDR report.


### PR DESCRIPTION
Generates a type-4 UUID, stores the value in a JDR server properties file and returns the value to the user once a JDR is generated.
