### PR TITLE
[WFLY-4797] Remove usage of deprecated code for ordered child resources

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkAddHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkAddHandler.java
@@ -54,13 +54,6 @@ import org.wildfly.clustering.spi.GroupBuilderProvider;
 public class ForkAddHandler extends AbstractAddStepHandler {
 
     @Override
-    protected ResourceCreator getResourceCreator() {
-        //Use the ordered resource creator to flag that the protocol children are indexed, and can be inserted
-        //if the add-index parameter is specified
-        return new OrderedResourceCreator(false, ModelKeys.PROTOCOL);
-    }
-
-    @Override
     protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         installRuntimeServices(context, operation, resource.getModel());
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkProtocolAddHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkProtocolAddHandler.java
@@ -43,12 +43,6 @@ public class ForkProtocolAddHandler extends AbstractAddStepHandler {
     }
 
     @Override
-    protected ResourceCreator getResourceCreator() {
-        //Set this up as an ordered child, which should have indexed adds
-        return new OrderedResourceCreator(true);
-    }
-
-    @Override
     protected void populateModel(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         super.populateModel(context, operation, resource);
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -188,23 +188,15 @@ public class ProtocolResourceDefinition extends SimpleResourceDefinition {
     }
 
     ProtocolResourceDefinition() {
-        this(new ReloadRequiredAddStepHandler(ATTRIBUTES) {
-            @Override
-            protected ResourceCreator getResourceCreator() {
-                //Set this up as an ordered child, which should have indexed adds
-                return new OrderedResourceCreator(true);
-            }
-        });
+        this(new ReloadRequiredAddStepHandler(ATTRIBUTES));
     }
 
     ProtocolResourceDefinition(OperationStepHandler addHandler) {
-        super(WILDCARD_PATH, new JGroupsResourceDescriptionResolver(ModelKeys.PROTOCOL), addHandler, new ReloadRequiredRemoveStepHandler());
-    }
-
-    @Override
-    protected boolean isOrderedChildResource() {
-        //Set this up as an ordered child resource so that the add handler gets the add-index parameter added
-        return true;
+        super(
+                new Parameters(WILDCARD_PATH, new JGroupsResourceDescriptionResolver(ModelKeys.PROTOCOL))
+                    .setAddHandler(addHandler)
+                    .setRemoveHandler(new ReloadRequiredRemoveStepHandler())
+                    .setOrderedChild());
     }
 
     @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackAddHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackAddHandler.java
@@ -44,13 +44,6 @@ import org.wildfly.clustering.jgroups.spi.service.ProtocolStackServiceName;
 public class StackAddHandler extends AbstractAddStepHandler {
 
     @Override
-    protected ResourceCreator getResourceCreator() {
-        //Use the ordered resource creator to flag that the protocol children are indexed, and can be inserted
-        //if the add-index parameter is specified
-        return new OrderedResourceCreator(false, ModelKeys.PROTOCOL);
-    }
-
-    @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
         installRuntimeServices(context, operation, Resource.Tools.readModel(context.readResource(PathAddress.EMPTY_ADDRESS)));
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
@@ -177,7 +177,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition {
         // Nothing to transform yet
     }
 
-    //@Override this will be brought in my WFCORE-759/https://github.com/wildfly/wildfly-core/pull/813
+    @Override
     public boolean isOrderedChild() {
         return false;
     }


### PR DESCRIPTION
Now that core 2.0.0.Alpha5 has been released
