### PR TITLE
Backport messaging commits into messaging-activemq

### DIFF
--- a/messaging-activemq/pom.xml
+++ b/messaging-activemq/pom.xml
@@ -32,9 +32,7 @@
         <version>10.0.0.Alpha4-SNAPSHOT</version>
     </parent>
 
-    <groupId>org.wildfly</groupId>
     <artifactId>wildfly-messaging-activemq</artifactId>
-    <version>10.0.0.Alpha4-SNAPSHOT</version>
 
     <name>WildFly: Messaging Subsystem With ActiveMQ Artemis</name>
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQReloadRequiredHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQReloadRequiredHandlers.java
@@ -41,6 +41,8 @@ import org.jboss.dmr.ModelNode;
 public interface ActiveMQReloadRequiredHandlers {
     static class AddStepHandler extends AbstractAddStepHandler {
 
+        private boolean reloadRequired = false;
+
         public AddStepHandler(Collection<? extends AttributeDefinition> attributes) {
             super(attributes);
         }
@@ -53,28 +55,33 @@ public interface ActiveMQReloadRequiredHandlers {
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
             if (ActiveMQServerService.isServiceInstalled(context)) {
                 context.reloadRequired();
+                reloadRequired = true;
             }
         }
 
         @Override
         protected void rollbackRuntime(OperationContext context, ModelNode operation, Resource resource) {
-            if (ActiveMQServerService.isServiceInstalled(context)) {
+            if (reloadRequired && ActiveMQServerService.isServiceInstalled(context)) {
                 context.revertReloadRequired();
             }
         }
     }
 
     final class RemoveStepHandler extends AbstractRemoveStepHandler {
+
+        private boolean reloadRequired = false;
+
         @Override
         protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
             if (ActiveMQServerService.isServiceInstalled(context)) {
                 context.reloadRequired();
+                reloadRequired = true;
             }
         }
 
         @Override
         protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
-            if (ActiveMQServerService.isServiceInstalled(context)) {
+            if (reloadRequired && ActiveMQServerService.isServiceInstalled(context)) {
                 context.revertReloadRequired();
             }
         }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingsValidator.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingsValidator.java
@@ -79,14 +79,14 @@ class AddressSettingsValidator {
     private static void checkExpiryAddress(OperationContext context, ModelNode model, Resource activeMQServer, String addressSetting) throws OperationFailedException {
         ModelNode expiryAddress = EXPIRY_ADDRESS.resolveModelAttribute(context, model);
         if (!findMatchingResource(expiryAddress, activeMQServer)) {
-            MessagingLogger.MESSAGING_LOGGER.noMatchingExpiryAddress(expiryAddress.asString(), addressSetting);
+            MessagingLogger.ROOT_LOGGER.noMatchingExpiryAddress(expiryAddress.asString(), addressSetting);
         }
     }
 
     private static void checkDeadLetterAddress(OperationContext context, ModelNode model, Resource activeMQServer, String addressSetting) throws OperationFailedException {
         ModelNode deadLetterAddress = DEAD_LETTER_ADDRESS.resolveModelAttribute(context, model);
         if (!findMatchingResource(deadLetterAddress, activeMQServer)) {
-            MessagingLogger.MESSAGING_LOGGER.noMatchingDeadLetterAddress(deadLetterAddress.asString(), addressSetting);
+            MessagingLogger.ROOT_LOGGER.noMatchingDeadLetterAddress(deadLetterAddress.asString(), addressSetting);
         }
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BinderServiceUtil.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BinderServiceUtil.java
@@ -37,7 +37,9 @@ import org.jboss.as.naming.deployment.ContextNames;
 import org.jboss.as.naming.service.BinderService;
 import org.jboss.msc.service.AbstractServiceListener;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.ImmediateValue;
 import org.jboss.msc.value.Values;
@@ -78,15 +80,22 @@ public class BinderServiceUtil {
      */
     public static void installBinderService(final ServiceTarget serviceTarget,
                                             final String name,
-                                            final Service<?> service) {
+                                            final Service<?> service,
+                                            final ServiceName... dependencies) {
         final BindInfo bindInfo = ContextNames.bindInfoFor(name);
         final BinderService binderService = new BinderService(bindInfo.getBindName());
 
-        serviceTarget.addService(bindInfo.getBinderServiceName(), binderService)
+        final ServiceBuilder serviceBuilder = serviceTarget.addService(bindInfo.getBinderServiceName(), binderService)
                 .addDependency(bindInfo.getParentContextServiceName(), ServiceBasedNamingStore.class, binderService.getNamingStoreInjector())
                 .addInjection(binderService.getManagedObjectInjector(), new ValueManagedReferenceFactory(service))
-                .setInitialMode(ServiceController.Mode.ACTIVE)
-                .install();
+                // we set it in passive mode so that missing dependencies (which is possible/valid when it's a backup HornetQ server and the services
+                // haven't been activated on it due to the presence of a different live server) don't cause jms-topic/jms-queue add operations
+                // to fail
+                .setInitialMode(ServiceController.Mode.PASSIVE);
+        if (dependencies != null && dependencies.length > 0) {
+            serviceBuilder.addDependencies(dependencies);
+        }
+        serviceBuilder.install();
     }
 
     public static void installAliasBinderService(final ServiceTarget serviceTarget,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
@@ -28,7 +28,6 @@ import static org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnecto
 import static org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector.SEC_ACTIVEMQ_REMOTING_KEY;
 import static org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CORE;
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.MESSAGING_LOGGER;
 
 import java.io.IOException;
 
@@ -49,6 +48,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.xnio.ChannelListener;
 import org.xnio.StreamConnection;
 import org.xnio.netty.transport.WrappingXnioSocketChannel;
@@ -96,7 +96,7 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
         httpUpgradeMetadata = new ListenerRegistry.HttpUpgradeMetadata(ACTIVEMQ_REMOTING, CORE);
         listenerInfo.addHttpUpgradeMetadata(httpUpgradeMetadata);
 
-        MESSAGING_LOGGER.registeredHTTPUpgradeHandler(ACTIVEMQ_REMOTING, acceptorName);
+        MessagingLogger.ROOT_LOGGER.registeredHTTPUpgradeHandler(ACTIVEMQ_REMOTING, acceptorName);
         ServiceController<?> activeMQService = context.getController().getServiceContainer().getService(MessagingServices.getActiveMQServiceName(activeMQServerName));
         ActiveMQServer activeMQServer = ActiveMQServer.class.cast(activeMQService.getValue());
 
@@ -142,7 +142,7 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
         return new ChannelListener<StreamConnection>() {
             @Override
             public void handleEvent(final StreamConnection connection) {
-                MESSAGING_LOGGER.debugf("Switching to %s protocol for %s http-acceptor", ACTIVEMQ_REMOTING, acceptorName);
+                MessagingLogger.ROOT_LOGGER.debugf("Switching to %s protocol for %s http-acceptor", ACTIVEMQ_REMOTING, acceptorName);
                 SocketChannel channel = new WrappingXnioSocketChannel(connection);
                 RemotingService remotingService = activeMQServer.getRemotingService();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/QueueService.java
@@ -22,8 +22,6 @@
 
 package org.wildfly.extension.messaging.activemq;
 
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.MESSAGING_LOGGER;
-
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.CoreQueueConfiguration;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
@@ -73,7 +71,7 @@ class QueueService implements Service<Void> {
             final ActiveMQServer server = this.activeMQServer.getValue();
             server.destroyQueue(new SimpleString(queueConfiguration.getName()), null, false);
         } catch(Exception e) {
-            MESSAGING_LOGGER.failedToDestroy("queue", queueConfiguration.getName());
+            MessagingLogger.ROOT_LOGGER.failedToDestroy("queue", queueConfiguration.getName());
         }
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -235,7 +235,7 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
             if (value == null || "".equals(value)) {
                 it.remove();
             } else if (!attributeNames.contains(entry.getKey())) {
-                MessagingLogger.MESSAGING_LOGGER.unknownPooledConnectionFactoryAttribute(entry.getKey());
+                MessagingLogger.ROOT_LOGGER.unknownPooledConnectionFactoryAttribute(entry.getKey());
                 it.remove();
             }
         }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSConnectionFactoryDefinitionInjectionSource.java
@@ -48,7 +48,9 @@ import org.jboss.as.ee.component.InjectionSource;
 import org.jboss.as.ee.resource.definition.ResourceDefinitionInjectionSource;
 import org.jboss.as.naming.ManagedReferenceFactory;
 import org.jboss.as.naming.deployment.ContextNames;
+import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentResourceSupport;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.dmr.ModelNode;
@@ -201,7 +203,8 @@ public class JMSConnectionFactoryDefinitionInjectionSource extends ResourceDefin
         //create the management registration
         String managementName = managementName(context, name);
         final PathElement serverElement = PathElement.pathElement(SERVER, getActiveMQServerName());
-        deploymentUnit.createDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
+        final DeploymentResourceSupport deploymentResourceSupport = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT);
+        deploymentResourceSupport.getDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
         final PathElement pcfPath = PathElement.pathElement(POOLED_CONNECTION_FACTORY, managementName);
         PathAddress registration = PathAddress.pathAddress(serverElement, pcfPath);
         MessagingXmlInstallDeploymentUnitProcessor.createDeploymentSubModel(registration, deploymentUnit);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSDestinationDefinitionInjectionSource.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSDestinationDefinitionInjectionSource.java
@@ -40,6 +40,8 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.ee.component.InjectionSource;
 import org.jboss.as.ee.resource.definition.ResourceDefinitionInjectionSource;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentResourceSupport;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
 import org.wildfly.extension.messaging.activemq.jms.JMSQueueConfigurationRuntimeHandler;
@@ -161,7 +163,8 @@ public class JMSDestinationDefinitionInjectionSource extends ResourceDefinitionI
         //create the management registration
         final PathElement serverElement = PathElement.pathElement(SERVER, getActiveMQServerName());
         final PathElement dest = PathElement.pathElement(JMS_QUEUE, queueName);
-        deploymentUnit.createDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
+        final DeploymentResourceSupport deploymentResourceSupport = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT);
+        deploymentResourceSupport.getDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
         PathAddress registration = PathAddress.pathAddress(serverElement, dest);
         MessagingXmlInstallDeploymentUnitProcessor.createDeploymentSubModel(registration, deploymentUnit);
         JMSQueueConfigurationRuntimeHandler.INSTANCE.registerResource(getActiveMQServerName(), queueName, destination);
@@ -183,7 +186,8 @@ public class JMSDestinationDefinitionInjectionSource extends ResourceDefinitionI
         //create the management registration
         final PathElement serverElement = PathElement.pathElement(SERVER, getActiveMQServerName());
         final PathElement dest = PathElement.pathElement(JMS_TOPIC, topicName);
-        deploymentUnit.createDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
+        final DeploymentResourceSupport deploymentResourceSupport = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT);
+        deploymentResourceSupport.getDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
         PathAddress registration = PathAddress.pathAddress(serverElement, dest);
         MessagingXmlInstallDeploymentUnitProcessor.createDeploymentSubModel(registration, deploymentUnit);
         JMSTopicConfigurationRuntimeHandler.INSTANCE.registerResource(getActiveMQServerName(), topicName, destination);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/MessagingXmlInstallDeploymentUnitProcessor.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/MessagingXmlInstallDeploymentUnitProcessor.java
@@ -36,6 +36,8 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.server.deployment.Attachments;
+import org.jboss.as.server.deployment.DeploymentResourceSupport;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
@@ -64,6 +66,7 @@ public class MessagingXmlInstallDeploymentUnitProcessor implements DeploymentUni
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final List<ParseResult> parseResults = deploymentUnit.getAttachmentList(MessagingAttachments.PARSE_RESULT);
+        final DeploymentResourceSupport deploymentResourceSupport = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_RESOURCE_SUPPORT);
         for (final ParseResult parseResult : parseResults) {
 
             for (final JmsDestination topic : parseResult.getTopics()) {
@@ -78,7 +81,7 @@ public class MessagingXmlInstallDeploymentUnitProcessor implements DeploymentUni
                 //create the management registration
                 final PathElement serverElement = PathElement.pathElement(SERVER, topic.getServer());
                 final PathElement destination = PathElement.pathElement(JMS_TOPIC, topic.getName());
-                deploymentUnit.createDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
+                deploymentResourceSupport.getDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
                 PathAddress registration = PathAddress.pathAddress(serverElement, destination);
                 createDeploymentSubModel(registration, deploymentUnit);
 
@@ -102,7 +105,7 @@ public class MessagingXmlInstallDeploymentUnitProcessor implements DeploymentUni
                 //create the management registration
                 final PathElement serverElement = PathElement.pathElement(SERVER, queue.getServer());
                 final PathElement dest = PathElement.pathElement(JMS_QUEUE, queue.getName());
-                deploymentUnit.createDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
+                deploymentResourceSupport.getDeploymentSubModel(MessagingExtension.SUBSYSTEM_NAME, serverElement);
                 PathAddress registration = PathAddress.pathAddress(serverElement, dest);
                 createDeploymentSubModel(registration, deploymentUnit);
                 JMSQueueConfigurationRuntimeHandler.INSTANCE.registerResource(queue.getServer(), queue.getName(), destination);

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryService.java
@@ -22,8 +22,6 @@
 
 package org.wildfly.extension.messaging.activemq.jms;
 
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.MESSAGING_LOGGER;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -34,6 +32,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 
 /**
  * {@code Service} responsible for creating and destroying a {@code javax.jms.ConnectionFactory}.
@@ -50,7 +49,7 @@ class ConnectionFactoryService implements Service<Void> {
     public ConnectionFactoryService(final ConnectionFactoryConfiguration configuration) {
         name = configuration.getName();
         if(name == null) {
-            throw MESSAGING_LOGGER.nullVar("cf name");
+            throw MessagingLogger.ROOT_LOGGER.nullVar("cf name");
         }
         this.configuration = configuration;
     }
@@ -65,7 +64,7 @@ class ConnectionFactoryService implements Service<Void> {
                     jmsManager.createConnectionFactory(false, configuration, configuration.getBindings());
                     context.complete();
                 } catch (Throwable e) {
-                    context.failed(MESSAGING_LOGGER.failedToCreate(e, "connection-factory"));
+                    context.failed(MessagingLogger.ROOT_LOGGER.failedToCreate(e, "connection-factory"));
                 }
             }
         };
@@ -87,7 +86,7 @@ class ConnectionFactoryService implements Service<Void> {
                 try {
                     jmsManager.destroyConnectionFactory(name);
                 } catch (Throwable e) {
-                    MESSAGING_LOGGER.failedToDestroy("connection-factory", name);
+                    MessagingLogger.ROOT_LOGGER.failedToDestroy("connection-factory", name);
                 }
                 context.complete();
             }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueAdd.java
@@ -73,9 +73,11 @@ public class JMSQueueAdd extends AbstractAddStepHandler {
         Service<Queue> queueService = JMSQueueService.installService(name, serviceTarget, serviceName, selector, durable, new String[0]);
 
         final ModelNode entries = CommonAttributes.DESTINATION_ENTRIES.resolveModelAttribute(context, model);
+        final ServiceName jmsQueueServiceName = JMSServices.getJmsQueueBaseServiceName(serviceName).append(name);
         final String[] jndiBindings = JMSServices.getJndiBindings(entries);
         for (String jndiBinding : jndiBindings) {
-            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, queueService);
+            // install a binder service which depends on the JMS queue service
+            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, queueService, jmsQueueServiceName);
         }
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSQueueService.java
@@ -23,7 +23,6 @@
 package org.wildfly.extension.messaging.activemq.jms;
 
 import static org.jboss.as.server.Services.addServerExecutorDependency;
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.MESSAGING_LOGGER;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -102,7 +101,7 @@ public class JMSQueueService implements Service<Queue> {
                     jmsManager.removeQueueFromBindingRegistry(queueName);
                     queue = null;
                 } catch (Throwable e) {
-                    MESSAGING_LOGGER.failedToDestroy(e, "queue", queueName);
+                    MessagingLogger.ROOT_LOGGER.failedToDestroy(e, "queue", queueName);
                 }
                 context.complete();
             }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
@@ -27,7 +27,6 @@ import static org.jboss.msc.service.ServiceController.Mode.ACTIVE;
 import static org.jboss.msc.service.ServiceController.Mode.REMOVE;
 import static org.jboss.msc.service.ServiceController.State.REMOVED;
 import static org.jboss.msc.service.ServiceController.State.STOPPING;
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.MESSAGING_LOGGER;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
@@ -186,7 +185,7 @@ public class JMSService implements Service<JMSServerManager> {
             jmsServer.stop();
             jmsServer = null;
         } catch (Exception e) {
-            MESSAGING_LOGGER.errorStoppingJmsServer(e);
+            MessagingLogger.ROOT_LOGGER.errorStoppingJmsServer(e);
         }
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicAdd.java
@@ -63,9 +63,11 @@ public class JMSTopicAdd extends AbstractAddStepHandler {
         JMSTopicService jmsTopicService = JMSTopicService.installService(name, serviceName, serviceTarget, new String[0]);
 
         final ModelNode entries = CommonAttributes.DESTINATION_ENTRIES.resolveModelAttribute(context, model);
+        final ServiceName jmsTopicServiceName = JMSServices.getJmsTopicBaseServiceName(serviceName).append(name);
         final String[] jndiBindings = JMSServices.getJndiBindings(entries);
         for (String jndiBinding : jndiBindings) {
-            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, jmsTopicService);
+            // install a binder service which depends on the JMS topic service
+            BinderServiceUtil.installBinderService(serviceTarget, jndiBinding, jmsTopicService, jmsTopicServiceName);
         }
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicService.java
@@ -22,8 +22,6 @@
 
 package org.wildfly.extension.messaging.activemq.jms;
 
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.MESSAGING_LOGGER;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
@@ -97,7 +95,7 @@ public class JMSTopicService implements Service<Topic> {
                     jmsManager.removeTopicFromBindingRegistry(name);
                     topic = null;
                 } catch (Throwable e) {
-                    MESSAGING_LOGGER.failedToDestroy(e, "jms topic", name);
+                    MessagingLogger.ROOT_LOGGER.failedToDestroy(e, "jms topic", name);
                 }
                 context.complete();
             }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
@@ -93,18 +93,20 @@ class JMSBridgeService implements Service<JMSBridge> {
     }
 
     public void startBridge() throws Exception {
-        if (moduleName == null) {
-            bridge.start();
+        final Module module;
+        if (moduleName != null) {
+            ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
+            module =  Module.getContextModuleLoader().loadModule(moduleID);
         } else {
-            ClassLoader oldTccl= WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
-            try {
-                ModuleIdentifier moduleID = ModuleIdentifier.create(moduleName);
-                Module module = Module.getCallerModuleLoader().loadModule(moduleID);
-                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
-                bridge.start();
-            } finally {
-                WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
-            }
+            module = Module.forClass(JMSBridgeService.class);
+        }
+
+        ClassLoader oldTccl= WildFlySecurityManager.getCurrentContextClassLoaderPrivileged();
+        try {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(module.getClassLoader());
+            bridge.start();
+        } finally {
+            WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
         }
         MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);
     }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeService.java
@@ -22,15 +22,12 @@
 
 package org.wildfly.extension.messaging.activemq.jms.bridge;
 
-import static org.wildfly.extension.messaging.activemq.logging.MessagingLogger.MESSAGING_LOGGER;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 
 import javax.transaction.TransactionManager;
 
 import org.apache.activemq.artemis.jms.bridge.JMSBridge;
-import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -40,6 +37,7 @@ import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StartException;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -108,7 +106,7 @@ class JMSBridgeService implements Service<JMSBridge> {
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
         }
-        MessagingLogger.MESSAGING_LOGGER.startedService("JMS Bridge", bridgeName);
+        MessagingLogger.ROOT_LOGGER.startedService("JMS Bridge", bridgeName);
     }
 
     @Override
@@ -118,11 +116,11 @@ class JMSBridgeService implements Service<JMSBridge> {
             public void run() {
                 try {
                     bridge.stop();
-                    MessagingLogger.MESSAGING_LOGGER.stoppedService("JMS Bridge", bridgeName);
+                    MessagingLogger.ROOT_LOGGER.stoppedService("JMS Bridge", bridgeName);
 
                     context.complete();
                 } catch(Exception e) {
-                    MESSAGING_LOGGER.failedToDestroy("bridge", bridgeName);
+                    MessagingLogger.ROOT_LOGGER.failedToDestroy("JMS Bridge", bridgeName);
                 }
             }
         };

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -63,11 +63,6 @@ public interface MessagingLogger extends BasicLogger {
     MessagingLogger ROOT_LOGGER = Logger.getMessageLogger(MessagingLogger.class, "org.wildfly.extension.messaging-activemq");
 
     /**
-     * A logger with the category {@code org.wildfly.extension.messaging-activemq}.
-     */
-    MessagingLogger MESSAGING_LOGGER = ROOT_LOGGER;
-
-    /**
      * Logs a warning message indicating AIO was not found.
      */
     @LogMessage(level = WARN)

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -119,6 +119,4 @@
                                 entries="java:jboss/exported/jms/RemoteConnectionFactory" />
         </replacement>
     </supplement>
-
-    <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
 </config>


### PR DESCRIPTION
These are the commits that were applied to the messaging subsystem after I copied it to create the messaging-activemq subsystem.

This PR ensures that there is no functional regression between the two subsystems.

I did not backport 8358e0ff241a8b91654a18a454c8c941c1c8b9b7 as it is already included in #7623 
