### PR TITLE
tests for JBJCA-747, JBJCA-825, JBJCA-826 + minor jca test changes

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment17TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/BasicDeployment17TestCase.java
@@ -1,0 +1,126 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2010, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.basic;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.connector.subsystems.resourceadapters.Namespace;
+import org.jboss.as.connector.subsystems.resourceadapters.ResourceAdapterSubsystemParser;
+import org.jboss.as.test.integration.jca.rar.MultipleAdminObject1;
+import org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1;
+import org.jboss.as.test.integration.management.base.AbstractMgmtServerSetupTask;
+import org.jboss.as.test.integration.management.base.AbstractMgmtTestBase;
+import org.jboss.as.test.integration.management.base.ContainerResourceMgmtTestBase;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.FileUtils;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.jboss.staxmapper.XMLElementReader;
+import org.jboss.staxmapper.XMLElementWriter;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import java.util.List;
+
+import static org.junit.Assert.assertNotNull;
+
+
+/**
+ * @author <a href="msimka@redhat.com">Martin Simka</a>
+ *         JBQA-5737 basic subsystem deployment
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(BasicDeployment17TestCase.BasicDeploymentTestCaseSetup.class)
+public class BasicDeployment17TestCase extends ContainerResourceMgmtTestBase {
+
+    static class BasicDeploymentTestCaseSetup extends AbstractMgmtServerSetupTask {
+
+        @Override
+        public void doSetup(final ManagementClient managementClient) throws Exception {
+            String xml = FileUtils.readFile(BasicDeployment17TestCase.class, "basic17.xml");
+            List<ModelNode> operations = xmlToModelOperations(xml, Namespace.RESOURCEADAPTERS_1_0.getUriString(), new ResourceAdapterSubsystemParser());
+            executeOperation(operationListToCompositeOperation(operations));
+        }
+
+        @Override
+        public void tearDown(final ManagementClient managementClient, final String containerId) throws Exception {
+
+            final ModelNode address = new ModelNode();
+            address.add("subsystem", "resource-adapters");
+            address.add("resource-adapter", "basic17.rar");
+            address.protect();
+            remove(address);
+        }
+    }
+
+    /**
+     * Define the deployment
+     *
+     * @return The deployment archive
+     */
+    @Deployment
+    public static ResourceAdapterArchive createDeployment() throws Exception {
+
+        String deploymentName = "basic17.rar";
+
+        ResourceAdapterArchive raa =
+                ShrinkWrap.create(ResourceAdapterArchive.class, deploymentName);
+        JavaArchive ja = ShrinkWrap.create(JavaArchive.class, "multiple.jar");
+        ja.addPackage(MultipleConnectionFactory1.class.getPackage()).
+                addClasses(BasicDeployment17TestCase.class,  MgmtOperationException.class, XMLElementReader.class, XMLElementWriter.class,
+                        BasicDeploymentTestCaseSetup.class);
+
+        ja.addPackage(AbstractMgmtTestBase.class.getPackage());
+        raa.addAsLibrary(ja);
+
+        raa.addAsManifestResource(BasicDeployment17TestCase.class.getPackage(), "ra17.xml", "ra.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client,org.jboss.dmr,org.jboss.as.cli\n"), "MANIFEST.MF");
+        ;
+        return raa;
+    }
+
+    @Resource(mappedName = "java:jboss/name1")
+    private MultipleConnectionFactory1 connectionFactory1;
+
+
+    @Resource(mappedName = "java:jboss/Name3")
+    private MultipleAdminObject1 adminObject1;
+
+
+    /**
+     * Test configuration
+     *
+     * @throws Throwable Thrown if case of an error
+     */
+    @Test
+    public void testConfiguration() throws Throwable {
+
+        assertNotNull("CF1 not found", connectionFactory1);
+        assertNotNull("AO1 not found", adminObject1);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/basic17.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/basic17.xml
@@ -1,0 +1,14 @@
+<subsystem xmlns="urn:jboss:domain:resource-adapters:1.0">
+ <resource-adapters>
+  <resource-adapter>
+   <archive>basic17.rar</archive>
+      <transaction-support>NoTransaction</transaction-support>
+        <connection-definitions>
+        	<connection-definition  class-name="org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1" jndi-name="java:jboss/name1"  pool-name="Pool1">    </connection-definition>
+		</connection-definitions>
+        <admin-objects>
+          <admin-object class-name="org.jboss.as.test.integration.jca.rar.MultipleAdminObject1Impl"  jndi-name="java:jboss/Name3"	pool-name="Pool3">  </admin-object>
+         </admin-objects>
+    </resource-adapter>
+  </resource-adapters>
+</subsystem>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/ra17.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/basic/ra17.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+           http://xmlns.jcp.org/xml/ns/javaee/connector_1_7.xsd"
+           version="1.7" metadata-complete="true">
+
+   <vendor-name>Red Hat Middleware LLC</vendor-name>
+   <eis-type>Test RA</eis-type>
+   <resourceadapter-version>0.1</resourceadapter-version>
+
+   <resourceadapter>
+      <resourceadapter-class>org.jboss.as.test.integration.jca.rar.MultipleResourceAdapter</resourceadapter-class>
+
+      <outbound-resourceadapter>
+         <connection-definition>
+            <managedconnectionfactory-class>org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory1</managedconnectionfactory-class>
+
+            <connectionfactory-interface>org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1</connectionfactory-interface>
+            <connectionfactory-impl-class>org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory1Impl</connectionfactory-impl-class>
+            <connection-interface>org.jboss.as.test.integration.jca.rar.MultipleConnection1</connection-interface>
+            <connection-impl-class>org.jboss.as.test.integration.jca.rar.MultipleConnection1Impl</connection-impl-class>
+         </connection-definition>
+         <transaction-support>NoTransaction</transaction-support>
+         <reauthentication-support>false</reauthentication-support>
+      </outbound-resourceadapter>
+      <adminobject>
+         <adminobject-interface>org.jboss.as.test.integration.jca.rar.MultipleAdminObject1</adminobject-interface>
+         <adminobject-class>org.jboss.as.test.integration.jca.rar.MultipleAdminObject1Impl</adminobject-class>
+      </adminobject>
+   </resourceadapter>
+</connector>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationAbstractTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationAbstractTestCase.java
@@ -1,0 +1,73 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager;
+
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactoryImpl;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionImpl;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyLocalTransaction;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionMetaData;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyResourceAdapter;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyXAResource;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+
+/**
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public abstract class LazyAssociationAbstractTestCase {
+    protected static final String RAR_NAME = "lazy.rar";
+    protected static final String LIB_JAR_NAME = "common.jar";
+
+    protected static Archive<ResourceAdapterArchive> createResourceAdapter(String raFileName,
+                                                                           String configurationFileName,
+                                                                           Class testClass) {
+        ResourceAdapterArchive rar = ShrinkWrap.create(ResourceAdapterArchive.class, RAR_NAME);
+        rar.addAsManifestResource(LazyResourceAdapter.class.getPackage(), raFileName, "ra.xml");
+        rar.addAsManifestResource(LazyResourceAdapter.class.getPackage(), configurationFileName, "ironjacamar.xml");
+
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, LIB_JAR_NAME);
+        jar.addClass(LazyResourceAdapter.class)
+                .addClass(LazyManagedConnectionFactory.class)
+                .addClass(LazyManagedConnection.class)
+                .addClass(LazyConnection.class)
+                .addClass(LazyConnectionImpl.class)
+                .addClass(LazyXAResource.class)
+                .addClass(LazyLocalTransaction.class)
+                .addClass(LazyManagedConnectionMetaData.class)
+                .addClass(LazyConnectionFactory.class)
+                .addClass(LazyConnectionFactoryImpl.class);
+
+        jar.addClass(LazyAssociationAbstractTestCase.class);
+        jar.addClass(testClass);
+
+        rar.addAsLibrary(jar);
+        return rar;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationLocalTransactionEnlistmentFalseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationLocalTransactionEnlistmentFalseTestCase.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.transaction.UserTransaction;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive using LocalTransaction with enlistment=false
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+@RunWith(Arquillian.class)
+public class LazyAssociationLocalTransactionEnlistmentFalseTestCase extends LazyAssociationAbstractTestCase {
+    private static Logger logger = Logger.getLogger(LazyAssociationLocalTransactionEnlistmentFalseTestCase.class);
+
+    @Deployment(name = LazyAssociationAbstractTestCase.RAR_NAME)
+    public static Archive<ResourceAdapterArchive> createDeployment() {
+        return createResourceAdapter("ra-localtx.xml",
+                "ironjacamar-enlistmentfalse.xml",
+                LazyAssociationLocalTransactionEnlistmentFalseTestCase.class);
+    }
+
+    @Resource(mappedName = "java:/eis/Lazy")
+    private LazyConnectionFactory lcf;
+
+    @Resource(mappedName = "java:jboss/UserTransaction")
+    private UserTransaction userTransaction;
+
+    @Test
+    public void verifyEagerlyEnlisted() throws Throwable {
+        assertNotNull(lcf);
+        assertNotNull(userTransaction);
+
+        boolean status = true;
+        userTransaction.begin();
+
+        LazyConnection lc = null;
+        try {
+            lc = lcf.getConnection();
+
+            assertTrue(lc.isManagedConnectionSet());
+            assertTrue(lc.closeManagedConnection());
+            assertFalse(lc.isManagedConnectionSet());
+            assertTrue(lc.associate());
+            assertTrue(lc.isManagedConnectionSet());
+
+            assertTrue(lc.isEnlisted());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            status = false;
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc != null)
+                lc.close();
+
+            if (status) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationLocalTransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationLocalTransactionTestCase.java
@@ -1,0 +1,213 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.transaction.UserTransaction;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive using LocalTransaction
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+@RunWith(Arquillian.class)
+public class LazyAssociationLocalTransactionTestCase extends LazyAssociationAbstractTestCase {
+    private static Logger logger = Logger.getLogger(LazyAssociationLocalTransactionTestCase.class);
+
+    @Deployment(name = LazyAssociationAbstractTestCase.RAR_NAME)
+    public static Archive<ResourceAdapterArchive> createDeployment() {
+        return createResourceAdapter("ra-localtx.xml",
+                "ironjacamar-default.xml",
+                LazyAssociationLocalTransactionTestCase.class);
+    }
+
+    @Resource(mappedName = "java:/eis/Lazy")
+    private LazyConnectionFactory lcf;
+
+    @Resource(mappedName = "java:jboss/UserTransaction")
+    private UserTransaction userTransaction;
+
+    @Test
+    public void testBasic() throws Throwable {
+        assertNotNull(lcf);
+        assertNotNull(userTransaction);
+
+        boolean status = true;
+        userTransaction.begin();
+
+        LazyConnection lc = null;
+        try {
+            lc = lcf.getConnection();
+
+            assertTrue(lc.isManagedConnectionSet());
+            assertTrue(lc.closeManagedConnection());
+            assertFalse(lc.isManagedConnectionSet());
+            assertTrue(lc.associate());
+            assertTrue(lc.isManagedConnectionSet());
+
+            assertFalse(lc.isEnlisted());
+            assertTrue(lc.enlist());
+            assertTrue(lc.isEnlisted());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            status = false;
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc != null)
+                lc.close();
+
+            if (status) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+    /**
+     * Two connections - one managed connection - without enlistment
+     *
+     * @throws Throwable Thrown if case of an error
+     */
+    @Test
+    public void testTwoConnectionsWithoutEnlistment() throws Throwable {
+        assertNotNull(lcf);
+        assertNotNull(userTransaction);
+
+        boolean status = true;
+        userTransaction.begin();
+
+        LazyConnection lc1 = null;
+        LazyConnection lc2 = null;
+        try {
+            lc1 = lcf.getConnection();
+            assertTrue(lc1.isManagedConnectionSet());
+
+            logger.trace("testTwoConnectionsWithoutEnlistment: Before 2nd getConnection");
+
+            lc2 = lcf.getConnection();
+            assertTrue(lc2.isManagedConnectionSet());
+            assertFalse(lc1.isManagedConnectionSet());
+
+            logger.trace("testTwoConnectionsWithoutEnlistment: Before closeManagedConnection");
+            assertTrue(lc2.closeManagedConnection());
+
+            assertFalse(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+
+            logger.trace("testTwoConnectionsWithoutEnlistment: Before associate");
+
+            assertTrue(lc1.associate());
+
+            assertTrue(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+
+            logger.infof("testTwoConnectionsWithoutEnlistment: After associate");
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            status = false;
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc1 != null)
+                lc1.close();
+            if (lc2 != null)
+                lc2.close();
+
+            if (status) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+    /**
+     * Two connections - one managed connection - with enlistment
+     *
+     * @throws Throwable Thrown if case of an error
+     */
+    @Test
+    public void testTwoConnectionsWithEnlistment() throws Throwable {
+        assertNotNull(lcf);
+        assertNotNull(userTransaction);
+
+        boolean status = true;
+        userTransaction.begin();
+
+        LazyConnection lc1 = null;
+        LazyConnection lc2 = null;
+        try {
+            lc1 = lcf.getConnection();
+
+            assertTrue(lc1.isManagedConnectionSet());
+            assertFalse(lc1.isEnlisted());
+            assertTrue(lc1.enlist());
+            assertTrue(lc1.isEnlisted());
+
+            lc2 = lcf.getConnection();
+
+            assertTrue(lc2.isManagedConnectionSet());
+            assertFalse(lc1.isManagedConnectionSet());
+
+            assertTrue(lc2.closeManagedConnection());
+
+            assertFalse(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+
+            assertTrue(lc1.associate());
+
+            assertTrue(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            status = false;
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc1 != null)
+                lc1.close();
+            if (lc2 != null)
+                lc2.close();
+
+            if (status) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationSharableDefaultTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationSharableDefaultTestCase.java
@@ -1,0 +1,130 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+@RunWith(Arquillian.class)
+public class LazyAssociationSharableDefaultTestCase extends LazyAssociationAbstractTestCase {
+    private static Logger logger = Logger.getLogger(LazyAssociationSharableDefaultTestCase.class);
+
+    @Deployment(name = LazyAssociationAbstractTestCase.RAR_NAME)
+    public static Archive<ResourceAdapterArchive> createDeployment() {
+        return createResourceAdapter("ra-notx.xml",
+                "ironjacamar-default.xml",
+                LazyAssociationSharableDefaultTestCase.class);
+    }
+
+    @Resource(mappedName = "java:/eis/Lazy")
+    private LazyConnectionFactory lcf;
+
+    @Test
+    public void testBasic() {
+        assertNotNull(lcf);
+
+        LazyConnection lc = null;
+        try {
+            lc = lcf.getConnection();
+
+            assertTrue(lc.isManagedConnectionSet());
+            assertTrue(lc.closeManagedConnection());
+            assertFalse(lc.isManagedConnectionSet());
+
+            assertTrue(lc.associate());
+
+            assertTrue(lc.isManagedConnectionSet());
+
+            assertFalse(lc.isEnlisted());
+            assertTrue(lc.enlist());
+            assertFalse(lc.isEnlisted());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc != null)
+                lc.close();
+        }
+    }
+
+    /**
+     * Two connections - one managed connection
+     *
+     * @throws Throwable Thrown if case of an error
+     */
+    @Test
+    public void testTwoConnections() {
+        assertNotNull(lcf);
+
+        LazyConnection lc1 = null;
+        LazyConnection lc2 = null;
+        try {
+            lc1 = lcf.getConnection();
+
+            assertTrue(lc1.isManagedConnectionSet());
+
+            lc2 = lcf.getConnection();
+
+            assertTrue(lc2.isManagedConnectionSet());
+            assertFalse(lc1.isManagedConnectionSet());
+
+            assertTrue(lc2.closeManagedConnection());
+
+            assertFalse(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+
+            assertTrue(lc1.associate());
+
+            assertTrue(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc1 != null)
+                lc1.close();
+
+            if (lc2 != null)
+                lc2.close();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationSharableFalseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationSharableFalseTestCase.java
@@ -1,0 +1,113 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.resource.ResourceException;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive with sharable=false
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+@RunWith(Arquillian.class)
+public class LazyAssociationSharableFalseTestCase extends LazyAssociationAbstractTestCase {
+    private static Logger logger = Logger.getLogger(LazyAssociationSharableFalseTestCase.class);
+
+    @Deployment(name = LazyAssociationAbstractTestCase.RAR_NAME)
+    public static Archive<ResourceAdapterArchive> createDeployment() {
+        return createResourceAdapter("ra-notx.xml",
+                "ironjacamar-sharablefalse.xml",
+                LazyAssociationSharableFalseTestCase.class);
+    }
+
+    @Resource(mappedName = "java:/eis/Lazy")
+    private LazyConnectionFactory lcf;
+
+    @Test
+    public void verifyDisabledLazyAssociation() {
+        assertNotNull(lcf);
+
+        LazyConnection lc1 = null;
+        LazyConnection lc2 = null;
+        try {
+            lc1 = lcf.getConnection();
+            assertTrue(lc1.isManagedConnectionSet());
+
+            try {
+                lc2 = lcf.getConnection();
+                fail("Exception should have been thrown");
+            } catch (ResourceException re) {
+                // expected
+            }
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            fail("Throwable:" + t.getLocalizedMessage());
+        } finally {
+            if (lc1 != null)
+                lc1.close();
+            if (lc2 != null)
+                lc2.close();
+        }
+    }
+
+    @Test
+    public void testDefaultBehaviorWithoutLazyAssociation() {
+        assertNotNull(lcf);
+
+        LazyConnection lc1 = null;
+        LazyConnection lc2 = null;
+        try {
+            lc1 = lcf.getConnection();
+            assertTrue(lc1.isManagedConnectionSet());
+            lc1.close();
+
+            lc2 = lcf.getConnection();
+            assertTrue(lc2.isManagedConnectionSet());
+            lc2.close();
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            fail("Throwable:" + t.getLocalizedMessage());
+        } finally {
+            if (lc1 != null)
+                lc1.close();
+            if (lc2 != null)
+                lc2.close();
+        }
+
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationXATransactionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/LazyAssociationXATransactionTestCase.java
@@ -1,0 +1,215 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection;
+import org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.ResourceAdapterArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.annotation.Resource;
+import javax.transaction.UserTransaction;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test cases for deploying a lazy association resource adapter archive using XATransaction
+ *
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+@RunWith(Arquillian.class)
+public class LazyAssociationXATransactionTestCase extends LazyAssociationAbstractTestCase {
+    private static Logger logger = Logger.getLogger(LazyAssociationXATransactionTestCase.class);
+
+    @Deployment(name = LazyAssociationAbstractTestCase.RAR_NAME)
+    public static Archive<ResourceAdapterArchive> createDeployment() {
+        return createResourceAdapter("ra-xatx.xml",
+                "ironjacamar-xa-default.xml",
+                LazyAssociationXATransactionTestCase.class);
+    }
+
+    @Resource(mappedName = "java:/eis/Lazy")
+    private LazyConnectionFactory lcf;
+
+    @Resource(mappedName = "java:jboss/UserTransaction")
+    private UserTransaction userTransaction;
+
+    @Test
+    public void testBasic() throws Throwable {
+        assertNotNull(lcf);
+        assertNotNull(userTransaction);
+
+        boolean status = true;
+        userTransaction.begin();
+
+        LazyConnection lc = null;
+        try {
+            lc = lcf.getConnection();
+
+            assertTrue(lc.isManagedConnectionSet());
+
+            lc.closeManagedConnection();
+
+            assertFalse(lc.isManagedConnectionSet());
+
+            lc.associate();
+
+            assertTrue(lc.isManagedConnectionSet());
+
+            assertFalse(lc.isEnlisted());
+            assertTrue(lc.enlist());
+            assertTrue(lc.isEnlisted());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            status = false;
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc != null)
+                lc.close();
+
+            if (status) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+    /**
+     * Two connections - one managed connection - without enlistment
+     *
+     * @throws Throwable Thrown if case of an error
+     */
+    @Test
+    public void testTwoConnectionsWithoutEnlistment() throws Throwable {
+        assertNotNull(lcf);
+        assertNotNull(userTransaction);
+
+        boolean status = true;
+        userTransaction.begin();
+
+        LazyConnection lc1 = null;
+        LazyConnection lc2 = null;
+        try {
+            lc1 = lcf.getConnection();
+
+            assertTrue(lc1.isManagedConnectionSet());
+
+            lc2 = lcf.getConnection();
+
+            assertTrue(lc2.isManagedConnectionSet());
+            assertFalse(lc1.isManagedConnectionSet());
+
+            assertTrue(lc2.closeManagedConnection());
+
+            assertFalse(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+
+            assertTrue(lc1.associate());
+
+            assertTrue(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            status = false;
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc1 != null)
+                lc1.close();
+
+            if (lc2 != null)
+                lc2.close();
+
+            if (status) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+    /**
+     * Two connections - one managed connection - with enlistment
+     *
+     * @throws Throwable Thrown if case of an error
+     */
+    @Test
+    public void testTwoConnectionsWithEnlistment() throws Throwable {
+        assertNotNull(lcf);
+        assertNotNull(userTransaction);
+
+        boolean status = true;
+        userTransaction.begin();
+
+        LazyConnection lc1 = null;
+        LazyConnection lc2 = null;
+        try {
+            lc1 = lcf.getConnection();
+
+            assertTrue(lc1.isManagedConnectionSet());
+            assertFalse(lc1.isEnlisted());
+            assertTrue(lc1.enlist());
+            assertTrue(lc1.isEnlisted());
+
+            lc2 = lcf.getConnection();
+
+            assertTrue(lc2.isManagedConnectionSet());
+            assertFalse(lc1.isManagedConnectionSet());
+
+            assertTrue(lc2.closeManagedConnection());
+
+            assertFalse(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+
+            assertTrue(lc1.associate());
+
+            assertTrue(lc1.isManagedConnectionSet());
+            assertFalse(lc2.isManagedConnectionSet());
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+            status = false;
+            fail("Throwable:" + t.getMessage());
+        } finally {
+            if (lc1 != null)
+                lc1.close();
+
+            if (lc2 != null)
+                lc2.close();
+
+            if (status) {
+                userTransaction.commit();
+            } else {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnection.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnection.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public interface LazyConnection {
+    public boolean isManagedConnectionSet();
+
+    public boolean closeManagedConnection();
+
+    public boolean associate();
+
+    public boolean isEnlisted();
+
+    public boolean enlist();
+
+    public void close();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnectionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnectionFactory.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import javax.resource.Referenceable;
+import javax.resource.ResourceException;
+import java.io.Serializable;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public interface LazyConnectionFactory extends Serializable, Referenceable {
+
+    public LazyConnection getConnection() throws ResourceException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnectionFactoryImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnectionFactoryImpl.java
@@ -1,0 +1,66 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.naming.NamingException;
+import javax.naming.Reference;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyConnectionFactoryImpl implements LazyConnectionFactory {
+
+    private static Logger logger = Logger.getLogger(LazyConnectionFactoryImpl.class);
+
+    private Reference reference;
+    private LazyManagedConnectionFactory mcf;
+    private ConnectionManager connectionManager;
+
+    public LazyConnectionFactoryImpl(LazyManagedConnectionFactory mcf, ConnectionManager connectionManager) {
+        logger.trace("#LazyConnectionFactoryImpl");
+        this.mcf = mcf;
+        this.connectionManager = connectionManager;
+    }
+
+    @Override
+    public LazyConnection getConnection() throws ResourceException {
+        logger.trace("#LazyConnectionFactoryImpl.getConnection");
+        return (LazyConnection) connectionManager.allocateConnection(mcf, null);
+    }
+
+    @Override
+    public Reference getReference() throws NamingException {
+        logger.trace("#LazyConnectionFactoryImpl.getReference");
+        return reference;
+    }
+
+    @Override
+    public void setReference(Reference reference) {
+        logger.trace("#LazyConnectionFactoryImpl.setReference");
+        this.reference = reference;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnectionImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyConnectionImpl.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.LazyAssociatableConnectionManager;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyConnectionImpl implements LazyConnection {
+
+    private static Logger logger = Logger.getLogger(LazyConnectionImpl.class);
+
+    private ConnectionManager cm;
+    private LazyManagedConnection mc;
+    private LazyManagedConnectionFactory mcf;
+    private ConnectionRequestInfo cri;
+
+    public LazyConnectionImpl(ConnectionManager cm, LazyManagedConnection mc, LazyManagedConnectionFactory mcf, ConnectionRequestInfo cri) {
+        logger.trace("#LazyConnectionImpl");
+        this.cm = cm;
+        this.mc = mc;
+        this.mcf = mcf;
+        this.cri = cri;
+    }
+
+    @Override
+    public boolean isManagedConnectionSet() {
+        logger.trace("#LazyConnectionImpl.isManagedConnectionSet");
+        return mc != null;
+    }
+
+    @Override
+    public boolean closeManagedConnection() {
+        logger.trace("#LazyConnectionImpl.closeManagedConnection");
+        if (isManagedConnectionSet()) {
+            try {
+                mc.dissociateConnections();
+                mc = null;
+                return true;
+            } catch (Throwable t) {
+                logger.error("closeManagedConnection()", t);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean associate() {
+        logger.trace("#LazyConnectionImpl.associate");
+        if (mc == null) {
+            if (cm instanceof LazyAssociatableConnectionManager) {
+                try {
+                    LazyAssociatableConnectionManager lcm = (LazyAssociatableConnectionManager) cm;
+                    lcm.associateConnection(this, mcf, cri);
+                    return true;
+                } catch (Throwable t) {
+                    logger.error("associate()", t);
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean isEnlisted() {
+        logger.trace("#LazyConnectionImpl.isEnlisted");
+        return mc.isEnlisted();
+    }
+
+    @Override
+    public boolean enlist() {
+        logger.trace("#LazyConnectionImpl.enlist");
+        return mc.enlist();
+    }
+
+    @Override
+    public void close() {
+        logger.trace("#LazyConnectionImpl.close");
+        if (mc != null) {
+            mc.closeHandle(this);
+        } else {
+            if (cm instanceof LazyAssociatableConnectionManager) {
+                LazyAssociatableConnectionManager lacm = (LazyAssociatableConnectionManager) cm;
+                lacm.inactiveConnectionClosed(this, mcf);
+            }
+        }
+
+    }
+
+    public void setManagedConnection(LazyManagedConnection mc) {
+        logger.trace("#LazyConnectionImpl.setManagedConnection");
+        this.mc = mc;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyLocalTransaction.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyLocalTransaction.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.LocalTransaction;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyLocalTransaction implements LocalTransaction {
+    private static Logger logger = Logger.getLogger(LazyLocalTransaction.class);
+
+    private LazyManagedConnection mc;
+
+    public LazyLocalTransaction(LazyManagedConnection mc) {
+        this.mc = mc;
+    }
+
+    @Override
+    public void begin() throws ResourceException {
+        logger.trace("#LazyLocalTransaction.begin");
+        mc.setEnlisted(true);
+    }
+
+    @Override
+    public void commit() throws ResourceException {
+        logger.trace("#LazyLocalTransaction.commit");
+        mc.setEnlisted(false);
+    }
+
+    @Override
+    public void rollback() throws ResourceException {
+        logger.trace("#LazyLocalTransaction.rollback");
+        mc.setEnlisted(false);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnection.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnection.java
@@ -1,0 +1,221 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.resource.NotSupportedException;
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionEvent;
+import javax.resource.spi.ConnectionEventListener;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.DissociatableManagedConnection;
+import javax.resource.spi.LazyEnlistableConnectionManager;
+import javax.resource.spi.LazyEnlistableManagedConnection;
+import javax.resource.spi.LocalTransaction;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionMetaData;
+import javax.security.auth.Subject;
+import javax.transaction.xa.XAResource;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyManagedConnection implements ManagedConnection, DissociatableManagedConnection,
+        LazyEnlistableManagedConnection {
+
+    private static Logger logger = Logger.getLogger(LazyManagedConnection.class);
+
+    private boolean localTransaction;
+    private boolean xaTransaction;
+    private boolean enlisted;
+    private LazyConnectionImpl connection;
+    private List<ConnectionEventListener> listeners;
+    private PrintWriter logwriter;
+    private LazyLocalTransaction lazyLocalTransaction;
+    private LazyXAResource lazyXAResource;
+    private ConnectionManager cm;
+    private LazyManagedConnectionFactory mcf;
+
+    public LazyManagedConnection(boolean localTransaction, boolean xaTransaction, ConnectionManager cm, LazyManagedConnectionFactory mcf) {
+        logger.trace("#LazyManagedConnection");
+
+        this.localTransaction = localTransaction;
+        this.xaTransaction = xaTransaction;
+        this.cm = cm;
+        this.mcf = mcf;
+        this.enlisted = false;
+        this.listeners = Collections.synchronizedList(new ArrayList<ConnectionEventListener>(1));
+
+        if (localTransaction)
+            this.lazyLocalTransaction = new LazyLocalTransaction(this);
+        if (xaTransaction)
+            this.lazyXAResource = new LazyXAResource(this);
+    }
+
+    @Override
+    public void dissociateConnections() throws ResourceException {
+        logger.trace("#LazyManagedConnection.dissociateConnections");
+        if (connection != null) {
+            connection.setManagedConnection(null);
+            connection = null;
+        }
+
+    }
+
+    @Override
+    public Object getConnection(Subject subject, ConnectionRequestInfo cri) throws ResourceException {
+        logger.trace("#LazyManagedConnection.getConnection");
+
+        if (connection != null) {
+            connection.setManagedConnection(null);
+        }
+
+        connection = new LazyConnectionImpl(cm, this, mcf, cri);
+        return connection;
+    }
+
+    @Override
+    public void destroy() throws ResourceException {
+        logger.trace("#LazyManagedConnection.destroy");
+    }
+
+    @Override
+    public void cleanup() throws ResourceException {
+        logger.trace("#LazyManagedConnection.cleanup");
+        if (connection != null) {
+            connection.setManagedConnection(null);
+            connection = null;
+        }
+    }
+
+    @Override
+    public void associateConnection(Object connection) throws ResourceException {
+        logger.trace("#LazyManagedConnection.associateConnection");
+        if (this.connection != null) {
+            this.connection.setManagedConnection(null);
+        }
+
+        if (connection != null) {
+            if (!(connection instanceof LazyConnectionImpl))
+                throw new ResourceException("Connection isn't LazyConnectionImpl: " + connection.getClass().getName());
+
+            this.connection = (LazyConnectionImpl) connection;
+            this.connection.setManagedConnection(this);
+        } else {
+            this.connection = null;
+        }
+    }
+
+    @Override
+    public void addConnectionEventListener(ConnectionEventListener listener) {
+        logger.trace("#LazyManagedConnection.addConnectionEventListener");
+        if (listener == null)
+            throw new IllegalArgumentException("Listener is null");
+        listeners.add(listener);
+
+    }
+
+    @Override
+    public void removeConnectionEventListener(ConnectionEventListener listener) {
+        logger.trace("#LazyManagedConnection.removeConnectionEventListener");
+        if (listener == null)
+            throw new IllegalArgumentException("Listener is null");
+        listeners.remove(listener);
+    }
+
+    @Override
+    public XAResource getXAResource() throws ResourceException {
+        logger.trace("#LazyManagedConnection.getXAResource");
+        if (!xaTransaction || localTransaction) {
+            throw new NotSupportedException("GetXAResource not supported not supported");
+        } else {
+            return lazyXAResource;
+        }
+    }
+
+    @Override
+    public LocalTransaction getLocalTransaction() throws ResourceException {
+        logger.trace("#LazyManagedConnection.getLocalTransaction");
+        if (!localTransaction || xaTransaction) {
+            throw new NotSupportedException("LocalTransaction not supported");
+        } else {
+            return lazyLocalTransaction;
+        }
+    }
+
+    @Override
+    public ManagedConnectionMetaData getMetaData() throws ResourceException {
+        logger.trace("#LazyManagedConnection.getMetaData");
+        return new LazyManagedConnectionMetaData();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter printWriter) throws ResourceException {
+        logger.trace("#LazyManagedConnection.setLogWriter");
+        logwriter = printWriter;
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws ResourceException {
+        logger.trace("#LazyManagedConnection.getLogWriter");
+        return logwriter;
+    }
+
+    boolean isEnlisted() {
+        logger.trace("#LazyManagedConnection.isEnlisted");
+        return enlisted;
+    }
+
+    void setEnlisted(boolean enlisted) {
+        logger.trace("#LazyManagedConnection.setEnlisted");
+        this.enlisted = enlisted;
+    }
+
+    boolean enlist() {
+        logger.trace("#LazyManagedConnection.enlist");
+        try {
+            if (cm instanceof LazyEnlistableConnectionManager) {
+                LazyEnlistableConnectionManager lecm = (LazyEnlistableConnectionManager) cm;
+                lecm.lazyEnlist(this);
+                return true;
+            }
+        } catch (Throwable t) {
+            logger.error(t.getMessage(), t);
+        }
+        return false;
+    }
+
+    void closeHandle(LazyConnection handle) {
+        ConnectionEvent event = new ConnectionEvent(this, ConnectionEvent.CONNECTION_CLOSED);
+        event.setConnectionHandle(handle);
+        for (ConnectionEventListener cel : listeners) {
+            cel.connectionClosed(event);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnectionFactory.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnectionFactory.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterAssociation;
+import javax.security.auth.Subject;
+import java.io.PrintWriter;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyManagedConnectionFactory implements ManagedConnectionFactory, ResourceAdapterAssociation {
+
+    private static final long serialVersionUID = 8167326732027615486L;
+    private static Logger logger = Logger.getLogger(LazyManagedConnectionFactory.class);
+
+    private ConnectionManager cm;
+    private ResourceAdapter ra;
+    private PrintWriter logwriter;
+
+    public LazyManagedConnectionFactory() {
+    }
+
+    @Override
+    public Object createConnectionFactory(ConnectionManager connectionManager) throws ResourceException {
+        logger.trace("#LazyManagedConnectionFactory.createConnectionFactory");
+
+        this.cm = connectionManager;
+        return new LazyConnectionFactoryImpl(this, connectionManager);
+    }
+
+    @Override
+    public Object createConnectionFactory() throws ResourceException {
+        throw new ResourceException("This resource adapter doesn't support non-managed environments");
+    }
+
+    @Override
+    public ManagedConnection createManagedConnection(Subject subject, ConnectionRequestInfo connectionRequestInfo) throws ResourceException {
+        logger.trace("#LazyManagedConnectionFactory.createManagedConnection");
+        LazyResourceAdapter lra = (LazyResourceAdapter) ra;
+
+        return new LazyManagedConnection(lra.getLocalTransaction().booleanValue(),
+                lra.getXATransaction().booleanValue(),
+                cm, this);
+    }
+
+    @Override
+    public ManagedConnection matchManagedConnections(Set connectionSet, Subject subject, ConnectionRequestInfo connectionRequestInfo) throws ResourceException {
+        logger.trace("#LazyManagedConnectionFactory.matchManagedConnections");
+        ManagedConnection result = null;
+        Iterator it = connectionSet.iterator();
+        while (result == null && it.hasNext()) {
+            ManagedConnection mc = (ManagedConnection) it.next();
+            if (mc instanceof LazyManagedConnection) {
+                result = mc;
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter printWriter) throws ResourceException {
+        logger.trace("#LazyManagedConnectionFactory.setLogWriter");
+
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws ResourceException {
+        logger.trace("#LazyManagedConnectionFactory.getLogWriter");
+        return null;
+    }
+
+    @Override
+    public ResourceAdapter getResourceAdapter() {
+        logger.trace("#LazyManagedConnectionFactory.getResourceAdapter");
+        return null;
+    }
+
+    @Override
+    public void setResourceAdapter(ResourceAdapter resourceAdapter) throws ResourceException {
+        logger.trace("#LazyManagedConnectionFactory.setResourceAdapter");
+        this.ra = resourceAdapter;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null)
+            return false;
+        if (other == this)
+            return true;
+        if (!(other instanceof LazyManagedConnectionFactory))
+            return false;
+        LazyManagedConnectionFactory obj = (LazyManagedConnectionFactory) other;
+        boolean result = true;
+        return result;
+    }
+
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnectionMetaData.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyManagedConnectionMetaData.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ManagedConnectionMetaData;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyManagedConnectionMetaData implements ManagedConnectionMetaData {
+    private static Logger logger = Logger.getLogger(LazyManagedConnectionMetaData.class);
+
+    @Override
+    public String getEISProductName() throws ResourceException {
+        logger.trace("#LazyManagedConnectionMetaData.getEISProductName");
+        return "LAZY";
+    }
+
+    @Override
+    public String getEISProductVersion() throws ResourceException {
+        logger.trace("#LazyManagedConnectionMetaData.getEISProductVersion");
+        return "1.0";
+    }
+
+    @Override
+    public int getMaxConnections() throws ResourceException {
+        logger.trace("#LazyManagedConnectionMetaData.getMaxConnections");
+        return 0;
+    }
+
+    @Override
+    public String getUserName() throws ResourceException {
+        logger.trace("#LazyManagedConnectionMetaData.getUserName");
+        return null;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyResourceAdapter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyResourceAdapter.java
@@ -1,0 +1,145 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.resource.ResourceException;
+import javax.resource.spi.ActivationSpec;
+import javax.resource.spi.BootstrapContext;
+import javax.resource.spi.ResourceAdapter;
+import javax.resource.spi.ResourceAdapterInternalException;
+import javax.resource.spi.endpoint.MessageEndpointFactory;
+import javax.transaction.xa.XAResource;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyResourceAdapter implements ResourceAdapter {
+
+    private static Logger logger = Logger.getLogger(LazyResourceAdapter.class);
+
+    private Boolean enable;
+    private Boolean localTransaction;
+    private Boolean xaTransaction;
+
+    public LazyResourceAdapter() {
+        logger.trace("#LazyResourceAdapter");
+        enable = Boolean.TRUE;
+        localTransaction = Boolean.FALSE;
+        xaTransaction = Boolean.FALSE;
+    }
+
+    @Override
+    public void start(BootstrapContext ctx) throws ResourceAdapterInternalException {
+        logger.trace("#LazyResourceAdapter.start");
+    }
+
+    @Override
+    public void stop() {
+        logger.trace("#LazyResourceAdapter.stop");
+    }
+
+    @Override
+    public void endpointActivation(MessageEndpointFactory endpointFactory, ActivationSpec spec) throws ResourceException {
+        logger.trace("#LazyResourceAdapter.endpointActivation");
+    }
+
+    @Override
+    public void endpointDeactivation(MessageEndpointFactory endpointFactory, ActivationSpec spec) {
+        logger.trace("#LazyResourceAdapter.endpointDeactivation");
+    }
+
+    @Override
+    public XAResource[] getXAResources(ActivationSpec[] specs) throws ResourceException {
+        logger.trace("#LazyResourceAdapter.getXAResources");
+        return null;
+    }
+
+    public Boolean getEnable() {
+        return enable;
+    }
+
+    public void setEnable(Boolean enable) {
+        this.enable = enable;
+    }
+
+    public Boolean getXATransaction() {
+        return xaTransaction;
+    }
+
+    public void setXATransaction(Boolean xaTransaction) {
+        this.xaTransaction = xaTransaction;
+    }
+
+    public Boolean getLocalTransaction() {
+        return localTransaction;
+    }
+
+    public void setLocalTransaction(Boolean localTransaction) {
+        this.localTransaction = localTransaction;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 17;
+        if (enable != null)
+            result += 31 * result + 7 * enable.hashCode();
+        else
+            result += 31 * result + 7;
+        if (localTransaction != null)
+            result += 31 * result + 7 * localTransaction.hashCode();
+        else
+            result += 31 * result + 7;
+        if (xaTransaction != null)
+            result += 31 * result + 7 * xaTransaction.hashCode();
+        else
+            result += 31 * result + 7;
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null)
+            return false;
+        if (other == this)
+            return true;
+        if (!(other instanceof LazyResourceAdapter))
+            return false;
+        LazyResourceAdapter obj = (LazyResourceAdapter) other;
+        boolean result = true;
+        if (result) {
+            if (localTransaction == null)
+                result = obj.getLocalTransaction() == null;
+            else
+                result = localTransaction.equals(obj.getLocalTransaction());
+        }
+        if (result) {
+            if (xaTransaction == null)
+                result = obj.getXATransaction() == null;
+            else
+                result = xaTransaction.equals(obj.getXATransaction());
+        }
+        return result;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyXAResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/LazyXAResource.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.jca.lazyconnectionmanager.rar;
+
+import org.jboss.logging.Logger;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+/**
+ * @author <a href="mailto:jesper.pedersen@ironjacamar.org">Jesper Pedersen</a>
+ * @author <a href="mailto:msimka@redhat.com">Martin Simka</a>
+ */
+public class LazyXAResource implements XAResource {
+
+    private static Logger logger = Logger.getLogger(LazyXAResource.class);
+
+    private LazyManagedConnection mc;
+
+    public LazyXAResource(LazyManagedConnection mc) {
+        logger.trace("#LazyXAResource");
+        this.mc = mc;
+    }
+
+    @Override
+    public void commit(Xid xid, boolean b) throws XAException {
+        logger.trace("#LazyXAResource.commit");
+        mc.setEnlisted(false);
+    }
+
+    @Override
+    public void end(Xid xid, int i) throws XAException {
+        logger.trace("#LazyXAResource.end");
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        logger.trace("#LazyXAResource.forget");
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        logger.trace("#LazyXAResource.getTransactionTimeout");
+        return 0;
+    }
+
+    @Override
+    public boolean isSameRM(XAResource xaResource) throws XAException {
+        logger.trace("#LazyXAResource.isSameRM");
+        if (xaResource != null)
+            return xaResource instanceof LazyXAResource;
+        return false;
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        logger.trace("#LazyXAResource.prepare");
+        return XAResource.XA_OK;
+    }
+
+    @Override
+    public Xid[] recover(int i) throws XAException {
+        logger.trace("#LazyXAResource.recover");
+        return new Xid[0];
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        logger.trace("#LazyXAResource.rollback");
+        mc.setEnlisted(false);
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int i) throws XAException {
+        logger.trace("#LazyXAResource.setTransactionTimeout");
+        return true;
+    }
+
+    @Override
+    public void start(Xid xid, int i) throws XAException {
+        logger.trace("#LazyXAResource.start");
+        mc.setEnlisted(true);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-default.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-default.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ironjacamar>
+    <connection-definitions>
+        <connection-definition
+                class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"
+                jndi-name="java:/eis/Lazy">
+            <pool>
+                <min-pool-size>0</min-pool-size>
+                <max-pool-size>1</max-pool-size>
+            </pool>
+            <timeout>
+                <blocking-timeout-millis>100</blocking-timeout-millis>
+            </timeout>
+        </connection-definition>
+    </connection-definitions>
+</ironjacamar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-enlistmentfalse.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-enlistmentfalse.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ironjacamar>
+    <connection-definitions>
+        <connection-definition
+                class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"
+                jndi-name="java:/eis/Lazy" enlistment="false">
+            <pool>
+                <min-pool-size>0</min-pool-size>
+                <max-pool-size>1</max-pool-size>
+            </pool>
+            <timeout>
+                <blocking-timeout-millis>100</blocking-timeout-millis>
+            </timeout>
+        </connection-definition>
+    </connection-definitions>
+</ironjacamar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-sharablefalse.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-sharablefalse.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ironjacamar>
+    <connection-definitions>
+        <connection-definition
+                class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"
+                jndi-name="java:/eis/Lazy" sharable="false">
+            <pool>
+                <min-pool-size>0</min-pool-size>
+                <max-pool-size>1</max-pool-size>
+            </pool>
+            <timeout>
+                <blocking-timeout-millis>100</blocking-timeout-millis>
+            </timeout>
+        </connection-definition>
+    </connection-definitions>
+</ironjacamar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-xa-default.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ironjacamar-xa-default.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ironjacamar>
+    <connection-definitions>
+        <connection-definition
+                class-name="org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory"
+                jndi-name="java:/eis/Lazy">
+            <xa-pool>
+                <min-pool-size>0</min-pool-size>
+                <max-pool-size>1</max-pool-size>
+            </xa-pool>
+            <timeout>
+                <blocking-timeout-millis>100</blocking-timeout-millis>
+            </timeout>
+        </connection-definition>
+    </connection-definitions>
+</ironjacamar>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ra-localtx.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ra-localtx.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+           http://xmlns.jcp.org/xml/ns/javaee/connector_1_7.xsd"
+           version="1.7" metadata-complete="true">
+
+    <vendor-name>Red Hat Middleware LLC</vendor-name>
+    <eis-type>Test RA</eis-type>
+    <resourceadapter-version>0.1</resourceadapter-version>
+
+    <resourceadapter>
+        <resourceadapter-class>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyResourceAdapter
+        </resourceadapter-class>
+        <config-property>
+            <config-property-name>Enable</config-property-name>
+            <config-property-type>java.lang.Boolean</config-property-type>
+            <config-property-value>true</config-property-value>
+        </config-property>
+        <config-property>
+            <config-property-name>LocalTransaction</config-property-name>
+            <config-property-type>java.lang.Boolean</config-property-type>
+            <config-property-value>true</config-property-value>
+        </config-property>
+
+        <outbound-resourceadapter>
+            <connection-definition>
+                <managedconnectionfactory-class>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory
+                </managedconnectionfactory-class>
+
+                <connectionfactory-interface>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory
+                </connectionfactory-interface>
+                <connectionfactory-impl-class>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactoryImpl
+                </connectionfactory-impl-class>
+                <connection-interface>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection
+                </connection-interface>
+                <connection-impl-class>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionImpl
+                </connection-impl-class>
+            </connection-definition>
+            <transaction-support>LocalTransaction</transaction-support>
+            <reauthentication-support>false</reauthentication-support>
+        </outbound-resourceadapter>
+    </resourceadapter>
+</connector>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ra-notx.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ra-notx.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://java.sun.com/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+           http://java.sun.com/xml/ns/j2ee/connector_1_7.xsd"
+           version="1.7" metadata-complete="true">
+
+    <vendor-name>Red Hat Middleware LLC</vendor-name>
+    <eis-type>Test RA</eis-type>
+    <resourceadapter-version>0.1</resourceadapter-version>
+
+    <resourceadapter>
+        <resourceadapter-class>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyResourceAdapter
+        </resourceadapter-class>
+        <config-property>
+            <config-property-name>Enable</config-property-name>
+            <config-property-type>java.lang.Boolean</config-property-type>
+            <config-property-value>true</config-property-value>
+        </config-property>
+
+        <outbound-resourceadapter>
+            <connection-definition>
+                <managedconnectionfactory-class>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory
+                </managedconnectionfactory-class>
+
+                <connectionfactory-interface>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory
+                </connectionfactory-interface>
+                <connectionfactory-impl-class>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactoryImpl
+                </connectionfactory-impl-class>
+                <connection-interface>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection
+                </connection-interface>
+                <connection-impl-class>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionImpl
+                </connection-impl-class>
+            </connection-definition>
+            <transaction-support>NoTransaction</transaction-support>
+            <reauthentication-support>false</reauthentication-support>
+        </outbound-resourceadapter>
+    </resourceadapter>
+</connector>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ra-xatx.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/lazyconnectionmanager/rar/ra-xatx.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<connector xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+           http://xmlns.jcp.org/xml/ns/javaee/connector_1_7.xsd"
+           version="1.7" metadata-complete="true">
+
+    <vendor-name>Red Hat Middleware LLC</vendor-name>
+    <eis-type>Test RA</eis-type>
+    <resourceadapter-version>0.1</resourceadapter-version>
+
+    <resourceadapter>
+        <resourceadapter-class>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyResourceAdapter
+        </resourceadapter-class>
+        <config-property>
+            <config-property-name>Enable</config-property-name>
+            <config-property-type>java.lang.Boolean</config-property-type>
+            <config-property-value>true</config-property-value>
+        </config-property>
+        <config-property>
+            <config-property-name>XATransaction</config-property-name>
+            <config-property-type>java.lang.Boolean</config-property-type>
+            <config-property-value>true</config-property-value>
+        </config-property>
+
+        <outbound-resourceadapter>
+            <connection-definition>
+                <managedconnectionfactory-class>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyManagedConnectionFactory
+                </managedconnectionfactory-class>
+
+                <connectionfactory-interface>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactory
+                </connectionfactory-interface>
+                <connectionfactory-impl-class>
+                    org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionFactoryImpl
+                </connectionfactory-impl-class>
+                <connection-interface>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnection
+                </connection-interface>
+                <connection-impl-class>org.jboss.as.test.integration.jca.lazyconnectionmanager.rar.LazyConnectionImpl
+                </connection-impl-class>
+            </connection-definition>
+            <transaction-support>XATransaction</transaction-support>
+            <reauthentication-support>false</reauthentication-support>
+        </outbound-resourceadapter>
+    </resourceadapter>
+</connector>


### PR DESCRIPTION
tests for:
https://issues.jboss.org/browse/JBJCA-747 LazyAssociatableConnectionManager/NoTx
https://issues.jboss.org/browse/JBJCA-825 LazyAssociatableConnectionManager/Tx
https://issues.jboss.org/browse/JBJCA-826 LazyEnlistableConnectionManager

More or less straight port from the IronJacamar test suite from package org.jboss.jca.deployers.test.unit.lazy. 

Included only basic tests to ensure that integration works - tests without transaction, with local transaction and with xa transaction. Omitted tests with multiple threads and with interleaving. 
- in comparison to IJ TS there are no significant changes - changed logging messages and log level

Also added some additional tests with RA that implements DissociatableManagedConnection, LazyEnlistableManagedConnection but both is disabled in configuration. 
- added basic test for JCA 1.7 RA deployment, which isn't related to lazy connection manager, but I noticed that it's missing
