### PR TITLE
WFLY-4360 remove jboss-common-core

### DIFF
--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -32,6 +32,7 @@ vi:ts=4:sw=4:expandtab
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-parent</artifactId>
         <version>10.0.0.Alpha1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>wildfly-ejb3</artifactId>
@@ -39,6 +40,11 @@ vi:ts=4:sw=4:expandtab
     <name>WildFly: EJB Subsystem</name>
 
     <dependencies>
+        <dependency>
+            <groupId>org.jboss.common</groupId>
+            <artifactId>jboss-common-beans</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-connector</artifactId>
@@ -98,11 +104,6 @@ vi:ts=4:sw=4:expandtab
         <dependency>
             <groupId>org.hibernate.javax.persistence</groupId>
             <artifactId>hibernate-jpa-2.1-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.jboss</groupId>
-            <artifactId>jboss-common-core</artifactId>
         </dependency>
 
         <dependency>

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBUtilities.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
 import javax.resource.ResourceException;
 import javax.resource.spi.ActivationSpec;
 import javax.transaction.TransactionManager;
@@ -36,8 +35,9 @@ import javax.transaction.UserTransaction;
 
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.core.security.ServerSecurityManager;
-import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.inflow.EndpointDeployer;
+import org.jboss.as.ejb3.logging.EjbLogger;
+import org.jboss.common.beans.property.BeanUtils;
 import org.jboss.jca.core.spi.rar.Activation;
 import org.jboss.jca.core.spi.rar.Endpoint;
 import org.jboss.jca.core.spi.rar.MessageListener;
