### PR TITLE
[WFLY-4801] datasource jndi-name expression value should be resolved …

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/common/pool/PoolOperations.java
@@ -64,7 +64,7 @@ public abstract class PoolOperations implements OperationStepHandler {
         ModelNode model;
         if (!address.getElement(0).getKey().equals(ModelDescriptionConstants.DEPLOYMENT) &&
                 (model = context.readResource(PathAddress.EMPTY_ADDRESS, false).getModel()).isDefined()) {
-            jndiName = Util.getJndiName(model);
+            jndiName = Util.getJndiName(context, model);
         } else {
             jndiName = address.getLastElement().getValue();
         }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -104,7 +104,7 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
                                 final ModelNode model) throws OperationFailedException {
         final ModelNode address = operation.require(OP_ADDR);
         final String dsName = PathAddress.pathAddress(address).getLastElement().getValue();
-        final String jndiName = model.get(JNDI_NAME.getName()).asString();
+        final String jndiName = JNDI_NAME.resolveModelAttribute(context, model).asString();
         final boolean jta = JTA.resolveModelAttribute(context, operation).asBoolean();
         // The STATISTICS_ENABLED.resolveModelAttribute(context, model) call should remain as it serves to validate that any
         // expression in the model can be resolved to a correct value.

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceRemove.java
@@ -54,12 +54,12 @@ public abstract class AbstractDataSourceRemove extends AbstractRemoveStepHandler
         this.addHandler = addHandler;
     }
 
-    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) {
+    protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
 
         final ServiceRegistry registry = context.getServiceRegistry(true);
         final ModelNode address = operation.require(OP_ADDR);
         final String dsName = PathAddress.pathAddress(address).getLastElement().getValue();
-        final String jndiName = model.get(JNDI_NAME.getName()).asString();
+        final String jndiName = JNDI_NAME.resolveModelAttribute(context, model).asString();
 
         final ServiceName binderServiceName = ContextNames.bindInfoFor(jndiName).getBinderServiceName();
         final ServiceController<?> binderController = registry.getService(binderServiceName);

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
@@ -75,7 +75,7 @@ public class DataSourceDisable implements OperationStepHandler {
 
                         final ModelNode address = operation.require(OP_ADDR);
                         final String dsName = PathAddress.pathAddress(address).getLastElement().getValue();
-                        final String jndiName = model.get(JNDI_NAME.getName()).asString();
+                        final String jndiName = JNDI_NAME.resolveModelAttribute(context, model).asString();
 
                         final ServiceRegistry registry = context.getServiceRegistry(true);
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
@@ -101,7 +101,7 @@ public class DataSourceEnable implements OperationStepHandler {
 
         final ModelNode address = operation.require(OP_ADDR);
         final String dsName = PathAddress.pathAddress(address).getLastElement().getValue();
-        final String jndiName = model.get(JNDI_NAME.getName()).asString();
+        final String jndiName = JNDI_NAME.resolveModelAttribute(context, model).asString();
         final ServiceRegistry registry = context.getServiceRegistry(true);
         final List<ServiceName> serviceNames = registry.getServiceNames();
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Util.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Util.java
@@ -25,6 +25,8 @@ package org.jboss.as.connector.subsystems.datasources;
 import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.connector.subsystems.datasources.Constants.USE_JAVA_CONTEXT;
 
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -42,8 +44,8 @@ public class Util {
      *
      * @return the compliant jndi name
      */
-    public static String getJndiName(final ModelNode modelNode) {
-        final String rawJndiName = modelNode.require(JNDI_NAME.getName()).asString();
+    public static String getJndiName(final OperationContext context, final ModelNode modelNode) throws OperationFailedException {
+        final String rawJndiName = JNDI_NAME.resolveModelAttribute(context, modelNode).asString();
         return cleanJndiName(rawJndiName, modelNode.hasDefined(USE_JAVA_CONTEXT.getName()) && modelNode.get(USE_JAVA_CONTEXT.getName()).asBoolean());
     }
 


### PR DESCRIPTION
…for property substitution.
https://issues.jboss.org/browse/WFLY-4801
datasource jndi-name expression value is not resolved, although it's expressions-allowed for property substitution
