### PR TITLE
[WFLY-4656] Export javax.jms.api dependency for org.jboss.genericjms

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/genericjms/main/module.xml
@@ -27,7 +27,8 @@
     </resources>
     <dependencies>
         <module name="javax.api" slot="main"/>
-        <module name="javax.jms.api" slot="main"/>
+        <!-- WFLY-4656 export the JMS API module,  otherwise MDB using this RA will not found JMS classes -->
+        <module name="javax.jms.api" slot="main" export="true"/>
         <module name="javax.resource.api" slot="main"/>
         <module name="org.jboss.logging" slot="main"/>
 


### PR DESCRIPTION
- Export the JMS API module,  otherwise MDB using this RA will not found
  JMS classes.

JIRA: https://issues.jboss.org/browse/WFLY-4656
