### PR TITLE
[WFLY-4534] Ensure all wildfly-client-all transitive dependencies are excluded

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1944,12 +1944,8 @@
             <artifactId>wildfly-client-all</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-ejb-client-bom</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-jms-client-bom</artifactId>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
I'll admit I'm not sure why this fixes the issue, but it does for maven 3.3.x. It seems more correct and consistent with how the other dependencies are defined anyway.
