### PR TITLE
[WFLY-4845] Remove geronimo JMS 2.0 specs from jboss client jars

### DIFF
--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -58,6 +58,12 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-client</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jms_2.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- required until HORNETQ-1053 is fixed -->

--- a/client/shade/pom.xml
+++ b/client/shade/pom.xml
@@ -57,6 +57,12 @@
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-jms-client-bom</artifactId>
             <type>pom</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jms_2.0_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
- in client/jms POM, exclude org.apache.geronimo.specs:geronimo-jms_2.0_spec from
  org.apache.activemq:artemis-jms-client
- do the the same in client/shade POM as it skips dependency from
  client/jms when creating the shaded jar.

JIRA: https://issues.jboss.org/browse/WFLY-4845
