### PR TITLE
[WFLY-4731] Change default value for journal-type to NIO

### DIFF
--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -7,6 +7,7 @@
             <?CLUSTERED?>
 
             <journal
+                    type="NIO"
                     file-size="102400" />
 
             <security-setting name="#">


### PR DESCRIPTION
By default ActiveMQ Artemis is using ASYNCIO as journal type. This prints warning to server log if server is started on non-linux platform (like Windows, Solaris) where are no natives or if libAIO are not installed. 
