### PR TITLE
WFLY-4654 JGroups transport type can't be set

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/SimpleAddOperationTransformer.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/SimpleAddOperationTransformer.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.controller.transform;
 
+import java.util.Arrays;
+
 import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.PathAddress;
@@ -37,9 +39,13 @@ import org.jboss.dmr.ModelNode;
 public class SimpleAddOperationTransformer implements org.jboss.as.controller.transform.OperationTransformer {
 
     private final OperationTransformer transformer;
-    private final AttributeDefinition[] attributes;
+    private final Iterable<AttributeDefinition> attributes;
 
-    public SimpleAddOperationTransformer(final PathAddressTransformer transformer, AttributeDefinition... attributes) {
+    public SimpleAddOperationTransformer(PathAddressTransformer transformer, AttributeDefinition... attributes) {
+        this(transformer, Arrays.asList(attributes));
+    }
+
+    public SimpleAddOperationTransformer(final PathAddressTransformer transformer, Iterable<AttributeDefinition> attributes) {
         this.transformer = new OperationTransformer() {
             @Override
             public ModelNode transformOperation(ModelNode operation) {
@@ -50,6 +56,10 @@ public class SimpleAddOperationTransformer implements org.jboss.as.controller.tr
     }
 
     public SimpleAddOperationTransformer(OperationTransformer transformer, AttributeDefinition... attributes) {
+        this(transformer, Arrays.asList(attributes));
+    }
+
+    public SimpleAddOperationTransformer(OperationTransformer transformer, Iterable<AttributeDefinition> attributes) {
         this.transformer = transformer;
         this.attributes = attributes;
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PropertyResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PropertyResourceDefinition.java
@@ -54,9 +54,9 @@ import org.jboss.dmr.ModelType;
  *   /subsystem=jgroups/stack=X/transport=TRANSPORT/property=Z
  *   /subsystem=jgroups/stack=X/protocol=Y/property=Z
  *
+ * This resource is deprecated - replaced by a map attribute of the transport/protocol.
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-@Deprecated
 public class PropertyResourceDefinition extends SimpleResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -22,6 +22,10 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.jboss.as.clustering.controller.ReloadRequiredAddStepHandler;
 import org.jboss.as.clustering.controller.transform.DefaultValueAttributeConverter;
 import org.jboss.as.clustering.controller.transform.PathAddressTransformer;
@@ -37,11 +41,9 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -55,7 +57,7 @@ import org.jboss.dmr.ModelType;
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class TransportResourceDefinition extends SimpleResourceDefinition {
+public class TransportResourceDefinition extends ProtocolResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -127,11 +129,15 @@ public class TransportResourceDefinition extends SimpleResourceDefinition {
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 
-    // the list of attributes used by the transport resource
-    static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {
-            ProtocolResourceDefinition.TYPE, ProtocolResourceDefinition.MODULE, SHARED, ProtocolResourceDefinition.SOCKET_BINDING, DIAGNOSTICS_SOCKET_BINDING,
-            ProtocolResourceDefinition.PROPERTIES, DEFAULT_EXECUTOR, OOB_EXECUTOR, TIMER_EXECUTOR, THREAD_FACTORY, SITE, RACK, MACHINE
+    static final AttributeDefinition[] TRANSPORT_ATTRIBUTES = new AttributeDefinition[] {
+            SHARED, DIAGNOSTICS_SOCKET_BINDING, DEFAULT_EXECUTOR, OOB_EXECUTOR, TIMER_EXECUTOR, THREAD_FACTORY, SITE, RACK, MACHINE
     };
+    // the list of attributes used by the transport resource
+    static final Collection<AttributeDefinition> ATTRIBUTES = new ArrayList<>(TRANSPORT_ATTRIBUTES.length + ProtocolResourceDefinition.ATTRIBUTES.length);
+    static {
+        Collections.addAll(ATTRIBUTES, TRANSPORT_ATTRIBUTES);
+        Collections.addAll(ATTRIBUTES, ProtocolResourceDefinition.ATTRIBUTES);
+    }
 
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder builder = parent.addChildResource(WILDCARD_PATH);
@@ -169,13 +175,15 @@ public class TransportResourceDefinition extends SimpleResourceDefinition {
     };
 
     TransportResourceDefinition() {
-        super(WILDCARD_PATH, new JGroupsResourceDescriptionResolver(ModelKeys.TRANSPORT), new ReloadRequiredAddStepHandler(ATTRIBUTES), ReloadRequiredRemoveStepHandler.INSTANCE);
+        super(WILDCARD_PATH, new ReloadRequiredAddStepHandler(ATTRIBUTES));
     }
 
     @Override
     public void registerAttributes(ManagementResourceRegistration registration) {
-        final OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(ATTRIBUTES);
-        for (AttributeDefinition attr : ATTRIBUTES) {
+        super.registerAttributes(registration);
+
+        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(TRANSPORT_ATTRIBUTES);
+        for (AttributeDefinition attr : TRANSPORT_ATTRIBUTES) {
             if (attr.isDeprecated()) {
                 registration.registerReadWriteAttribute(attr, null, new ThreadsAttributesWriteHandler(attr));
             } else {
@@ -186,7 +194,7 @@ public class TransportResourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerChildren(ManagementResourceRegistration registration) {
-        registration.registerSubModel(new PropertyResourceDefinition());
+        super.registerChildren(registration);
 
         for (ThreadPoolResourceDefinition pool : ThreadPoolResourceDefinition.values()) {
             registration.registerSubModel(pool);

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationsTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationsTestCase.java
@@ -64,6 +64,29 @@ public class OperationsTestCase extends OperationTestCaseBase {
         Assert.assertEquals("new-rack", result.get(RESULT).asString());
     }
 
+    /*
+     * Tests access to the deprecated transport type attribute
+     */
+    @Test
+    public void testTransportTypeReadWriteOperation() throws Exception {
+
+        KernelServices services = this.buildKernelServices();
+
+        // read the deprecated transport "type" attribute
+        ModelNode result = services.executeOperation(getTransportReadOperation("maximal", "TCP", ModelKeys.TYPE));
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals("TCP", result.get(RESULT).resolve().asString());
+
+        // write the deprecated transport type attribute
+        result = services.executeOperation(getTransportWriteOperation("maximal", "TCP", ModelKeys.TYPE, "UDP"));
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
+
+        // re-read the rack attribute
+        result = services.executeOperation(getTransportReadOperation("maximal", "UDP", ModelKeys.TYPE));
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals("UDP", result.get(RESULT).asString());
+    }
+
     @Test
     public void testTransportReadWriteWithParameters() throws Exception {
         // Parse and install the XML into the controller


### PR DESCRIPTION
Add custom read/write-attribute handler for deprecated type attribute.

https://issues.jboss.org/browse/JBEAP-131
