### PR TITLE
Fix for WFLY-4751 

### DIFF
--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSQueueAdd.java
@@ -75,8 +75,10 @@ public class JMSQueueAdd extends AbstractAddStepHandler {
 
         final ModelNode entries = CommonAttributes.DESTINATION_ENTRIES.resolveModelAttribute(context, model);
         final String[] jndiBindings = JMSServices.getJndiBindings(entries);
+        final ServiceName jmsQueueServiceName = JMSServices.getJmsQueueBaseServiceName(hqServiceName).append(name);
         for (String jndiBinding : jndiBindings) {
-            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, queueService);
+            // install a binder service which depends on the JMS queue service
+            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, queueService, jmsQueueServiceName);
         }
     }
 

--- a/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/jms/JMSTopicAdd.java
@@ -66,8 +66,10 @@ public class JMSTopicAdd extends AbstractAddStepHandler {
 
         final ModelNode entries = CommonAttributes.DESTINATION_ENTRIES.resolveModelAttribute(context, model);
         final String[] jndiBindings = JMSServices.getJndiBindings(entries);
+        final ServiceName jmsTopicServiceName = JMSServices.getJmsTopicBaseServiceName(hqServiceName).append(name);
         for (String jndiBinding : jndiBindings) {
-            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, jmsTopicService);
+            // install a binder service which depends on the JMS topic service
+            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, jmsTopicService, jmsTopicServiceName);
         }
     }
 


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/WFLY-4751 by adding a dependency on the JMSTopicService/JMSQueueService for the binder services that are created for the JNDI names of the topic/queue. This should ensure that the lookups on those JNDI names don't result in null values when the JMSTopicService/JMSQueueService is still not up.

Forum reference https://developer.jboss.org/thread/259981?start=0&tstart=0 (long thread with multiple different weird exceptions, but all of which are a result of the JNDI lookup returning null).

Please have this reviewed by @jmesnil  or someone else from the messaging team.
