### PR TITLE
[WFLY-4825] Add capability for data sources defined on the subsystem.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceAdd.java
@@ -30,6 +30,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.STATISTICS
 import static org.jboss.as.connector.subsystems.jca.Constants.DEFAULT_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import javax.sql.DataSource;
 import java.sql.Driver;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -68,8 +69,8 @@ import org.jboss.security.SubjectFactory;
  */
 public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
 
-    AbstractDataSourceAdd(final Collection<AttributeDefinition> attributes) {
-        super(attributes);
+    AbstractDataSourceAdd(Collection<AttributeDefinition> attributes) {
+        super(Capabilities.DATA_SOURCE_CAPABILITY, attributes);
     }
 
     @Override
@@ -113,11 +114,13 @@ public abstract class AbstractDataSourceAdd extends AbstractAddStepHandler {
         AbstractDataSourceService dataSourceService = createDataSourceService(dsName, jndiName);
 
         final ManagementResourceRegistration registration = context.getResourceRegistrationForUpdate();
-        final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
+        final ServiceName dataSourceServiceNameAlias = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
+        final ServiceName dataSourceServiceName = context.getCapabilityServiceName(Capabilities.DATA_SOURCE_CAPABILITY_NAME, dsName, DataSource.class);
         final ServiceBuilder<?> dataSourceServiceBuilder =
                 Services.addServerExecutorDependency(
                         serviceTarget.addService(dataSourceServiceName, dataSourceService),
                         dataSourceService.getExecutorServiceInjector(), false)
+                        .addAliases(dataSourceServiceNameAlias)
                 .addDependency(ConnectorServices.MANAGEMENT_REPOSITORY_SERVICE, ManagementRepository.class,
                         dataSourceService.getManagementRepositoryInjector())
                 .addDependency(SubjectFactoryService.SERVICE_NAME, SubjectFactory.class,

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceRemove.java
@@ -51,6 +51,7 @@ public abstract class AbstractDataSourceRemove extends AbstractRemoveStepHandler
     private AbstractDataSourceAdd addHandler;
 
     protected AbstractDataSourceRemove(final AbstractDataSourceAdd addHandler) {
+        super(Capabilities.DATA_SOURCE_CAPABILITY);
         this.addHandler = addHandler;
     }
 
@@ -101,7 +102,7 @@ public abstract class AbstractDataSourceRemove extends AbstractRemoveStepHandler
             context.removeService(xaDataSourceConfigServiceName);
         }
 
-        final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
+        final ServiceName dataSourceServiceName = Capabilities.DATA_SOURCE_CAPABILITY.getCapabilityServiceName(dsName);
         final ServiceController<?> dataSourceController = registry.getService(dataSourceServiceName);
         if (dataSourceController != null) {
             context.removeService(dataSourceServiceName);

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceRemove.java
@@ -122,7 +122,7 @@ public abstract class AbstractDataSourceRemove extends AbstractRemoveStepHandler
 
     protected void recoverServices(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
 
-        addHandler.performRuntime(context, operation, /* resource (unused there anyway) */ null, model);
+        addHandler.performRuntime(context, operation, model);
 
         boolean enabled = ! operation.hasDefined(ENABLED.getName()) || ENABLED.resolveModelAttribute(context, model).asBoolean();
         if (context.isNormalServer() && enabled) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -99,6 +99,10 @@ import org.wildfly.security.manager.action.SetContextClassLoaderFromClassAction;
  */
 public abstract class AbstractDataSourceService implements Service<DataSource> {
 
+    /**
+     * Consumers outside of the data-source subsystem should use the capability {@code org.wildfly.data-source} where
+     * the dynamic name is the resource name in the model.
+     */
     public static final ServiceName SERVICE_NAME_BASE = ServiceName.JBOSS.append("data-source");
     private static final DeployersLogger DEPLOYERS_LOGGER = Logger.getMessageLogger(DeployersLogger.class, AS7DataSourceDeployer.class.getName());
     protected final InjectedValue<TransactionIntegration> transactionIntegrationValue = new InjectedValue<TransactionIntegration>();
@@ -141,6 +145,8 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
             DS_DEPLOYER_LOGGER.debugf("Adding datasource: %s", deploymentMD.getCfJndiNames()[0]);
             CommonDeploymentService cdService = new CommonDeploymentService(deploymentMD);
             startContext.getController().getServiceContainer().addService(CommonDeploymentService.SERVICE_NAME_BASE.append(jndiName),cdService)
+                    // The dependency added must be the JNDI name which for subsystem resources is an alias. This service
+                    // is also used in deployments where the capability service name is not registered for the service.
                     .addDependency(SERVICE_NAME_BASE.append(jndiName))
                     .setInitialMode(ServiceController.Mode.ACTIVE).install();
         } catch (Throwable t) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Capabilities.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Capabilities.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.connector.subsystems.datasources;
+
+import javax.sql.DataSource;
+
+import org.jboss.as.controller.capability.RuntimeCapability;
+
+/**
+ * Holds the capabilities for data sources.
+ * <p>
+ * This is for internal use only and should not be used outside the data source subsystem.
+ * </p>
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class Capabilities {
+
+    /**
+     * The name for the data-source capability
+     */
+    public static final String DATA_SOURCE_CAPABILITY_NAME = "org.wildfly.data-source";
+
+    /**
+     * The data-source capability
+     */
+    public static final RuntimeCapability<Void> DATA_SOURCE_CAPABILITY = RuntimeCapability.Builder.of(DATA_SOURCE_CAPABILITY_NAME, true, DataSource.class)
+            .build();
+}

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -27,7 +27,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENA
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 
@@ -350,7 +349,7 @@ public class Constants {
             .setAllowExpression(true)
             .build();
 
-    static SimpleAttributeDefinition CONNECTION_PROPERTIES = new SimpleAttributeDefinitionBuilder(CONNECTION_PROPERTIES_NAME, ModelType.STRING, true)
+    static final PropertiesAttributeDefinition CONNECTION_PROPERTIES = new PropertiesAttributeDefinition.Builder(CONNECTION_PROPERTIES_NAME, true)
             .setXmlName(DataSource.Tag.CONNECTION_PROPERTY.getLocalName())
             .setAllowExpression(true)
             .build();
@@ -586,7 +585,7 @@ public class Constants {
             USERNAME, PASSWORD, SECURITY_DOMAIN,
             REAUTH_PLUGIN_CLASSNAME,
             org.jboss.as.connector.subsystems.common.pool.Constants.POOL_FLUSH_STRATEGY,
-            ALLOW_MULTIPLE_USERS, CONNECTION_LISTENER_CLASS, CONNECTION_PROPERTIES,
+            ALLOW_MULTIPLE_USERS, CONNECTION_LISTENER_CLASS,
             PREPARED_STATEMENTS_CACHE_SIZE,
             SHARE_PREPARED_STATEMENTS,
             TRACK_STATEMENTS,
@@ -612,6 +611,7 @@ public class Constants {
             EXCEPTION_SORTER_PROPERTIES,
             STALE_CONNECTION_CHECKER_PROPERTIES,
             VALID_CONNECTION_CHECKER_PROPERTIES, CONNECTION_LISTENER_PROPERTIES,
+            CONNECTION_PROPERTIES,
             org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES, org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES,
 
     };
@@ -694,7 +694,7 @@ public class Constants {
             org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_INCREMENTER_PROPERTIES, org.jboss.as.connector.subsystems.common.pool.Constants.CAPACITY_DECREMENTER_PROPERTIES,
     };
 
-    static SimpleAttributeDefinition XADATASOURCE_PROPERTIES = new SimpleAttributeDefinitionBuilder(XADATASOURCEPROPERTIES_NAME, ModelType.STRING, false)
+    static final PropertiesAttributeDefinition XADATASOURCE_PROPERTIES = new PropertiesAttributeDefinition.Builder(XADATASOURCEPROPERTIES_NAME, false)
             .setXmlName(XaDataSource.Tag.XA_DATASOURCE_PROPERTY.getLocalName())
             .setAllowExpression(true)
             .build();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceAdd.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
-import static org.jboss.as.connector.subsystems.datasources.Constants.CONNECTION_PROPERTIES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_ATTRIBUTE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.DATASOURCE_PROPERTIES_ATTRIBUTES;
 
@@ -40,8 +39,8 @@ import org.jboss.msc.service.ServiceTarget;
 public class DataSourceAdd extends AbstractDataSourceAdd {
     static final DataSourceAdd INSTANCE = new DataSourceAdd();
 
-    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-        populateAddModel(operation, model, CONNECTION_PROPERTIES.getName(), DATASOURCE_ATTRIBUTE, DATASOURCE_PROPERTIES_ATTRIBUTES);
+    private DataSourceAdd() {
+        super(join(DATASOURCE_ATTRIBUTE, DATASOURCE_PROPERTIES_ATTRIBUTES));
     }
 
     protected AbstractDataSourceService createDataSourceService(final String dsName,final String jndiName) throws OperationFailedException {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceDisable.java
@@ -26,6 +26,7 @@ import static org.jboss.as.connector.subsystems.datasources.Constants.JNDI_NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import javax.sql.DataSource;
 import java.util.List;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
@@ -80,7 +81,7 @@ public class DataSourceDisable implements OperationStepHandler {
 
                         final ServiceRegistry registry = context.getServiceRegistry(true);
 
-                        final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
+                        final ServiceName dataSourceServiceName = context.getCapabilityServiceName(Capabilities.DATA_SOURCE_CAPABILITY_NAME, dsName, DataSource.class);
                         final ServiceController<?> dataSourceController = registry.getService(dataSourceServiceName);
                         if (dataSourceController != null) {
                             if (ServiceController.State.UP.equals(dataSourceController.getState())) {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceEnable.java
@@ -30,6 +30,7 @@ import static org.jboss.as.connector.subsystems.datasources.DataSourceModelNodeU
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ENABLED;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 
+import javax.sql.DataSource;
 import java.util.List;
 
 import org.jboss.as.connector.logging.ConnectorLogger;
@@ -195,7 +196,8 @@ public class DataSourceEnable implements OperationStepHandler {
             builder.install();
         }
 
-        final ServiceName dataSourceServiceName = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName);
+        final ServiceName dataSourceServiceName = context.getCapabilityServiceName(Capabilities.DATA_SOURCE_CAPABILITY_NAME, dsName, DataSource.class);
+        final ServiceName dataSourceServiceNameAlias = AbstractDataSourceService.SERVICE_NAME_BASE.append(jndiName).append(Constants.STATISTICS);
 
 
         final ServiceController<?> dataSourceController = registry.getService(dataSourceServiceName);
@@ -205,6 +207,7 @@ public class DataSourceEnable implements OperationStepHandler {
                 final boolean statsEnabled = STATISTICS_ENABLED.resolveModelAttribute(context, model).asBoolean();
                 DataSourceStatisticsService statsService = new DataSourceStatisticsService(datasourceRegistration, statsEnabled);
                 serviceTarget.addService(dataSourceServiceName.append(Constants.STATISTICS), statsService)
+                        .addAliases(dataSourceServiceNameAlias)
                         .addDependency(dataSourceServiceName)
                         .addDependency(CommonDeploymentService.SERVICE_NAME_BASE.append(jndiName), CommonDeployment.class, statsService.getCommonDeploymentInjector())
                         .setInitialMode(ServiceController.Mode.PASSIVE)

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceAdd.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.connector.subsystems.datasources;
 
-import static org.jboss.as.connector.subsystems.datasources.Constants.XADATASOURCE_PROPERTIES;
 import static org.jboss.as.connector.subsystems.datasources.Constants.XA_DATASOURCE_ATTRIBUTE;
 import static org.jboss.as.connector.subsystems.datasources.Constants.XA_DATASOURCE_PROPERTIES_ATTRIBUTES;
 
@@ -41,8 +40,8 @@ import org.jboss.msc.service.ServiceTarget;
 public class XaDataSourceAdd extends AbstractDataSourceAdd {
     static final XaDataSourceAdd INSTANCE = new XaDataSourceAdd();
 
-    protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
-        populateAddModel(operation, model, XADATASOURCE_PROPERTIES.getName(), XA_DATASOURCE_ATTRIBUTE, XA_DATASOURCE_PROPERTIES_ATTRIBUTES);
+    private XaDataSourceAdd() {
+        super(join(XA_DATASOURCE_ATTRIBUTE, XA_DATASOURCE_PROPERTIES_ATTRIBUTES));
     }
 
     protected AbstractDataSourceService createDataSourceService(final String dsName, final String jndiName) throws OperationFailedException {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase-remove.cli
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/SecuredDataSourceTestCase-remove.cli
@@ -1,3 +1,2 @@
-/subsystem=datasources/data-source=SecuredDataSourceTestCase:disable
 /subsystem=datasources/data-source=SecuredDataSourceTestCase:remove
 /subsystem=security/security-domain=SecuredDataSourceTestCase:remove


### PR DESCRIPTION
The first commit just cleans up the add handler for a data source to use the standard abstraction.

The second commit adds the `org.wildfly.data-source` capability to the subsystem. This currently only uses the capability on the resources added to the subsystem with an alias of the `jboss.data-source.$JNDI`. The deployment processors that add services still use the `jboss.data-source.$JNDI` name as the primary service name.

It could make sense to expand the capabilities to add something specific for XA data sources and non-XA data sources with the current capability the standard for them all. If this is needed I can add that to the PR.
