### PR TITLE
[WFLY-4697] Use suspend/resume to send out module unavailable/available messages to EJBClient

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionResourceDefinition.java
@@ -33,6 +33,7 @@ import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.clustering.controller.ReloadRequiredAddStepHandler;
 import org.jboss.as.clustering.controller.transform.AttributeOperationTransformer;
 import org.jboss.as.clustering.controller.transform.ChainedOperationTransformer;
+import org.jboss.as.clustering.controller.transform.DefaultValueAttributeConverter;
 import org.jboss.as.clustering.controller.transform.SimpleOperationTransformer;
 import org.jboss.as.clustering.controller.transform.OperationTransformer;
 import org.jboss.as.controller.AttributeDefinition;
@@ -91,7 +92,7 @@ public class TransactionResourceDefinition extends SimpleResourceDefinition {
             .setMeasurementUnit(MeasurementUnit.MILLISECONDS)
             .setAllowExpression(true)
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
-            .setDefaultValue(new ModelNode().set(30000))
+            .setDefaultValue(new ModelNode().set(10000))
             .build();
 
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { MODE, STOP_TIMEOUT, LOCKING };
@@ -192,6 +193,9 @@ public class TransactionResourceDefinition extends SimpleResourceDefinition {
                 }
             };
             builder.setCustomResourceTransformer(modeTransformer);
+
+            // change default value of stop-timeout attribute
+            builder.getAttributeBuilder().setValueConverter(new DefaultValueAttributeConverter(STOP_TIMEOUT), STOP_TIMEOUT);
         }
 
         buildOperationTransformation(builder, ModelDescriptionConstants.ADD, addOperationTransformers);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemoteConnectorService.java
@@ -40,6 +40,7 @@ import org.jboss.as.ejb3.remote.protocol.versionone.VersionOneProtocolChannelRec
 import org.jboss.as.ejb3.remote.protocol.versiontwo.VersionTwoProtocolChannelReceiver;
 import org.jboss.as.network.ClientMapping;
 import org.jboss.as.remoting.RemotingConnectorBindingInfoService;
+import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.ejb.client.ConstantContextSelector;
 import org.jboss.ejb.client.EJBClientTransactionContext;
 import org.jboss.ejb.client.remoting.PackedInteger;
@@ -82,6 +83,7 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
     private final InjectedValue<TransactionManager> txManager = new InjectedValue<TransactionManager>();
     private final InjectedValue<TransactionSynchronizationRegistry> txSyncRegistry = new InjectedValue<TransactionSynchronizationRegistry>();
     private final InjectedValue<RemotingConnectorBindingInfoService.RemotingConnectorInfo> remotingConnectorInfoInjectedValue = new InjectedValue<>();
+    private final InjectedValue<SuspendController> suspendControllerInjectedValue = new InjectedValue<>();
     private volatile Registration registration;
     private final byte serverProtocolVersion;
     private final String[] supportedMarshallingStrategies;
@@ -249,19 +251,20 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
                 final DeploymentRepository deploymentRepository = EJBRemoteConnectorService.this.deploymentRepositoryInjectedValue.getValue();
                 final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector = EJBRemoteConnectorService.this.clusterRegistryCollector.getValue();
                 final RemoteAsyncInvocationCancelStatusService asyncInvocationCancelStatus = EJBRemoteConnectorService.this.remoteAsyncInvocationCancelStatus.getValue();
+                final SuspendController suspendController = EJBRemoteConnectorService.this.suspendControllerInjectedValue.getValue();
 
                 switch (version) {
                     case 0x01:
                         final VersionOneProtocolChannelReceiver versionOneProtocolHandler = new VersionOneProtocolChannelReceiver(this.channelAssociation, deploymentRepository,
                                 EJBRemoteConnectorService.this.ejbRemoteTransactionsRepositoryInjectedValue.getValue(), clientMappingRegistryCollector,
-                                marshallerFactory, executorService.getValue(), asyncInvocationCancelStatus);
+                                marshallerFactory, executorService.getValue(), asyncInvocationCancelStatus, suspendController);
                         // trigger the receiving
                         versionOneProtocolHandler.startReceiving();
                         break;
                     case 0x02:
                         final VersionTwoProtocolChannelReceiver versionTwoProtocolHandler = new VersionTwoProtocolChannelReceiver(this.channelAssociation, deploymentRepository,
                                 EJBRemoteConnectorService.this.ejbRemoteTransactionsRepositoryInjectedValue.getValue(), clientMappingRegistryCollector,
-                                marshallerFactory, executorService.getValue(), asyncInvocationCancelStatus);
+                                marshallerFactory, executorService.getValue(), asyncInvocationCancelStatus, suspendController);
                         // trigger the receiving
                         versionTwoProtocolHandler.startReceiving();
                         break;
@@ -304,6 +307,10 @@ public class EJBRemoteConnectorService implements Service<EJBRemoteConnectorServ
 
     public InjectedValue<RemotingConnectorBindingInfoService.RemotingConnectorInfo> getRemotingConnectorInfoInjectedValue() {
         return remotingConnectorInfoInjectedValue;
+    }
+
+    public InjectedValue<SuspendController> getSuspendControllerInjectedValue() {
+        return suspendControllerInjectedValue;
     }
 
     private boolean isSupportedMarshallingStrategy(final String strategy) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/VersionTwoProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versiontwo/VersionTwoProtocolChannelReceiver.java
