### PR TITLE
Add EAP6.2 transformers w/ tests and remove legacy from ejb3 & jca subsystems 

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourcesSubsystemRootDefinition.java
@@ -96,11 +96,20 @@ public class DataSourcesSubsystemRootDefinition extends SimpleResourceDefinition
     }
 
     static void registerTransformers(SubsystemRegistration subsystem) {
-        TransformationDescription.Tools.register(get110TransformationDescription(), subsystem, ModelVersion.create(1, 1, 0));
-        TransformationDescription.Tools.register(get111TransformationDescription(), subsystem, ModelVersion.create(1, 1, 1));
+        TransformationDescription.Tools.register(get120TransformationDescription(), subsystem, ModelVersion.create(1, 2, 0)); //EAP 6.2.0
         TransformationDescription.Tools.register(get200TransformationDescription(), subsystem, ModelVersion.create(2, 0, 0));
     }
 
+
+    static TransformationDescription get120TransformationDescription() {
+
+        ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+        //No change
+        //JdbcDriverDefinition.registerTransformers110(builder);
+        DataSourceDefinition.registerTransformers120(builder);
+        XaDataSourceDefinition.registerTransformers120(builder);
+        return builder.build();
+    }
 
     static TransformationDescription get200TransformationDescription() {
 
@@ -109,24 +118,6 @@ public class DataSourcesSubsystemRootDefinition extends SimpleResourceDefinition
         //JdbcDriverDefinition.registerTransformers110(builder);
         DataSourceDefinition.registerTransformers200(builder);
         XaDataSourceDefinition.registerTransformers200(builder);
-        return builder.build();
-    }
-
-    static TransformationDescription get110TransformationDescription() {
-
-        ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        JdbcDriverDefinition.registerTransformers110(builder);
-        DataSourceDefinition.registerTransformers110(builder);
-        XaDataSourceDefinition.registerTransformers110(builder);
-        return builder.build();
-    }
-
-    static TransformationDescription get111TransformationDescription() {
-
-        ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        JdbcDriverDefinition.registerTransformers111(builder);
-        DataSourceDefinition.registerTransformers111(builder);
-        XaDataSourceDefinition.registerTransformers111(builder);
         return builder.build();
     }
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceDefinition.java
@@ -25,14 +25,9 @@
 package org.jboss.as.connector.subsystems.datasources;
 
 import static org.jboss.as.connector.subsystems.datasources.Constants.CONNECTABLE;
-import static org.jboss.as.connector.subsystems.datasources.Constants.CONNECTION_LISTENER_CLASS;
-import static org.jboss.as.connector.subsystems.datasources.Constants.CONNECTION_LISTENER_PROPERTIES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_DISABLE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_ENABLE;
-import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_PROPERTIES_ATTRIBUTES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DUMP_QUEUED_THREADS;
-import static org.jboss.as.connector.subsystems.datasources.Constants.ENABLE_ADD_TRANSFORMER;
-import static org.jboss.as.connector.subsystems.datasources.Constants.ENABLE_TRANSFORMER;
 import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_ALL_CONNECTION;
 import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_GRACEFULLY_CONNECTION;
 import static org.jboss.as.connector.subsystems.datasources.Constants.FLUSH_IDLE_CONNECTION;
@@ -60,7 +55,6 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.constraint.ApplicationTypeConfig;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.ApplicationTypeAccessConstraintDefinition;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.TransformationContext;
@@ -165,20 +159,11 @@ public class XaDataSourceDefinition extends SimpleResourceDefinition {
         return accessConstraints;
     }
 
-    static void registerTransformers110(ResourceTransformationDescriptionBuilder parentBuilder) {
-        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PATH_XA_DATASOURCE)
-                .getAttributeBuilder()
-                .setDiscard(DiscardAttributeChecker.UNDEFINED,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES, CONNECTION_LISTENER_CLASS,
-                        CONNECTION_LISTENER_PROPERTIES,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE
-                )
+    static void registerTransformers120(ResourceTransformationDescriptionBuilder parentBuilder) {
+        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PATH_XA_DATASOURCE);
+        builder.getAttributeBuilder()
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), CONNECTABLE)
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, false, new ModelNode(true)), STATISTICS_ENABLED)
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, TRACKING)
                 .addRejectCheck(new RejectAttributeChecker.DefaultRejectAttributeChecker() {
 
                     @Override
@@ -193,104 +178,13 @@ public class XaDataSourceDefinition extends SimpleResourceDefinition {
                         return !attributeValue.isDefined() || !attributeValue.asString().equals("true");
                     }
                 }, STATISTICS_ENABLED)
-                .addRejectCheck(RejectAttributeChecker.DEFINED,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES, CONNECTION_LISTENER_CLASS,
-                        CONNECTION_LISTENER_PROPERTIES,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE,
-                        Constants.URL_PROPERTY, CONNECTABLE, TRACKING
-                )
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, DATASOURCE_PROPERTIES_ATTRIBUTES)
-                 /*These are nillable in the old model, but appear as not nillable in CompareModelUtils due to problems in the resource description
-                  (leave the line commented out so no one else gets confused)
-                  .addRejectCheck(RejectAttributeChecker.UNDEFINED, Constants.EXCEPTION_SORTER_PROPERTIES, Constants.REAUTHPLUGIN_PROPERTIES, Constants.STALE_CONNECTION_CHECKER_PROPERTIES, Constants.VALID_CONNECTION_CHECKER_PROPERTIES)*/
-                        //Reject expressions for enabled, since if they are used we don't know their value for the operation transformer override
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, Constants.ENABLED)
-                .end()
-                .addOperationTransformationOverride(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION)
-                    .inheritResourceAttributeDefinitions()
-                    .setCustomOperationTransformer(ENABLE_TRANSFORMER)
-                    .end()
-                .addOperationTransformationOverride(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION)
-                    .inheritResourceAttributeDefinitions()
-                    .setCustomOperationTransformer(ENABLE_TRANSFORMER)
-                    .end()
-                .addOperationTransformationOverride(ModelDescriptionConstants.ADD)
-                    .inheritResourceAttributeDefinitions()
-                    .setCustomOperationTransformer(ENABLE_ADD_TRANSFORMER)
-                    .end()
-                //We're rejecting operations when statistics-enabled=false, so let it through in the enable/disable ops which do not use that attribute
-                .addOperationTransformationOverride(DATASOURCE_ENABLE.getName())
-                .end()
-                .addOperationTransformationOverride(DATASOURCE_DISABLE.getName())
-                .end();
-
-        ConnectionPropertyDefinition.registerTransformers11x(builder);
-    }
-
-    static void registerTransformers111(ResourceTransformationDescriptionBuilder parentBuilder) {
-        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PATH_XA_DATASOURCE);
-        builder.getAttributeBuilder()
-                .setDiscard(DiscardAttributeChecker.UNDEFINED,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES, CONNECTION_LISTENER_CLASS,
-                        CONNECTION_LISTENER_PROPERTIES,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS,
-                        Constants.CONNECTION_PROPERTIES,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES,
-                        org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE
-                )
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), CONNECTABLE)
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, false, new ModelNode(true)), STATISTICS_ENABLED)
                 .setDiscard(DiscardAttributeChecker.UNDEFINED, TRACKING)
