### PR TITLE
[WFLY-4815] AdvancedLdapLoginModuleTestCase fails on RHEL5 and IBM JDK

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/PicketLinkTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/picketlink/PicketLinkTestBase.java
@@ -51,7 +51,6 @@ import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
 import org.jboss.as.test.integration.security.common.negotiation.JBossNegotiateSchemeFactory;
 import org.jboss.logging.Logger;
-import org.jboss.security.auth.callback.UsernamePasswordHandler;
 
 /**
  * Base class with common utilities for PicketLink integration tests
@@ -265,10 +264,10 @@ public class PicketLinkTestBase {
             EntityUtils.consume(entity);
 
         // Use our custom configuration to avoid reliance on external config
-        Configuration.setConfiguration(new Krb5LoginConfiguration());
+        final Krb5LoginConfiguration krb5configuration = new Krb5LoginConfiguration(Utils.getLoginConfiguration());
+        Configuration.setConfiguration(krb5configuration);
         // 1. Authenticate to Kerberos.
-        final LoginContext lc = new LoginContext(Utils.class.getName(), new UsernamePasswordHandler(user, pass));
-        lc.login();
+        final LoginContext lc = Utils.loginWithKerberos(krb5configuration, user, pass);
 
         // 2. Perform the work as authenticated Subject.
         final String responseBody = Subject.doAs(lc.getSubject(), new PrivilegedExceptionAction<String>() {
@@ -280,6 +279,7 @@ public class PicketLinkTestBase {
             }
         });
         lc.logout();
+        krb5configuration.resetConfiguration();
         return responseBody;
     }
 

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractKrb5ConfServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractKrb5ConfServerSetupTask.java
@@ -87,7 +87,7 @@ public abstract class AbstractKrb5ConfServerSetupTask implements ServerSetupTask
         final String cannonicalHost = NetworkUtils.formatPossibleIpv6Address(Utils.getCannonicalHost(managementClient));
         final Map<String, String> map = new HashMap<String, String>();
         map.put("hostname", cannonicalHost);
-        final String supportedEncTypes = getSupportedEncTypes();
+        final String supportedEncTypes = Utils.IBM_JDK ? getSupportedEncTypes() : "des-cbc-md5,des3-cbc-sha1-kd";
         map.put("enctypes", supportedEncTypes);
         LOGGER.info("Supported enctypes in krb5.conf: " + supportedEncTypes);
         FileUtils.write(

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Krb5LoginConfiguration.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Krb5LoginConfiguration.java
@@ -25,11 +25,11 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 
-import org.apache.commons.lang.SystemUtils;
 
 /**
  * Simple Krb5LoginModule configuration.
@@ -40,14 +40,16 @@ public class Krb5LoginConfiguration extends Configuration {
 
     /** The list with configuration entries. */
     private final AppConfigurationEntry[] configList = new AppConfigurationEntry[1];
+    private final String name;
+    private final Configuration wrapped;
 
     /**
      * Create a new Krb5LoginConfiguration. Neither principal nor keytab are not filled and JGSS credential type is initiator.
      *
      * @throws MalformedURLException
      */
