### PR TITLE
[WFLY-4811] Deprecate the batch subsystem model. This a deprecation of the model only

### DIFF
--- a/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemDefinition.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/BatchSubsystemDefinition.java
@@ -30,6 +30,7 @@ import javax.xml.stream.XMLStreamWriter;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.DefaultAttributeMarshaller;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
@@ -65,6 +66,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
     public static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(SUBSYSTEM, NAME);
     static final PathElement THREAD_POOL_PATH = PathElement.pathElement(BatchConstants.THREAD_POOL, BatchConstants.THREAD_POOL_NAME);
 
+    @Deprecated
     static final SimpleAttributeDefinition JOB_REPOSITORY_TYPE = SimpleAttributeDefinitionBuilder.create("job-repository-type", ModelType.STRING, true)
             .setAllowExpression(false)
             .setAttributeMarshaller(new DefaultAttributeMarshaller() {
@@ -98,6 +100,7 @@ public class BatchSubsystemDefinition extends SimpleResourceDefinition {
             .setDefaultValue(new ModelNode(JobRepositoryType.IN_MEMORY.toString()))
             .setValidator(new EnumValidator<>(JobRepositoryType.class, true, true))
             .setRestartJVM()
+            .setDeprecated(ModelVersion.create(1, 0, 0))
             .build();
 
     public static final BatchSubsystemDefinition INSTANCE = new BatchSubsystemDefinition();

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/JobRepositoryDefinition.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/JobRepositoryDefinition.java
@@ -24,6 +24,8 @@ package org.wildfly.extension.batch;
 
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.DeprecationData;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
@@ -45,6 +47,7 @@ import org.wildfly.extension.batch.job.repository.JobRepositoryType;
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
+@Deprecated
 class JobRepositoryDefinition extends SimpleResourceDefinition {
 
     /**
@@ -58,6 +61,7 @@ class JobRepositoryDefinition extends SimpleResourceDefinition {
     public static final SimpleAttributeDefinition JNDI_NAME = SimpleAttributeDefinitionBuilder.create("jndi-name", ModelType.STRING, true)
             .setAllowExpression(true)
             .setValidator(new StringLengthValidator(1, true, true))
+            .setDeprecated(ModelVersion.create(1, 0, 0))
             .build();
 
     /**
@@ -67,7 +71,7 @@ class JobRepositoryDefinition extends SimpleResourceDefinition {
 
     private JobRepositoryDefinition(final String name, final AttributeDefinition... attributes) {
         super(PathElement.pathElement(NAME, name), BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME, name),
-                new JobRepositoryAdd(attributes), ReloadRequiredRemoveStepHandler.INSTANCE);
+                new JobRepositoryAdd(attributes), ReloadRequiredRemoveStepHandler.INSTANCE, new DeprecationData(ModelVersion.create(1, 0, 0)));
     }
 
     @Override

--- a/batch/extension/src/main/resources/org/wildfly/extension/batch/LocalDescriptions.properties
+++ b/batch/extension/src/main/resources/org/wildfly/extension/batch/LocalDescriptions.properties
@@ -29,13 +29,19 @@ batch.remove=Removes the batch subsystem.
 
 # Job Repository
 batch.job-repository-type=Defines the job repository type.
+batch.job-repository-type.deprecated=The model will change in the next version and this attribute will likely be removed. There \
+  is no alternative at this point.
 
 # JDBC job repository
 batch.job-repository=Settings for the job repository type.
 batch.job-repository.jdbc=A JDBC job repository.
+batch.job-repository.jdbc.deprecated=The model will change in the next version and this resource will likely be removed. There \
+  is no alternative at this point.
 batch.job-repository.jdbc.add=Adds the JDBC job repository.
 batch.job-repository.jdbc.remove=Removes JDBC job repository.
 batch.job-repository.jdbc.jndi-name=The JNDI name a JDBC job-repository will use to connect to the database.
+batch.job-repository.jdbc.jndi-name.deprecated=The model will change in the next version and this attribute will likely be removed. There \
+  is no alternative at this point.
 
 # Thread pool
 batch.thread-pool=The thread pool used for batch jobs.


### PR DESCRIPTION
The batch subsystem model is going to changed for the better in WildFly 10. Adding deprecated messages to 9.x to inform users of the changes.
