### PR TITLE
Weld Probe integration

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1146,6 +1146,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jboss.weld.probe</groupId>
+            <artifactId>weld-probe-core</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.jboss.weld</groupId>
             <artifactId>weld-core-jsf</artifactId>
         </dependency>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<module xmlns="urn:jboss:module:1.3" name="org.jboss.weld.probe">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+    <resources>
+        <artifact name="${org.jboss.weld.probe:weld-probe-core}"/>
+    </resources>
+
+    <dependencies>
+        <module name="ch.qos.cal10n" />
+        <module name="com.google.guava"/>
+        <module name="javax.annotation.api"/>
+        <module name="javax.enterprise.api"/>
+        <module name="javax.inject.api"/>
+        <module name="javax.interceptor.api"/>
+        <module name="javax.servlet.api"/>
+        <module name="org.jboss.weld.api" />
+        <module name="org.jboss.weld.core" />
+        <module name="org.jboss.weld.spi" />
+        <module name="org.jboss.logging" />
+    </dependencies>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -5462,6 +5462,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.weld.probe</groupId>
+                <artifactId>weld-probe-core</artifactId>
+                <version>${version.org.jboss.weld.weld}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
                 <groupId>org.jboss.xnio.netty</groupId>
                 <artifactId>netty-xnio-transport</artifactId>
                 <version>${version.org.jboss.xnio.netty.netty-xnio-transport}</version>

--- a/weld/src/main/java/org/jboss/as/weld/WeldSubsystemAdd.java
+++ b/weld/src/main/java/org/jboss/as/weld/WeldSubsystemAdd.java
@@ -38,6 +38,7 @@ import org.jboss.as.weld.deployment.processors.BeanArchiveProcessor;
 import org.jboss.as.weld.deployment.processors.BeanDefiningAnnotationProcessor;
 import org.jboss.as.weld.deployment.processors.BeansXmlProcessor;
 import org.jboss.as.weld.deployment.processors.CdiBeanValidationFactoryProcessor;
+import org.jboss.as.weld.deployment.processors.DevelopmentModeProcessor;
 import org.jboss.as.weld.deployment.processors.ExternalBeanArchiveProcessor;
 import org.jboss.as.weld.deployment.processors.WebIntegrationProcessor;
 import org.jboss.as.weld.deployment.processors.WeldBeanManagerServiceProcessor;
@@ -93,6 +94,7 @@ class WeldSubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_WELD_IMPLICIT_DEPLOYMENT_DETECTION, new WeldImplicitDeploymentProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_WELD, new WeldDependencyProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_WEB_INTEGRATION, new WebIntegrationProcessor());
+                processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_DEVELOPMENT_MODE, new DevelopmentModeProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_BEAN_ARCHIVE, new BeanArchiveProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_EXTERNAL_BEAN_ARCHIVE, new ExternalBeanArchiveProcessor());
                 processorTarget.addDeploymentProcessor(WeldExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_WELD_PORTABLE_EXTENSIONS, new WeldPortableExtensionProcessor());

