### PR TITLE
Added negative tests for sharing sessions in EAR archive.

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/sharedsession/SharedSessionTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/sharedsession/SharedSessionTestCase.java
@@ -24,19 +24,17 @@ package org.jboss.as.test.integration.web.sharedsession;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
-import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
-import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,25 +48,41 @@ import static org.junit.Assert.assertEquals;
 @RunAsClient
 public class SharedSessionTestCase {
 
-    @Deployment
-    public static Archive<?> dependent() {
+    private static final String EAR_DEPLOYMENT_SHARED_SESSIONS = "sharedSession.ear";
+    private static final String EAR_DEPLOYMENT_NOT_SHARED_SESSIONS = "notSharedSession.ear";
 
+    @Deployment(name = EAR_DEPLOYMENT_SHARED_SESSIONS)
+    public static Archive<?> sharedSessionEarDeployment() {
         WebArchive war1 = ShrinkWrap.create(WebArchive.class, "war1.war")
                 .addClass(SharedSessionServlet.class);
-
         WebArchive war2 = ShrinkWrap.create(WebArchive.class, "war2.war")
                 .addClass(SharedSessionServlet.class);
-
-        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "sharedSession.ear")
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_SHARED_SESSIONS)
                 .addAsModule(war1)
                 .addAsModule(war2)
                 .addAsManifestResource(SharedSessionTestCase.class.getPackage(), "jboss-all.xml", "jboss-all.xml");
         return ear;
     }
 
+    @Deployment(name = EAR_DEPLOYMENT_NOT_SHARED_SESSIONS)
+    public static Archive<?> notSharedEarDeployment() {
+        WebArchive war1 = ShrinkWrap.create(WebArchive.class, "warX.war")
+                .addClass(SharedSessionServlet.class);
+        WebArchive war2 = ShrinkWrap.create(WebArchive.class, "warY.war")
+                .addClass(SharedSessionServlet.class);
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_DEPLOYMENT_NOT_SHARED_SESSIONS)
+                .addAsModule(war1)
+                .addAsModule(war2);
+        return ear;
+    }
+
+    /**
+     * Covers test case when there is EAR with enabled session sharing
+     */
     @Test
-    public void testSharedSessions() throws Exception {
-        HttpClient client = new DefaultHttpClient();
+    @OperateOnDeployment(EAR_DEPLOYMENT_SHARED_SESSIONS)
+    public void testSharedSessionsOneEar() throws IOException {
+        HttpClient client = HttpClientBuilder.create().build();
         HttpGet get1 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war1/SharedSessionServlet");
         HttpGet get2 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war2/SharedSessionServlet");
 
@@ -87,5 +101,51 @@ public class SharedSessionTestCase {
     private String runGet(HttpGet get, HttpClient client) throws IOException {
         HttpResponse res = client.execute(get);
         return EntityUtils.toString(res.getEntity());
+    }
+
+    /**
+     * Covers test case when there is EAR with disabled session sharing
+     */
+    @Test
+    @OperateOnDeployment(EAR_DEPLOYMENT_NOT_SHARED_SESSIONS)
+    public void testUnsharedSessions() throws IOException {
+        HttpClient client = HttpClientBuilder.create().build();
+        HttpGet getX = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/warX/SharedSessionServlet");
+        HttpGet getY = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/warY/SharedSessionServlet");
+
+        String result = runGet(getX, client);
+        assertEquals("0", result);
+        result = runGet(getX, client);
+        assertEquals("1", result);
+        result = runGet(getY, client);
+        assertEquals("0", result);
+        result = runGet(getY, client);
+        assertEquals("1", result);
+        result = runGet(getX, client);
+        assertEquals("2", result);
+    }
+
+    /**
+     * Covers test case when there is one ear with shared sessions between wars and second without sharing.
+     * This test checks that the sessions sharing in one EAR doesn't intervene with sessions in second EAR
+     */
+    @Test
+    public void testSharedSessionsDoesntInterleave() throws IOException {
+        HttpClient client = HttpClientBuilder.create().build();
+        HttpGet get1 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war1/SharedSessionServlet");
+        HttpGet get2 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war2/SharedSessionServlet");
+        HttpGet getX = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/warX/SharedSessionServlet");
+        HttpGet getY = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/warY/SharedSessionServlet");
+
+        String result = runGet(get1, client);
+        assertEquals("0", result);
+        result = runGet(get2, client);
+        assertEquals("1", result);
+        result = runGet(getX, client);
+        assertEquals("0", result);
+        result = runGet(getY, client);
+        assertEquals("0", result);
+        result = runGet(get1, client);
+        assertEquals("2", result);
     }
 }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-1891 part of https://issues.jboss.org/browse/EAP7-294

Created negative tests for session sharing in EAR archive.

Namely if not enabled then no sharing is done. And also added test that when the session sharing isn't propagated outside of the EAR archive.
