### PR TITLE
Utilization of capabilities and requirements

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -108,7 +108,7 @@
             </exclusions>
         </dependency>
 
-        <!-- module and copy artifact dependencies -->		        
+        <!-- module and copy artifact dependencies -->
 
         <dependency>
             <groupId>org.wildfly</groupId>
@@ -903,7 +903,7 @@
                     <artifactId>*</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>    
+        </dependency>
 
         <dependency>
             <groupId>org.jboss.mod_cluster</groupId>
@@ -1650,7 +1650,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-infinispan</artifactId>
@@ -1661,7 +1661,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-orm</artifactId>
@@ -1727,7 +1727,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>org.hibernate.hql</groupId>
             <artifactId>hibernate-hql-parser</artifactId>
@@ -1943,7 +1943,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-version</artifactId>
@@ -2216,7 +2216,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        
+
         <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-jberet</artifactId>

--- a/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
+++ b/feature-pack/src/main/resources/content/appclient/configuration/appclient.xml
@@ -26,6 +26,7 @@
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
+        <extension module="org.jboss.as.jmx"/>
         <extension module="org.jboss.as.jpa"/>
         <extension module="org.jboss.as.logging"/>
         <extension module="org.jboss.as.naming"/>
@@ -133,6 +134,7 @@
                 </long-running-threads>
             </default-workmanager>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jmx:1.3"/>
         <subsystem xmlns="urn:jboss:domain:jpa:1.1">
             <jpa default-datasource=""/>
         </subsystem>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jacorb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jacorb/main/module.xml
@@ -42,8 +42,9 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
+        <!-- JTSCapability must be loadable, but only if transaction support is configured -->
+        <module name="org.jboss.as.transactions" optional="true"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.metadata.ejb"/>
@@ -54,5 +55,6 @@
         <module name="org.jboss.jts.integration"/>
         <module name="org.picketbox"/>
         <module name="org.wildfly.iiop-openjdk"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/messaging/main/module.xml
@@ -48,6 +48,7 @@
         <module name="org.jboss.as.cli" />
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
+        <module name="org.jboss.as.jmx"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <!-- required only to access the HttpListenerRegistryService used by http-acceptor -->

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -43,6 +43,7 @@
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
+        <module name="org.jboss.as.jmx"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.server"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/transactions/main/module.xml
@@ -52,7 +52,6 @@
         <module name="org.jboss.jts"/>
         <module name="org.jboss.jts.integration"/>
         <module name="org.omg.api"/>
-        <module name="org.wildfly.iiop-openjdk"/>
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.narayana.compensations"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -55,6 +55,7 @@
         <module name="org.jboss.as.ejb3"/>
         <module name="org.jboss.as.server"/>
         <module name="org.jboss.as.ee"/>
+        <module name="org.jboss.as.jmx"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
         <module name="org.jboss.as.security"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/iiop-openjdk/main/module.xml
@@ -38,8 +38,9 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.jboss.as.network"/>
-        <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>
+        <!-- JTSCapability must be loadable, but only if transaction support is configured -->
+        <module name="org.jboss.as.transactions" optional="true"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.metadata.common"/>
         <module name="org.jboss.metadata.ejb"/>
@@ -49,5 +50,6 @@
         <module name="org.jboss.jts" />
         <module name="org.jboss.jts.integration"/>
         <module name="org.picketbox"/>
+        <module name="org.wildfly.security.elytron"/>
     </dependencies>
 </module>