--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/DevelopmentModeProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/DevelopmentModeProcessor.java
@@ -1,0 +1,132 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.weld.deployment.processors;
+
+import static org.jboss.as.weld.util.Reflections.loadClass;
+
+import java.util.ArrayList;
+import java.util.Collections;
+
+import org.jboss.as.ee.structure.DeploymentType;
+import org.jboss.as.ee.structure.DeploymentTypeMarker;
+import org.jboss.as.ee.weld.WeldDeploymentMarker;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.web.common.WarMetaData;
+import org.jboss.as.weld.deployment.WeldPortableExtensions;
+import org.jboss.as.weld.util.Reflections;
+import org.jboss.as.weld.util.Utils;
+import org.jboss.metadata.javaee.spec.ParamValueMetaData;
+import org.jboss.metadata.web.jboss.JBossWebMetaData;
+import org.jboss.metadata.web.spec.DispatcherType;
+import org.jboss.metadata.web.spec.FilterMappingMetaData;
+import org.jboss.metadata.web.spec.FilterMetaData;
+import org.jboss.metadata.web.spec.FiltersMetaData;
+import org.jboss.modules.Module;
+
+/**
+ * Deployment processor that initializes Weld Probe if the development mode has been enabled.
+ *
+ * @author Jozef Hartinger
+ *
+ */
+public class DevelopmentModeProcessor implements DeploymentUnitProcessor {
+
+    private static final String CONTEXT_PARAM_DEV_MODE = "org.jboss.weld.development";
+    private static final String PROBE_FILTER_NAME = "weld-probe-filter";
+    private static final String PROBE_FILTER_CLASS_NAME = "org.jboss.weld.probe.ProbeFilter";
+    private static final String PROBE_EXTENSION_CLASS_NAME = "org.jboss.weld.probe.ProbeExtension";
+    private static final FilterMetaData PROBE_FILTER;
+    private static final FilterMappingMetaData PROBE_FILTER_MAPPING;
+
+    static {
+        PROBE_FILTER = new FilterMetaData();
+        PROBE_FILTER.setName(PROBE_FILTER_NAME);
+        PROBE_FILTER.setFilterClass(PROBE_FILTER_CLASS_NAME);
+
+        PROBE_FILTER_MAPPING = new FilterMappingMetaData();
+        PROBE_FILTER_MAPPING.setFilterName(PROBE_FILTER_NAME);
+        PROBE_FILTER_MAPPING.setUrlPatterns(Collections.singletonList("/*"));
+        PROBE_FILTER_MAPPING.setDispatchers(Collections.singletonList(DispatcherType.REQUEST));
+    }
+
+    @Override
+    public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
+        final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
+        final Module module = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE);
+
+        if (!DeploymentTypeMarker.isType(DeploymentType.WAR, deploymentUnit)) {
+            return; // Skip non web deployments
+        }
+        if (!WeldDeploymentMarker.isWeldDeployment(deploymentUnit)) {
+            return; // skip non weld deployments
+        }
+
+        if (deploymentUnit.getAttachment(WarMetaData.ATTACHMENT_KEY) == null) {
+            return;
+        }
+        final JBossWebMetaData webMetaData = deploymentUnit.getAttachment(WarMetaData.ATTACHMENT_KEY).getMergedJBossWebMetaData();
+        if (webMetaData == null) {
+            return;
+        }
+
+        if (webMetaData.getContextParams() == null) {
+            webMetaData.setContextParams(new ArrayList<ParamValueMetaData>());
+        }
+
+        final WeldConfiguration configuration = Utils.getRootDeploymentUnit(deploymentUnit).getAttachment(WeldConfiguration.ATTACHMENT_KEY);
+        final boolean devModeContextParam = webMetaData.getContextParams().stream()
+                .anyMatch(param -> CONTEXT_PARAM_DEV_MODE.equals(param.getParamName()) && Boolean.valueOf(param.getParamValue()));
+
+        // development mode is available when enabled in web.xml, jboss-all.xml or domain mode
+        // and the optional probe module is available
+        if (!configuration.isDevelopmentMode() && !devModeContextParam) {
+            return;
+        }
+        if (!Reflections.isAccessible(PROBE_FILTER_CLASS_NAME, module.getClassLoader())) {
+            return;
+        }
+
+        if (webMetaData.getFilters() == null) {
+            webMetaData.setFilters(new FiltersMetaData());
+        }
+        if (webMetaData.getFilterMappings() == null) {
+            webMetaData.setFilterMappings(new ArrayList<FilterMappingMetaData>());
+        }
+
+        // probe filter
+        webMetaData.getFilters().add(PROBE_FILTER);
+        // probe filter mapping
+        webMetaData.getFilterMappings().add(0, PROBE_FILTER_MAPPING);
+        Utils.registerAsComponent(PROBE_FILTER_CLASS_NAME, deploymentUnit);
+
+        WeldPortableExtensions.getPortableExtensions(deploymentUnit).tryRegisterExtension(loadClass(PROBE_EXTENSION_CLASS_NAME, module.getClassLoader()),
+                deploymentUnit);
+    }
+
+    @Override
+    public void undeploy(DeploymentUnit context) {
+    }
+
+}

--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/WebIntegrationProcessor.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.as.weld.deployment.processors;
 
+import static org.jboss.as.weld.util.Utils.registerAsComponent;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
@@ -37,7 +39,6 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.web.common.ExpressionFactoryWrapper;
 import org.jboss.as.web.common.WarMetaData;
-import org.jboss.as.web.common.WebComponentDescription;
 import org.jboss.as.weld.WeldStartService;
 import org.jboss.as.weld.logging.WeldLogger;
 import org.jboss.as.weld.webtier.jsp.WeldJspExpressionFactoryWrapper;
@@ -139,8 +140,8 @@ public class WebIntegrationProcessor implements DeploymentUnitProcessor {
         listeners.add(TERMINAL_LISTENER_MEDATADA);
 
         //These listeners use resource injection, so they need to be components
-        registerAsComponent(WELD_INITIAL_LISTENER, module, deploymentUnit, applicationClasses);
-        registerAsComponent(WELD_TERMINAL_LISTENER, module, deploymentUnit, applicationClasses);
+        registerAsComponent(WELD_INITIAL_LISTENER, deploymentUnit);
+        registerAsComponent(WELD_TERMINAL_LISTENER, deploymentUnit);
 
         deploymentUnit.addToAttachmentList(ExpressionFactoryWrapper.ATTACHMENT_KEY, WeldJspExpressionFactoryWrapper.INSTANCE);
 
@@ -175,7 +176,7 @@ public class WebIntegrationProcessor implements DeploymentUnitProcessor {
                 }
                 if (!filterFound) {
                     webMetaData.getFilters().add(conversationFilterMetadata);
-                    registerAsComponent(CONVERSATION_FILTER_CLASS, module, deploymentUnit, applicationClasses);
+                    registerAsComponent(CONVERSATION_FILTER_CLASS, deploymentUnit);
                     webMetaData.getContextParams().add(CONVERSATION_FILTER_INITIALIZED);
                 }
             }
