### PR TITLE
fix validation of minimum value in EE submodule Concurrency utilities, WFLY-4684

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedExecutorServiceResourceDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.LongRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -77,6 +78,7 @@ public class ManagedExecutorServiceResourceDefinition extends SimpleResourceDefi
     public static final SimpleAttributeDefinition HUNG_TASK_THRESHOLD_AD =
             new SimpleAttributeDefinitionBuilder(HUNG_TASK_THRESHOLD, ModelType.LONG, true)
                     .setAllowExpression(true)
+                    .setValidator(new LongRangeValidator(0, Long.MAX_VALUE, true, true))
                     .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
                     .setDefaultValue(new ModelNode(0))
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
@@ -107,6 +109,7 @@ public class ManagedExecutorServiceResourceDefinition extends SimpleResourceDefi
     public static final SimpleAttributeDefinition KEEPALIVE_TIME_AD =
             new SimpleAttributeDefinitionBuilder(KEEPALIVE_TIME, ModelType.LONG, true)
                     .setAllowExpression(true)
+                    .setValidator(new LongRangeValidator(0, Long.MAX_VALUE, true, true))
                     .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setDefaultValue(new ModelNode(60000))

--- a/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
+++ b/ee/src/main/java/org/jboss/as/ee/subsystem/ManagedScheduledExecutorServiceResourceDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.operations.validation.EnumValidator;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
+import org.jboss.as.controller.operations.validation.LongRangeValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -75,6 +76,7 @@ public class ManagedScheduledExecutorServiceResourceDefinition extends SimpleRes
     public static final SimpleAttributeDefinition HUNG_TASK_THRESHOLD_AD =
             new SimpleAttributeDefinitionBuilder(HUNG_TASK_THRESHOLD, ModelType.LONG, true)
                     .setAllowExpression(true)
+                    .setValidator(new LongRangeValidator(0, Long.MAX_VALUE, true, true))
                     .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
                     .setDefaultValue(new ModelNode(0))
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
@@ -97,6 +99,7 @@ public class ManagedScheduledExecutorServiceResourceDefinition extends SimpleRes
     public static final SimpleAttributeDefinition KEEPALIVE_TIME_AD =
             new SimpleAttributeDefinitionBuilder(KEEPALIVE_TIME, ModelType.LONG, true)
                     .setAllowExpression(true)
+                    .setValidator(new LongRangeValidator(0, Long.MAX_VALUE, true, true))
                     .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setDefaultValue(new ModelNode(60000))


### PR DESCRIPTION
Add validation for time params - value must be >= 0
https://issues.jboss.org/browse/WFLY-4684
