### PR TITLE
[WFLY-4357] : Update the JDR Subsystem to Include a Type 4 UUID in its Report

### DIFF
--- a/feature-pack/src/main/resources/content/bin/jdr.sh
+++ b/feature-pack/src/main/resources/content/bin/jdr.sh
@@ -59,6 +59,8 @@ if $cygwin; then
     JBOSS_MODULEPATH=`cygpath --path --windows "$JBOSS_MODULEPATH"`
 fi
 
+#JAVA_OPTS="$JAVA_OPTS -agentlib:jdwp=transport=dt_socket,address=8787,server=y,suspend=y"
+
 eval \"$JAVA\" $JAVA_OPTS \
          -Djboss.home.dir=\""$JBOSS_HOME"\" \
          -jar \""$JBOSS_HOME"/jboss-modules.jar\" \

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportRequestHandler.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportRequestHandler.java
@@ -84,9 +84,5 @@ public class JdrReportRequestHandler implements OperationStepHandler {
                 context.completeStep(OperationContext.RollbackHandler.NOOP_ROLLBACK_HANDLER);
             }
         }, OperationContext.Stage.RUNTIME);
-
-
-
-        context.stepCompleted();
     }
 }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportService.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/JdrReportService.java
@@ -44,6 +44,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 
 import static java.security.AccessController.doPrivileged;
+import org.jboss.as.cli.scriptsupport.CLI;
 
 /**
  * Service that provides a {@link JdrReportCollector}.
@@ -74,22 +75,10 @@ public class JdrReportService implements JdrReportCollector, Service<JdrReportCo
 
     /**
      * Collect a JDR report when run outside the Application Server.
+     * @param cli
      */
-    public JdrReport standaloneCollect(String protocol, String host, String port) throws OperationFailedException {
-        String username = null;
-        String password = null;
-
-        if (host == null) {
-            host = "localhost";
-        }
-        if (port == null) {
-            port = "9990";
-        }
-        if(protocol == null) {
-            protocol = "http-remoting";
-        }
-
-        return new JdrRunner(protocol, username, password, host, port).collect();
+    public JdrReport standaloneCollect(CLI cli, String protocol, String host, int port) throws OperationFailedException {
+        return new JdrRunner(cli, protocol, host, port, null, null).collect();
     }
 
     /**

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/commands/JdrEnvironment.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/commands/JdrEnvironment.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.jdr.commands;
 
+import org.jboss.as.cli.scriptsupport.CLI;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.jdr.util.JdrZipFile;
 
@@ -40,6 +41,15 @@ public class JdrEnvironment {
     private String hostControllerName;
     private String serverName;
     private ModelControllerClient client;
+
+    public CLI getCli() {
+        return cli;
+    }
+
+    public void setCli(CLI cli) {
+        this.cli = cli;
+    }
+    private CLI cli;
     private JdrZipFile zip;
     private boolean isServerRunning;
 
@@ -55,6 +65,7 @@ public class JdrEnvironment {
         this.setHostControllerName(copy.getHostControllerName());
         this.setServerName(copy.getServerName());
         this.setClient(copy.getClient());
+        this.setCli(copy.getCli());
         this.setZip(copy.getZip());
         this.setServerRunning(copy.isServerRunning());
     }

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/logger/JdrLogger.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/logger/JdrLogger.java
@@ -22,6 +22,8 @@
 package org.jboss.as.jdr.logger;
 
 
+import java.io.IOException;
+import java.nio.file.Path;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
@@ -114,6 +116,17 @@ public interface JdrLogger extends BasicLogger {
     @Message(id = 10, value = "Parameter %s may not be null.")
     IllegalArgumentException varNull(String var);
 
+    /**
+     * Standalone property directory could not be located which is needed to find/create the JDR properties file.
+     */
+    @LogMessage(level = ERROR)
+    @Message(id = 11, value = "Could not find JDR properties file.")
+    void couldNotFindJDRPropertiesFile();
+
+    @LogMessage(level = ERROR)
+    @Message(id = 12, value = "Could not create JDR properties file at %s")
+    void couldNotCreateJDRPropertiesFile(@Cause IOException ioex, Path path);
+
     @Message(id = Message.NONE, value = "Display this message and exit")
     String jdrHelpMessage();
 
@@ -125,4 +138,7 @@ public interface JdrLogger extends BasicLogger {
 
     @Message(id = Message.NONE, value = "Protocol that is used to connect. Can be remote, http or https (default: http)")
     String jdrProtocolMessage();
+
+    @Message(id = Message.NONE, value = "Configuration file of the server if it is not running.")
+    String jdrConfigMessage();
 }


### PR DESCRIPTION
- Adds supportability for Windows properties when reading in JBOSS properties file
- Use CLI  with embedded server if no server is running
- Use UUID provided by the server instance.
- Moves logging statements to JdrLogger

BE CAREFUL, this requires WFCORE 2.0.0-Alpha5 (with commit for WFCORE-746 : https://issues.jboss.org/browse/WFCORE-746)

Jira: https://issues.jboss.org/browse/WFLY-4357
