### PR TITLE
[WFLY-4826] Add an alias for data-source service to bind the service …

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -132,10 +132,13 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
 
         final ManagementResourceRegistration registration = context.getResourceRegistrationForUpdate();
         final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
+        final ServiceName dataSourceAliasServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(dsName);
         final ServiceBuilder<?> dataSourceServiceBuilder =
                 Services.addServerExecutorDependency(
                         serviceTarget.addService(dataSourceServiceName, dataSourceService),
                         dataSourceService.getExecutorServiceInjector(), false)
+                // Add an alias to the data-source resource name
+                .addAliases(dataSourceAliasServiceName)
                 .addDependency(ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE, ManagementRepository.class,
                         dataSourceService.getManagementRepositoryInjector())
                 .addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class,


### PR DESCRIPTION
…resource name.

Currently data sources service is only bound to the JNDI name. This adds an alias to bind the service to the resource name as well. For example currently the default is only bound to `jboss.data-source.java:jboss/datasources/ExampleDS`. This PR adds an alias to also bind it to `jboss.data-source.ExampleDS`.
