### PR TITLE
Use Elytron instead of the WildFly Security Manager project.

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -55,7 +55,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/batch/pom.xml
+++ b/batch/pom.xml
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <!-- test -->

--- a/bean-validation/pom.xml
+++ b/bean-validation/pom.xml
@@ -83,7 +83,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/clustering/infinispan/spi/pom.xml
+++ b/clustering/infinispan/spi/pom.xml
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.infinispan</groupId>

--- a/clustering/marshalling/pom.xml
+++ b/clustering/marshalling/pom.xml
@@ -53,7 +53,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/clustering/web/infinispan/pom.xml
+++ b/clustering/web/infinispan/pom.xml
@@ -64,7 +64,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/ee/pom.xml
+++ b/ee/pom.xml
@@ -103,7 +103,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.spec.javax.interceptor</groupId>

--- a/ejb3/pom.xml
+++ b/ejb3/pom.xml
@@ -93,7 +93,7 @@ vi:ts=4:sw=4:expandtab
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/embedded/pom.xml
+++ b/embedded/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.jboss.jts"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.logging"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="com.google.guava"/>
         <module name="com.h2database.h2" optional="true"/>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/appclient/main/module.xml
@@ -71,7 +71,7 @@
         <module name="org.jboss.as.protocol"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.security"/>
-        <module name="org.wildfly.security.manager" services="import"/>
+        <module name="org.wildfly.security.elytron" services="import"/>
         <module name="org.jboss.as.version"/>
         <module name="org.picketbox"/>
         <module name="org.jboss.metadata.common"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/infinispan/main/module.xml
@@ -68,6 +68,6 @@
         <module name="org.wildfly.clustering.jgroups.spi"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.spi"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/jgroups/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/clustering/jgroups/main/module.xml
@@ -52,6 +52,6 @@
         <module name="org.wildfly.clustering.jgroups.spi"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.spi"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/connector/main/module.xml
@@ -46,7 +46,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.server" />
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.security" />
         <module name="org.jboss.as.ee" />
         <module name="org.jboss.as.threads"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -66,7 +66,7 @@
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.remoting"/>
         <module name="org.jboss.as.security"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.threads"/>
         <module name="org.jboss.as.transactions"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/embedded/main/module.xml
@@ -36,7 +36,7 @@
     </resources>
 
     <dependencies>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.controller-client"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jacorb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jacorb/main/module.xml
@@ -42,7 +42,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jaxrs/main/module.xml
@@ -42,7 +42,7 @@
         <module name="javax.servlet.api"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.web-common"/>
         <module name="org.wildfly.extension.undertow"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jdr/main/module.xml
@@ -47,7 +47,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.cli"/>
         <module name="org.jboss.modules"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
@@ -57,7 +57,7 @@
         <module name="org.jboss.as.ejb3"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.threads"/>
         <module name="org.jboss.as.transactions"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsf/main/module.xml
@@ -40,7 +40,7 @@
         <module name="org.wildfly.extension.bean-validation"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.as.weld"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
@@ -40,7 +40,7 @@
         <module name="org.jboss.as.ejb3"/>
         <module name="org.jboss.as.jmx"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.version"/>
         <module name="org.jboss.invocation"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -50,7 +50,7 @@
         <module name="org.jboss.as.network"/>
         <!-- required only to access the HttpListenerRegistryService used by http-acceptor -->
         <module name="org.jboss.as.remoting" optional="true"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.weld"/>
         <module name="org.jboss.jandex"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/pojo/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/pojo/main/module.xml
@@ -40,7 +40,7 @@
         <module name="org.jboss.common-beans"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/sar/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/sar/main/module.xml
@@ -40,7 +40,7 @@
         <module name="org.jboss.common-beans" services="import"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.jmx"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -58,7 +58,7 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.security"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.threads"/>
         <module name="org.jboss.modules"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -61,7 +61,7 @@
         <module name="org.jboss.as.jpa"/>
         <module name="org.jboss.as.jpa.spi"/>
         <module name="org.jboss.as.naming"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.security"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.transactions"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -42,7 +42,7 @@
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.as.controller"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.deployment-repository"/>
         <module name="org.jboss.as.transactions"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/ejb/infinispan/main/module.xml
@@ -57,6 +57,6 @@
         <module name="org.wildfly.clustering.server" services="import"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.spi"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/infinispan/spi/main/module.xml
@@ -40,7 +40,7 @@
         <!--module name="org.wildfly.clustering.jgroups.api"/-->
         <module name="org.wildfly.clustering.marshalling"/>
         <module name="org.wildfly.clustering.service"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.msc"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/marshalling/main/module.xml
