### PR TITLE
[WFLY-4863] Use default journal-file-size

### DIFF
--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -6,9 +6,6 @@
         <server name="default">
             <?CLUSTERED?>
 
-            <journal
-                    file-size="102400" />
-
             <security-setting name="#">
                 <role name="guest"
                       send="true"


### PR DESCRIPTION
- Do not provide a value for the journal-file-size in the subsystem
  configuration and use instead the default value of 10 MiB.

JIRA: https://issues.jboss.org/browse/WFLY-4863