@@ -202,11 +203,5 @@ public class WebIntegrationProcessor implements DeploymentUnitProcessor {
 
     @Override
     public void undeploy(DeploymentUnit context) {
-    }
-
-    private void registerAsComponent(String listener, EEModuleDescription module, DeploymentUnit deploymentUnit, EEApplicationClasses applicationClasses) {
-        final WebComponentDescription componentDescription = new WebComponentDescription(listener, listener, module, deploymentUnit.getServiceName(), applicationClasses);
-        module.addComponent(componentDescription);
-        deploymentUnit.addToAttachmentList(WebComponentDescription.WEB_COMPONENTS, componentDescription.getStartServiceName());
     }
 }

--- a/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldDependencyProcessor.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/processors/WeldDependencyProcessor.java
@@ -45,6 +45,7 @@ public class WeldDependencyProcessor implements DeploymentUnitProcessor {
     private static ModuleIdentifier JAVAX_PERSISTENCE_API_ID = ModuleIdentifier.create("javax.persistence.api");
     private static ModuleIdentifier JBOSS_AS_WELD_ID = ModuleIdentifier.create("org.jboss.as.weld");
     private static ModuleIdentifier WELD_CORE_ID = ModuleIdentifier.create("org.jboss.weld.core");
+    private static final ModuleIdentifier WELD_PROBE_ID = ModuleIdentifier.create("org.jboss.weld.probe");
     private static ModuleIdentifier WELD_API_ID = ModuleIdentifier.create("org.jboss.weld.api");
     private static ModuleIdentifier WELD_SPI_ID = ModuleIdentifier.create("org.jboss.weld.spi");
     private static ModuleIdentifier CDI_BEAN_VALIDATION_ID = ModuleIdentifier.create("org.hibernate.validator.cdi");
@@ -70,6 +71,7 @@ public class WeldDependencyProcessor implements DeploymentUnitProcessor {
         }
         addDependency(moduleSpecification, moduleLoader, JAVAX_PERSISTENCE_API_ID);
         addDependency(moduleSpecification, moduleLoader, WELD_CORE_ID);
+        addDependency(moduleSpecification, moduleLoader, WELD_PROBE_ID, true);
         addDependency(moduleSpecification, moduleLoader, WELD_API_ID);
         addDependency(moduleSpecification, moduleLoader, WELD_SPI_ID);
 
@@ -88,7 +90,12 @@ public class WeldDependencyProcessor implements DeploymentUnitProcessor {
 
     private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
                                ModuleIdentifier moduleIdentifier) {
-        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, false, false, true, false));
+        addDependency(moduleSpecification, moduleLoader, moduleIdentifier, false);
+    }
+
+    private void addDependency(ModuleSpecification moduleSpecification, ModuleLoader moduleLoader,
+            ModuleIdentifier moduleIdentifier, boolean optional) {
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, moduleIdentifier, optional, false, true, false));
     }
 
     @Override

--- a/weld/src/main/java/org/jboss/as/weld/util/Utils.java
+++ b/weld/src/main/java/org/jboss/as/weld/util/Utils.java
@@ -16,11 +16,15 @@
  */
 package org.jboss.as.weld.util;
 
+import org.jboss.as.ee.component.Attachments;
 import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEApplicationClasses;
+import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.managedbean.component.ManagedBeanComponentDescription;
 import org.jboss.as.ejb3.component.EJBComponentDescription;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.module.ResourceRoot;
+import org.jboss.as.web.common.WebComponentDescription;
 
 /**
  * Various utilities for working with WildFly APIs
@@ -58,5 +62,14 @@ public class Utils {
 
     public static boolean isComponentWithView(ComponentDescription component) {
         return (component instanceof EJBComponentDescription) || (component instanceof ManagedBeanComponentDescription);
+    }
+
+    public static void registerAsComponent(String listener, DeploymentUnit deploymentUnit) {
+        final EEApplicationClasses applicationClasses = deploymentUnit.getAttachment(Attachments.EE_APPLICATION_CLASSES_DESCRIPTION);
+        final EEModuleDescription module = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
+        final WebComponentDescription componentDescription = new WebComponentDescription(listener, listener, module, deploymentUnit.getServiceName(),
+                applicationClasses);
+        module.addComponent(componentDescription);
+        deploymentUnit.addToAttachmentList(WebComponentDescription.WEB_COMPONENTS, componentDescription.getStartServiceName());
     }
 }


### PR DESCRIPTION
Provides Weld Probe out of the box as long as the development mode is enabled (via web.xml, jboss-all.xml or managements model). Probe is a development tool that provides web view on CDI metadata, dependency graphs, event monitoring etc. For more info on Probe see:

http://weld.cdi-spec.org/news/2015/02/05/weld-300Alpha4/
http://weld.cdi-spec.org/news/2015/02/25/weld-300Alpha5/
http://probe-weld.itos.redhat.com/weld-numberguess/home.jsf
