### PR TITLE
Prevent NPE in HornetQService.stop()

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQService.java
@@ -308,10 +308,14 @@ class HornetQService implements Service<HornetQServer> {
                 // server.stop();
 
                 for (SocketBinding binding : socketBindings.values()) {
-                    binding.getSocketBindings().getNamedRegistry().unregisterBinding(binding.getName());
+                    if (binding != null) {
+                        binding.getSocketBindings().getNamedRegistry().unregisterBinding(binding.getName());
+                    }
                 }
                 for (SocketBinding binding : groupBindings.values()) {
-                    binding.getSocketBindings().getNamedRegistry().unregisterBinding(binding.getName());
+                    if (binding != null) {
+                        binding.getSocketBindings().getNamedRegistry().unregisterBinding(binding.getName());
+                    }
                 }
             }
             pathConfig.closeCallbacks(pathManager.getValue());


### PR DESCRIPTION
The server can use either socket-binding or outbound-socket-binding.
In its stop method check whether the binding is null before
unregistering it as it can be either in the socketBindings or the
groupBindings collection.
