### PR TITLE
WFLY-4435 Booting profile with infinispan/jgroups pre-3_0 subsystems fails with "Resource ... cannot be created until all ancestor resources have been added

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -69,5 +69,6 @@ public class InfinispanExtension implements Extension {
         for (InfinispanSchema schema: InfinispanSchema.values()) {
             context.setSubsystemXmlMapping(SUBSYSTEM_NAME, schema.getNamespaceUri(), new InfinispanSubsystemXMLReader(schema));
         }
+        context.setProfileParsingCompletionHandler(new InfinispanProfileParsingCompletionHandler());
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanProfileParsingCompletionHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanProfileParsingCompletionHandler.java
@@ -1,0 +1,87 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan.subsystem;
+
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.clustering.jgroups.subsystem.JGroupsExtension;
+import org.jboss.as.clustering.jgroups.subsystem.JGroupsSchema;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.parsing.ProfileParsingCompletionHandler;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Implementation of ProfileParsingCompletionHandler that moves channel add operations from Infinispan subsystem to
+ * JGroups subsystem.
+ *
+ * @author Radoslav Husar
+ * @version May 2015
+ */
+public class InfinispanProfileParsingCompletionHandler implements ProfileParsingCompletionHandler {
+
+    @Override
+    public void handleProfileParsingCompletion(final Map<String, List<ModelNode>> profileBootOperations, final List<ModelNode> otherBootOperations) {
+        // Find if legacy subsystem was parsed
+        List<ModelNode> legacyInfinispanOps = null;
+        for (InfinispanSchema schema : InfinispanSchema.values()) {
+            if (!schema.since(InfinispanSchema.VERSION_3_0)) {
+                legacyInfinispanOps = profileBootOperations.get(schema.getNamespaceUri());
+                if (legacyInfinispanOps != null) {
+                    break;
+                }
+            }
+        }
+        if (legacyInfinispanOps == null) return;
+
+        // Extract and remove operations intended for jgroups subsystem
+        List<ModelNode> jgroupsOps = new LinkedList<>();
+        for (Iterator<ModelNode> iterator = legacyInfinispanOps.iterator(); iterator.hasNext();) {
+            ModelNode op = iterator.next();
+            PathAddress operationAddress = Operations.getPathAddress(op);
+
+            // If this operation is intended for JGroups subsystem, remove it from here
+            if (operationAddress.getElement(0).getValue().equals(JGroupsExtension.SUBSYSTEM_NAME)) {
+                jgroupsOps.add(op);
+                iterator.remove();
+            }
+        }
+        if (jgroupsOps.isEmpty()) return;
+
+        // Re-add the operations in jgroups subsystem if jgroups subsystem is defined
+        List<ModelNode> jgroupsLegacyOps = null;
+        for (JGroupsSchema schema : JGroupsSchema.values()) {
+            jgroupsLegacyOps = profileBootOperations.get(schema.getNamespaceUri());
+            if (jgroupsLegacyOps != null) {
+                break;
+            }
+        }
+        if (jgroupsLegacyOps == null) return;
+
+        // Re-add all previously removed operations since jgroups subsystem is defined
+        jgroupsLegacyOps.addAll(jgroupsOps);
+    }
+}

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemXMLReader.java
@@ -254,7 +254,7 @@ public class InfinispanSubsystemXMLReader implements XMLElementReader<List<Model
 
         if (!this.schema.since(InfinispanSchema.VERSION_3_0)) {
             // We need to create a corresponding channel add operation
-            String channel = (cluster != null) ? cluster : containerAddress.getLastElement().getValue();
+            String channel = (cluster != null) ? cluster : ("ee-" + containerAddress.getLastElement().getValue());
             TransportResourceDefinition.CHANNEL.parseAndSetParameter(channel, operation, reader);
             PathAddress channelAddress = PathAddress.pathAddress(JGroupsSubsystemResourceDefinition.PATH, ChannelResourceDefinition.pathElement(channel));
             ModelNode channelOperation = Util.createAddOperation(channelAddress);

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/SubsystemParsingTestCase.java
@@ -65,13 +65,13 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
     @Parameters
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-            { InfinispanSchema.VERSION_1_0, 32 },
-            { InfinispanSchema.VERSION_1_1, 32 },
-            { InfinispanSchema.VERSION_1_2, 36 },
-            { InfinispanSchema.VERSION_1_3, 36 },
-            { InfinispanSchema.VERSION_1_4, 76 },
-            { InfinispanSchema.VERSION_1_5, 76 },
-            { InfinispanSchema.VERSION_2_0, 80 },
+            { InfinispanSchema.VERSION_1_0, 31 },
+            { InfinispanSchema.VERSION_1_1, 31 },
+            { InfinispanSchema.VERSION_1_2, 35 },
+            { InfinispanSchema.VERSION_1_3, 35 },
+            { InfinispanSchema.VERSION_1_4, 73 },
+            { InfinispanSchema.VERSION_1_5, 73 },
+            { InfinispanSchema.VERSION_2_0, 77 },
             { InfinispanSchema.VERSION_3_0, 77 },
         };
         return Arrays.asList(data);


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-4435

If this is good it will be needed in 9.0.0.Final too so that people dont end up with a broken configuration upon first boot...
