### PR TITLE
[WFLY-4740] Move JMS high-level commands to the messaging extension

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -44,6 +44,8 @@
         <module name="org.jboss.common-beans"/>
         <module name="org.jboss.as.transactions"/>
         <module name="org.jboss.staxmapper"/>
+        <!-- required to provide high-level JMS CLI commands loaded by the extension -->
+        <module name="org.jboss.as.cli" />
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.naming"/>

--- a/messaging/pom.xml
+++ b/messaging/pom.xml
@@ -44,6 +44,11 @@
 
         <dependency>
             <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-cli</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-controller</artifactId>
         </dependency>
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/cli/ConnectionFactoryHandlerProvider.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/cli/ConnectionFactoryHandlerProvider.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.cli;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHandler;
+import org.jboss.as.cli.CommandHandlerProvider;
+import org.jboss.as.cli.handlers.GenericTypeOperationHandler;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
+ */
+public class ConnectionFactoryHandlerProvider implements CommandHandlerProvider {
+    @Override
+    public CommandHandler createCommandHandler(CommandContext ctx) {
+        return new GenericTypeOperationHandler(ctx,  "/subsystem=messaging/hornetq-server=default/connection-factory", null);
+    }
+
+    @Override
+    public boolean isTabComplete() {
+        return true;
+    }
+
+    @Override
+    public String[] getNames() {
+        return new String[] { "connection-factory" };
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/cli/CreateJMSResourceHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/cli/CreateJMSResourceHandler.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.messaging.jms.cli;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.handlers.BatchModeCommandHandler;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+class CreateJMSResourceHandler extends BatchModeCommandHandler {
+
+    public CreateJMSResourceHandler(CommandContext ctx) {
+        super(ctx, "create-jms-resource", true);
+        this.addRequiredPath("/subsystem=messaging");
+    }
+
+    @Override
+    public ModelNode buildRequestWithoutHeaders(CommandContext ctx) throws OperationFormatException {
+
+        try {
+            if(!ctx.getParsedCommandLine().hasProperties()) {
+                throw new OperationFormatException("Arguments are missing");
+            }
+        } catch (CommandFormatException e) {
+            throw new OperationFormatException(e.getLocalizedMessage());
+        }
+
+        //String target = null;
+        String restype = null;
+        //String description = null;
+        String propsStr = null;
+        //boolean enabled = false;
+        String jndiName = null;
+
+        String[] args = ctx.getArgumentsString().split("\\s+");
+        int i = 0;
+        while(i < args.length) {
+            String arg = args[i++];
+            if(arg.equals("--restype")) {
+                if(i < args.length) {
+                    restype = args[i++];
+                }
+            } else if(arg.equals("--target")) {
+//                if(i < args.length) {
+//                    target = args[i++];
+//                }
+            } else if(arg.equals("--description")) {
+//                if(i < args.length) {
+//                    restype = args[i++];
+//                }
+            } else if(arg.equals("--property")) {
+                if (i < args.length) {
+                    propsStr = args[i++];
+                }
+            } else if(arg.equals("--enabled")) {
+//                if (i < args.length) {
+//                    enabled = Boolean.parseBoolean(args[i++]);
+//                }
+            } else {
+                jndiName = arg;
+            }
+        }
+
+        if(restype == null) {
+            throw new OperationFormatException("Required parameter --restype is missing.");
+        }
+
+        if(jndiName == null) {
+            throw new OperationFormatException("JNDI name is missing.");
+        }
+
+        String name = null;
+        String serverName = "default"; // TODO read server name from props
+        final Map<String, String> props;
+        if(propsStr != null) {
+            props = new HashMap<String, String>();
+            String[] propsArr = propsStr.split(":");
+            for(String prop : propsArr) {
+                int equalsIndex = prop.indexOf('=');
+                if(equalsIndex < 0 || equalsIndex == prop.length() - 1) {
+                    throw new OperationFormatException("Failed to parse property '" + prop + "'");
+                }
+
+                String propName = prop.substring(0, equalsIndex).trim();
+                String propValue = prop.substring(equalsIndex + 1).trim();
+                if(propName.isEmpty()) {
+                    throw new OperationFormatException("Failed to parse property '" + prop + "'");
+                }
+
+                if(propName.equals("imqDestinationName") ||propName.equalsIgnoreCase("name")) {
+                    name = propValue;
+                } else if("ClientId".equals(propName)) {
+                    props.put("client-id", propValue);
+                }
+            }
+        } else {
+            props = Collections.emptyMap();
+        }
+
+        if(name == null) {
+            name = jndiName.replace('/', '_');
+        }
+
+        if(restype.equals("javax.jms.Queue")) {
+
+            DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+            builder.addNode("subsystem", "messaging");
+            builder.addNode("hornetq-server", serverName);
+            builder.addNode("jms-queue", name);
+            builder.setOperationName("add");
+            builder.getModelNode().get("entries").add(jndiName);
+
+            for(String prop : props.keySet()) {
+                builder.addProperty(prop, props.get(prop));
+            }
+
+            return builder.buildRequest();
+
+        } else if(restype.equals("javax.jms.Topic")) {
+
+            DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+            builder.addNode("subsystem", "messaging");
+            builder.addNode("hornetq-server", serverName);
+            builder.addNode("jms-topic", name);
+            builder.setOperationName("add");
+            builder.getModelNode().get("entries").add(jndiName);
+
+            for(String prop : props.keySet()) {
+                builder.addProperty(prop, props.get(prop));
+            }
+
+            return builder.buildRequest();
+
+        } else if(restype.equals("javax.jms.ConnectionFactory") ||
+                restype.equals("javax.jms.TopicConnectionFactory") ||
+                restype.equals("javax.jms.QueueConnectionFactory")) {
+
+            DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+            builder.addNode("subsystem", "messaging");
+            builder.addNode("hornetq-server", serverName);
+            builder.addNode("connection-factory", name);
+            builder.setOperationName("add");
+            builder.getModelNode().get("entries").add(jndiName);
+
+            for(String prop : props.keySet()) {
+                builder.addProperty(prop, props.get(prop));
+            }
+
+            return builder.buildRequest();
+
+        } else {
+            throw new OperationFormatException("Resource type " + restype + " isn't supported.");
+        }
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/cli/CreateJMSResourceHandlerProvider.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/cli/CreateJMSResourceHandlerProvider.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.cli;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHandler;
+import org.jboss.as.cli.CommandHandlerProvider;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
+ */
+public class CreateJMSResourceHandlerProvider implements CommandHandlerProvider {
+    @Override
+    public CommandHandler createCommandHandler(CommandContext ctx) {
+        return new CreateJMSResourceHandler(ctx);
+    }
+
+    @Override
+    public boolean isTabComplete() {
+        return false;
+    }
+
+    @Override
+    public String[] getNames() {
+        return new String[] { "create-jms-resource" };
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/cli/DeleteJMSResourceHandler.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/cli/DeleteJMSResourceHandler.java
@@ -1,0 +1,96 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.messaging.jms.cli;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandFormatException;
+import org.jboss.as.cli.Util;
+import org.jboss.as.cli.handlers.BatchModeCommandHandler;
+import org.jboss.as.cli.operation.OperationFormatException;
+import org.jboss.as.cli.operation.impl.DefaultOperationRequestBuilder;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.dmr.ModelNode;
+
+/**
+ *
+ * @author Alexey Loubyansky
+ */
+class DeleteJMSResourceHandler extends BatchModeCommandHandler {
+
+    public DeleteJMSResourceHandler(CommandContext ctx) {
+        super(ctx, "delete-jms-resource", true);
+        this.addRequiredPath("/subsystem=messaging");
+    }
+
+    @Override
+    public ModelNode buildRequestWithoutHeaders(CommandContext ctx)
+            throws OperationFormatException {
+
+        try {
+            if(!ctx.getParsedCommandLine().hasProperties()) {
+                throw new OperationFormatException("Arguments are missing");
+            }
+        } catch (CommandFormatException e) {
+            throw new OperationFormatException(e.getLocalizedMessage());
+        }
+
+        //String target = null;
+        String jndiName = null;
+        String serverName = "default"; // TODO read server name from props
+
+        String[] args = ctx.getArgumentsString().split("\\s+");
+        int i = 0;
+        while(i < args.length) {
+            String arg = args[i++];
+            if(arg.equals("--target")) {
+//                if(i < args.length) {
+//                    target = args[i++];
+//                }
+            } else {
+                jndiName = arg;
+            }
+        }
+
+        if(jndiName == null) {
+            throw new OperationFormatException("name is missing.");
+        }
+
+        ModelControllerClient client = ctx.getModelControllerClient();
+        final String resource;
+        if(Util.isTopic(client, jndiName)) {
+            resource = "jms-topic";
+        } else if(Util.isQueue(client, jndiName)) {
+            resource = "jms-queue";
+        } else if(Util.isConnectionFactory(client, jndiName)) {
+            resource = "connection-factory";
+        } else {
+            throw new OperationFormatException("'" + jndiName +"' wasn't found among existing JMS resources.");
+        }
+
+        DefaultOperationRequestBuilder builder = new DefaultOperationRequestBuilder();
+        builder.addNode("subsystem", "messaging");
+        builder.addNode("hornetq-server", serverName);
+        builder.addNode(resource, jndiName);
+        builder.setOperationName("remove");
+        return builder.buildRequest();
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/cli/DeleteJMSResourceHandlerProvider.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/cli/DeleteJMSResourceHandlerProvider.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.cli;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHandler;
+import org.jboss.as.cli.CommandHandlerProvider;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
+ */
+public class DeleteJMSResourceHandlerProvider implements CommandHandlerProvider {
+    @Override
+    public CommandHandler createCommandHandler(CommandContext ctx) {
+        return new DeleteJMSResourceHandler(ctx);
+    }
+
+    @Override
+    public boolean isTabComplete() {
+        return false;
+    }
+
+    @Override
+    public String[] getNames() {
+        return new String[] { "delete-jms-resource" };
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/cli/JMSQueueHandlerProvider.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/cli/JMSQueueHandlerProvider.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.cli;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHandler;
+import org.jboss.as.cli.CommandHandlerProvider;
+import org.jboss.as.cli.handlers.GenericTypeOperationHandler;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
+ */
+public class JMSQueueHandlerProvider implements CommandHandlerProvider {
+    @Override
+    public CommandHandler createCommandHandler(CommandContext ctx) {
+        return new GenericTypeOperationHandler(ctx,  "/subsystem=messaging/hornetq-server=default/jms-queue", "queue-address");
+    }
+
+    @Override
+    public boolean isTabComplete() {
+        return true;
+    }
+
+    @Override
+    public String[] getNames() {
+        return new String[] { "jms-queue" };
+    }
+}

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/cli/JMSTopicHandlerProvider.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/cli/JMSTopicHandlerProvider.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.messaging.jms.cli;
+
+import org.jboss.as.cli.CommandContext;
+import org.jboss.as.cli.CommandHandler;
+import org.jboss.as.cli.CommandHandlerProvider;
+import org.jboss.as.cli.handlers.GenericTypeOperationHandler;
+
+/**
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
+ */
+public class JMSTopicHandlerProvider implements CommandHandlerProvider {
+    @Override
+    public CommandHandler createCommandHandler(CommandContext ctx) {
+        return new GenericTypeOperationHandler(ctx,  "/subsystem=messaging/hornetq-server=default/jms-topic", "topic-address");
+    }
+
+    @Override
+    public boolean isTabComplete() {
+        return true;
+    }
+
+    @Override
+    public String[] getNames() {
+        return new String[] { "jms-topic" };
+    }
+}

--- a/messaging/src/main/resources/META-INF/services/org.jboss.as.cli.CommandHandlerProvider
+++ b/messaging/src/main/resources/META-INF/services/org.jboss.as.cli.CommandHandlerProvider
@@ -1,0 +1,5 @@
+org.jboss.as.messaging.jms.cli.ConnectionFactoryHandlerProvider
+org.jboss.as.messaging.jms.cli.CreateJMSResourceHandlerProvider
+org.jboss.as.messaging.jms.cli.DeleteJMSResourceHandlerProvider
+org.jboss.as.messaging.jms.cli.JMSQueueHandlerProvider
+org.jboss.as.messaging.jms.cli.JMSTopicHandlerProvider


### PR DESCRIPTION
move JMS high-level commands (jms-queue, jms-topic, connection-factory,
create-jms-resource, delete-jms-resource) from wildfly-cli module to the
messaging extensions (that provides the server runtime for these commands)

JIRA: https://issues.jboss.org/browse/WFLY-4740
