### PR TITLE
Revert "[WFLY-3532] Re-instate RemoteFailoverTestCase"

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -275,6 +275,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
         }
     }
 
+    @Ignore("re-enable when WFLY-3532 resoolved")
     @Test
     public void testConcurrentFailover() throws Exception {
         ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);


### PR DESCRIPTION
This reverts commit 818a803359764c53ebcd68b72d405ba6b9660e59.

Test fails repeatedly. See Paul Ferraro for details.
