### PR TITLE
WFLY-4635 non-public post-activate and pre-passivate SFSB methods are…

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentConfigurator.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/DefaultComponentConfigurator.java
@@ -97,8 +97,8 @@ class DefaultComponentConfigurator extends AbstractComponentConfigurator impleme
 
 
                     if (description.isPassivationApplicable()) {
-                        handleClassMethod(clazz, interceptorConfig.getPrePassivate(), componentUserPrePassivate, false, false, configuration);
-                        handleClassMethod(clazz, interceptorConfig.getPostActivate(), componentUserPostActivate, false, false, configuration);
+                        handleClassMethod(clazz, interceptorConfig.getPrePassivate(), componentUserPrePassivate, false, true, configuration);
+                        handleClassMethod(clazz, interceptorConfig.getPostActivate(), componentUserPostActivate, false, true, configuration);
                     }
                 }
             }


### PR DESCRIPTION
… proper lifecycle callbacks too

SFSB PostActivate and PrePassivate methods can be non-public and still have to be executed in a transactional context defined by TransactionAttribute.
Test coverage is going to be provided by WFLY-4608.

https://issues.jboss.org/browse/WFLY-4635
