### PR TITLE
WFLY-4736 - Don't use MSC thread to start web components from within UndertowDeploymentService

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -35,6 +35,7 @@ import org.jboss.as.security.deployment.SecurityAttachments;
 import org.jboss.as.security.plugins.SecurityDomainContext;
 import org.jboss.as.security.service.JaccService;
 import org.jboss.as.security.service.SecurityDomainService;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentResourceSupport;
@@ -346,6 +347,9 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
                 .addDependency(hostServiceName, Host.class, service.getHost())
                 .addDependencies(deploymentUnit.getAttachmentList(Attachments.WEB_DEPENDENCIES))
                 .addDependency(deploymentInfoServiceName, DeploymentInfo.class, service.getDeploymentInfoInjectedValue());
+        // inject the server executor which can be used by the WebDeploymentService for blocking tasks in start/stop
+        // of that service
+        Services.addServerExecutorDependency(builder, service.getServerExecutorInjector(), false);
 
         deploymentUnit.addToAttachmentList(Attachments.DEPLOYMENT_COMPLETE_SERVICES, deploymentServiceName);
 


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-4736.

As part of the commit, the UndertowDeploymentService now uses the server executor service to run the web components' lifecycle methods instead of using the MSC thread.

This essentially is a port of the fix done for https://issues.jboss.org/browse/AS7-5969 (https://github.com/wildfly/wildfly/pull/3455).

Forum thread reporting this issue in 9.0.0.CR1 https://developer.jboss.org/message/932681#932681
