### PR TITLE
Disable StandardConfigsXMLValidationUnitTestCase until we can get the…

### DIFF
--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -40,6 +40,7 @@ import javax.xml.validation.Validator;
 
 import org.junit.After;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
@@ -49,6 +50,7 @@ import org.xml.sax.SAXException;
  * @author Brian Stansberry
  * @version $Revision: 1.1 $
  */
+@Ignore("WFCORE-645")
 public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidationUnitTest {
     private static Source[] SCHEMAS;
 


### PR DESCRIPTION
… core version in sync via WFCORE-645

This lets us test https://github.com/wildfly/wildfly-core/pull/709 without noise from this test.
