### PR TITLE
[9.x] Upgrade Weld to 2.2.14.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.3.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
         <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
         <version.org.jboss.spec.javax.websockets>1.1.1.Final</version.org.jboss.spec.javax.websockets>
-        <version.org.jboss.weld.weld>2.2.12.Final</version.org.jboss.weld.weld>
+        <version.org.jboss.weld.weld>2.2.14.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.2.SP4</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.3.Final</version.org.jboss.ws.api>
         <version.org.jboss.ws.spi>3.0.0.Final</version.org.jboss.ws.spi>


### PR DESCRIPTION
Not sure if there is still time for this component upgrade. Even if there is not it's not a big deal as this release does not contain any critical fixes. This is only relevant for 9.x as master has moved to 2.3.x Weld releases already.
