### PR TITLE
Update openjdk-orb library to 8.0.2.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <version.org.jboss.narayana>5.0.4.Final</version.org.jboss.narayana>
         <version.org.jboss.metadata>9.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.3.1.Final</version.org.jboss.mod_cluster>
-        <version.org.jboss.openjdk-orb>8.0.2.Beta2</version.org.jboss.openjdk-orb>
+        <version.org.jboss.openjdk-orb>8.0.2.Final</version.org.jboss.openjdk-orb>
         <version.org.jboss.xnio.netty.netty-xnio-transport>0.1.1.Final</version.org.jboss.xnio.netty.netty-xnio-transport>
         <version.org.jboss.remote-naming>2.0.4.Final</version.org.jboss.remote-naming>
         <version.org.jboss.resteasy>3.0.11.Final</version.org.jboss.resteasy>


### PR DESCRIPTION
This update + narayana  update (https://github.com/wildfly/wildfly/pull/7508) fixes orb shutdown/restart problems (WFLY-4548, WFLY-4549)
