### PR TITLE
Update WildFly Core to 1.0.0.CR3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.testng>6.1.1</version.org.testng>
         <version.org.wildfly.build-tools>1.0.0.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.1.Final</version.org.wildfly.checkstyle-config>
-        <version.org.wildfly.core>1.0.0.CR2</version.org.wildfly.core>
+        <version.org.wildfly.core>1.0.0.CR3</version.org.wildfly.core>
         <version.org.wildfly.arquillian>1.0.0.CR1</version.org.wildfly.arquillian>
         <version.org.yaml.snakeyaml>1.15</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11</version.sun.jaxb>


### PR DESCRIPTION
I've added the Hold label to this as our ongoing nexus issues mean the 1.0.0.CR3 release is not reliably downloadable.
