### PR TITLE
WFLY-4708 Upgrade to Narayana 5.0.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.2.4.Final</version.org.jboss.ironjacamar>
         <version.org.jboss.jboss-transaction-spi>7.1.1.Final</version.org.jboss.jboss-transaction-spi>
-        <version.org.jboss.narayana>5.0.5.Final</version.org.jboss.narayana>
+        <version.org.jboss.narayana>5.0.6.Final</version.org.jboss.narayana>
         <version.org.jboss.metadata>9.0.0.Final</version.org.jboss.metadata>
         <version.org.jboss.mod_cluster>1.3.1.Final</version.org.jboss.mod_cluster>
         <version.org.jboss.openjdk-orb>8.0.2.Beta2</version.org.jboss.openjdk-orb>


### PR DESCRIPTION
The narayana fix for the IIOP shutdown issue (see WFLY-4548) that is holding up the release of WF9 CR2.