@@ -50,7 +50,6 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.util.propertyeditor.PropertyEditors;
 
 /**
  * The gas, water & energy for the EJB subsystem.
@@ -109,7 +108,7 @@ public class EJBUtilities implements EndpointDeployer, Service<EJBUtilities> {
             final Properties validActivationConfigProps = this.filterUnknownActivationConfigProperties(resourceAdapterName, activation, activationConfigProperties);
             // now set the activation config properties on the ActivationSpec
             final ActivationSpec activationSpec = activation.createInstance();
-            PropertyEditors.mapJavaBeanProperties(activationSpec, validActivationConfigProps);
+            BeanUtils.mapJavaBeanProperties(activationSpec, validActivationConfigProps);
 
             return activationSpec;
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/iiop/handle/HandleDelegateImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/iiop/handle/HandleDelegateImpl.java
@@ -24,7 +24,6 @@ package org.jboss.as.ejb3.iiop.handle;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-
 import javax.ejb.EJBHome;
 import javax.ejb.EJBObject;
 import javax.ejb.spi.HandleDelegate;
@@ -34,7 +33,6 @@ import javax.rmi.CORBA.Stub;
 import javax.rmi.PortableRemoteObject;
 
 import org.jboss.as.ejb3.logging.EjbLogger;
-import org.jboss.util.NestedRuntimeException;
 import org.omg.CORBA.BAD_OPERATION;
 import org.omg.CORBA.ORB;
 import org.omg.CORBA.portable.ObjectImpl;
@@ -112,7 +110,7 @@ public class HandleDelegateImpl implements HandleDelegate {
             final InitialContext ctx = new InitialContext();
             return (HandleDelegate) ctx.lookup("java:comp/HandleDelegate");
         } catch (NamingException e) {
-            throw new NestedRuntimeException(e);
+            throw new RuntimeException(e);
         }
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/database/DatabaseTimerPersistence.java
@@ -38,6 +38,7 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -81,7 +82,6 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.util.Base64;
 
 /**
  * <p>
@@ -624,14 +624,14 @@ public class DatabaseTimerPersistence implements TimerPersistence, Service<Datab
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        return Base64.encodeBytes(out.toByteArray());
+        return Base64.getEncoder().encodeToString(out.toByteArray());
     }
 
     public Object deSerialize(final String data) throws SQLException {
         if (data == null) {
             return null;
         }
-        InputStream in = new ByteArrayInputStream(Base64.decode(data));
+        InputStream in = new ByteArrayInputStream(Base64.getDecoder().decode(data));
         try {
             final Unmarshaller unmarshaller = factory.createUnmarshaller(configuration);
             unmarshaller.start(new InputStreamByteInput(in));

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlParser_1_0.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlParser_1_0.java
@@ -57,6 +57,7 @@ import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -77,7 +78,6 @@ import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.Unmarshaller;
 import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
-import org.jboss.util.Base64;
 
 /**
  * Parser for persistent EJB timers that are stored in XML.
@@ -176,7 +176,7 @@ public class EjbTimerXmlParser_1_0 implements XMLElementReader<List<TimerImpl>> 
 
     private Object deserialize(final String info) throws IOException, ClassNotFoundException {
 
-        byte[] data = Base64.decode(info.trim());
+        byte[] data = Base64.getDecoder().decode(info.trim());
         Unmarshaller unmarshaller = factory.createUnmarshaller(configuration);
         unmarshaller.start(new ByteBufferInput(ByteBuffer.wrap(data)));
         try {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlPersister.java
@@ -22,6 +22,11 @@
 
 package org.jboss.as.ejb3.timerservice.persistence.filestore;
 
+import java.io.ByteArrayOutputStream;
+import java.util.Base64;
+import java.util.List;
+import javax.xml.stream.XMLStreamException;
+
 import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.ejb3.timerservice.CalendarTimer;
 import org.jboss.as.ejb3.timerservice.TimerImpl;
@@ -31,11 +36,6 @@ import org.jboss.marshalling.MarshallingConfiguration;
 import org.jboss.marshalling.OutputStreamByteOutput;
 import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
-import org.jboss.util.Base64;
-
-import javax.xml.stream.XMLStreamException;
-import java.io.ByteArrayOutputStream;
-import java.util.List;
 
 /**
  * @author Stuart Douglas
@@ -107,7 +107,7 @@ public class EjbTimerXmlPersister implements XMLElementWriter<List<TimerImpl>> {
                 marshaller.writeObject(timer.getInfo());
                 marshaller.finish();
                 marshaller.flush();
-                info = Base64.encodeBytes(out.toByteArray());
+                info = Base64.getEncoder().encodeToString(out.toByteArray());
             } catch (Exception e) {
                 EjbLogger.ROOT_LOGGER.failedToPersistTimer(timer, e);
                 return;
@@ -121,7 +121,7 @@ public class EjbTimerXmlPersister implements XMLElementWriter<List<TimerImpl>> {
                 marshaller.writeObject(timer.getPrimaryKey());
                 marshaller.finish();
                 marshaller.flush();
-                primaryKey = Base64.encodeBytes(out.toByteArray());
+                primaryKey = Base64.getEncoder().encodeToString(out.toByteArray());
             } catch (Exception e) {
                 EjbLogger.ROOT_LOGGER.failedToPersistTimer(timer, e);
                 return;
@@ -190,7 +190,7 @@ public class EjbTimerXmlPersister implements XMLElementWriter<List<TimerImpl>> {
                 marshaller.writeObject(timer.getInfo());
                 marshaller.finish();
                 marshaller.flush();
-                info = Base64.encodeBytes(out.toByteArray());
+                info = Base64.getEncoder().encodeToString(out.toByteArray());
             } catch (Exception e) {
                 EjbLogger.ROOT_LOGGER.failedToPersistTimer(timer, e);
                 return;
@@ -204,7 +204,7 @@ public class EjbTimerXmlPersister implements XMLElementWriter<List<TimerImpl>> {
                 marshaller.writeObject(timer.getPrimaryKey());
                 marshaller.finish();
                 marshaller.flush();
-                primaryKey = Base64.encodeBytes(out.toByteArray());
+                primaryKey = Base64.getEncoder().encodeToString(out.toByteArray());
             } catch (Exception e) {
                 EjbLogger.ROOT_LOGGER.failedToPersistTimer(timer, e);
                 return;

--- a/ejb3/src/test/java/org/jboss/as/ejb3/remote/protocol/versiontwo/CompressedMethodInvocationMessageHandlerTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/remote/protocol/versiontwo/CompressedMethodInvocationMessageHandlerTestCase.java
@@ -1,31 +1,6 @@
 package org.jboss.as.ejb3.remote.protocol.versiontwo;
 
-import org.jboss.as.ee.component.ComponentView;
-import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
-import org.jboss.as.ejb3.deployment.DeploymentRepository;
-import org.jboss.as.ejb3.deployment.EjbDeploymentInformation;
-import org.jboss.as.ejb3.deployment.ModuleDeployment;
-import org.jboss.as.ejb3.remote.CompressedMethodsInformation;
-import org.jboss.as.ejb3.remote.CompressionHintViewConfigurator;
-import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
-import org.jboss.ejb.client.EJBLocator;
-import org.jboss.ejb.client.StatelessEJBLocator;
-import org.jboss.ejb.client.annotation.CompressionHint;
-import org.jboss.marshalling.ByteOutput;
-import org.jboss.marshalling.Marshaller;
-import org.jboss.marshalling.MarshallerFactory;
-import org.jboss.marshalling.Marshalling;
-import org.jboss.marshalling.MarshallingConfiguration;
-import org.jboss.marshalling.reflect.SunReflectiveCreator;
-import org.jboss.marshalling.river.RiverMarshallerFactory;
-import org.jboss.msc.value.InjectedValue;
-import org.jboss.msc.value.Value;
-import org.jboss.remoting3.Channel;
-import org.jboss.remoting3.MessageOutputStream;
-import org.jboss.util.NotImplementedException;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
+import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutput;
@@ -50,7 +25,31 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
+import org.jboss.as.ee.component.ComponentView;
+import org.jboss.as.ejb3.deployment.DeploymentModuleIdentifier;
+import org.jboss.as.ejb3.deployment.DeploymentRepository;
+import org.jboss.as.ejb3.deployment.EjbDeploymentInformation;
+import org.jboss.as.ejb3.deployment.ModuleDeployment;
+import org.jboss.as.ejb3.remote.CompressedMethodsInformation;
+import org.jboss.as.ejb3.remote.CompressionHintViewConfigurator;
+import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
+import org.jboss.ejb.client.EJBLocator;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.ejb.client.annotation.CompressionHint;
+import org.jboss.marshalling.ByteOutput;
+import org.jboss.marshalling.Marshaller;
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.marshalling.Marshalling;
+import org.jboss.marshalling.MarshallingConfiguration;
+import org.jboss.marshalling.reflect.SunReflectiveCreator;
+import org.jboss.marshalling.river.RiverMarshallerFactory;
+import org.jboss.msc.value.InjectedValue;
+import org.jboss.msc.value.Value;
+import org.jboss.remoting3.Channel;
+import org.jboss.remoting3.MessageOutputStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 /**
  * @author <a href="mailto:thofman@redhat.com">Tomas Hofman</a>
@@ -314,12 +313,12 @@ public class CompressedMethodInvocationMessageHandlerTestCase {
 
         @Override
         public <T> Future<T> submit(Callable<T> callable) {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException("not implemented");
         }
 
         @Override
         public <T> Future<T> submit(Runnable runnable, T t) {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException("not implemented");
         }
 
         @Override
@@ -330,27 +329,27 @@ public class CompressedMethodInvocationMessageHandlerTestCase {
 
         @Override
         public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection) throws InterruptedException {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException("not implemented");
         }
 
         @Override
         public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit) throws InterruptedException {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException("not implemented");
         }
 
         @Override
         public <T> T invokeAny(Collection<? extends Callable<T>> collection) throws InterruptedException, ExecutionException {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException("not implemented");
         }
 
         @Override
         public <T> T invokeAny(Collection<? extends Callable<T>> collection, long l, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException("not implemented");
         }
 
         @Override
         public void execute(Runnable runnable) {
-            throw new NotImplementedException();
+            throw new UnsupportedOperationException("not implemented");
         }
     }
 

--- a/feature-pack/src/license/licenses.xml
+++ b/feature-pack/src/license/licenses.xml
@@ -1297,16 +1297,6 @@
     </dependency>
     <dependency>
       <groupId>org.jboss</groupId>
-      <artifactId>jboss-common-core</artifactId>
-      <licenses>
-        <license>
-          <name>GNU Lesser General Public License, Version 2.1</name>
-          <url>http://repository.jboss.org/licenses/lgpl-2.1.txt</url>
-        </license>
-      </licenses>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss</groupId>
       <artifactId>jboss-dmr</artifactId>
       <licenses>
         <license>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -42,6 +42,7 @@
         <!-- For message inflow -->
         <module name="javax.resource.api"/>
         <module name="org.hibernate"/>
+        <module name="org.jboss.common-beans" services="import"/>
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.wildfly.clustering.api"/>
         <module name="org.wildfly.clustering.ee.spi"/>
@@ -72,7 +73,6 @@
         <module name="org.jboss.classfilewriter"/>
         <module name="org.jboss.threads"/>
         <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.jboss.common-core"/>
         <module name="org.jboss.ejb-client" services="import"/>
         <module name="org.jboss.ejb3"/>
         <module name="org.jboss.iiop-client"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
@@ -36,6 +36,7 @@
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>
+        <module name="org.jboss.common-beans"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.mod_cluster.container.spi"/>
         <module name="org.jboss.mod_cluster.core"/>

--- a/mod_cluster/extension/pom.xml
+++ b/mod_cluster/extension/pom.xml
@@ -38,6 +38,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jboss.common</groupId>
+            <artifactId>jboss-common-beans</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.msc</groupId>
             <artifactId>jboss-msc</artifactId>
         </dependency>

--- a/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemAdd.java
+++ b/mod_cluster/extension/src/main/java/org/wildfly/extension/mod_cluster/ModClusterSubsystemAdd.java
@@ -78,6 +78,7 @@ import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.network.OutboundSocketBinding;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.as.network.SocketBindingManager;
+import org.jboss.common.beans.property.BeanUtils;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
 import org.jboss.modcluster.config.impl.ModClusterConfig;
@@ -91,7 +92,6 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.ValueService;
 import org.jboss.msc.value.ImmediateValue;
 import org.jboss.msc.value.InjectedValue;
-import org.jboss.util.propertyeditor.PropertyEditors;
 import org.wildfly.clustering.service.AsynchronousServiceBuilder;
 
 /**
@@ -349,7 +349,7 @@ class ModClusterSubsystemAdd extends AbstractBoottimeAddStepHandler {
                         props.putAll(propertyMap);
 
                         try {
-                            PropertyEditors.mapJavaBeanProperties(metric, props, true);
+                            BeanUtils.mapJavaBeanProperties(metric, props, true);
                         } catch (Exception ex) {
                             ROOT_LOGGER.errorApplyingMetricProperties(ex, loadMetricClass.getCanonicalName());
 
@@ -359,9 +359,7 @@ class ModClusterSubsystemAdd extends AbstractBoottimeAddStepHandler {
                     }
 
                     metrics.add(metric);
-                } catch (InstantiationException e) {
-                    ROOT_LOGGER.errorAddingMetrics(e);
-                } catch (IllegalAccessException e) {
+                } catch (InstantiationException | IllegalAccessException e) {
                     ROOT_LOGGER.errorAddingMetrics(e);
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,7 @@
         <version.org.javassist>3.18.1-GA</version.org.javassist>
         <version.org.jberet>1.1.0.Final</version.org.jberet>
         <version.org.jdom>1.1.3</version.org.jdom>
+        <version.org.jboss.common.jboss-common-beans>1.1.0.Final</version.org.jboss.common.jboss-common-beans>
         <version.org.jboss.hal.release-stream>2.6.8.Final</version.org.jboss.hal.release-stream>
         <version.org.jboss.ejb-client>2.0.3.Final</version.org.jboss.ejb-client>
         <version.org.jboss.ejb3.ext-api>2.1.0</version.org.jboss.ejb3.ext-api>
@@ -470,6 +471,7 @@
                                             <exclude>org.apache.xalan:xalan</exclude>
                                             <exclude>org.hibernate:ejb3-persistence</exclude>
                                             <exclude>org.hibernate.java-persistence:jpa-api</exclude>
+                                            <!--<exclude>org.jboss:jboss-common-core</exclude>-->
                                             <exclude>org.jboss.integration:jboss-jca-spi</exclude>
                                             <exclude>org.jboss.interceptor:jboss-interceptor-api</exclude>
                                             <exclude>org.jboss.javaee:jboss-javaee</exclude>
@@ -4920,6 +4922,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.common</groupId>
+                <artifactId>jboss-common-beans</artifactId>
+                <version>${version.org.jboss.common.jboss-common-beans}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.hal</groupId>
                 <artifactId>release-stream</artifactId>
                 <version>${version.org.jboss.hal.release-stream}</version>
@@ -5573,6 +5581,12 @@
                 <groupId>org.jboss.metadata</groupId>
                 <artifactId>jboss-metadata-common</artifactId>
                 <version>${version.org.jboss.metadata}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.jboss</groupId>
+                        <artifactId>jboss-common-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/web-feature-pack/pom.xml
+++ b/web-feature-pack/pom.xml
@@ -136,6 +136,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.common</groupId>
+            <artifactId>jboss-common-beans</artifactId>
+        </dependency>
+
+
+        <dependency>
             <groupId>org.jboss.spec.javax.annotation</groupId>
             <artifactId>jboss-annotations-api_1.2_spec</artifactId>
         </dependency>

--- a/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/common-beans/main/module.xml
+++ b/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/common-beans/main/module.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
+  ~ Copyright 2010, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -20,23 +21,13 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<module xmlns="urn:jboss:module:1.3" name="org.jboss.ejb3">
+
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.common-beans">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
-        <artifact name="${org.jboss.ejb3:jboss-ejb3-ext-api}"/>
+        <artifact name="${org.jboss.common:jboss-common-beans}"/>
     </resources>
-
-    <dependencies>
-        <module name="javax.ejb.api"/>
-        <module name="javax.persistence.api"/>
-        <module name="javax.interceptor.api"/>
-        <!-- EJBUtilities class needs it -->
-        <module name="org.jboss.common-beans"/>
-        <!-- org.jboss.util.deadlock.ApplicationDeadlockException -->
-        <module name="org.jboss.jboss-transaction-spi"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.marshalling"/>
-        <module name="org.jboss.marshalling.river"/>
-        <module name="org.jboss.metadata.ejb"/>
-    </dependencies>
 </module>

--- a/web-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/web-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -74,7 +74,6 @@
         <module name="org.jboss.vfs"/>
         <module name="org.jboss.as.version"/>
         <module name="org.jboss.logging"/>
-        <module name="org.jboss.common-core"/>
         <module name="org.picketbox"/>
         <module name="javax.security.jacc.api"/>
         <module name="org.jboss.xnio"/>


### PR DESCRIPTION
this is prerequisite for https://github.com/wildfly/wildfly-core/pull/689

it also already uses JDK8 apis, java.util.Base64 to be specific.