-    public Krb5LoginConfiguration() throws MalformedURLException {
-        this(null, null, false);
+    public Krb5LoginConfiguration(final Configuration wrapped) throws MalformedURLException {
+        this(null, null, false, wrapped);
     }
 
     /**
@@ -57,23 +59,31 @@ public class Krb5LoginConfiguration extends Configuration {
      * @param keyTab keytab file, may be <code>null</code>
      * @param acceptor flag for setting credential type. Set to true, if the authenticated subject should be acceptor (i.e.
      *        credsType=acceptor for IBM JDK, and storeKey=true for Oracle JDK)
+     * @param wrapped wrapped configuration (you can receive it for instance by calling Configuration#getConfiguration()
      * @throws MalformedURLException
      */
-    public Krb5LoginConfiguration(final String principal, final File keyTab, final boolean acceptor)
+    public Krb5LoginConfiguration(final String principal, final File keyTab, final boolean acceptor, final Configuration wrapped)
             throws MalformedURLException {
         final String loginModule = getLoginModule();
         Map<String, String> options = getOptions(principal, keyTab, acceptor);
         configList[0] = new AppConfigurationEntry(loginModule, AppConfigurationEntry.LoginModuleControlFlag.REQUIRED, options);
+        name = UUID.randomUUID().toString();
+        this.wrapped = wrapped;
     }
 
-    public static Map<String, String> getOptions() {
-        return getOptions(null, null, false);
-    }
-
+    /**
+     * Returns Map with Krb5LoginModule options. The result depends on currently running JVM.
+     *
+     * @param principal principal name, may be <code>null</code>
+     * @param keyTab keytab file, may be <code>null</code>
+     * @param acceptor flag for setting credential type. Set to true, if the authenticated subject should be acceptor (i.e.
+     *        credsType=acceptor for IBM JDK, and storeKey=true for Oracle JDK)
+     * @return HashMap with Krb5LoginModule options.
+     */
     public static Map<String, String> getOptions(final String principal, final File keyTab, final boolean acceptor) {
         final Map<String, String> res = new HashMap<String, String>();
 
-        if (SystemUtils.JAVA_VENDOR.startsWith("IBM")) {
+        if (Utils.IBM_JDK) {
             if (keyTab != null) {
                 res.put("useKeytab", keyTab.toURI().toString());
             }
@@ -103,12 +113,35 @@ public class Krb5LoginConfiguration extends Configuration {
         return res;
     }
 
+    /**
+     * Returns Krb5LoginModule class name. The returned name depends on the currently running JVM.
+     *
+     * @return class name
+     */
     public static String getLoginModule() {
-        if (SystemUtils.JAVA_VENDOR.startsWith("IBM")) {
+        if (Utils.IBM_JDK) {
             return "com.ibm.security.auth.module.Krb5LoginModule";
         } else {
             return "com.sun.security.auth.module.Krb5LoginModule";
         }
+    }
+
+    /**
+     * Returns this login configuration name.
+     *
+     * @return
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Returns the wrapped configuration.
+     *
+     * @return
+     */
+    protected Configuration getWrapped() {
+        return wrapped;
     }
 
     /**
@@ -119,8 +152,22 @@ public class Krb5LoginConfiguration extends Configuration {
      */
     @Override
     public AppConfigurationEntry[] getAppConfigurationEntry(String applicationName) {
-        // We will ignore the applicationName, since we want all apps to use Kerberos V5
-        return configList;
+        if (name.equals(applicationName)) {
+            // We will ignore the applicationName, since we want all apps to use Kerberos V5
+            return configList;
+        } else {
+            return wrapped == null ? null : wrapped.getAppConfigurationEntry(applicationName);
+        }
+    }
+
+    /**
+     * Resets configuration to the wrapped one and returns it.
+     *
+     * @return login configuration to which it was reseted
+     */
+    public Configuration resetConfiguration() {
+        Configuration.setConfiguration(wrapped);
+        return wrapped;
     }
 
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -485,6 +485,8 @@ public class Utils extends CoreUtils {
             final int expectedStatusCode) throws IOException, URISyntaxException, PrivilegedActionException, LoginException {
         LOGGER.info("Requesting URI: " + uri);
         final DefaultHttpClient httpClient = new DefaultHttpClient();
+        final Krb5LoginConfiguration krb5Configuration = new Krb5LoginConfiguration(getLoginConfiguration());
+
         try {
             httpClient.getAuthSchemes().register(AuthPolicy.SPNEGO, new JBossNegotiateSchemeFactory(true));
             httpClient.getCredentialsProvider().setCredentials(new AuthScope(null, -1, null), new NullHCCredentials());
@@ -512,10 +514,9 @@ public class Utils extends CoreUtils {
                 EntityUtils.consume(entity);
 
             // Use our custom configuration to avoid reliance on external config
-            Configuration.setConfiguration(new Krb5LoginConfiguration());
+            Configuration.setConfiguration(krb5Configuration);
             // 1. Authenticate to Kerberos.
-            final LoginContext lc = new LoginContext(CoreUtils.class.getName(), new UsernamePasswordHandler(user, pass));
-            lc.login();
+            final LoginContext lc = loginWithKerberos(krb5Configuration, user, pass);
 
             // 2. Perform the work as authenticated Subject.
             final String responseBody = Subject.doAs(lc.getSubject(), new PrivilegedExceptionAction<String>() {
@@ -533,6 +534,7 @@ public class Utils extends CoreUtils {
             // shut down the connection manager to ensure
             // immediate deallocation of all system resources
             httpClient.getConnectionManager().shutdown();
+            krb5Configuration.resetConfiguration();
         }
     }
 
@@ -560,6 +562,8 @@ public class Utils extends CoreUtils {
         final DefaultHttpClient httpClient = new DefaultHttpClient();
         httpClient.setRedirectStrategy(REDIRECT_STRATEGY);
         String unauthorizedPageBody = null;
+        final Krb5LoginConfiguration krb5Configuration = new Krb5LoginConfiguration(getLoginConfiguration());
+
         try {
             httpClient.getAuthSchemes().register(AuthPolicy.SPNEGO, new JBossNegotiateSchemeFactory(true));
             httpClient.getCredentialsProvider().setCredentials(new AuthScope(null, -1, null), new NullHCCredentials());
@@ -583,10 +587,9 @@ public class Utils extends CoreUtils {
             unauthorizedPageBody = EntityUtils.toString(response.getEntity());
 
             // Use our custom configuration to avoid reliance on external config
-            Configuration.setConfiguration(new Krb5LoginConfiguration());
+            Configuration.setConfiguration(krb5Configuration);
             // 1. Authenticate to Kerberos.
-            final LoginContext lc = new LoginContext(CoreUtils.class.getName(), new UsernamePasswordHandler(user, pass));
-            lc.login();
+            final LoginContext lc = loginWithKerberos(krb5Configuration, user, pass);
 
             // 2. Perform the work as authenticated Subject.
             final String responseBody = Subject.doAs(lc.getSubject(), new PrivilegedExceptionAction<String>() {
@@ -617,6 +620,8 @@ public class Utils extends CoreUtils {
             // shut down the connection manager to ensure
             // immediate deallocation of all system resources
             httpClient.getConnectionManager().shutdown();
+            // reset login configuration
+            krb5Configuration.resetConfiguration();
         }
     }
 
@@ -1028,5 +1033,51 @@ public class Utils extends CoreUtils {
     public static String getDefaultHost(boolean canonical) {
         final String hostname = System.getProperty("node0", "127.0.0.1");
         return canonical ? getCannonicalHost(hostname) : hostname;
+    }
+
+    /**
+     * Returns installed login configuration. This is workaround for Oracle JDK 6 behavior where
+     * {@link Configuration#getConfiguration()} throws a {@link SecurityException} when no configuration is installed and the
+     * default login configuration (file) is not found.
+     *
+     * @return Configuration (may be <code>null</code>)
+     */
+    public static Configuration getLoginConfiguration() {
+        Configuration configuration = null;
+        try {
+            configuration = Configuration.getConfiguration();
+        } catch (SecurityException e) {
+            if (SystemUtils.IS_JAVA_1_6 && !IBM_JDK) {
+                LOGGER.debug("Unable to load default login configuration", e);
+            } else {
+                throw e;
+            }
+        }
+        return configuration;
+    }
+
+    /**
+     * Creates login context for given {@link Krb5LoginConfiguration} and credentials and calls the {@link LoginContext#login()}
+     * method on it. This method contains workaround for IBM JDK issue described in bugzilla <a
+     * href="https://bugzilla.redhat.com/show_bug.cgi?id=1206177">https://bugzilla.redhat.com/show_bug.cgi?id=1206177</a>.
+     *
+     * @param krb5Configuration
+     * @param user
+     * @param pass
+     * @return
+     * @throws LoginException
+     */
+    public static LoginContext loginWithKerberos(final Krb5LoginConfiguration krb5Configuration, final String user,
+            final String pass) throws LoginException {
+        LoginContext lc = new LoginContext(krb5Configuration.getName(), new UsernamePasswordHandler(user, pass));
+        if (IBM_JDK) {
+            // workaround for IBM JDK on RHEL5 issue described in https://bugzilla.redhat.com/show_bug.cgi?id=1206177
+            // The first negotiation always fail, so let's do a dummy login/logout round.
+            lc.login();
+            lc.logout();
+            lc = new LoginContext(krb5Configuration.getName(), new UsernamePasswordHandler(user, pass));
+        }
+        lc.login();
+        return lc;
     }
 }

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -1036,24 +1036,12 @@ public class Utils extends CoreUtils {
     }
 
     /**
-     * Returns installed login configuration. This is workaround for Oracle JDK 6 behavior where
-     * {@link Configuration#getConfiguration()} throws a {@link SecurityException} when no configuration is installed and the
-     * default login configuration (file) is not found.
+     * Returns installed login configuration.
      *
-     * @return Configuration (may be <code>null</code>)
+     * @return Configuration
      */
     public static Configuration getLoginConfiguration() {
-        Configuration configuration = null;
-        try {
-            configuration = Configuration.getConfiguration();
-        } catch (SecurityException e) {
-            if (SystemUtils.IS_JAVA_1_6 && !IBM_JDK) {
-                LOGGER.debug("Unable to load default login configuration", e);
-            } else {
-                throw e;
-            }
-        }
-        return configuration;
+        return Configuration.getConfiguration();
     }
 
     /**


### PR DESCRIPTION
Upstream fix of https://bugzilla.redhat.com/show_bug.cgi?id=1206177
