### PR TITLE
Clean up WildFly Core dependencies in the parent pom.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -834,35 +834,13 @@
     <dependencyManagement>
         <dependencies>
 
-            <!-- Core Modules -->
-
-            <!-- TODO order order orderrrrrr -->
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-build-plugin</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
+            <!-- Import the core parent to get all the managed dependencies from core -->
             <dependency>
                 <groupId>org.wildfly.core</groupId>
                 <artifactId>wildfly-core-parent</artifactId>
                 <type>pom</type>
                 <version>${version.org.wildfly.core}</version>
                 <scope>import</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-feature-pack</artifactId>
-                <type>pom</type>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-feature-pack</artifactId>
-                <type>zip</type>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <!-- Modules in this project -->
@@ -916,14 +894,6 @@
                 <groupId>org.wildfly.checkstyle</groupId>
                 <artifactId>wildfly-checkstyle-config</artifactId>
                 <version>${version.org.wildfly.checkstyle-config}</version>
-            </dependency>
-
-
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-test-runner</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <dependency>
@@ -1051,66 +1021,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-controller</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-security-api</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-security</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-controller-client</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-deployment-repository</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-deployment-scanner</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-domain-http-error-context</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-domain-http-interface</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-domain-management</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-request-controller</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-dist</artifactId>
                 <version>${project.version}</version>
@@ -1118,46 +1028,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-cli</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-cli</artifactId>
-                <classifier>client</classifier>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-client-all</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-model-test</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-model-test-framework</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-model-test-controller-optional</artifactId>
-                <version>${version.org.wildfly.core}</version>
-             </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-model-test-controller-7.2.0</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <dependency>
@@ -1198,18 +1071,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-host-controller</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-io</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-iiop-openjdk</artifactId>
                 <version>${project.version}</version>
@@ -1240,12 +1101,6 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-jmx</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-jms-client-bom</artifactId>
                 <version>${project.version}</version>
@@ -1256,24 +1111,6 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-jsr77</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-logging</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-launcher</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-management-client-content</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <dependency>
@@ -1301,21 +1138,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-model-test</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-naming</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-network</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <dependency>
@@ -1338,36 +1163,6 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-pojo</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-patching</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-platform-mbean</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-process-controller</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-protocol</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-remoting</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <dependency>
@@ -1395,40 +1190,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-server</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-subsystem-test</artifactId>
-                <type>pom</type>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-subsystem-test-controller-7.2.0</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-subsystem-test-framework</artifactId>
-                <version>${version.org.wildfly.core}</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-system-jmx</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-threads</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <dependency>
@@ -1441,12 +1205,6 @@
                 <groupId>org.wildfly</groupId>
                 <artifactId>wildfly-undertow</artifactId>
                 <version>${project.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-version</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
 
             <dependency>
@@ -1529,12 +1287,6 @@
                 <artifactId>wildfly-testsuite-shared</artifactId>
                 <version>${project.version}</version>
                 <scope>test</scope>
-            </dependency>
-
-            <dependency>
-                <groupId>org.wildfly.core</groupId>
-                <artifactId>wildfly-core-testsuite-shared</artifactId>
-                <version>${version.org.wildfly.core}</version>
             </dependency>
             <!-- External Dependencies -->
 

--- a/testsuite/shared/pom.xml
+++ b/testsuite/shared/pom.xml
@@ -25,6 +25,12 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Not defined in the parent pom as this should only be used here -->
+            <dependency>
+                <groupId>org.wildfly.core</groupId>
+                <artifactId>wildfly-core-testsuite-shared</artifactId>
+                <version>${version.org.wildfly.core}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.directory.server</groupId>
                 <artifactId>apacheds-parent</artifactId>


### PR DESCRIPTION
There isn't a need to define each core dependency when we're importing the parent pom. Importing the feature-pack pom and zip does nothing either. When importing a pom only dependencies from the `<dependencyManagement/>` section are used.