@@ -36,6 +36,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.modules"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/server/main/module.xml
@@ -56,6 +56,6 @@
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.singleton"/>
         <module name="org.wildfly.clustering.spi"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/service/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/service/main/module.xml
@@ -37,6 +37,6 @@
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
         <module name="org.jboss.threads"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
@@ -58,6 +58,6 @@
         <module name="org.wildfly.clustering.spi"/>
         <module name="org.wildfly.clustering.web.api"/>
         <module name="org.wildfly.clustering.web.spi"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/batch/main/module.xml
@@ -49,6 +49,6 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.vfs"/>
         <module name="org.wildfly.jberet" services="import"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/bean-validation/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/bean-validation/main/module.xml
@@ -45,7 +45,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming" />
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server" />
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
@@ -38,7 +38,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/jberet/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/jberet/main/module.xml
@@ -41,6 +41,6 @@
         <module name="org.jboss.logging"/>
         <module name="org.jboss.msc"/>
         <module name="org.picketbox"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/mod_cluster/undertow/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/mod_cluster/undertow/main/module.xml
@@ -48,7 +48,7 @@
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.extension.mod_cluster"/>
         <module name="org.wildfly.extension.undertow"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="sun.jdk"/>
     </dependencies>
 </module>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -50,7 +50,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -87,7 +87,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-injection-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-injection-module.xml
@@ -42,7 +42,7 @@
         <module name="javax.enterprise.api"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.weld.core"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
 
         <module name="javax.faces.api" slot="${jsf-impl-name}-${jsf-version}"/>
     </dependencies>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -49,7 +49,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/naming/pom.xml
+++ b/naming/pom.xml
@@ -39,7 +39,7 @@
     <dependencies>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss</groupId>

--- a/pojo/pom.xml
+++ b/pojo/pom.xml
@@ -51,7 +51,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
              <groupId>org.jboss.common</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6202,6 +6202,12 @@
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-protocol-jmx</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wildfly.security</groupId>
+                        <artifactId>wildfly-security-manager</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -514,6 +514,8 @@
                                             <exclude>org.slf4j:slf4j-jdk14</exclude>
                                             <exclude>org.slf4j:slf4j-log4j12</exclude>
                                             <exclude>org.slf4j:slf4j-log4j13</exclude>
+                                            <!-- replaced by wildfly-elytron -->
+                                            <exclude>org.wildfly.security:wildfly-security-manager</exclude>
                                             <exclude>oro:oro</exclude>
                                             <exclude>relaxngDatatype:relaxngDatatype</exclude>
                                             <exclude>stax:stax-api</exclude>

--- a/sar/pom.xml
+++ b/sar/pom.xml
@@ -79,7 +79,7 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>

--- a/security/subsystem/pom.xml
+++ b/security/subsystem/pom.xml
@@ -78,7 +78,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>

--- a/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
+++ b/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ee/main/module.xml
@@ -46,7 +46,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming" optional="true"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.wildfly.extension.request-controller" />
         <module name="org.jboss.as.server" />
         <module name="org.jboss.invocation"/>

--- a/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
+++ b/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/naming/main/module.xml
@@ -36,7 +36,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.remoting"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.invocation"/>
         <module name="org.jboss.modules"/>

--- a/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
+++ b/web-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/security/main/module.xml
@@ -47,7 +47,7 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.domain-management"/>
         <module name="org.jboss.as.ee"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.transactions" optional="true"/>

--- a/web-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/web-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -57,7 +57,7 @@
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.security"/>
-        <module name="org.wildfly.security.manager"/>
+        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.threads"/>
         <module name="org.jboss.common-beans" services="import"/>

--- a/webservices/server-integration/pom.xml
+++ b/webservices/server-integration/pom.xml
@@ -51,7 +51,7 @@
 
     <dependency>
        <groupId>org.wildfly.security</groupId>
-       <artifactId>wildfly-security-manager</artifactId>
+       <artifactId>wildfly-elytron</artifactId>
     </dependency>
 
     <dependency>

--- a/weld/pom.xml
+++ b/weld/pom.xml
@@ -103,7 +103,7 @@
 
         <dependency>
             <groupId>org.wildfly.security</groupId>
-            <artifactId>wildfly-security-manager</artifactId>
+            <artifactId>wildfly-elytron</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The WildFly Security Manager API is an exact subset of the Elytron API, and has been absorbed by that project.
