### PR TITLE
WFLY-4810 Switch default locking isolation for web cache back to REPEATABLE_REA…

### DIFF
--- a/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
+++ b/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
@@ -14,10 +14,12 @@
             </cache-container>
             <cache-container name="web" default-cache="passivation" module="org.wildfly.clustering.web.infinispan">
                 <local-cache name="passivation">
+                    <locking isolation="REPEATABLE_READ"/>
                     <transaction mode="BATCH"/>
                     <file-store passivation="true" purge="false"/>
                 </local-cache>
                 <local-cache name="persistent">
+                    <locking isolation="REPEATABLE_READ"/>
                     <transaction mode="BATCH"/>
                     <file-store passivation="false" purge="false"/>
                 </local-cache>
@@ -59,6 +61,7 @@
             <cache-container name="web" default-cache="dist" module="org.wildfly.clustering.web.infinispan">
                 <transport lock-timeout="60000"/>
                 <distributed-cache name="dist" mode="ASYNC" l1-lifespan="0" owners="2">
+                    <locking isolation="REPEATABLE_READ"/>
                     <transaction mode="BATCH"/>
                     <file-store/>
                 </distributed-cache>


### PR DESCRIPTION
…D to ensure commits are visible to subsequent requests.

WFLY-4810 Fix FormAuthenticationWebFailoverTestCase
https://issues.jboss.org/browse/WFLY-4810