-                .addRejectCheck(new RejectAttributeChecker.DefaultRejectAttributeChecker() {
-
-                    @Override
-                    public String getRejectionLogMessage(Map<String, ModelNode> attributes) {
-                        return ConnectorLogger.ROOT_LOGGER.rejectAttributesMustBeTrue(attributes.keySet());
-                    }
-
-                    @Override
-                    protected boolean rejectAttribute(PathAddress address, String attributeName, ModelNode attributeValue,
-                                                      TransformationContext context) {
-                        //This will not get called if it was discarded, so reject if it is undefined (default==false) or if defined and != 'true'
-                        return !attributeValue.isDefined() || !attributeValue.asString().equals("true");
-                    }
-                }, STATISTICS_ENABLED).addRejectCheck(RejectAttributeChecker.DEFINED,
-                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES, CONNECTION_LISTENER_CLASS,
-                CONNECTION_LISTENER_PROPERTIES,
-                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS,
-                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS,
-                Constants.CONNECTION_PROPERTIES,
-                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES,
-                org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE,
-                Constants.URL_PROPERTY, CONNECTABLE, TRACKING
-        )
-                //Reject expressions for enabled, since if they are used we don't know their value for the operation transformer override
-                //Although 'enabled' appears in the legacy model and the 'add' handler, the add does not actually set its value in the model
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, Constants.ENABLED)
-                .end()
-                .addOperationTransformationOverride(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION)
-                    .inheritResourceAttributeDefinitions()
-                    .setCustomOperationTransformer(ENABLE_TRANSFORMER)
-                    .end()
-                .addOperationTransformationOverride(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION)
-                    .inheritResourceAttributeDefinitions()
-                    .setCustomOperationTransformer(ENABLE_TRANSFORMER)
-                    .end()
-                .addOperationTransformationOverride(ModelDescriptionConstants.ADD)
-                    .inheritResourceAttributeDefinitions()
-                    .setCustomOperationTransformer(ENABLE_ADD_TRANSFORMER)
-                    .end()
+                .addRejectCheck(RejectAttributeChecker.DEFINED, TRACKING).end()
                 //We're rejecting operations when statistics-enabled=false, so let it through in the enable/disable ops which do not use that attribute
                 .addOperationTransformationOverride(DATASOURCE_ENABLE.getName())
                 .end()
                 .addOperationTransformationOverride(DATASOURCE_DISABLE.getName())
                 .end();
-
-        ConnectionPropertyDefinition.registerTransformers11x(builder);
     }
 
     static void registerTransformers200(ResourceTransformationDescriptionBuilder parentBuilder) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
@@ -81,19 +81,8 @@ public class JcaSubsystemRootDefinition extends SimpleResourceDefinition {
     }
 
     static void registerTransformers(SubsystemRegistration subsystem) {
-        ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        JcaWorkManagerDefinition.registerTransformers110(builder);
-        JcaCachedConnectionManagerDefinition.registerTransformers110(builder);
-        builder.rejectChildResource(JcaDistributedWorkManagerDefinition.PATH_DISTRIBUTED_WORK_MANAGER);
-        builder.discardChildResource(TracerDefinition.PATH_TRACER);
-        TransformationDescription.Tools.register(builder.build(), subsystem, ModelVersion.create(1, 1, 0));
-        ResourceTransformationDescriptionBuilder builder12 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        builder12.rejectChildResource(JcaDistributedWorkManagerDefinition.PATH_DISTRIBUTED_WORK_MANAGER);
-        builder12.discardChildResource(TracerDefinition.PATH_TRACER);
-        TransformationDescription.Tools.register(builder12.build(), subsystem, ModelVersion.create(1, 2, 0));
         ResourceTransformationDescriptionBuilder builder20 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         builder20.discardChildResource(TracerDefinition.PATH_TRACER);
         TransformationDescription.Tools.register(builder20.build(), subsystem, ModelVersion.create(2, 0, 0));
-
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaSubsystemRootDefinition.java
@@ -81,8 +81,13 @@ public class JcaSubsystemRootDefinition extends SimpleResourceDefinition {
     }
 
     static void registerTransformers(SubsystemRegistration subsystem) {
+        ResourceTransformationDescriptionBuilder builder12 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+        builder12.rejectChildResource(JcaDistributedWorkManagerDefinition.PATH_DISTRIBUTED_WORK_MANAGER);
+        builder12.discardChildResource(TracerDefinition.PATH_TRACER);
+        TransformationDescription.Tools.register(builder12.build(), subsystem, ModelVersion.create(1, 2, 0));
         ResourceTransformationDescriptionBuilder builder20 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         builder20.discardChildResource(TracerDefinition.PATH_TRACER);
         TransformationDescription.Tools.register(builder20.build(), subsystem, ModelVersion.create(2, 0, 0));
+
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaWorkManagerDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/jca/JcaWorkManagerDefinition.java
@@ -22,6 +22,10 @@
 
 package org.jboss.as.connector.subsystems.jca;
 
+import static org.jboss.as.connector.subsystems.jca.Constants.WORKMANAGER;
+import static org.jboss.as.connector.subsystems.jca.Constants.WORKMANAGER_LONG_RUNNING;
+import static org.jboss.as.connector.subsystems.jca.Constants.WORKMANAGER_SHORT_RUNNING;
+
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
@@ -31,14 +35,9 @@ import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.threads.BoundedQueueThreadPoolResourceDefinition;
 import org.jboss.as.threads.ThreadsServices;
 import org.jboss.dmr.ModelType;
-
-import static org.jboss.as.connector.subsystems.jca.Constants.WORKMANAGER;
-import static org.jboss.as.connector.subsystems.jca.Constants.WORKMANAGER_LONG_RUNNING;
-import static org.jboss.as.connector.subsystems.jca.Constants.WORKMANAGER_SHORT_RUNNING;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2012 Red Hat Inc.
@@ -79,14 +78,7 @@ public class JcaWorkManagerDefinition extends SimpleResourceDefinition {
 
     }
 
-    static void registerTransformers110(ResourceTransformationDescriptionBuilder parentBuilder) {
-
-        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PATH_WORK_MANAGER);
-        BoundedQueueThreadPoolResourceDefinition.registerTransformers1_0(builder, WORKMANAGER_SHORT_RUNNING);
-        BoundedQueueThreadPoolResourceDefinition.registerTransformers1_0(builder, WORKMANAGER_LONG_RUNNING);
-    }
-
-    public static enum WmParameters {
+    public enum WmParameters {
         NAME(SimpleAttributeDefinitionBuilder.create("name", ModelType.STRING)
                 .setAllowExpression(false)
                 .setAllowNull(false)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionResourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ConnectionDefinitionResourceDefinition.java
@@ -21,15 +21,8 @@
 */
 package org.jboss.as.connector.subsystems.resourceadapters;
 
-import static org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS;
-import static org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES;
-import static org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS;
-import static org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES;
-import static org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE;
 import static org.jboss.as.connector.subsystems.common.pool.Constants.VALIDATE_ON_MATCH;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.CONNECTIONDEFINITIONS_NAME;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.ENLISTMENT;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SHARABLE;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
 
 import org.jboss.as.connector.subsystems.common.pool.PoolOperations;
@@ -122,7 +115,7 @@ public class ConnectionDefinitionResourceDefinition extends SimpleResourceDefini
 
     }
 
-    static void registerTransformer120(ResourceTransformationDescriptionBuilder parentBuilder) {
+    static void registerTransformer130(ResourceTransformationDescriptionBuilder parentBuilder) {
         parentBuilder.addChildResource(PATH).getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.ALWAYS, Constants.ENLISTMENT, Constants.SHARABLE, org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE,
                 org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS, org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS,
@@ -130,25 +123,5 @@ public class ConnectionDefinitionResourceDefinition extends SimpleResourceDefini
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), Constants.CONNECTABLE)
                 .setDiscard(DiscardAttributeChecker.UNDEFINED, TRACKING, VALIDATE_ON_MATCH)
                 .addRejectCheck(RejectAttributeChecker.DEFINED, Constants.CONNECTABLE, Constants.TRACKING, VALIDATE_ON_MATCH);
-    }
-
-    static void registerTransformer110(ResourceTransformationDescriptionBuilder parentBuilder) {
-        parentBuilder.addChildResource(PATH).getAttributeBuilder()
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, Constants.SECURITY_DOMAIN, Constants.SECURITY_DOMAIN_AND_APPLICATION, Constants.APPLICATION,
-                        CAPACITY_DECREMENTER_CLASS, CAPACITY_INCREMENTER_CLASS,
-                        INITIAL_POOL_SIZE, CAPACITY_DECREMENTER_PROPERTIES, CAPACITY_INCREMENTER_PROPERTIES)
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), ENLISTMENT, SHARABLE)
-                        .addRejectCheck(RejectAttributeChecker.DEFINED, Constants.SECURITY_DOMAIN, Constants.SECURITY_DOMAIN_AND_APPLICATION, Constants.APPLICATION,
-                                CAPACITY_DECREMENTER_CLASS, CAPACITY_INCREMENTER_CLASS,
-                                INITIAL_POOL_SIZE, CAPACITY_DECREMENTER_PROPERTIES, CAPACITY_INCREMENTER_PROPERTIES)
-                        .addRejectCheck(RejectAttributeChecker.UNDEFINED, ENLISTMENT, SHARABLE)
-                        .addRejectCheck(new RejectAttributeChecker.SimpleAcceptAttributeChecker(new ModelNode(true)), ENLISTMENT, SHARABLE)
-                                //Did not use to be nillable
-                        .addRejectCheck(RejectAttributeChecker.UNDEFINED, Constants.RECOVERLUGIN_PROPERTIES)
-                        .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, Constants.RECOVERLUGIN_PROPERTIES)
-                        .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), Constants.CONNECTABLE)
-                        .setDiscard(DiscardAttributeChecker.UNDEFINED, TRACKING, VALIDATE_ON_MATCH)
-                        .addRejectCheck(RejectAttributeChecker.DEFINED, Constants.CONNECTABLE, Constants.TRACKING, VALIDATE_ON_MATCH);
-
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterResourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdapterResourceDefinition.java
@@ -114,7 +114,7 @@ public class ResourceAdapterResourceDefinition extends SimpleResourceDefinition 
         ConnectionDefinitionResourceDefinition.registerTransformer200(builder);
     }
 
