### PR TITLE
Merge entity exceptions fix into 9.x

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanRemoteViewInstanceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/EntityBeanRemoteViewInstanceFactory.java
@@ -93,7 +93,7 @@ public class EntityBeanRemoteViewInstanceFactory implements ViewInstanceFactory 
             exceptionOnCreate = false;
         } finally {
             if (exceptionOnCreate) {
-                entityBeanComponent.releaseEntityBeanInstance(instance);
+                entityBeanComponent.discardEntityBeanInstance(instance);
             }
         }
         instance.associate(primaryKey);

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/ReferenceCountingEntityCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/ReferenceCountingEntityCache.java
@@ -164,8 +164,16 @@ public class ReferenceCountingEntityCache implements ReadyEntityCache {
 
     private EntityBeanComponentInstance createInstance(final Object pk) {
         final EntityBeanComponentInstance instance = component.acquireUnAssociatedInstance();
-        instance.activate(pk);
-        return instance;
+        boolean exceptionOnActivate = true;
+        try {
+            instance.activate(pk);
+            exceptionOnActivate = false;
+            return instance;
+        } finally {
+            if (exceptionOnActivate) {
+                component.discardEntityBeanInstance(instance);
+            }
+        }
     }
 
     private class CacheEntry {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/TransactionLocalEntityCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/entitycache/TransactionLocalEntityCache.java
@@ -200,8 +200,16 @@ public class TransactionLocalEntityCache implements ReadyEntityCache {
 
     private EntityBeanComponentInstance createInstance(Object pk) {
         final EntityBeanComponentInstance instance = component.acquireUnAssociatedInstance();
-        instance.activate(pk);
-        return instance;
+        boolean exceptionOnActivate = true;
+        try {
+            instance.activate(pk);
+            exceptionOnActivate = false;
+            return instance;
+        } finally {
+            if (exceptionOnActivate) {
+                component.discardEntityBeanInstance(instance);
+            }
+        }
     }
 
     private boolean isTransactionActive() {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/interceptors/EntityBeanEjbCreateMethodInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/entity/interceptors/EntityBeanEjbCreateMethodInterceptor.java
@@ -83,7 +83,7 @@ public class EntityBeanEjbCreateMethodInterceptor implements Interceptor {
             exceptionOnCreate = false;
         } finally {
             if (exceptionOnCreate) {
-                entityBeanComponent.releaseEntityBeanInstance(instance);
+                entityBeanComponent.discardEntityBeanInstance(instance);
             }
         }
         instance.associate(primaryKey);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityExceptionsBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/EntityExceptionsBase.java
@@ -111,8 +111,12 @@ public abstract class EntityExceptionsBase {
         return localFind("find-test-local");
     }
 
+    protected ExceptionsRemoteInterface remoteFind(String key) throws Exception {
+        return getRemoteHome().findByPrimaryKey(key);
+    }
+
     protected ExceptionsRemoteInterface remoteFind() throws Exception {
-        return getRemoteHome().findByPrimaryKey("find-test-remote");
+        return remoteFind("find-test-remote");
     }
 
     protected UserTransaction getUserTransaction() throws NamingException {
@@ -189,6 +193,40 @@ public abstract class EntityExceptionsBase {
             fail("business method should throw exception");
         } catch (RemoteException e) {
             // Expected exception
+        }
+
+        // There should be no exception here
+        remoteFind();
+    }
+
+    @Test
+    public void shouldReleaseInstanceToPoolOnLocalLoadException() throws Exception {
+        UserTransaction ut = getUserTransaction();
+        ut.begin();
+        try {
+            localFind("key1-exceptionOnLoad").test();
+            fail("onLoad should throw exception");
+        } catch (Exception e) {
+            // Expected exception
+        } finally {
+            ut.rollback();
+        }
+
+        // There should be no exception here
+        localFind();
+    }
+
+    @Test
+    public void shouldReleaseInstanceToPoolOnRemoteLoadException() throws Exception {
+        UserTransaction ut = getUserTransaction();
+        ut.begin();
+        try {
+            remoteFind("key1-exceptionOnLoad").test();
+            fail("onLoad should throw exception");
+        } catch (Exception e) {
+            // Expected exception
+        } finally {
+            ut.rollback();
         }
 
         // There should be no exception here

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ExceptionsBean.java
@@ -26,9 +26,11 @@ import java.rmi.RemoteException;
 
 public class ExceptionsBean implements EntityBean {
 
+    private EntityContext ctx;
+
     @Override
     public void setEntityContext(EntityContext ctx) throws EJBException, RemoteException {
-
+        this.ctx = ctx;
     }
 
     @Override
@@ -48,7 +50,9 @@ public class ExceptionsBean implements EntityBean {
 
     @Override
     public void ejbLoad() throws EJBException, RemoteException {
-
+        if (((String)ctx.getPrimaryKey()).endsWith("exceptionOnLoad")) {
+            throw new EJBException("Expected exception on load");
+        }
     }
 
     @Override


### PR DESCRIPTION
If it's not too late for 9.x branch - I'd like to merge fix for leaked entity instances on exceptions (https://issues.jboss.org/browse/WFLY-4638) into 9.x branch.
