### PR TITLE
[9.x] WFLY-4601 Upgrade Infinispan to 7.2.1.Final

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ManagedExecutorFactory.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ManagedExecutorFactory.java
@@ -34,7 +34,7 @@ import org.jboss.as.clustering.concurrent.ManagedExecutorService;
  * Executor factory that produces {@link ManagedExecutorService} instances.
  * @author Paul Ferraro
  */
-public class ManagedExecutorFactory implements ExecutorFactory, ThreadPoolExecutorFactory {
+public class ManagedExecutorFactory implements ExecutorFactory, ThreadPoolExecutorFactory<ExecutorService> {
 
     private final Executor executor;
 
@@ -47,7 +47,6 @@ public class ManagedExecutorFactory implements ExecutorFactory, ThreadPoolExecut
         return this.createExecutor();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public ExecutorService createExecutor(ThreadFactory factory) {
         return this.createExecutor();

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ManagedScheduledExecutorFactory.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ManagedScheduledExecutorFactory.java
@@ -33,7 +33,7 @@ import org.jboss.as.clustering.concurrent.ManagedScheduledExecutorService;
  * Executor factory that produces {@link ManagedScheduledExecutorService} instances.
  * @author Paul Ferraro
  */
-public class ManagedScheduledExecutorFactory implements ScheduledExecutorFactory, ThreadPoolExecutorFactory {
+public class ManagedScheduledExecutorFactory implements ScheduledExecutorFactory, ThreadPoolExecutorFactory<ScheduledExecutorService> {
 
     private final ScheduledExecutorService executor;
 
@@ -46,7 +46,6 @@ public class ManagedScheduledExecutorFactory implements ScheduledExecutorFactory
         return this.createExecutor();
     }
 
-    @SuppressWarnings("unchecked")
     @Override
     public ScheduledExecutorService createExecutor(ThreadFactory factory) {
         return this.createExecutor();

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
@@ -260,7 +260,7 @@ public class CacheAddHandler extends AbstractAddStepHandler {
                 builder.eviction().strategy(strategy);
 
                 if (strategy.isEnabled()) {
-                    final int maxEntries = EvictionResourceDefinition.MAX_ENTRIES.resolveModelAttribute(context, eviction).asInt();
+                    final long maxEntries = EvictionResourceDefinition.MAX_ENTRIES.resolveModelAttribute(context, eviction).asLong();
                     builder.eviction().maxEntries(maxEntries);
                 }
             }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerConfigurationBuilder.java
@@ -156,7 +156,7 @@ public class CacheContainerConfigurationBuilder implements Builder<GlobalConfigu
         }
         ScheduledExecutorService evictionExecutor = (this.evictionExecutor != null) ? this.evictionExecutor.getValue() : null;
         if (evictionExecutor != null) {
-            builder.evictionThreadPool().threadPoolFactory(new ManagedScheduledExecutorFactory(evictionExecutor));
+            builder.expirationThreadPool().threadPoolFactory(new ManagedScheduledExecutorFactory(evictionExecutor));
         }
         ScheduledExecutorService replicationQueueExecutor = (this.replicationQueueExecutor != null) ? this.replicationQueueExecutor.getValue() : null;
         if (replicationQueueExecutor != null) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheMetric.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheMetric.java
@@ -70,7 +70,7 @@ public enum CacheMetric implements Metric<Cache<?, ?>> {
         @Override
         public ModelNode execute(Cache<?, ?> cache) {
             CacheMgmtInterceptor interceptor = findInterceptor(cache, CacheMgmtInterceptor.class);
-            return new ModelNode((interceptor != null) ? interceptor.getElapsedTime() : 0);
+            return new ModelNode((interceptor != null) ? interceptor.getTimeSinceStart() : 0);
         }
     },
     HIT_RATIO(MetricKeys.HIT_RATIO, ModelType.DOUBLE) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionResourceDefinition.java
@@ -59,11 +59,11 @@ public class EvictionResourceDefinition extends SimpleResourceDefinition {
             .setDefaultValue(new ModelNode().set(EvictionStrategy.NONE.name()))
             .build();
 
-    static final SimpleAttributeDefinition MAX_ENTRIES = new SimpleAttributeDefinitionBuilder(ModelKeys.MAX_ENTRIES, ModelType.INT, true)
+    static final SimpleAttributeDefinition MAX_ENTRIES = new SimpleAttributeDefinitionBuilder(ModelKeys.MAX_ENTRIES, ModelType.LONG, true)
             .setXmlName(Attribute.MAX_ENTRIES.getLocalName())
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode().set(-1))
+            .setDefaultValue(new ModelNode(-1L))
             .build();
 
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { STRATEGY, MAX_ENTRIES };

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1871,6 +1871,10 @@
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-directory-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.infinispan</groupId>
             <artifactId>infinispan-lucene-directory</artifactId>
         </dependency>
         <dependency>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/lucene-directory/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/lucene-directory/main/module.xml
@@ -29,6 +29,7 @@
 
     <resources>
         <artifact name="${org.infinispan:infinispan-lucene-directory}"/>
+        <artifact name="${org.infinispan:infinispan-directory-provider}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -141,9 +141,9 @@
         <version.org.hibernate.validator>5.1.3.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.1.0.Final</version.org.hibernate.hql>
-        <version.org.hibernate.search>5.1.2.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>5.2.0.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
-        <version.org.infinispan>7.1.1.Final</version.org.infinispan>
+        <version.org.infinispan>7.2.1.Final</version.org.infinispan>
         <version.org.jasypt>1.9.1</version.org.jasypt>
         <version.org.javassist>3.18.1-GA</version.org.javassist>
         <version.org.jberet>1.1.0.Final</version.org.jberet>
@@ -4287,6 +4287,17 @@
                     <exclusion>
                         <groupId>org.jboss.marshalling</groupId>
                         <artifactId>jboss-marshalling-osgi</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.infinispan</groupId>
+                <artifactId>infinispan-directory-provider</artifactId>
+                <version>${version.org.infinispan}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hibernate</groupId>
+                        <artifactId>hibernate-search-engine</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
Also updates hibernate-search to 5.2.0.Final.
Fixes some critical issues with:
- Deadlocking with state transfer on topology change
- Local TM fixes.

https://issues.jboss.org/browse/WFLY-4601
