### PR TITLE
WFLY-4824 Increase maven opts heap size

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ ROOT="/"
 M2_HOME=""
 MAVEN_HOME=""
 
-MAVEN_OPTS="$MAVEN_OPTS -Xmx768M"
+MAVEN_OPTS="$MAVEN_OPTS -Xmx1024M"
 export MAVEN_OPTS
 
 ./tools/download-maven.sh


### PR DESCRIPTION
I have increased it to -Xmx1024M since we often see failures in CI whilst downloading the licenses.
