### PR TITLE
[WFLY-4845][WFLY-4854] exclude artifacts brought by Artemis dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1800,6 +1800,10 @@
                 <version>${version.org.apache.activemq.artemis}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>org.jboss.logmanager</groupId>
+                        <artifactId>jboss-logmanager</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>commons-logging</groupId>
                         <artifactId>commons-logging</artifactId>
                     </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -1864,6 +1864,12 @@
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-jms-client</artifactId>
                 <version>${version.org.apache.activemq.artemis}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jms_2.0_spec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- WFLY-4845 - exclude org.apache.geronimo.specs:geronimo-jms_2.0_spec
- WFLY-4854 - exclude org.jboss.logmanager:jboss-logmanager