--- a/iiop-openjdk/pom.xml
+++ b/iiop-openjdk/pom.xml
@@ -96,6 +96,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-transactions</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.narayana.jts</groupId>
             <artifactId>narayana-jts-idlj</artifactId>
         </dependency>

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPInitializer.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPInitializer.java
@@ -44,8 +44,9 @@ public enum IIOPInitializer {
 
     // the transaction group encompasses the Interposition and InboundCurrent initializers.
     TRANSACTIONS("transactions",
-            "com.arjuna.ats.jts.orbspecific.javaidl.interceptors.interposition.InterpositionORBInitializerImpl",
-            "com.arjuna.ats.jbossatx.jts.InboundTransactionCurrentInitializer",
+            // These used to be hard coded here but now are provided via the org.jboss.as.txn.subsystem.JTSCapability
+            //"com.arjuna.ats.jts.orbspecific.javaidl.interceptors.interposition.InterpositionORBInitializerImpl",
+            //"com.arjuna.ats.jbossatx.jts.InboundTransactionCurrentInitializer",
             "org.wildfly.iiop.openjdk.tm.TxIORInterceptorInitializer",
             "org.wildfly.iiop.openjdk.tm.TxServerInterceptorInitializer"),
 

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaNamingService.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaNamingService.java
@@ -50,7 +50,7 @@ import org.wildfly.iiop.openjdk.naming.CorbaNamingContext;
  */
 public class CorbaNamingService implements Service<NamingContextExt> {
 
-    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append(IIOPExtension.SUBSYSTEM_NAME, "naming-service");
+    public static final ServiceName SERVICE_NAME = IIOPExtension.IIOP_CAPABILITY.getCapabilityServiceName(NamingContextExt.class);
 
     private static final Properties properties = new Properties();
 

--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaORBService.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/service/CorbaORBService.java
@@ -61,7 +61,7 @@ import com.sun.corba.se.impl.orbutil.ORBConstants;
  */
 public class CorbaORBService implements Service<ORB> {
 
-    public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append(IIOPExtension.SUBSYSTEM_NAME, "orb-service");
+    public static final ServiceName SERVICE_NAME = IIOPExtension.IIOP_CAPABILITY.getCapabilityServiceName(ORB.class);
 
     private static final Properties properties = new Properties();
 

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementRootResource.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementRootResource.java
@@ -23,6 +23,7 @@ package org.jboss.as.jsr77.subsystem;
 
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 
 /**
@@ -31,9 +32,13 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
  */
 public class JSR77ManagementRootResource extends SimpleResourceDefinition {
 
+    static final String JMX_CAPABILITY = "org.wildfly.extension.jmx";
+    static final RuntimeCapability<Void> JSR77_CAPABILITY = new RuntimeCapability<>("org.wildfly.extension.jsr77", null,
+            JMX_CAPABILITY);
+
     static JSR77ManagementRootResource INSTANCE = new JSR77ManagementRootResource();
 
-    private JSR77ManagementRootResource() {
+    JSR77ManagementRootResource() {
         super(PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JSR77ManagementExtension.SUBSYSTEM_NAME),
                 JSR77ManagementExtension.getResourceDescriptionResolver(JSR77ManagementExtension.SUBSYSTEM_NAME),
                 JSR77ManagementSubsystemAdd.INSTANCE, JSR77ManagementSubsystemRemove.INSTANCE);

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemRemove.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemRemove.java
@@ -38,6 +38,7 @@ class JSR77ManagementSubsystemRemove extends AbstractRemoveStepHandler {
     static JSR77ManagementSubsystemRemove INSTANCE = new JSR77ManagementSubsystemRemove();
 
     private JSR77ManagementSubsystemRemove() {
+        super(JSR77ManagementRootResource.JSR77_CAPABILITY);
     }
 
     @Override

--- a/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
+++ b/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
@@ -38,6 +38,8 @@ import org.junit.Test;
  */
 public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest {
 
+    private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities(JSR77ManagementRootResource.JMX_CAPABILITY);
+
     public JSR77ManagementSubsystemTestCase() {
         super(JSR77ManagementExtension.SUBSYSTEM_NAME, new JSR77ManagementExtension());
     }
@@ -45,6 +47,11 @@ public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest 
     @Override
     protected String getSubsystemXml() throws IOException {
         return "<subsystem xmlns=\"urn:jboss:domain:jsr77:1.0\"/>";
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return ADDITIONAL_INITIALIZATION;
     }
 
     @Override
@@ -98,12 +105,13 @@ public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest 
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+        KernelServicesBuilder builder = createKernelServicesBuilder(ADDITIONAL_INITIALIZATION)
                 .setSubsystemXml(getSubsystemXml());
 
         // Add legacy subsystems
         builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-jsr77:" + controllerVersion.getMavenGavVersion());
+                .addMavenResourceURL("org.jboss.as:jboss-as-jsr77:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(ADDITIONAL_INITIALIZATION, null);
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);

--- a/legacy/jacorb/pom.xml
+++ b/legacy/jacorb/pom.xml
@@ -103,6 +103,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-transactions</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.metadata</groupId>
             <artifactId>jboss-metadata-common</artifactId>
         </dependency>

--- a/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemAdd.java
+++ b/legacy/jacorb/src/main/java/org/jboss/as/jacorb/JacORBSubsystemAdd.java
@@ -49,7 +49,7 @@ public class JacORBSubsystemAdd extends IIOPSubsystemAdd {
     static final JacORBSubsystemAdd INSTANCE = new JacORBSubsystemAdd();
 
     private JacORBSubsystemAdd() {
-        super(JacORBSubsystemDefinitions.SUBSYSTEM_ATTRIBUTES);
+        super(JacORBSubsystemDefinitions.SUBSYSTEM_ATTRIBUTES, JacORBSubsystemDefinitions.ORB_INIT_TX);
     }
 
     @Override

--- a/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/HornetQServerAdd.java
@@ -247,8 +247,11 @@ class HornetQServerAdd implements OperationStepHandler {
 
                 // Add the HornetQ Service
                 ServiceName hqServiceName = MessagingServices.getHornetQServiceName(serverName);
-                final ServiceBuilder<HornetQServer> serviceBuilder = serviceTarget.addService(hqServiceName, hqService)
-                        .addDependency(DependencyType.OPTIONAL, ServiceName.JBOSS.append("mbean", "server"), MBeanServer.class, hqService.getMBeanServer());
+                final ServiceBuilder<HornetQServer> serviceBuilder = serviceTarget.addService(hqServiceName, hqService);
+                if (context.hasOptionalCapability(MessagingSubsystemRootResourceDefinition.JMX_CAPABILITY, MessagingSubsystemRootResourceDefinition.MESSAGING_CAPABILITY.getName(), null)) {
+                    ServiceName jmxCapability = context.getCapabilityServiceName(MessagingSubsystemRootResourceDefinition.JMX_CAPABILITY, MBeanServer.class);
+                    serviceBuilder.addDependency(jmxCapability, MBeanServer.class, hqService.getMBeanServer());
+                }
 
                 serviceBuilder.addDependency(PathManagerService.SERVICE_NAME, PathManager.class, hqService.getPathManagerInjector());
 

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemAdd.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemAdd.java
@@ -50,6 +50,7 @@ class MessagingSubsystemAdd extends AbstractBoottimeAddStepHandler {
     public static final MessagingSubsystemAdd INSTANCE = new MessagingSubsystemAdd();
 
     private MessagingSubsystemAdd() {
+        super(MessagingSubsystemRootResourceDefinition.MESSAGING_CAPABILITY);
     }
 
     @Override

--- a/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemRootResourceDefinition.java
+++ b/messaging/src/main/java/org/jboss/as/messaging/MessagingSubsystemRootResourceDefinition.java
@@ -24,6 +24,7 @@ package org.jboss.as.messaging;
 
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 
 /**
  * {@link org.jboss.as.controller.ResourceDefinition} for the messaging subsystem root resource.
@@ -32,13 +33,19 @@ import org.jboss.as.controller.SimpleResourceDefinition;
  */
 public class MessagingSubsystemRootResourceDefinition extends SimpleResourceDefinition {
 
+    static final String JMX_CAPABILITY = "org.wildfly.extension.jmx";
+
+    static final RuntimeCapability<Void> MESSAGING_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.messaging")
+            .addRuntimeOnlyRequirements(JMX_CAPABILITY)
+            .build();
+
     public static final MessagingSubsystemRootResourceDefinition INSTANCE = new MessagingSubsystemRootResourceDefinition();
 
     private MessagingSubsystemRootResourceDefinition() {
         super(MessagingExtension.SUBSYSTEM_PATH,
                 MessagingExtension.getResourceDescriptionResolver(MessagingExtension.SUBSYSTEM_NAME),
                 MessagingSubsystemAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+                new ReloadRequiredRemoveStepHandler(MESSAGING_CAPABILITY));
         setDeprecated(MessagingExtension.DEPRECATED_SINCE);
     }
 }

--- a/sar/src/main/java/org/jboss/as/service/MBeanServices.java
+++ b/sar/src/main/java/org/jboss/as/service/MBeanServices.java
@@ -28,7 +28,6 @@ import java.util.List;
 import javax.management.MBeanServer;
 
 import org.jboss.as.jmx.MBeanRegistrationService;
-import org.jboss.as.jmx.MBeanServerService;
 import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
@@ -61,21 +60,22 @@ final class MBeanServices {
     private final ServiceBuilder<?> createDestroyServiceBuilder;
     private final ServiceBuilder<?> startStopServiceBuilder;
     private final ServiceTarget target;
+    private final ServiceName mbeanServerServiceName;
     private boolean installed;
 
     private final List<SetupAction> setupActions;
 
     /**
-     *
      * @param mBeanName
      * @param mBeanInstance
      * @param mBeanClassHierarchy
      * @param target
      * @param componentInstantiator
      * @param setupActions the deployment unit's service name
+     * @param mbeanServerServiceName
      */
-    MBeanServices(final String mBeanName, final Object mBeanInstance, final List<ClassReflectionIndex<?>> mBeanClassHierarchy, final ServiceTarget target,ServiceComponentInstantiator componentInstantiator,
-                  final List<SetupAction> setupActions, final ClassLoader mbeanContextClassLoader) {
+    MBeanServices(final String mBeanName, final Object mBeanInstance, final List<ClassReflectionIndex<?>> mBeanClassHierarchy, final ServiceTarget target, ServiceComponentInstantiator componentInstantiator,
+                  final List<SetupAction> setupActions, final ClassLoader mbeanContextClassLoader, final ServiceName mbeanServerServiceName) {
         if (mBeanClassHierarchy == null) {
             throw SarLogger.ROOT_LOGGER.nullVar("mBeanName");
         }
@@ -84,6 +84,9 @@ final class MBeanServices {
         }
         if (target == null) {
             throw SarLogger.ROOT_LOGGER.nullVar("target");
+        }
+        if (mbeanServerServiceName == null) {
+            throw SarLogger.ROOT_LOGGER.nullVar("mbeanServerServiceName");
         }
 
         final Method createMethod = ReflectionUtils.getMethod(mBeanClassHierarchy, CREATE_METHOD_NAME, NO_ARGS, false);
@@ -108,6 +111,7 @@ final class MBeanServices {
         this.mBeanName = mBeanName;
         this.target = target;
         this.setupActions = setupActions;
+        this.mbeanServerServiceName = mbeanServerServiceName;
     }
 
     Service<Object> getCreateDestroyService() {
@@ -150,7 +154,7 @@ final class MBeanServices {
         // Add service to register the mbean in the mbean server
         final MBeanRegistrationService<Object> mbeanRegistrationService = new MBeanRegistrationService<Object>(mBeanName, setupActions);
         target.addService(MBeanRegistrationService.SERVICE_NAME.append(mBeanName), mbeanRegistrationService)
-            .addDependency(MBeanServerService.SERVICE_NAME, MBeanServer.class, mbeanRegistrationService.getMBeanServerInjector())
+            .addDependency(mbeanServerServiceName, MBeanServer.class, mbeanRegistrationService.getMBeanServerInjector())
             .addDependency(startStopServiceName, Object.class, mbeanRegistrationService.getValueInjector())
             .install();
 

--- a/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
+++ b/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
@@ -59,6 +59,7 @@ import org.jboss.modules.Module;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.inject.MethodInjector;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.ImmediateValue;
 import org.jboss.msc.value.MethodValue;
@@ -75,6 +76,13 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Eduardo Martins
  */
 public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor {
+
+    private final ServiceName mbeanServerServiceName;
+
+    ParsedServiceDeploymentProcessor(ServiceName mbeanServerServiceName) {
+
+        this.mbeanServerServiceName = mbeanServerServiceName;
+    }
 
     /**
      * Process a deployment for JbossService configuration.  Will install a {@code JBossService} for each configured service.
@@ -122,7 +130,7 @@ public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor
         final String mBeanName = mBeanConfig.getName();
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
 
-        final MBeanServices mBeanServices = new MBeanServices(mBeanName, mBeanInstance, mBeanClassHierarchy, target, componentInstantiator, deploymentUnit.getAttachmentList(Attachments.SETUP_ACTIONS), classLoader);
+        final MBeanServices mBeanServices = new MBeanServices(mBeanName, mBeanInstance, mBeanClassHierarchy, target, componentInstantiator, deploymentUnit.getAttachmentList(Attachments.SETUP_ACTIONS), classLoader, mbeanServerServiceName);
 
         final JBossServiceDependencyConfig[] dependencyConfigs = mBeanConfig.getDependencyConfigs();
         addDependencies(dependencyConfigs, mBeanClassHierarchy, mBeanServices);

--- a/sar/src/main/java/org/jboss/as/service/SarExtension.java
+++ b/sar/src/main/java/org/jboss/as/service/SarExtension.java
@@ -40,6 +40,7 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
@@ -71,8 +72,14 @@ public class SarExtension implements Extension {
     private static final String RESOURCE_NAME = SarExtension.class.getPackage().getName() + ".LocalDescriptions";
     private static final ResourceDescriptionResolver RESOLVER = new StandardResourceDescriptionResolver("sar", RESOURCE_NAME, SarExtension.class.getClassLoader());
     private static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SarExtension.SUBSYSTEM_NAME);
+
+    static final String JMX_CAPABILITY = "org.wildfly.extension.jmx";
+    static final RuntimeCapability<Void> SAR_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.sar")
+            .addRequirements(JMX_CAPABILITY)
+            .build();
+
     private static final ResourceDefinition RESOURCE_DEFINITION = new SimpleResourceDefinition(PATH, RESOLVER,
-                            SarSubsystemAdd.INSTANCE, ReloadRequiredRemoveStepHandler.INSTANCE,
+                            SarSubsystemAdd.INSTANCE, new ReloadRequiredRemoveStepHandler(SAR_CAPABILITY),
                             OperationEntry.Flag.RESTART_ALL_SERVICES, OperationEntry.Flag.RESTART_ALL_SERVICES);
 
     private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(1, 0, 0);

--- a/sar/src/main/java/org/jboss/as/service/SarSubsystemAdd.java
+++ b/sar/src/main/java/org/jboss/as/service/SarSubsystemAdd.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.service;
 
+import javax.management.MBeanServer;
+
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.server.AbstractDeploymentChainStep;
@@ -29,6 +31,7 @@ import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.service.component.ServiceComponentProcessor;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * @author Emanuel Muckenhuber
@@ -38,22 +41,26 @@ public class SarSubsystemAdd extends AbstractBoottimeAddStepHandler {
     static final SarSubsystemAdd INSTANCE = new SarSubsystemAdd();
 
     private SarSubsystemAdd() {
+        super(SarExtension.SAR_CAPABILITY);
     }
 
     protected void populateModel(ModelNode operation, ModelNode model) {
         model.setEmptyObject();
     }
 
-    protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model) {
+    protected void performBoottime(final OperationContext context, ModelNode operation, ModelNode model) {
 
         context.addStep(new AbstractDeploymentChainStep() {
             public void execute(DeploymentProcessorTarget processorTarget) {
+
+                ServiceName jmxCapability = context.getCapabilityServiceName(SarExtension.JMX_CAPABILITY, MBeanServer.class);
+
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_SAR_SUB_DEPLOY_CHECK, new SarSubDeploymentProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_SAR, new SarStructureProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_SAR_MODULE, new SarModuleDependencyProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_SERVICE_DEPLOYMENT, new ServiceDeploymentParsingProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_SAR_SERVICE_COMPONENT, new ServiceComponentProcessor());
-                processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_SERVICE_DEPLOYMENT, new ParsedServiceDeploymentProcessor());
+                processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_SERVICE_DEPLOYMENT, new ParsedServiceDeploymentProcessor(jmxCapability));
             }
         }, OperationContext.Stage.RUNTIME);
 

--- a/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
+++ b/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
@@ -39,8 +39,15 @@ import org.junit.Test;
  */
 public class SarSubsystemTestCase extends AbstractSubsystemBaseTest {
 
+    private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities("org.wildfly.extension.jmx");
+
     public SarSubsystemTestCase() {
         super(SarExtension.SUBSYSTEM_NAME, new SarExtension());
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return ADDITIONAL_INITIALIZATION;
     }
 
     @Override
@@ -98,12 +105,13 @@ public class SarSubsystemTestCase extends AbstractSubsystemBaseTest {
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion, String commonBeansVersion) throws Exception {
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+        KernelServicesBuilder builder = createKernelServicesBuilder(ADDITIONAL_INITIALIZATION)
                 .setSubsystemXml(getSubsystemXml());
 
         // Add legacy subsystems
         LegacyKernelServicesInitializer initializer = builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-sar:" + controllerVersion.getMavenGavVersion());
+                .addMavenResourceURL("org.jboss.as:jboss-as-sar:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(ADDITIONAL_INITIALIZATION, null);
         if (commonBeansVersion != null) {
             initializer.addMavenResourceURL("org.jboss.common:jboss-common-beans:" + commonBeansVersion);
         }

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -743,6 +743,7 @@
             </subsystem>
         </profile>
         <profile name="ignored">
+            <subsystem xmlns="urn:jboss:domain:jmx:1.0"/>
             <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
         </profile>
         <profile name="minimal">

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -44,10 +44,6 @@
             <artifactId>wildfly-ee</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.wildfly</groupId>
-            <artifactId>wildfly-iiop-openjdk</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.openjdk-orb</groupId>
             <artifactId>openjdk-orb</artifactId>
         </dependency>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>wildfly-controller</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.wildfly.core</groupId>
+            <artifactId>wildfly-jmx</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-ee</artifactId>
         </dependency>

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/JTSCapability.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/JTSCapability.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.txn.subsystem;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Runtime API exposed by the JTS capability.
+ *
+ * @author Brian Stansberry (c) 2014 Red Hat Inc.
+ */
+public class JTSCapability {
+
+    private final List<String> initializerClasses = Collections.unmodifiableList(Arrays.asList(
+            "com.arjuna.ats.jts.orbspecific.jacorb.interceptors.interposition.InterpositionORBInitializerImpl",
+            "com.arjuna.ats.jbossatx.jts.InboundTransactionCurrentInitializer"));
+
+    /**
+     * Gets the names of the {@link org.omg.PortableInterceptor.ORBInitializer} implementations that should be included
+     * as part of the {@link org.omg.CORBA.ORB#init(String[], java.util.Properties) initialization of an ORB}.
+     *
+     * @return the names of the classes implementing {@code ORBInitializer}. Will not be {@code null}.
+     */
+    public List<String> getORBInitializerClasses() {
+        return initializerClasses;
+    }
+}

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionExtension.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionExtension.java
@@ -74,7 +74,6 @@ public class TransactionExtension implements Extension {
 
     private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(3, 0, 0);
 
-    private static final ServiceName MBEAN_SERVER_SERVICE_NAME = ServiceName.JBOSS.append("mbean", "server");
     static final PathElement LOG_STORE_PATH = PathElement.pathElement(LogStoreConstants.LOG_STORE, LogStoreConstants.LOG_STORE);
     static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, TransactionExtension.SUBSYSTEM_NAME);
     static final PathElement PARTICIPANT_PATH = PathElement.pathElement(LogStoreConstants.PARTICIPANTS);
@@ -90,8 +89,9 @@ public class TransactionExtension implements Extension {
     }
 
     static MBeanServer getMBeanServer(OperationContext context) {
+        ServiceName jmxCapability = context.getCapabilityServiceName(TransactionSubsystemRootResourceDefinition.JMX_CAPABILITY, MBeanServer.class);
         final ServiceRegistry serviceRegistry = context.getServiceRegistry(false);
-        final ServiceController<?> serviceController = serviceRegistry.getService(MBEAN_SERVER_SERVICE_NAME);
+        final ServiceController<?> serviceController = serviceRegistry.getService(jmxCapability);
         if (serviceController == null) {
             throw TransactionLogger.ROOT_LOGGER.jmxSubsystemNotInstalled();
         }

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -24,10 +24,6 @@ package org.jboss.as.txn.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.Set;
-
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
@@ -40,6 +36,7 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.client.helpers.MeasurementUnit;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.validation.IntRangeValidator;
@@ -231,25 +228,36 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
             .setAllowExpression(true)
             .setRequires(CommonAttributes.USE_JDBC_STORE).build();
 
+    static final RuntimeCapability<Void> BASIC_CAPABILITY =
+            RuntimeCapability.Builder.of("org.wildfly.extension.transactions")
+                .build();
+    static final RuntimeCapability<JTSCapability> JTS_CAPABILITY =
+            RuntimeCapability.Builder.of("org.wildfly.extension.transactions.jts", new JTSCapability())
+                .addRequirements(BASIC_CAPABILITY.getName(), "org.wildfly.extension.iiop")
+                .build();
 
     private final boolean registerRuntimeOnly;
 
     TransactionSubsystemRootResourceDefinition(boolean registerRuntimeOnly) {
         super(TransactionExtension.SUBSYSTEM_PATH,
                 TransactionExtension.getResourceDescriptionResolver(),
-                TransactionSubsystemAdd.INSTANCE, ReloadRequiredRemoveStepHandler.INSTANCE,
+                TransactionSubsystemAdd.INSTANCE,
+                new ReloadRequiredRemoveStepHandler(BASIC_CAPABILITY, JTS_CAPABILITY),
                 OperationEntry.Flag.RESTART_ALL_SERVICES, OperationEntry.Flag.RESTART_ALL_SERVICES);
         this.registerRuntimeOnly = registerRuntimeOnly;
     }
 
-    // all attributes
-    static final AttributeDefinition[] attributes = new AttributeDefinition[] {
-            BINDING, STATUS_BINDING, RECOVERY_LISTENER, NODE_IDENTIFIER, PROCESS_ID_UUID, PROCESS_ID_SOCKET_BINDING,
-            PROCESS_ID_SOCKET_MAX_PORTS, RELATIVE_TO, PATH, STATISTICS_ENABLED, ENABLE_TSM_STATUS, DEFAULT_TIMEOUT,
-            OBJECT_STORE_RELATIVE_TO, OBJECT_STORE_PATH, JTS, USEHORNETQSTORE, USE_JDBC_STORE, JDBC_STORE_DATASOURCE,
+    // all attributes except JTS, USEHORNETQSTORE, USE_JDBC_STORE and PROCESS_ID_xxx
+    private static final AttributeDefinition[] basicAttributes = new AttributeDefinition[] {
+            BINDING, STATUS_BINDING, RECOVERY_LISTENER, NODE_IDENTIFIER, RELATIVE_TO, PATH, STATISTICS_ENABLED,
+            ENABLE_TSM_STATUS, DEFAULT_TIMEOUT, OBJECT_STORE_RELATIVE_TO, OBJECT_STORE_PATH, JDBC_STORE_DATASOURCE,
             JDBC_ACTION_STORE_DROP_TABLE, JDBC_ACTION_STORE_TABLE_PREFIX, JDBC_COMMUNICATION_STORE_DROP_TABLE,
             JDBC_COMMUNICATION_STORE_TABLE_PREFIX, JDBC_STATE_STORE_DROP_TABLE, JDBC_STATE_STORE_TABLE_PREFIX,
             HORNETQ_STORE_ENABLE_ASYNC_IO
+    };
+
+    private static final AttributeDefinition[] attributesWithMutuals = new AttributeDefinition[] {
+            PROCESS_ID_UUID, PROCESS_ID_SOCKET_BINDING, USEHORNETQSTORE, USE_JDBC_STORE
     };
 
     static final AttributeDefinition[] ATTRIBUTES_WITH_EXPRESSIONS_AFTER_1_1_0 = new AttributeDefinition[] {
@@ -269,20 +277,32 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
 
     @Override
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
-        // Register all attributes except of the mutual ones
-        Set<AttributeDefinition> attributesWithoutMutuals = new HashSet<>(Arrays.asList(attributes));
-        attributesWithoutMutuals.remove(USEHORNETQSTORE);
-        attributesWithoutMutuals.remove(USE_JDBC_STORE);
-
-        attributesWithoutMutuals.remove(PROCESS_ID_UUID);
-        attributesWithoutMutuals.remove(PROCESS_ID_SOCKET_BINDING);
-        attributesWithoutMutuals.remove(PROCESS_ID_SOCKET_MAX_PORTS);
-
-
-        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(attributesWithoutMutuals);
-        for(final AttributeDefinition def : attributesWithoutMutuals) {
+        // Register all attributes except the mutual ones and JTS, which require special handling
+        OperationStepHandler writeHandler = new ReloadRequiredWriteAttributeHandler(basicAttributes);
+        for(final AttributeDefinition def : basicAttributes) {
             resourceRegistration.registerReadWriteAttribute(def, null, writeHandler);
         }
+
+        // Register JTS with support for adding/removing the capability
+        resourceRegistration.registerReadWriteAttribute(JTS, null, new ReloadRequiredWriteAttributeHandler(JTS) {
+            @Override
+            protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue, ModelNode oldValue, Resource model) throws OperationFailedException {
+
+                super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
+
+                assert !JTS.isAllowExpression(); // if someone changes that we need to deal with it.
+                // Don't change it :)
+                boolean jts = newValue.asBoolean(JTS.getDefaultValue().asBoolean());
+                boolean was = oldValue.asBoolean(JTS.getDefaultValue().asBoolean());
+                if (jts != was) {
+                    if (jts) {
+                        context.registerCapability(JTS_CAPABILITY, JTS.getName());
+                    } else {
+                        context.deregisterCapability(JTS_CAPABILITY.getName());
+                    }
+                }
+            }
+        });
 
         // Register mutual object store attributes
         OperationStepHandler mutualWriteHandler = new ObjectStoreMutualWriteHandler(USEHORNETQSTORE, USE_JDBC_STORE);

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -228,8 +228,10 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
             .setAllowExpression(true)
             .setRequires(CommonAttributes.USE_JDBC_STORE).build();
 
+    static final String JMX_CAPABILITY = "org.wildfly.extension.jmx";
     static final RuntimeCapability<Void> BASIC_CAPABILITY =
             RuntimeCapability.Builder.of("org.wildfly.extension.transactions")
+                    .addRequirements(JMX_CAPABILITY)
                 .build();
     static final RuntimeCapability<JTSCapability> JTS_CAPABILITY =
             RuntimeCapability.Builder.of("org.wildfly.extension.transactions.jts", new JTSCapability())

--- a/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
+++ b/transactions/src/test/java/org/jboss/as/txn/TransactionSubsystemTestCase.java
@@ -49,20 +49,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.capability.RuntimeCapability;
-import org.jboss.as.controller.capability.registry.CapabilityContext;
-import org.jboss.as.controller.capability.registry.RegistrationPoint;
-import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistration;
-import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
-import org.jboss.as.controller.extension.ExtensionRegistry;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.transform.OperationTransformer;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
 import org.jboss.as.model.test.ModelFixer;
@@ -89,7 +80,7 @@ import org.junit.Test;
  */
 public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
 
-    private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities("org.wildfly.extension.iiop");
+    private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities("org.wildfly.extension.iiop", "org.wildfly.extension.jmx");
 
     public TransactionSubsystemTestCase() {
         super(TransactionExtension.SUBSYSTEM_NAME, new TransactionExtension());
@@ -184,7 +175,7 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
         String subsystemXml = readResource("full.xml");
         ModelVersion modelVersion = ModelVersion.create(1, 1, 0);
         //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+        KernelServicesBuilder builder = createKernelServicesBuilder(ADDITIONAL_INITIALIZATION)
                 .setSubsystemXml(subsystemXml);
 
         final PathAddress subsystemAddress = PathAddress.pathAddress(PathElement.pathElement(SUBSYSTEM, getMainSubsystemName()));
@@ -192,7 +183,7 @@ public class TransactionSubsystemTestCase extends AbstractSubsystemBaseTest {
         // Add legacy subsystems
         LegacyKernelServicesInitializer init = builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
             .addMavenResourceURL("org.jboss.as:jboss-as-transactions:" + controllerVersion.getMavenGavVersion())
-            .configureReverseControllerCheck(AdditionalInitialization.MANAGEMENT, ADD_REMOVED_HORNETQ_STORE_ENABLE_ASYNC_IO, RemoveProcessUUIDOperationFixer.INSTANCE)
+            .configureReverseControllerCheck(ADDITIONAL_INITIALIZATION, ADD_REMOVED_HORNETQ_STORE_ENABLE_ASYNC_IO, RemoveProcessUUIDOperationFixer.INSTANCE)
             .excludeFromParent(SingleClassFilter.createFilter(TransactionLogger.class));
         if (controllerVersion == ModelTestControllerVersion.EAP_6_0_0) {
             //EAP_6_0_0 does not have OperationFixer, so disable the validation of the ADD operation

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSExtension.java
@@ -42,6 +42,7 @@ import org.jboss.as.controller.ResourceBuilder;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -106,6 +107,12 @@ public final class WSExtension implements Extension {
         }
         return new StandardResourceDescriptionResolver(prefix.toString(), RESOURCE_NAME, WSExtension.class.getClassLoader(), true, false);
     }
+
+    static final String JMX_CAPABILITY = "org.wildfly.extension.jmx";
+
+    static final RuntimeCapability<Void> WEBSERVICES_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.webservices")
+            .addRuntimeOnlyRequirements(JMX_CAPABILITY)
+            .build();
 
     @Override
     public void initialize(final ExtensionContext context) {

--- a/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemRemove.java
+++ b/webservices/server-integration/src/main/java/org/jboss/as/webservices/dmr/WSSubsystemRemove.java
@@ -35,8 +35,9 @@ class WSSubsystemRemove extends ReloadRequiredRemoveStepHandler {
     static final WSSubsystemRemove INSTANCE = new WSSubsystemRemove();
 
     private WSSubsystemRemove() {
-
+       super(WSExtension.WEBSERVICES_CAPABILITY);
     }
+
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         super.performRuntime(context, operation, model);


### PR DESCRIPTION
This PR introduces some utilization of the capabilities/requirements functionality added in WildFly Core.

The first commit is the most significant one, as it introduces use of capabilities/requirements to mediate the interaction between the iiop and transactions subsystems.

The other commits are simpler, replacing how subsystems needing access to the MBeanServer get it from the JMX subsystem.
