### PR TITLE
WFLY-4590 l1-lifespan attribute in distributed cache configuration does not enable l1 cache

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAddHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheAddHandler.java
@@ -71,7 +71,7 @@ public class DistributedCacheAddHandler extends SharedStateCacheAddHandler {
 
         long lifespan = DistributedCacheResourceDefinition.L1_LIFESPAN.resolveModelAttribute(context, cache).asLong();
         if (lifespan > 0) {
-            builder.clustering().l1().lifespan(lifespan);
+            builder.clustering().l1().enable().lifespan(lifespan);
         } else {
             builder.clustering().l1().disable();
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4590
