### PR TITLE
(9.x) Fix for WFLY-4799

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlParser_1_0.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/persistence/filestore/EjbTimerXmlParser_1_0.java
@@ -127,6 +127,7 @@ public class EjbTimerXmlParser_1_0 implements XMLElementReader<List<TimerImpl>> 
     private void parseTimer(XMLExtendedStreamReader reader, List<TimerImpl> timers) throws XMLStreamException {
         LoadableElements loadableElements = new LoadableElements();
         TimerImpl.Builder builder = TimerImpl.builder();
+        builder.setPersistent(true);
         final Set<String> required = new HashSet<>(Arrays.asList(new String[]{TIMED_OBJECT_ID, TIMER_ID, INITIAL_DATE, REPEAT_INTERVAL, TIMER_STATE}));
         for (int i = 0; i < reader.getAttributeCount(); ++i) {
             String attr = reader.getAttributeValue(i);
@@ -207,7 +208,7 @@ public class EjbTimerXmlParser_1_0 implements XMLElementReader<List<TimerImpl>> 
     private void parseCalendarTimer(XMLExtendedStreamReader reader, List<TimerImpl> timers) throws XMLStreamException {
         LoadableElements loadableElements = new LoadableElements();
         CalendarTimer.Builder builder = CalendarTimer.builder();
-        builder.setAutoTimer(false);
+        builder.setAutoTimer(false).setPersistent(true);
         final Set<String> required = new HashSet<>(Arrays.asList(new String[]{
                 TIMED_OBJECT_ID,
                 TIMER_ID,


### PR DESCRIPTION
Currently timers that are persisted to the file store, when retrieved/loaded back aren't marked as "persistent". This causes issues with the way the timers are dealt with later, one of which is reported in https://issues.jboss.org/browse/WFLY-4799.

The commit here fixes the issue by marking such persisted timers as persistent.

PR for master branch: https://github.com/wildfly/wildfly/pull/7620
