### PR TITLE
WFLY-1366: adding test for definition of an embedded datasource

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/DataSourceBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/DataSourceBean.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.integration.ee.datasourcedefinition;
 
 import javax.annotation.Resource;
 import javax.annotation.sql.DataSourceDefinition;
+import javax.annotation.sql.DataSourceDefinitions;
 import javax.ejb.Stateless;
 import javax.sql.DataSource;
 
@@ -31,12 +32,19 @@ import java.sql.SQLException;
 /**
  * @author Stuart Douglas
  */
-@DataSourceDefinition(
-        name = "java:comp/ds",
-        user = "sa",
-        password = "sa",
-        className = "org.h2.jdbcx.JdbcDataSource",
-        url = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
+@DataSourceDefinitions({
+        @DataSourceDefinition(
+                name = "java:comp/ds",
+                user = "sa",
+                password = "sa",
+                className = "org.h2.jdbcx.JdbcDataSource",
+                url = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1"
+        ),
+        @DataSourceDefinition(
+                name = "java:comp/dse",
+                className = "org.jboss.as.test.integration.ee.datasourcedefinition.EmbeddedDataSource"
+        )
+}
 )
 @Stateless
 public class DataSourceBean {
@@ -56,6 +64,8 @@ public class DataSourceBean {
     @Resource(lookup="org.jboss.as.test.integration.ee.datasourcedefinition.DataSourceBean/dataSource3")
     private DataSource dataSource4;
 
+    @Resource(lookup="java:comp/dse")
+    private DataSource dataSource5;
 
     public void createTable() throws SQLException {
         dataSource.getConnection().createStatement().execute("create table if not exists coffee(id int not null);");
@@ -84,5 +94,9 @@ public class DataSourceBean {
 
     public DataSource getDataSource4() {
         return dataSource4;
+    }
+
+    public DataSource getDataSource5() {
+        return dataSource5;
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/DataSourceDefinitionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/DataSourceDefinitionTestCase.java
@@ -109,7 +109,16 @@ public class DataSourceDefinitionTestCase {
         Assert.assertNotNull(bean.getDataSource2());
         Assert.assertNotNull(bean.getDataSource3());
         Assert.assertNotNull(bean.getDataSource4());
-
     }
 
+    /**
+     * Tests an embedded datasource resource def.
+     * @throws NamingException
+     * @throws SQLException
+     */
+    @Test
+    public void testEmbeddedDatasource() throws NamingException, SQLException {
+        DataSourceBean bean = (DataSourceBean)ctx.lookup("java:module/" + DataSourceBean.class.getSimpleName());
+        Assert.assertEquals(bean.getDataSource5().getConnection().nativeSQL("dse"),"dse");
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/EmbeddedDataSource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/datasourcedefinition/EmbeddedDataSource.java
@@ -1,0 +1,354 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.ee.datasourcedefinition;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.*;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Executor;
+import java.util.logging.Logger;
+
+/**
+ * A dummy {@link DataSource} impl, which connection's nativeSql(String) method echoes its string arg value.
+ * @author emmartins
+ */
+public class EmbeddedDataSource implements DataSource {
+    @Override
+    public Connection getConnection() throws SQLException {
+        return new Connection();
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return new Connection();
+    }
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return null;
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return 0;
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return null;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        return null;
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return false;
+    }
+    
+    private class Connection implements java.sql.Connection {
+
+        @Override
+        public Statement createStatement() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public String nativeSQL(String sql) throws SQLException {
+            return sql;
+        }
+
+        @Override
+        public void setAutoCommit(boolean autoCommit) throws SQLException {
+
+        }
+
+        @Override
+        public boolean getAutoCommit() throws SQLException {
+            return false;
+        }
+
+        @Override
+        public void commit() throws SQLException {
+
+        }
+
+        @Override
+        public void rollback() throws SQLException {
+
+        }
+
+        @Override
+        public void close() throws SQLException {
+
+        }
+
+        @Override
+        public boolean isClosed() throws SQLException {
+            return false;
+        }
+
+        @Override
+        public DatabaseMetaData getMetaData() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setReadOnly(boolean readOnly) throws SQLException {
+
+        }
+
+        @Override
+        public boolean isReadOnly() throws SQLException {
+            return false;
+        }
+
+        @Override
+        public void setCatalog(String catalog) throws SQLException {
+
+        }
+
+        @Override
+        public String getCatalog() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setTransactionIsolation(int level) throws SQLException {
+
+        }
+
+        @Override
+        public int getTransactionIsolation() throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public SQLWarning getWarnings() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void clearWarnings() throws SQLException {
+
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Map<String, Class<?>> getTypeMap() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setTypeMap(Map<String, Class<?>> map) throws SQLException {
+
+        }
+
+        @Override
+        public void setHoldability(int holdability) throws SQLException {
+
+        }
+
+        @Override
+        public int getHoldability() throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public Savepoint setSavepoint() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Savepoint setSavepoint(String name) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void rollback(Savepoint savepoint) throws SQLException {
+
+        }
+
+        @Override
+        public void releaseSavepoint(Savepoint savepoint) throws SQLException {
+
+        }
+
+        @Override
+        public Statement createStatement(int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public CallableStatement prepareCall(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int autoGeneratedKeys) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, int[] columnIndexes) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public PreparedStatement prepareStatement(String sql, String[] columnNames) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Clob createClob() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Blob createBlob() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public NClob createNClob() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public SQLXML createSQLXML() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public boolean isValid(int timeout) throws SQLException {
+            return false;
+        }
+
+        @Override
+        public void setClientInfo(String name, String value) throws SQLClientInfoException {
+
+        }
+
+        @Override
+        public void setClientInfo(Properties properties) throws SQLClientInfoException {
+
+        }
+
+        @Override
+        public String getClientInfo(String name) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Properties getClientInfo() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Array createArrayOf(String typeName, Object[] elements) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public Struct createStruct(String typeName, Object[] attributes) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void setSchema(String schema) throws SQLException {
+
+        }
+
+        @Override
+        public String getSchema() throws SQLException {
+            return null;
+        }
+
+        @Override
+        public void abort(Executor executor) throws SQLException {
+
+        }
+
+        @Override
+        public void setNetworkTimeout(Executor executor, int milliseconds) throws SQLException {
+
+        }
+
+        @Override
+        public int getNetworkTimeout() throws SQLException {
+            return 0;
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> iface) throws SQLException {
+            return null;
+        }
+
+        @Override
+        public boolean isWrapperFor(Class<?> iface) throws SQLException {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
The issue is out of date, but I believe it makes sense to merge the test I made to check it.