-    static void registerTransformers120(ResourceTransformationDescriptionBuilder parentBuilder) {
+    static void registerTransformers130(ResourceTransformationDescriptionBuilder parentBuilder) {
         ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PathElement.pathElement(RESOURCEADAPTER_NAME))
                 .getAttributeBuilder()
                 .setDiscard(DiscardAttributeChecker.UNDEFINED, WM_SECURITY_MAPPING_USER, WM_SECURITY_MAPPING_GROUP,
@@ -128,29 +128,7 @@ public class ResourceAdapterResourceDefinition extends SimpleResourceDefinition 
                         WM_SECURITY_DOMAIN, STATISTICS_ENABLED)
                 .end();
 
-        ConnectionDefinitionResourceDefinition.registerTransformer120(builder);
-    }
-
-    static void registerTransformers110(ResourceTransformationDescriptionBuilder parentBuilder) {
-        ResourceTransformationDescriptionBuilder builder = parentBuilder.addChildResource(PathElement.pathElement(RESOURCEADAPTER_NAME)).getAttributeBuilder()
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, WM_SECURITY_MAPPING_USER, WM_SECURITY_MAPPING_GROUP,
-                        WM_SECURITY_MAPPING_GROUPS, WM_SECURITY_MAPPING_USERS, WM_SECURITY_DEFAULT_GROUP,
-                        WM_SECURITY_DEFAULT_GROUPS, WM_SECURITY_DEFAULT_PRINCIPAL)
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, new ModelNode(false)), WM_SECURITY, WM_SECURITY_MAPPING_REQUIRED, STATISTICS_ENABLED)
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(false, true, new ModelNode("other")), WM_SECURITY_DOMAIN)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, WM_SECURITY, WM_SECURITY_MAPPING_USER, WM_SECURITY_MAPPING_GROUP,
-                        WM_SECURITY_MAPPING_GROUPS, WM_SECURITY_MAPPING_USERS, WM_SECURITY_DEFAULT_GROUP,
-                        WM_SECURITY_DEFAULT_GROUPS, WM_SECURITY_DEFAULT_PRINCIPAL, WM_SECURITY_MAPPING_REQUIRED,
-                        WM_SECURITY_DOMAIN, STATISTICS_ENABLED)
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, Constants.MODULE)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, Constants.MODULE)
-                //These used to be non-nillable so reject if undefined
-                .addRejectCheck(RejectAttributeChecker.UNDEFINED, Constants.BEANVALIDATIONGROUP, Constants.ARCHIVE)
-                //Expressions not allowed
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, Constants.BEANVALIDATIONGROUP, Constants.ARCHIVE)
-                .end();
-
-        ConnectionDefinitionResourceDefinition.registerTransformer110(builder);
+        ConnectionDefinitionResourceDefinition.registerTransformer130(builder);
     }
 
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersRootResourceDefinition.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersRootResourceDefinition.java
@@ -58,14 +58,9 @@ public class ResourceAdaptersRootResourceDefinition extends SimpleResourceDefini
     }
 
     static void registerTransformers(SubsystemRegistration subsystem) {
-        ResourceTransformationDescriptionBuilder builder110 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        ResourceAdapterResourceDefinition.registerTransformers110(builder110);
-        TransformationDescription.Tools.register(builder110.build(), subsystem, ModelVersion.create(1, 1, 0));
-        ResourceTransformationDescriptionBuilder builder120 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        ResourceAdapterResourceDefinition.registerTransformers120(builder120);
-        TransformationDescription.Tools.register(builder120.build(), subsystem, ModelVersion.create(1, 2, 0));
-        // Apply same to RBAC-updated version
-        TransformationDescription.Tools.register(builder120.build(), subsystem, ModelVersion.create(1, 3, 0));
+        ResourceTransformationDescriptionBuilder builder130 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
+        ResourceAdapterResourceDefinition.registerTransformers130(builder130);
+        TransformationDescription.Tools.register(builder130.build(), subsystem, ModelVersion.create(1, 3, 0));
         ResourceTransformationDescriptionBuilder builder200 = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         ResourceAdapterResourceDefinition.registerTransformers200(builder200);
         TransformationDescription.Tools.register(builder200.build(), subsystem, ModelVersion.create(2, 0, 0));

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/datasources/DatasourcesSubsystemTestCase.java
@@ -21,27 +21,13 @@
 */
 package org.jboss.as.connector.subsystems.datasources;
 
-import static org.jboss.as.connector.subsystems.datasources.Constants.CONNECTION_LISTENER_CLASS;
-import static org.jboss.as.connector.subsystems.datasources.Constants.CONNECTION_LISTENER_PROPERTIES;
-import static org.jboss.as.connector.subsystems.datasources.Constants.URL_DELIMITER;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
-import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.transform.OperationTransformer.TransformedOperation;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
-import org.jboss.as.model.test.FailedOperationTransformationConfig.AttributesPathAddressConfig;
-import org.jboss.as.model.test.FailedOperationTransformationConfig.ChainedConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.model.test.SingleClassFilter;
@@ -52,7 +38,6 @@ import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.as.subsystem.test.LegacyKernelServicesInitializer;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 
@@ -61,13 +46,6 @@ import org.junit.Test;
  * @author <a href="stefano.maestri@redhat.com>Stefano Maestri</a>
  */
 public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
-
-    static final AttributeDefinition[] ALL_DS_ATTRIBUTES_REJECTED_1_1_0  = new AttributeDefinition[Constants.DATASOURCE_PROPERTIES_ATTRIBUTES.length + 2];
-    static {
-        System.arraycopy(Constants.DATASOURCE_PROPERTIES_ATTRIBUTES, 0, ALL_DS_ATTRIBUTES_REJECTED_1_1_0, 0, Constants.DATASOURCE_PROPERTIES_ATTRIBUTES.length);
-        ALL_DS_ATTRIBUTES_REJECTED_1_1_0[Constants.DATASOURCE_PROPERTIES_ATTRIBUTES.length] = Constants.CONNECTABLE;
-        ALL_DS_ATTRIBUTES_REJECTED_1_1_0[Constants.DATASOURCE_PROPERTIES_ATTRIBUTES.length + 1] = Constants.STATISTICS_ENABLED;
-    }
 
     public DatasourcesSubsystemTestCase() {
         super(DataSourcesExtension.SUBSYSTEM_NAME, new DataSourcesExtension());
@@ -86,7 +64,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String[] getSubsystemTemplatePaths() throws IOException {
-        return new String[] {
+        return new String[]{
                 "/subsystem-templates/datasources.xml"
         };
     }
@@ -106,52 +84,20 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testTransformerAS712() throws Exception {
-        testRejectTransformers1_1_0("datasources-full110.xml", ModelTestControllerVersion.V7_1_2_FINAL);
+    public void testTransformerEAP62() throws Exception {
+        testTransformer("datasources-full.xml", ModelTestControllerVersion.EAP_6_2_0, ModelVersion.create(1, 2, 0));
     }
 
     @Test
-    public void testTransformerAS713() throws Exception {
-        testRejectTransformers1_1_0("datasources-full110.xml", ModelTestControllerVersion.V7_1_3_FINAL);
+    public void testTransformerExpressionEAP62() throws Exception {
+        testTransformer("datasources-full-expression111.xml", ModelTestControllerVersion.EAP_6_2_0, ModelVersion.create(1, 2, 0));
     }
+
 
     @Test
-    public void testTransformerAS720() throws Exception {
-        testTransformer("datasources-full-no-tracking.xml", ModelTestControllerVersion.V7_2_0_FINAL, ModelVersion.create(1, 1, 1));
+    public void testTransformerWF8() throws Exception {
+        testTransformer("datasources-full.xml", ModelTestControllerVersion.WILDFLY_8_0_0_FINAL, ModelVersion.create(2, 0, 0));
     }
-
-    @Test
-    public void testTransformerExpressionAS720() throws Exception {
-        testTransformer("datasources-full-expression111.xml", ModelTestControllerVersion.V7_2_0_FINAL, ModelVersion.create(1, 1, 1));
-    }
-
-    @Test @Ignore("The improved model validation breaks this test. We no longer worry about transformation to 7.2.0, so I (Kabir) am @Ignoring it rather than trying to fix")
-    public void testTransformerRejectingAS720() throws Exception {
-        testRejectTransformers1_1_1("wildfly-datasources_2_0.xml", ModelTestControllerVersion.V7_2_0_FINAL);
-    }
-
-    @Test
-    public void tesExpressionsAS712() throws Exception {
-        //this file contain expression for all supported fields except reauth-plugin-properties, exception-sorter-properties,
-        // stale-connection-checker-properties, valid-connection-checker-properties, recovery-plugin-properties
-        // for a limitation in test suite not permitting to have expression in type LIST or OBJECT for legacyServices
-        testRejectTransformers1_1_0("datasources-full-expression110.xml", ModelTestControllerVersion.V7_1_2_FINAL);
-    }
-
-    @Test
-    public void testExpressionsAS713() throws Exception {
-        //this file contain expression for all supported fields except reauth-plugin-properties, exception-sorter-properties,
-        // stale-connection-checker-properties, valid-connection-checker-properties, recovery-plugin-properties
-        // for a limitation in test suite not permitting to have expression in type LIST or OBJECT for legacyServices
-        testRejectTransformers1_1_0("datasources-full-expression110.xml", ModelTestControllerVersion.V7_1_3_FINAL);
-    }
-
-    @Test
-        public void testTransformerWF8() throws Exception {
-            testTransformer("datasources-full-no-tracking.xml", ModelTestControllerVersion.WILDFLY_8_0_0_FINAL, ModelVersion.create(2, 0, 0));
-        }
-
-
 
 
     /**
@@ -165,7 +111,7 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
 
 
         // Add legacy subsystems
-        LegacyKernelServicesInitializer initializer =builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion);
+        LegacyKernelServicesInitializer initializer = builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion);
         if (controllerVersion.equals(ModelTestControllerVersion.WILDFLY_8_0_0_FINAL)) {
             initializer.addMavenResourceURL("org.wildfly:wildfly-connector:" + controllerVersion.getMavenGavVersion());
         } else {
@@ -186,231 +132,8 @@ public class DatasourcesSubsystemTestCase extends AbstractSubsystemBaseTest {
         PathAddress subsystemAddress = PathAddress.pathAddress(DataSourcesSubsystemRootDefinition.PATH_SUBSYSTEM);
 
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops, new FailedOperationTransformationConfig()
-                        .addFailedAttribute(subsystemAddress.append(DataSourceDefinition.PATH_DATASOURCE), FAILED_TRANSFORMER_2_0_0)
-                        .addFailedAttribute(subsystemAddress.append(XaDataSourceDefinition.PATH_XA_DATASOURCE), FAILED_TRANSFORMER_2_0_0)
+                        .addFailedAttribute(subsystemAddress.append(DataSourceDefinition.PATH_DATASOURCE), new FailedOperationTransformationConfig.NewAttributesConfig(Constants.TRACKING))
+                        .addFailedAttribute(subsystemAddress.append(XaDataSourceDefinition.PATH_XA_DATASOURCE), new FailedOperationTransformationConfig.NewAttributesConfig(Constants.TRACKING))
         );
-    }
-
-
-    public void testRejectTransformers1_1_0(String subsystemXml, ModelTestControllerVersion controllerVersion) throws Exception {
-        ModelVersion modelVersion = ModelVersion.create(1, 1, 0); //The old model version
-        //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
-
-        // Add legacy subsystems
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-connector:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL("org.jboss.ironjacamar:ironjacamar-spec-api:1.1.4.Final")
-                .addMavenResourceURL("org.jboss.ironjacamar:ironjacamar-common-api:1.1.4.Final")
-                .setExtensionClassName("org.jboss.as.connector.subsystems.datasources.DataSourcesExtension")
-                .excludeFromParent(SingleClassFilter.createFilter(ConnectorLogger.class));
-
-        KernelServices mainServices = builder.build();
-        assertTrue(mainServices.isSuccessfulBoot());
-        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
-        assertNotNull(legacyServices);
-        assertTrue(legacyServices.isSuccessfulBoot());
-
-        List<ModelNode> ops = builder.parseXmlResource(subsystemXml);
-        PathAddress subsystemAddress = PathAddress.pathAddress(DataSourcesSubsystemRootDefinition.PATH_SUBSYSTEM);
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops, new FailedOperationTransformationConfig()
-                .addFailedAttribute(subsystemAddress.append(JdbcDriverDefinition.PATH_DRIVER),
-                        new FailedOperationTransformationConfig.RejectExpressionsConfig(Constants.DRIVER_MINOR_VERSION, Constants.DRIVER_MAJOR_VERSION) {
-                            @Override
-                            protected boolean isAttributeWritable(String attributeName) {
-                                return false;
-                            }
-                        })
-                .addFailedAttribute(subsystemAddress.append(DataSourceDefinition.PATH_DATASOURCE), FAILED_TRANSFORMER_1_1_0)
-                .addFailedAttribute(subsystemAddress.append(XaDataSourceDefinition.PATH_XA_DATASOURCE), FAILED_TRANSFORMER_1_1_0)
-        );
-
-        checkCanEnableAndDisable(mainServices, modelVersion,
-                PathAddress.pathAddress(subsystemAddress.append(DataSourceDefinition.PATH_DATASOURCE)),
-                PathAddress.pathAddress(subsystemAddress.append(XaDataSourceDefinition.PATH_XA_DATASOURCE)));
-    }
-
-    public void testRejectTransformers1_1_1(String subsystemXml, ModelTestControllerVersion controllerVersion) throws Exception {
-            ModelVersion modelVersion = ModelVersion.create(1, 1, 1); //The old model version
-            //Use the non-runtime version of the extension which will happen on the HC
-            KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
-
-            // Add legacy subsystems
-            builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                    .addMavenResourceURL("org.jboss.as:jboss-as-connector:" + controllerVersion.getMavenGavVersion())
-                    .addMavenResourceURL("org.jboss.ironjacamar:ironjacamar-spec-api:1.1.4.Final")
-                    .addMavenResourceURL("org.jboss.ironjacamar:ironjacamar-common-api:1.1.4.Final")
-                    .setExtensionClassName("org.jboss.as.connector.subsystems.datasources.DataSourcesExtension")
-                    .excludeFromParent(SingleClassFilter.createFilter(ConnectorLogger.class))
-            .skipReverseControllerCheck();
-
-            KernelServices mainServices = builder.build();
-            assertTrue(mainServices.isSuccessfulBoot());
-            KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
-            assertNotNull(legacyServices);
-            assertTrue(legacyServices.isSuccessfulBoot());
-
-            List<ModelNode> ops = builder.parseXmlResource(subsystemXml);
-        PathAddress subsystemAddress = PathAddress.pathAddress(DataSourcesSubsystemRootDefinition.PATH_SUBSYSTEM);
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, modelVersion, ops, new FailedOperationTransformationConfig()
-                .addFailedAttribute(subsystemAddress.append(DataSourceDefinition.PATH_DATASOURCE),FAILED_TRANSFORMER_1_1_1)
-                .addFailedAttribute(subsystemAddress.append(XaDataSourceDefinition.PATH_XA_DATASOURCE), FAILED_TRANSFORMER_1_1_1)
-        );
-
-        checkCanEnableAndDisable(mainServices, modelVersion,
-                PathAddress.pathAddress(subsystemAddress.append(DataSourceDefinition.PATH_DATASOURCE)),
-                PathAddress.pathAddress(subsystemAddress.append(XaDataSourceDefinition.PATH_XA_DATASOURCE)));
-    }
-
-
-    private static FailedOperationTransformationConfig.ChainedConfig FAILED_TRANSFORMER_1_1_0 =
-            FailedOperationTransformationConfig.ChainedConfig.createBuilder(ALL_DS_ATTRIBUTES_REJECTED_1_1_0)
-            .addConfig(new FailedOperationTransformationConfig.RejectExpressionsConfig(Constants.DATASOURCE_PROPERTIES_ATTRIBUTES))
-            .addConfig(new SetToTrue(Constants.STATISTICS_ENABLED))
-            .build();
-
-    private static FailedOperationTransformationConfig.ChainedConfig FAILED_TRANSFORMER_2_0_0 =
-                FailedOperationTransformationConfig.ChainedConfig.createBuilder(Constants.TRACKING)
-                .addConfig(new SetToTrue(Constants.STATISTICS_ENABLED))
-                .build();
-
-    private static class NonWritableChainedConfig extends FailedOperationTransformationConfig.ChainedConfig {
-
-        public NonWritableChainedConfig(List<AttributesPathAddressConfig<?>> configs, String[] attributes) {
-            // FIXME NonWritableChainedConfig constructor
-            super(configs, attributes);
-        }
-
-        public static Builder createBuilder(final String...attributes) {
-            return new Builder() {
-                ArrayList<AttributesPathAddressConfig<?>> list = new ArrayList<FailedOperationTransformationConfig.AttributesPathAddressConfig<?>>();
-                @Override
-                public ChainedConfig build() {
-                    return new NonWritableChainedConfig(list, attributes);
-                }
-
-                @Override
-                public Builder addConfig(AttributesPathAddressConfig<?> cfg) {
-                    list.add(cfg);
-                    return this;
-                }
-            };
-        }
-
-        @Override
-        protected boolean isAttributeWritable(String attributeName) {
-            //TODO use the same old behaviour of not writable attributes (this is actually due to missing functionality in ChainedConfig)
-            return false;
-        }
-    }
-
-
-    private void checkCanEnableAndDisable(KernelServices services, ModelVersion modelVersion, PathAddress...pathAddresses) throws OperationFailedException {
-        final ModelNode success = new ModelNode();
-        success.get(ModelDescriptionConstants.OUTCOME).set(ModelDescriptionConstants.SUCCESS);
-        success.get(ModelDescriptionConstants.RESULT);
-        success.protect();
-
-        for (PathAddress address : pathAddresses) {
-            ModelNode enable = Util.createEmptyOperation("enable", address);
-            TransformedOperation transformedEnable = services.transformOperation(modelVersion, enable);
-            Assert.assertNotNull(transformedEnable.getTransformedOperation());
-            Assert.assertFalse(transformedEnable.getFailureDescription(), transformedEnable.rejectOperation(success));
-
-            ModelNode disable = Util.createEmptyOperation("disable", address);
-            TransformedOperation transformedDisable = services.transformOperation(modelVersion, disable);
-            Assert.assertNotNull(transformedDisable.getTransformedOperation());
-            Assert.assertFalse(transformedDisable.getFailureDescription(), transformedDisable.rejectOperation(success));
-        }
-
-    }
-
-    private static FailedOperationTransformationConfig.ChainedConfig FAILED_TRANSFORMER_1_1_1 = NonWritableChainedConfig.createBuilder(
-                                org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE.getName(),
-                                URL_DELIMITER.getName(), CONNECTION_LISTENER_CLASS.getName(), CONNECTION_LISTENER_PROPERTIES.getName(),
-                                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS.getName(),
-                                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS.getName(),
-                                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES.getName(),
-                        org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES.getName(), Constants.CONNECTABLE.getName()  )
-                        .addConfig(new FailedOperationTransformationConfig.AttributesPathAddressConfig(org.jboss.as.connector.subsystems.common.pool.Constants.INITIAL_POOL_SIZE.getName(),
-                                URL_DELIMITER.getName(), CONNECTION_LISTENER_CLASS.getName(), CONNECTION_LISTENER_PROPERTIES.getName(),
-                                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_CLASS.getName(), org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_CLASS.getName(),
-                                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES.getName(),
-                                org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES.getName(), Constants.TRACKING.getName()
-                        ) {
-
-                            @Override
-                            protected boolean isAttributeWritable(String attributeName) {
-                                return false;
-                            }
-
-                            @Override
-                            protected boolean checkValue(String attrName, ModelNode attribute, boolean isWriteAttribute) {
-                                if (attribute.isDefined()) {
-                                    return true;
-                                } else {
-                                    return false;
-                                }
-                            }
-
-                            @Override
-                            protected ModelNode correctValue(ModelNode toResolve, boolean isWriteAttribute) {
-                                return new ModelNode();
-                            }
-                        })
-                        .addConfig(new RejectExpressionsAndSetToTrue(Constants.CONNECTABLE))
-                        .addConfig(new SetToTrue(Constants.STATISTICS_ENABLED))
-                        .build();
-
-    private static class RejectExpressionsAndSetToTrue extends FailedOperationTransformationConfig.RejectExpressionsConfig {
-
-        public RejectExpressionsAndSetToTrue(AttributeDefinition... attributes) {
-            // FIXME RejectExpressionsAndSetToTrue constructor
-            super(attributes);
-        }
-
-        public RejectExpressionsAndSetToTrue(String... attributes) {
-            // FIXME RejectExpressionsAndSetToTrue constructor
-            super(attributes);
-        }
-
-        @Override
-        protected boolean checkValue(String attrName, ModelNode attribute, boolean isWriteAttribute) {
-            if (super.checkValue(attrName, attribute, isWriteAttribute)) {
-                return true;
-            }
-            return attribute.asBoolean();
-        }
-
-        @Override
-        protected ModelNode correctValue(ModelNode toResolve, boolean isWriteAttribute) {
-            return new ModelNode(false);
-        }
-    }
-
-    private static class SetToTrue extends FailedOperationTransformationConfig.AttributesPathAddressConfig<SetToTrue> {
-        public SetToTrue(AttributeDefinition... attributes) {
-            super(convert(attributes));
-        }
-
-        public SetToTrue(String... attributes) {
-            super(attributes);
-        }
-
-        @Override
-        protected boolean checkValue(String attrName, ModelNode attribute, boolean isWriteAttribute) {
-            //Fix if undefined or false
-            return !attribute.isDefined() || !attribute.asBoolean();
-        }
-
-        @Override
-        protected ModelNode correctValue(ModelNode toResolve, boolean isWriteAttribute) {
-            return new ModelNode(true);
-        }
-
-        @Override
-        protected boolean isAttributeWritable(String attributeName) {
-            return true;
-        }
     }
 }

--- a/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
+++ b/connector/src/test/java/org/jboss/as/connector/subsystems/resourceadapters/ResourceAdaptersSubsystemTestCase.java
@@ -74,7 +74,7 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
 
     @Override
     protected String[] getSubsystemTemplatePaths() throws IOException {
-        return new String[] {
+        return new String[]{
                 "/subsystem-templates/resource-adapters.xml",
                 "/subsystem-templates/resource-adapters-genericjms.xml"
         };
@@ -113,40 +113,17 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
     }
 
     @Test
-    public void testTransformerAS712() throws Exception {
-        testTransformer("resource-adapters-xapool.xml", ModelTestControllerVersion.V7_1_2_FINAL, ModelVersion.create(1, 1, 0));
+    public void testTransformerEAP62() throws Exception {
+        testRejectingTransformer("resource-adapters-pool-20.xml", ModelTestControllerVersion.EAP_6_2_0, ModelVersion.create(1, 3, 0));
     }
 
     @Test
-    public void testTransformerAS713() throws Exception {
-        testTransformer("resource-adapters-xapool.xml", ModelTestControllerVersion.V7_1_3_FINAL, ModelVersion.create(1, 1, 0));
-    }
-
-    @Test
-    public void tesExpressionsAS712() throws Exception {
+    public void testExpressionsEAP62() throws Exception {
         //this file contain expression for all supported fields except bean-validation-groups and recovery-plugin-properties
         // for a limitation in test suite not permitting to have expression in type LIST or OBJECT for legacyServices
-        testTransformer("resource-adapters-xapool-expression2.xml", ModelTestControllerVersion.V7_1_2_FINAL, ModelVersion.create(1, 1, 0));
+        testTransformer("resource-adapters-xapool-expression.xml", ModelTestControllerVersion.EAP_6_2_0, ModelVersion.create(1, 3, 0));
     }
 
-    @Test
-    public void testExpressionsAS713() throws Exception {
-        //this file contain expression for all supported fields except bean-validation-groups and recovery-plugin-properties
-        // for a limitation in test suite not permitting to have expression in type LIST or OBJECT for legacyServices
-        testTransformer("resource-adapters-xapool-expression2.xml", ModelTestControllerVersion.V7_1_3_FINAL, ModelVersion.create(1, 1, 0));
-    }
-
-    @Test
-    public void testTransformerAS72() throws Exception {
-        testRejectingTransformer("resource-adapters-pool-20.xml", ModelTestControllerVersion.V7_2_0_FINAL, ModelVersion.create(1, 2, 0));
-    }
-
-    @Test
-    public void testExpressionsAS72() throws Exception {
-        //this file contain expression for all supported fields except bean-validation-groups and recovery-plugin-properties
-        // for a limitation in test suite not permitting to have expression in type LIST or OBJECT for legacyServices
-        testTransformer("resource-adapters-xapool-expression.xml", ModelTestControllerVersion.V7_2_0_FINAL, ModelVersion.create(1, 2, 0));
-    }
     /**
      * Tests transformation of model from current to passed one
      *
@@ -174,10 +151,12 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
                     public ModelNode fixModel(ModelNode modelNode) {
                         //Replace the value used in the xml
                         if (modelNode.get(Constants.RESOURCEADAPTER_NAME).hasDefined("myRA")) {
-                            if (modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.ENLISTMENT.getName()).isDefined())
+                            if (modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.ENLISTMENT.getName()).isDefined()) {
                                 modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.ENLISTMENT.getName()).set(false);
-                            if (modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.SHARABLE.getName()).isDefined())
+                            }
+                            if (modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.SHARABLE.getName()).isDefined()) {
                                 modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.SHARABLE.getName()).set(false);
+                            }
 
                         }
                         return modelNode;
@@ -194,17 +173,18 @@ public class ResourceAdaptersSubsystemTestCase extends AbstractSubsystemBaseTest
 
         checkSubsystemModelTransformation(mainServices, modelVersion, new ModelFixer() {
 
-                            @Override
-                            public ModelNode fixModel(ModelNode modelNode) {
-                                //Replace the value used in the xml
-                                if (modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").isDefined()) {
-                                    if(! modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").hasDefined(Constants.APPLICATION.getName()))
-                                        modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.APPLICATION.getName()).set(false);
-                                }
-                                return modelNode;
+            @Override
+            public ModelNode fixModel(ModelNode modelNode) {
+                //Replace the value used in the xml
+                if (modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").isDefined()) {
+                    if (!modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").hasDefined(Constants.APPLICATION.getName())) {
+                        modelNode.get(Constants.RESOURCEADAPTER_NAME).get("myRA").get(Constants.CONNECTIONDEFINITIONS_NAME).get("poolName").get(Constants.APPLICATION.getName()).set(false);
+                    }
+                }
+                return modelNode;
 
-                            }
-                        });
+            }
+        });
 
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -22,13 +22,10 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import java.util.Map;
-
 import org.jboss.as.controller.AbstractWriteAttributeHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -43,7 +40,6 @@ import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.services.path.PathManager;
-import org.jboss.as.controller.transform.TransformationContext;
 import org.jboss.as.controller.transform.description.AttributeConverter;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
@@ -269,58 +265,10 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
     }
 
     static void registerTransformers(SubsystemRegistration subsystemRegistration) {
-        registerTransformers_1_1_0(subsystemRegistration);
-        registerTransformers_1_2_0(subsystemRegistration);
         registerTransformers_1_2_1(subsystemRegistration);
         registerTransformers_3_0_0(subsystemRegistration);
     }
 
-    private static void registerTransformers_1_1_0(SubsystemRegistration subsystemRegistration) {
-
-        ModelVersion subsystem110 = ModelVersion.create(1, 1);
-
-        ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance()
-                .getAttributeBuilder()
-                .addRejectCheck(RejectAttributeChecker.SIMPLE_EXPRESSIONS, EJB3SubsystemRootResourceDefinition.ENABLE_STATISTICS)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)
-                .addRejectCheck(RejectAttributeChecker.DEFINED, EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
-                .setDiscard(DiscardAttributeChecker.ALWAYS, EJB3SubsystemRootResourceDefinition.LOG_EJB_EXCEPTIONS) //always discard, as this only affects logging
-                .addRejectCheck(new RejectAttributeChecker.DefaultRejectAttributeChecker() {
-
-                    @Override
-                    public String getRejectionLogMessage(Map<String, ModelNode> attributes) {
-                        return EjbLogger.ROOT_LOGGER.rejectTransformationDefinedDefaultMissingMethodPermissionsDenyAccess();
-                    }
-
-                    @Override
-                    protected boolean rejectAttribute(PathAddress address, String attributeName, ModelNode attributeValue,
-                                                      TransformationContext context) {
-                        return attributeValue.isDefined() && attributeValue.asBoolean();
-                    }
-                }, EJB3SubsystemRootResourceDefinition.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS)
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN)
-                .setDiscard(DiscardAttributeChecker.UNDEFINED, EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE)
-                // We can always discard this attribute, because it's meaningless without the security-manager subsystem, and
-                // a legacy slave can't have that subsystem in its profile.
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
-                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(false)), EJB3SubsystemRootResourceDefinition.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS)
-                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME)
-                .end();
-        EJB3RemoteResourceDefinition.registerTransformers_1_1_0(builder);
-        UnboundedQueueThreadPoolResourceDefinition.registerTransformers1_0(builder, EJB3SubsystemModel.THREAD_POOL);
-        StrictMaxPoolResourceDefinition.registerTransformers_1_1_0(builder);
-        PassivationStoreResourceDefinition.registerTransformers_1_1_0(builder);
-        FilePassivationStoreResourceDefinition.registerTransformers_1_1_0(builder);
-        ClusterPassivationStoreResourceDefinition.registerTransformers_1_1_0(builder);
-        TimerServiceResourceDefinition.registerTransformers_1_1_0(builder);
-        builder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE));
-        TransformationDescription.Tools.register(builder.build(), subsystemRegistration, subsystem110);
-    }
-
-    private static void registerTransformers_1_2_0(SubsystemRegistration subsystemRegistration) {
-        registerTransformers1_2(subsystemRegistration, ModelVersion.create(1, 2, 0));
-    }
 
     private static void registerTransformers_1_2_1(SubsystemRegistration subsystemRegistration) {
         registerTransformers1_2(subsystemRegistration, ModelVersion.create(1, 2, 1));

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -22,12 +22,7 @@
 
 package org.jboss.as.ejb3.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
-
 import java.io.IOException;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.jboss.as.controller.AttributeDefinition;
@@ -42,7 +37,6 @@ import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
-import org.jboss.as.threads.PoolAttributeDefinitions;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.junit.Assert;
@@ -91,70 +85,10 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
     }
 
     @Test
-    public void testTransformerAS712() throws Exception {
-        testTransformer_1_1_0(ModelTestControllerVersion.V7_1_2_FINAL);
+    public void testTransformerEAP620() throws Exception {
+        testTransformer_1_2_x(ModelTestControllerVersion.EAP_6_2_0, 1);
     }
 
-    @Test
-    public void testTransformerAS713() throws Exception {
-        testTransformer_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL);
-    }
-
-    @Test
-    public void testTransformerEAP600() throws Exception {
-        testTransformer_1_1_0(ModelTestControllerVersion.EAP_6_0_0);
-    }
-
-    @Test
-    public void testTransformerEAP601() throws Exception {
-        testTransformer_1_1_0(ModelTestControllerVersion.EAP_6_0_1);
-    }
-
-    /**
-     * Tests transformation of model from 2.0.0 version into 1.1.0 version, where
-     * all operations in the XML file are expected to transform successfully.
-     *
-     * @throws Exception
-     */
-    private void testTransformer_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
-        String subsystemXml = "transform_1_1_0.xml";   //This has no expressions not understood by 1.1.0
-        ModelVersion modelVersion = ModelVersion.create(1, 1, 0); //The old model version
-        //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
-                .setSubsystemXmlResource(subsystemXml);
-
-        // Add legacy subsystems
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-ejb3:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL("org.jboss.as:jboss-as-clustering-registry:" + controllerVersion.getMavenGavVersion())
-                .skipReverseControllerCheck()
-                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName())))
-                .addOperationValidationResolve("add", PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()), PathElement.pathElement("strict-max-bean-instance-pool")));
-
-        // boot the models
-        KernelServices mainServices = builder.build();
-        KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);
-        Assert.assertNotNull(mainServices);
-        Assert.assertNotNull(legacyServices);
-        // check that the transformed model is the same as the model built from transformed operations
-        checkSubsystemModelTransformation(mainServices, modelVersion, V_1_1_0_FIXER);
-    }
-
-    @Test
-    public void testTransformerAS720() throws Exception {
-        testTransformer_1_2_x(ModelTestControllerVersion.V7_2_0_FINAL, 0);
-    }
-
-    @Test
-    public void testTransformerEAP610() throws Exception {
-        testTransformer_1_2_x(ModelTestControllerVersion.EAP_6_1_0, 1);
-    }
-
-    @Test
-    public void testTransformerEAP611() throws Exception {
-        testTransformer_1_2_x(ModelTestControllerVersion.EAP_6_1_1, 1);
-    }
 
     /**
      * Tests transformation of model from 1.2.0 version into 1.1.0 version.
@@ -183,53 +117,12 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         checkSubsystemModelTransformation(mainServices, modelVersion, V_1_1_0_FIXER);
     }
 
-    @Test
-    public void testRejectExpressionsAS712() throws Exception {
-        testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_2_FINAL);
-    }
 
-    @Test
-    public void testRejectExpressionsAS713() throws Exception {
-        testRejectExpressions_1_1_0(ModelTestControllerVersion.V7_1_3_FINAL);
-    }
-
-    @Test
-    public void testRejectExpressionsEAP600() throws Exception {
-        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_0);
-    }
-
-    @Test
-    public void testRejectExpressionsAS601() throws Exception {
-        testRejectExpressions_1_1_0(ModelTestControllerVersion.EAP_6_0_1);
-    }
-
-    private void testRejectExpressions_1_1_0(ModelTestControllerVersion controllerVersion) throws Exception {
-        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
-
-        // create builder for legacy subsystem version
-        ModelVersion version_1_1_0 = ModelVersion.create(1, 1, 0);
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version_1_1_0)
-                .addMavenResourceURL("org.jboss.as:jboss-as-ejb3:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL("org.jboss.as:jboss-as-clustering-registry:" + controllerVersion.getMavenGavVersion())
-        ;
-
-        KernelServices mainServices = builder.build();
-        KernelServices legacyServices = mainServices.getLegacyServices(version_1_1_0);
-
-        Assert.assertNotNull(legacyServices);
-        Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
-        Assert.assertTrue(legacyServices.isSuccessfulBoot());
-
-        List<ModelNode> xmlOps = builder.parseXmlResource("transform_1_1_0_expressions.xml");
-        // for each operation, check installs in main and if it fails in legacy, that it is noted in the failure config
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version_1_1_0, xmlOps, getConfig_1_1_0());
-    }
 
     @Ignore
     @Test
-    public void testRejectBadAttributesAs720() throws Exception {
-        testRejectBadAttributes_1_2_0(ModelTestControllerVersion.V7_2_0_FINAL);
+    public void testRejectBadAttributesEAP62() throws Exception {
+        testRejectBadAttributes_1_2_0(ModelTestControllerVersion.EAP_6_2_0);
     }
 
 
@@ -265,72 +158,6 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version_1_2_0, xmlOps, getConfig_1_2_0());
     }
 
-
-    @Test
-    public void testRejectFileStorePathExpressionsAS713() throws Exception {
-        testRejectFileStorePathExpressions(ModelTestControllerVersion.V7_1_3_FINAL, true);
-    }
-
-    private void testRejectFileStorePathExpressions(ModelTestControllerVersion controllerVersion, boolean expectReject) throws Exception {
-        // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(createAdditionalInitialization());
-
-        // create builder for legacy subsystem version
-        ModelVersion version_1_1_0 = ModelVersion.create(1, 1, 0);
-        builder.createLegacyKernelServicesBuilder(null, controllerVersion, version_1_1_0)
-                .addMavenResourceURL("org.jboss.as:jboss-as-ejb3:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL("org.jboss.as:jboss-as-threads:" + controllerVersion.getMavenGavVersion())
-                .addMavenResourceURL("org.jboss.as:jboss-as-clustering-registry:" + controllerVersion.getMavenGavVersion())
-        ;
-
-        KernelServices mainServices = builder.build();
-        KernelServices legacyServices = mainServices.getLegacyServices(version_1_1_0);
-
-        Assert.assertNotNull(legacyServices);
-        Assert.assertTrue("main services did not boot", mainServices.isSuccessfulBoot());
-        Assert.assertTrue(legacyServices.isSuccessfulBoot());
-
-        List<ModelNode> xmlOps = builder.parseXmlResource("timer_path_expr.xml");
-
-        FailedOperationTransformationConfig failedConfig = expectReject ? getFileStorePathConfig() : new FailedOperationTransformationConfig();
-        ModelTestUtils.checkFailedTransformedBootOperations(mainServices, version_1_1_0, xmlOps, failedConfig);
-    }
-
-    /*
-     * Specifies the operations for which we expect transformation failure when:
-     * - transforming from current to model version 1.1.0
-     * - using the XML configuration file transform_1_1_0_expressions.xml
-     */
-    private FailedOperationTransformationConfig getConfig_1_1_0() {
-        PathAddress subsystemAddress = PathAddress.pathAddress(EJB3Extension.SUBSYSTEM_PATH);
-        FailedOperationTransformationConfig.RejectExpressionsConfig keepaliveOnly =
-                new FailedOperationTransformationConfig.RejectExpressionsConfig(PoolAttributeDefinitions.KEEPALIVE_TIME);
-
-        return new FailedOperationTransformationConfig()
-                .addFailedAttribute(subsystemAddress,
-                        FailedOperationTransformationConfig.ChainedConfig.createBuilder(
-                                EJB3SubsystemRootResourceDefinition.ENABLE_STATISTICS,
-                                EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN,
-                                EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE,
-                                EJB3SubsystemRootResourceDefinition.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS,
-                                EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)
-                                .addConfig(new FailedOperationTransformationConfig.RejectExpressionsConfig(EJB3SubsystemRootResourceDefinition.ENABLE_STATISTICS))
-                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemRootResourceDefinition.DEFAULT_SECURITY_DOMAIN))
-                                .addConfig(new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemRootResourceDefinition.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE))
-                                .addConfig(new CorrectFalseToTrue(EJB3SubsystemRootResourceDefinition.DEFAULT_MISSING_METHOD_PERMISSIONS_DENY_ACCESS, EJB3SubsystemRootResourceDefinition.DISABLE_DEFAULT_EJB_PERMISSIONS)).build())
-                .addFailedAttribute(subsystemAddress.append(PathElement.pathElement(EJB3SubsystemModel.THREAD_POOL)),
-                        keepaliveOnly)
-                .addFailedAttribute(subsystemAddress.append(StrictMaxPoolResourceDefinition.INSTANCE.getPathElement()),
-                        new FailedOperationTransformationConfig.RejectExpressionsConfig(StrictMaxPoolResourceDefinition.INSTANCE_ACQUISITION_TIMEOUT_UNIT))
-                .addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.TIMER_SERVICE_PATH),
-                        new FailedOperationTransformationConfig.RejectExpressionsConfig(FileDataStoreResourceDefinition.PATH))
-                .addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.REMOTE_SERVICE_PATH, RemoteConnectorChannelCreationOptionResource.INSTANCE.getPathElement()),
-                        new FailedOperationTransformationConfig.RejectExpressionsConfig(RemoteConnectorChannelCreationOptionResource.CHANNEL_CREATION_OPTION_VALUE))
-                .addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.TIMER_SERVICE_PATH, PathElement.pathElement(EJB3SubsystemModel.FILE_DATA_STORE, "file-data-store-rejected")), FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                .addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.TIMER_SERVICE_PATH, EJB3SubsystemModel.DATABASE_DATA_STORE_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE)
-                ;
-    }
-
     /*
      * Specifies the operations for which we expect transformation failure when:
      * - transforming from current to model version 1.2.0
@@ -349,16 +176,6 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
         .addFailedAttribute(subsystemAddress.append(EJB3SubsystemModel.TIMER_SERVICE_PATH, EJB3SubsystemModel.DATABASE_DATA_STORE_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE)
         ;
     }
-
-    private FailedOperationTransformationConfig getFileStorePathConfig() {
-        return new FailedOperationTransformationConfig()
-                .addFailedAttribute(PathAddress.pathAddress(EJB3Extension.SUBSYSTEM_PATH), new FailedOperationTransformationConfig.NewAttributesConfig(EJB3SubsystemModel.DEFAULT_SFSB_PASSIVATION_DISABLED_CACHE))
-                .addFailedAttribute(PathAddress.pathAddress(EJB3Extension.SUBSYSTEM_PATH, EJB3SubsystemModel.TIMER_SERVICE_PATH,
-                        PathElement.pathElement(EJB3SubsystemModel.FILE_DATA_STORE, "file-data-store")),
-                        new FailedOperationTransformationConfig.RejectExpressionsConfig(FileDataStoreResourceDefinition.PATH));
-    }
-
-
 
     private static final ModelFixer V_1_1_0_FIXER = new ModelFixer()  {
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/DomainAdjuster620.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/DomainAdjuster620.java
@@ -47,6 +47,7 @@ public class DomainAdjuster620 extends DomainAdjuster630 {
     protected List<ModelNode> adjustForVersion(final DomainClient client, PathAddress profileAddress) throws Exception {
         List<ModelNode> list = super.adjustForVersion(client, profileAddress);
         list.addAll(adjustLogging(profileAddress.append(SUBSYSTEM, "logging")));
+        list.add(getWriteAttributeOperation(profileAddress.append(SUBSYSTEM, "datasources").append("data-source","ExampleDS"), "statistics-enabled", new ModelNode("true")));
         return list;
     }
 


### PR DESCRIPTION
added EAP6.2 tests & transformers for connector subsystems, drop older transformers

Mostly removing to be able to cleanup threads subsystem in core. https://github.com/wildfly/wildfly-core/pull/739
