### PR TITLE
[9.x] WFLY-4651 Change default locking isolation of infinispan caches to READ_COMMITTED

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactory.java
@@ -25,7 +25,10 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.infinispan.Cache;
+import org.infinispan.context.Flag;
 import org.infinispan.remoting.transport.Address;
+import org.infinispan.transaction.LockingMode;
+import org.infinispan.util.concurrent.IsolationLevel;
 import org.wildfly.clustering.dispatcher.CommandDispatcherFactory;
 import org.wildfly.clustering.ee.infinispan.TransactionBatch;
 import org.wildfly.clustering.ejb.BeanManager;
@@ -78,7 +81,8 @@ public class InfinispanBeanManagerFactory<G, I, T> implements BeanManagerFactory
         final boolean evictionAllowed = config.persistence().usingStores();
         final boolean passivationEnabled = evictionAllowed && config.persistence().passivation();
         final boolean persistent = config.clustering().cacheMode().isClustered() || (evictionAllowed && !passivationEnabled);
-        BeanFactory<G, I, T> beanFactory = new InfinispanBeanFactory<>(beanName, groupFactory, beanCache, this.configuration.getBeanContext().getTimeout(), persistent ? passivationListener : null);
+        boolean lockOnRead = config.transaction().transactionMode().isTransactional() && (config.transaction().lockingMode() == LockingMode.PESSIMISTIC) && (config.locking().isolationLevel() == IsolationLevel.REPEATABLE_READ);
+        BeanFactory<G, I, T> beanFactory = new InfinispanBeanFactory<>(beanName, groupFactory, lockOnRead ? beanCache.getAdvancedCache().withFlags(Flag.FORCE_WRITE_LOCK) : beanCache, this.configuration.getBeanContext().getTimeout(), persistent ? passivationListener : null);
         Configuration<I, BeanKey<I>, BeanEntry<G>, BeanFactory<G, I, T>> beanConfiguration = new SimpleConfiguration<>(beanCache, beanFactory, beanIdentifierFactory);
         final NodeFactory<Address> nodeFactory = this.configuration.getNodeFactory();
         final Registry<String, ?> registry = this.configuration.getRegistry();

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
@@ -22,9 +22,7 @@
 package org.wildfly.clustering.ejb.infinispan.bean;
 
 import org.infinispan.Cache;
-import org.infinispan.configuration.cache.TransactionConfiguration;
 import org.infinispan.context.Flag;
-import org.infinispan.transaction.LockingMode;
 import org.wildfly.clustering.ee.infinispan.CacheEntryMutator;
 import org.wildfly.clustering.ee.infinispan.Mutator;
 import org.wildfly.clustering.ejb.Bean;
@@ -82,10 +80,7 @@ public class InfinispanBeanFactory<G, I, T> implements BeanFactory<G, I, T> {
 
     @Override
     public BeanEntry<G> findValue(I id) {
-        TransactionConfiguration transaction = this.cache.getCacheConfiguration().transaction();
-        boolean pessimistic = transaction.transactionMode().isTransactional() && (transaction.lockingMode() == LockingMode.PESSIMISTIC);
-        Cache<BeanKey<I>, BeanEntry<G>> cache = pessimistic ? this.cache.getAdvancedCache().withFlags(Flag.FORCE_WRITE_LOCK) : this.cache;
-        return cache.get(this.createKey(id));
+        return this.cache.get(this.createKey(id));
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/resources/infinispan-defaults.xml
+++ b/clustering/infinispan/extension/src/main/resources/infinispan-defaults.xml
@@ -25,7 +25,7 @@
 <infinispan xmlns="urn:infinispan:config:7.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:infinispan:config:7.1 http://infinispan.org/schemas/infinispan-config-7.1.xsd">
     <cache-container default-cache="LOCAL">
         <local-cache name="LOCAL">
-            <locking isolation="REPEATABLE_READ" acquire-timeout="15000" concurrency-level="1000"/>
+            <locking acquire-timeout="15000" concurrency-level="1000"/>
             <transaction locking="PESSIMISTIC"/>
             <store-as-binary keys="false" values="false"/>
         </local-cache>

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
@@ -25,9 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.infinispan.Cache;
-import org.infinispan.configuration.cache.TransactionConfiguration;
 import org.infinispan.context.Flag;
-import org.infinispan.transaction.LockingMode;
 import org.wildfly.clustering.ee.infinispan.CacheEntryMutator;
 import org.wildfly.clustering.ee.infinispan.MutableCacheEntry;
 import org.wildfly.clustering.ee.infinispan.Mutator;
@@ -119,10 +117,7 @@ public class CoarseSessionFactory<L> implements SessionFactory<CoarseSessionEntr
 
     @Override
     public CoarseSessionEntry<L> findValue(String id) {
-        TransactionConfiguration transaction = this.sessionCache.getCacheConfiguration().transaction();
-        boolean pessimistic = transaction.transactionMode().isTransactional() && (transaction.lockingMode() == LockingMode.PESSIMISTIC);
-        Cache<String, CoarseSessionCacheEntry<L>> cache = pessimistic ? this.sessionCache.getAdvancedCache().withFlags(Flag.FORCE_WRITE_LOCK) : this.sessionCache;
-        CoarseSessionCacheEntry<L> entry = cache.get(id);
+        CoarseSessionCacheEntry<L> entry = this.sessionCache.get(id);
         if (entry != null) {
             MutableCacheEntry<CoarseSessionCacheEntry<L>> sessionEntry = new MutableCacheEntry<>(entry, new CacheEntryMutator<>(this.sessionCache, id, entry));
             SessionAttributesCacheKey key = new SessionAttributesCacheKey(id);

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/fine/FineSessionFactory.java
@@ -24,9 +24,7 @@ package org.wildfly.clustering.web.infinispan.session.fine;
 import java.util.Map;
 
 import org.infinispan.Cache;
-import org.infinispan.configuration.cache.TransactionConfiguration;
 import org.infinispan.context.Flag;
-import org.infinispan.transaction.LockingMode;
 import org.wildfly.clustering.ee.infinispan.CacheEntryMutator;
 import org.wildfly.clustering.ee.infinispan.MutableCacheEntry;
 import org.wildfly.clustering.ee.infinispan.Mutator;
@@ -86,10 +84,7 @@ public class FineSessionFactory<L> implements SessionFactory<MutableCacheEntry<F
 
     @Override
     public MutableCacheEntry<FineSessionCacheEntry<L>> findValue(String id) {
-        TransactionConfiguration transaction = this.sessionCache.getCacheConfiguration().transaction();
-        boolean pessimistic = transaction.transactionMode().isTransactional() && (transaction.lockingMode() == LockingMode.PESSIMISTIC);
-        Cache<String, FineSessionCacheEntry<L>> cache = pessimistic ? this.sessionCache.getAdvancedCache().withFlags(Flag.FORCE_WRITE_LOCK) : this.sessionCache;
-        FineSessionCacheEntry<L> value = cache.get(id);
+        FineSessionCacheEntry<L> value = this.sessionCache.get(id);
         if (value == null) return null;
         // Preemptively read all attributes to detect invalid session attributes
         for (Map.Entry<SessionAttributeCacheKey, MarshalledValue<Object, MarshallingContext>> entry : this.attributeCache.getAdvancedCache().getGroup(id).entrySet()) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4651

This improves concurrency of asynchronous web requests that only need read-access the HttpSession.
This is meant to address a number of issues with lock timeouts reported by users with this use case on the forums.