@@ -30,6 +30,7 @@ import org.jboss.as.ejb3.remote.protocol.MessageHandler;
 import org.jboss.as.ejb3.remote.protocol.versionone.ChannelAssociation;
 import org.jboss.as.ejb3.remote.protocol.versionone.VersionOneProtocolChannelReceiver;
 import org.jboss.as.network.ClientMapping;
+import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.remoting3.Channel;
 
@@ -49,8 +50,9 @@ public class VersionTwoProtocolChannelReceiver extends VersionOneProtocolChannel
 
     public VersionTwoProtocolChannelReceiver(final ChannelAssociation channelAssociation, final DeploymentRepository deploymentRepository,
                                              final EJBRemoteTransactionsRepository transactionsRepository, final RegistryCollector<String, List<ClientMapping>> clientMappingRegistryCollector,
-                                             final MarshallerFactory marshallerFactory, final ExecutorService executorService, final RemoteAsyncInvocationCancelStatusService asyncInvocationCancelStatusService) {
-        super(channelAssociation, deploymentRepository, transactionsRepository, clientMappingRegistryCollector, marshallerFactory, executorService, asyncInvocationCancelStatusService);
+                                             final MarshallerFactory marshallerFactory, final ExecutorService executorService,
+                                             final RemoteAsyncInvocationCancelStatusService asyncInvocationCancelStatusService, final SuspendController suspendController) {
+        super(channelAssociation, deploymentRepository, transactionsRepository, clientMappingRegistryCollector, marshallerFactory, executorService, asyncInvocationCancelStatusService, suspendController);
     }
 
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
@@ -46,6 +46,7 @@ import org.jboss.as.ejb3.remote.RegistryInstallerService;
 import org.jboss.as.ejb3.remote.RemoteAsyncInvocationCancelStatusService;
 import org.jboss.as.remoting.RemotingConnectorBindingInfoService;
 import org.jboss.as.remoting.RemotingServices;
+import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.as.txn.service.TransactionManagerService;
 import org.jboss.as.txn.service.TransactionSynchronizationRegistryService;
 import org.jboss.as.txn.service.TxnServices;
@@ -153,6 +154,7 @@ public class EJB3RemoteServiceAdd extends AbstractAddStepHandler {
                 .addDependency(TransactionSynchronizationRegistryService.SERVICE_NAME, TransactionSynchronizationRegistry.class, ejbRemoteConnectorService.getTxSyncRegistryInjector())
                 .addDependency(RemoteAsyncInvocationCancelStatusService.SERVICE_NAME, RemoteAsyncInvocationCancelStatusService.class, ejbRemoteConnectorService.getAsyncInvocationCancelStatusInjector())
                 .addDependency(remotingServerInfoServiceName, RemotingConnectorBindingInfoService.RemotingConnectorInfo.class, ejbRemoteConnectorService.getRemotingConnectorInfoInjectedValue())
+                .addDependency(SuspendController.SERVICE_NAME, SuspendController.class, ejbRemoteConnectorService.getSuspendControllerInjectedValue())
                 .setInitialMode(ServiceController.Mode.ACTIVE)
                 .install();
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -39,6 +39,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.as.test.clustering.EJBClientContextSelector;
 import org.jboss.as.test.clustering.cluster.ClusterAbstractTestCase;
 import org.jboss.as.test.clustering.cluster.ejb.remote.bean.Incrementor;
@@ -97,11 +98,13 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
         return jar;
     }
 
+    @InSequence(1)
     @Test
     public void testStatelessFailover() throws Exception {
         this.testStatelessFailover(CLIENT_PROPERTIES, StatelessIncrementorBean.class);
     }
 
+    @InSequence(4)
     @Test
     public void testSecureStatelessFailover() throws Exception {
         this.testStatelessFailover(SECURE_CLIENT_PROPERTIES, SecureStatelessIncrementorBean.class);
@@ -185,6 +188,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
         }
     }
 
+    @InSequence(2)
     @Test
     public void testStatefulFailover() throws Exception {
         ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
@@ -275,7 +279,8 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
         }
     }
 
-    @Ignore("re-enable when WFLY-3532 resoolved")
+    // @Ignore("re-enable when WFLY-3532 resoolved")
+    @InSequence(3)
     @Test
     public void testConcurrentFailover() throws Exception {
         ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);


### PR DESCRIPTION
This PR makes the following changes:
- uses suspend/resume to send module availability/unavailablity messages to connected EJBClients to inform them that the server is suspending/resuming
  - fixes a related issue with cache topology timeouts when invocations which are redirected to another node try to commit as the node on which the original invocation was made is shutting down
  - reinstates RemoteFailoverTestCase which was failing due to problems with EJBClients making invocations on nodes as they were shutting down

Please see https://issues.jboss.org/browse/WFLY-4697 for more details.
