### PR TITLE
[WFLY-4858] Test coverage for WildflySecurityManager permissions assignments

### DIFF
--- a/testsuite/integration/pom.xml
+++ b/testsuite/integration/pom.xml
@@ -61,6 +61,7 @@
                 <module>multinode</module>
                 <module>manualmode</module>
                 <module>picketlink</module>
+                <module>secman</module>
             </modules>
         </profile>
         <!-- Define ts.integration uber-group. -->
@@ -79,6 +80,7 @@
                 <module>multinode</module>
                 <module>manualmode</module>
                 <module>picketlink</module>
+                <module>secman</module>
             </modules>
         </profile>
 
@@ -179,6 +181,15 @@
             <activation><property><name>ts.picketlink</name></property></activation>
             <modules>
                 <module>picketlink</module>
+            </modules>
+        </profile>
+
+        <!-- -Dts.secman -->
+        <profile>
+            <id>ts.integ.group.secman</id>
+            <activation><property><name>ts.secman</name></property></activation>
+            <modules>
+                <module>secman</module>
             </modules>
         </profile>
     </profiles>

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.wildfly</groupId>
         <artifactId>wildfly-ts-integ</artifactId>
-        <version>10.0.0.Alpha5-SNAPSHOT</version>
+        <version>10.0.0.Beta1-SNAPSHOT</version>
     </parent>
 
 

--- a/testsuite/integration/secman/pom.xml
+++ b/testsuite/integration/secman/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+
+
+    <parent>
+        <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-ts-integ</artifactId>
+        <version>10.0.0.Alpha5-SNAPSHOT</version>
+    </parent>
+
+
+	<artifactId>wildfly-ts-integ-secman</artifactId>
+
+	<name>WildFly Test Suite: Integration - Security Manager</name>
+
+	<properties>
+		<jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
+		<jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
+		<jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+	</properties>
+
+	<profiles>
+		<profile>
+			<id>secman.integration.tests.profile</id>
+			<activation>
+				<property>
+					<name>!no.secman.integration.tests</name>
+				</property>
+			</activation>
+
+			<!-- Server configuration executions. -->
+			<build>
+				<plugins>
+					<plugin>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<executions>
+
+							<!-- Disable default-test execution. -->
+							<execution>
+								<id>default-test</id>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<phase>none</phase>
+							</execution>
+
+							<execution>
+								<id>secman-integration.surefire</id>
+								<phase>test</phase>
+								<goals>
+									<goal>test</goal>
+								</goals>
+								<configuration>
+									<includes>
+										<include>org/jboss/as/testsuite/integration/secman/**/*Test*.java</include>
+									</includes>
+
+                                    <environmentVariables>
+                                        <JBOSS_HOME>${jboss.dist}</JBOSS_HOME>
+                                    </environmentVariables>
+
+									<systemPropertyVariables>
+										<jboss.server.config.file.name>standalone-full.xml</jboss.server.config.file.name>
+										<jboss.inst>${basedir}/target/jbossas</jboss.inst>
+									</systemPropertyVariables>
+								</configuration>
+							</execution>
+						</executions>
+					</plugin>
+					<plugin>
+						<artifactId>maven-checkstyle-plugin</artifactId>
+						<configuration>
+							<!-- workaround for not working includeTestSourceDirectory parameter -->
+							<sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+						</configuration>
+						<executions>
+							<execution>
+								<id>check-style</id>
+								<phase>test-compile</phase>
+								<goals>
+									<goal>checkstyle</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
+
+</project>

--- a/testsuite/integration/secman/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/secman/src/test/config/arq/arquillian.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="jmx-as7" />
+
+    <container qualifier="jboss" default="true">
+        <configuration>
+            <property name="jbossHome">${basedir}/target/jbossas</property>
+            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
+            <property name="serverConfig">${jboss.server.config.file.name:standalone-full.xml}</property>
+            <property name="jbossArguments">-secmgr</property>
+            <property name="allowConnectingToRunningServer">true</property>
+            <property name="managementAddress">${node0:127.0.0.1}</property>
+            <property name="managementPort">${as.managementPort:9990}</property>
+            <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9990}</property>
+            <property name="waitForPortsTimeoutInSeconds">8</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/PBStaticMethodsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/PBStaticMethodsTestCase.java
@@ -1,0 +1,320 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.security.AccessControlException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.security.ExternalPasswordCache;
+import org.jboss.security.Util;
+import org.jboss.security.config.SecurityConfiguration;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks if static methods in PicketBox are protected by permission checks.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+public class PBStaticMethodsTestCase {
+
+    /**
+     * Creates test archive.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment()
+    public static WebArchive deployment() {
+        return ShrinkWrap.create(WebArchive.class, "pbsm.war");
+    }
+
+    // SecurityConfiguration ---------------------------------------------------
+
+    /**
+     * Test method for
+     * {@link org.jboss.security.config.SecurityConfiguration#addApplicationPolicy(org.jboss.security.config.ApplicationPolicy)}
+     * .
+     */
+    @Test
+    public void testAddApplicationPolicy() {
+        try {
+            SecurityConfiguration.addApplicationPolicy(null);
+            fail("Access should be denied");
+        } catch (AccessControlException e) {
+            RuntimePermission expectedPerm = new RuntimePermission(
+                    "org.jboss.security.config.SecurityConfiguration.addApplicationPolicy");
+            assertEquals("Permission type doesn't match", expectedPerm, e.getPermission());
+        }
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#removeApplicationPolicy(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testRemoveApplicationPolicy() {
+        SecurityConfiguration.removeApplicationPolicy("test");
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getApplicationPolicy(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetApplicationPolicy() {
+        SecurityConfiguration.getApplicationPolicy("test");
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getCipherAlgorithm()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetCipherAlgorithm() {
+        SecurityConfiguration.getCipherAlgorithm();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setCipherAlgorithm(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetCipherAlgorithm() {
+        SecurityConfiguration.setCipherAlgorithm(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getCipherKey()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetCipherKey() {
+        SecurityConfiguration.getCipherKey();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setCipherKey(java.security.Key)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetCipherKey() {
+        SecurityConfiguration.setCipherKey(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getCipherSpec()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetCipherSpec() {
+        SecurityConfiguration.getCipherSpec();
+    }
+
+    /**
+     * Test method for
+     * {@link org.jboss.security.config.SecurityConfiguration#setCipherSpec(java.security.spec.AlgorithmParameterSpec)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetCipherSpec() {
+        SecurityConfiguration.setCipherSpec(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getIterationCount()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetIterationCount() {
+        SecurityConfiguration.getIterationCount();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setIterationCount(int)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetIterationCount() {
+        SecurityConfiguration.setIterationCount(0);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getSalt()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetSalt() {
+        SecurityConfiguration.getSalt();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setSalt(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetSalt() {
+        SecurityConfiguration.setSalt(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getKeyStoreType()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetKeyStoreType() {
+        SecurityConfiguration.getKeyStoreType();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setKeyStoreType(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetKeyStoreType() {
+        SecurityConfiguration.setKeyStoreType(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getKeyStoreURL()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetKeyStoreURL() {
+        SecurityConfiguration.getKeyStoreURL();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setKeyStoreURL(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetKeyStoreURL() {
+        SecurityConfiguration.setKeyStoreURL(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getKeyStorePass()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetKeyStorePass() {
+        SecurityConfiguration.getKeyStorePass();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setKeyStorePass(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetKeyStorePass() {
+        SecurityConfiguration.setKeyStorePass(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getTrustStoreType()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetTrustStoreType() {
+        SecurityConfiguration.getTrustStoreType();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setTrustStoreType(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetTrustStoreType() {
+        SecurityConfiguration.setTrustStoreType(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getTrustStorePass()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetTrustStorePass() {
+        SecurityConfiguration.getTrustStorePass();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setTrustStorePass(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetTrustStorePass() {
+        SecurityConfiguration.setTrustStorePass(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#getTrustStoreURL()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testGetTrustStoreURL() {
+        SecurityConfiguration.getTrustStoreURL();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setTrustStoreURL(java.lang.String)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetTrustStoreURL() {
+        SecurityConfiguration.setTrustStoreURL(null);
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#isDeepCopySubjectMode()}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testIsDeepCopySubjectMode() {
+        SecurityConfiguration.isDeepCopySubjectMode();
+    }
+
+    /**
+     * Test method for {@link org.jboss.security.config.SecurityConfiguration#setDeepCopySubjectMode(boolean)}.
+     */
+    @Test(expected = AccessControlException.class)
+    public void testSetDeepCopySubjectMode() {
+        SecurityConfiguration.setDeepCopySubjectMode(false);
+    }
+
+    // ExternalPasswordCache ---------------------------------------------------
+
+    /**
+     * Test method for {@link org.jboss.security.ExternalPasswordCache#getExternalPasswordCacheInstance()}.
+     */
+    @Test
+    public void testGetExternalPasswordCacheInstance() {
+        try {
+            ExternalPasswordCache.getExternalPasswordCacheInstance();
+            fail("Access should be denied");
+        } catch (AccessControlException e) {
+            RuntimePermission expectedPerm = new RuntimePermission(
+                    "org.jboss.security.ExternalPasswordCache.getExternalPasswordCacheInstance");
+            assertEquals("Permission type doesn't match", expectedPerm, e.getPermission());
+        }
+    }
+
+    // Util --------------------------------------------------------------------
+
+    /**
+     * Test method for {@link org.jboss.security.Util#loadPassword(String)}.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLoadPassword() throws Exception {
+        try {
+            Util.loadPassword("cat /etc/passwd");
+            fail("Access should be denied");
+        } catch (AccessControlException e) {
+            RuntimePermission expectedPerm = new RuntimePermission("org.jboss.security.Util.loadPassword");
+            assertEquals("Permission type doesn't match", expectedPerm, e.getPermission());
+        }
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/PermissionUtil.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/PermissionUtil.java
@@ -1,0 +1,41 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman;
+
+/**
+ * Helper class for permissions testing. This class is usually packaged to a library-like archive in a test deployment.
+ *
+ * @author Josef Cacek
+ */
+public class PermissionUtil {
+
+    /**
+     * Simply calls {@link System#getProperty(String)} method.
+     *
+     * @param property
+     * @return system property
+     */
+    public static String getSystemProperty(String property) {
+        return System.getProperty(property);
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyBean.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyBean.java
@@ -1,0 +1,40 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.integration.secman.ejbs;
+
+import javax.ejb.Local;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+
+/**
+ * A SLSB bean which reads the given system property and returns its value.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+@Stateless
+@Remote(ReadSystemPropertyRemote.class)
+@Local(ReadSystemPropertyLocal.class)
+public class ReadSystemPropertyBean {
+    public String readSystemProperty(final String propertyName) {
+        return System.getProperty(propertyName, "");
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyLocal.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyLocal.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.integration.secman.ejbs;
+
+/**
+ * Local interface dedicated for ReadSystemPropertyBean.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+public interface ReadSystemPropertyLocal {
+    String readSystemProperty(final String propertyName);
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyRemote.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/ejbs/ReadSystemPropertyRemote.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.integration.secman.ejbs;
+
+/**
+ * Remote interface dedicated for ReadSystemPropertyBean.
+ *
+ * @author <a href="mailto:istudens@redhat.com">Ivo Studensky</a>
+ */
+public interface ReadSystemPropertyRemote {
+    String readSystemProperty(final String propertyName);
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/AbstractCustomModuleServerSetup.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/AbstractCustomModuleServerSetup.java
@@ -1,0 +1,95 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.module;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.util.CustomCLIExecutor;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * Server setup task base, which adds a custom module to the AS configuration. Child classes have to implement
+ * {@link #getModuleSuffix()} method, which is used to generate module name and to determine which descriptor file will be used
+ * as the final module.xml.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractCustomModuleServerSetup implements ServerSetupTask {
+
+    private static Logger LOGGER = Logger.getLogger(AbstractCustomModuleServerSetup.class);
+
+    public static final String MODULE_NAME_BASE = "org.jboss.test.secman";
+
+    private static final String MODULE_JAR = "modperm.jar";
+    private static final File WORK_DIR = new File("cust-module-test");
+    private static final File MODULE_JAR_FILE = new File(WORK_DIR, MODULE_JAR);
+
+    /**
+     * Creates work-directory where JAR containing {@link CheckJSMUtils} is stored. The JAR is then deployed as an AS module.
+     */
+    @Override
+    public void setup(ManagementClient managementClient, String containerId) throws Exception {
+        LOGGER.info("(Re)Creating workdir: " + WORK_DIR.getAbsolutePath());
+        FileUtils.deleteDirectory(WORK_DIR);
+        WORK_DIR.mkdirs();
+
+        ShrinkWrap.create(JavaArchive.class, MODULE_JAR).addClass(CheckJSMUtils.class)
+                .as(org.jboss.shrinkwrap.api.exporter.ZipExporter.class).exportTo(MODULE_JAR_FILE, true);
+        addModule(getModuleSuffix());
+    }
+
+    /**
+     * Removes work-directory and removes the AS module.
+     */
+    @Override
+    public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+        LOGGER.info("Removing custom module");
+        FileUtils.deleteDirectory(WORK_DIR);
+        removeModule(getModuleSuffix());
+    }
+
+    /**
+     * Returns last part of module name. The name base is {@value #MODULE_NAME_BASE}
+     */
+    protected abstract String getModuleSuffix();
+
+    private void addModule(String suffix) throws URISyntaxException {
+        File tmpFile = new File(getClass().getResource("module-" + suffix + ".xml").toURI());
+        CustomCLIExecutor.execute(null, "module add --name=" + MODULE_NAME_BASE + "." + suffix + " --resources="
+                + escapePath(MODULE_JAR_FILE.getAbsolutePath()) + " --module-xml=" + escapePath(tmpFile.getAbsolutePath()));
+    }
+
+    private void removeModule(String suffix) throws URISyntaxException {
+        CustomCLIExecutor.execute(null, "module remove --name=" + MODULE_NAME_BASE + "." + suffix);
+    }
+
+    private String escapePath(final String str) {
+        return str == null ? null : str.replaceAll("([\\s])", "\\\\$1");
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/CheckJSMUtils.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/CheckJSMUtils.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.module;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ * Utility class which will be placed in a custom module deployed to the AS. It has only limited set of permissions granted in
+ * its module.xml descriptor.
+ *
+ * @author Josef Cacek
+ */
+public class CheckJSMUtils {
+
+    public static String getSystemProperty(final String propName) throws IllegalStateException {
+        SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            return AccessController.doPrivileged(new PrivilegedAction<String>() {
+                @Override
+                public String run() {
+                    return System.getProperty(propName);
+                }
+            });
+        }
+        throw new IllegalStateException("Java Security Manager is not initialized");
+    }
+
+    public static void checkRuntimePermission(final String permissionName) throws IllegalStateException {
+        final SecurityManager sm = System.getSecurityManager();
+        if (sm != null) {
+            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+                @Override
+                public Void run() {
+                    sm.checkPermission(new RuntimePermission(permissionName));
+                    return null;
+                }
+            });
+        } else {
+            throw new IllegalStateException("Java Security Manager is not initialized");
+        }
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/DenyModulePermissionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/DenyModulePermissionsTestCase.java
@@ -1,0 +1,101 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.module;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.security.AccessControlException;
+import java.security.Permission;
+import java.util.PropertyPermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks if empty permissions set is used for an installed module when empty <code>&lt;permissions&gt;</code>
+ * element is provided in module.xml.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(DenyModulePermissionsTestCase.CustomModuleSetup.class)
+public class DenyModulePermissionsTestCase {
+
+    /**
+     * Creates test archive.
+     *
+     * @return test application
+     */
+    @Deployment()
+    public static JavaArchive deployment() {
+        return ShrinkWrap
+                .create(JavaArchive.class, "modperm-deny.jar")
+                .addClass(AbstractCustomModuleServerSetup.class)
+                .addAsManifestResource(
+                        Utils.getJBossDeploymentStructure(AbstractCustomModuleServerSetup.MODULE_NAME_BASE + ".deny"),
+                        "jboss-deployment-structure.xml");
+    }
+
+    /**
+     * Test which reads a system property.
+     */
+    @Test
+    public void testReadJavaHome() {
+        try {
+            CheckJSMUtils.getSystemProperty("java.home");
+            fail("Access should be denied");
+        } catch (AccessControlException e) {
+            Permission expectedPerm = new PropertyPermission("java.home", "read");
+            assertEquals("Permission type doesn't match", expectedPerm, e.getPermission());
+        }
+    }
+
+    /**
+     * Test which checks a custom permission which should not be granted.
+     */
+    @Test
+    public void testCustomPermission() {
+        final String permissionName = "org.jboss.security.Permission";
+        try {
+            CheckJSMUtils.checkRuntimePermission(permissionName);
+            fail("Access should be denied");
+        } catch (AccessControlException e) {
+            Permission expectedPerm = new RuntimePermission(permissionName);
+            assertEquals("Permission type doesn't match", expectedPerm, e.getPermission());
+        }
+    }
+
+    static class CustomModuleSetup extends AbstractCustomModuleServerSetup {
+        @Override
+        protected String getModuleSuffix() {
+            return "deny";
+        }
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/GrantModulePermissionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/GrantModulePermissionsTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.module;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks if full permissions set is used for an installed module when no <code>&lt;permissions&gt;</code>
+ * element is provided in module.xml.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(GrantModulePermissionsTestCase.CustomModuleSetup.class)
+public class GrantModulePermissionsTestCase {
+
+    /**
+     * Creates test archive.
+     *
+     * @return test application
+     */
+    @Deployment()
+    public static JavaArchive deployment() {
+        return ShrinkWrap
+                .create(JavaArchive.class, "modperm-grant.jar")
+                .addClass(AbstractCustomModuleServerSetup.class)
+                .addAsManifestResource(
+                        Utils.getJBossDeploymentStructure(AbstractCustomModuleServerSetup.MODULE_NAME_BASE + ".grant"),
+                        "jboss-deployment-structure.xml");
+    }
+
+    /**
+     * Test which reads system property.
+     */
+    @Test
+    public void testReadJavaHome() {
+        CheckJSMUtils.getSystemProperty("java.home");
+    }
+
+    /**
+     * Test which checks a custom permission.
+     */
+    @Test
+    public void testCustomPermission() {
+        CheckJSMUtils.checkRuntimePermission("org.jboss.security.Permission");
+    }
+
+    static class CustomModuleSetup extends AbstractCustomModuleServerSetup {
+        @Override
+        protected String getModuleSuffix() {
+            return "grant";
+        }
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/LimitedModulePermissionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/LimitedModulePermissionsTestCase.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.module;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.security.AccessControlException;
+import java.security.Permission;
+import java.util.PropertyPermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks if limited permissions set defined in module.xml is used for an installed module.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(LimitedModulePermissionsTestCase.CustomModuleSetup.class)
+public class LimitedModulePermissionsTestCase {
+
+    /**
+     * Creates test archive.
+     *
+     * @return test application
+     */
+    @Deployment()
+    public static JavaArchive deployment() {
+        return ShrinkWrap
+                .create(JavaArchive.class, "modperm-limited.jar")
+                .addClass(AbstractCustomModuleServerSetup.class)
+                .addAsManifestResource(
+                        Utils.getJBossDeploymentStructure(AbstractCustomModuleServerSetup.MODULE_NAME_BASE + ".limited"),
+                        "jboss-deployment-structure.xml");
+    }
+
+    /**
+     * Test which reads system property without Permission.
+     */
+    @Test
+    public void testReadJavaHome() {
+        try {
+            CheckJSMUtils.getSystemProperty("java.home");
+            fail("Access should be denied");
+        } catch (AccessControlException e) {
+            Permission expectedPerm = new PropertyPermission("java.home", "read");
+            assertEquals("Permission type doesn't match", expectedPerm, e.getPermission());
+        }
+    }
+
+    /**
+     * Test which checks custom permission which should not be granted.
+     */
+    @Test
+    public void testCustomPermWithoutGrant() {
+        final String permissionName = "org.jboss.security.Permission";
+        try {
+            CheckJSMUtils.checkRuntimePermission(permissionName);
+            fail("Access should be denied");
+        } catch (AccessControlException e) {
+            Permission expectedPerm = new RuntimePermission(permissionName);
+            assertEquals("Permission type doesn't match", expectedPerm, e.getPermission());
+        }
+    }
+
+    /**
+     * Test which checks granted permission.
+     */
+    @Test
+    public void testGrantedCustomPerm() {
+        CheckJSMUtils.checkRuntimePermission("secman.test.Permission");
+    }
+
+    static class CustomModuleSetup extends AbstractCustomModuleServerSetup {
+        @Override
+        protected String getModuleSuffix() {
+            return "limited";
+        }
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/module-deny.xml
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/module-deny.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+
+<module xmlns="urn:jboss:module:1.2" name="org.jboss.test.secman.deny">
+
+	<permissions/>
+
+	<resources>
+		<resource-root path="modperm.jar" />
+	</resources>
+</module>

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/module-grant.xml
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/module-grant.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" ?>
+
+<module xmlns="urn:jboss:module:1.2" name="org.jboss.test.secman.grant">
+	<resources>
+		<resource-root path="modperm.jar" />
+	</resources>
+</module>

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/module-limited.xml
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/module-limited.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+
+<module xmlns="urn:jboss:module:1.2" name="org.jboss.test.secman.limited">
+
+	<permissions>
+		<grant permission="java.lang.RuntimePermission" name="secman.test.*" />
+<!--
+		<grant permission="" name="" actions=""/> 
+-->
+	</permissions>
+
+	<resources>
+		<resource-root path="modperm.jar" />
+	</resources>
+</module>

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/package-info.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/module/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * This package contains tests for permissions assigned to custom AS modules (<i>i.e. Permissions defined in module.xml</i>).
+ */
+package org.jboss.as.testsuite.integration.secman.module;

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/package-info.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * This package contains a part of the AS integration testsuite, which checks permissions granted when running
+ * the AS with Java Security Manager (JSM) enabled.<br>
+ * <i>Permissions for jboss-modules are defined in src/test/config/security.policy</i>
+ */
+package org.jboss.as.testsuite.integration.secman;
+

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithJSP.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithJSP.java
@@ -1,0 +1,139 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.jboss.as.testsuite.integration.secman.propertypermission.SystemPropertiesSetup.PROPERTY_NAME;
+
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+
+/**
+ * Abstract parent for PropertyPermission testcases, which have also readproperty.jsp page included.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractPPTestsWithJSP extends AbstractPropertyPermissionTests {
+
+    /**
+     * Check standard java property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testJavaHomePropertyInJSPGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application, where JSP don't get PropertyPermissions (servlets get them).
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testJavaHomePropertyInJSPLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testJavaHomePropertyInJSPDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testASLevelPropertyInJSPGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testASLevelPropertyInJSPLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testASLevelPropertyInJSPDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    protected void checkJavaHomePropertyInJSP(URL webAppURL, int expectedStatus) throws Exception {
+        checkPropertyInJSP(webAppURL, "java.home", expectedStatus, "java.home=");
+    }
+
+    /**
+     * Check access to {@value #WEBAPP_BASE_NAME} property.
+     */
+    protected void checkTestPropertyInJSP(URL webAppURL, final int expectedStatus) throws Exception {
+        checkPropertyInJSP(webAppURL, PROPERTY_NAME, expectedStatus, PROPERTY_NAME);
+    }
+
+    /**
+     * Checks access to a system property on the server using <code>readproperty.jsp</code>.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBodyStart expected beginning of response value; if null then response body is not checked
+     * @throws Exception
+     */
+    protected abstract void checkPropertyInJSP(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBodyStart) throws Exception;
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithLibrary.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPPTestsWithLibrary.java
@@ -1,0 +1,100 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.PermissionUtil;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+/**
+ * Abstract parent for tests which creates deployments with library JAR including {@link PermissionUtil}.
+ *
+ * @author Josef Cacek
+ */
+public abstract class AbstractPPTestsWithLibrary extends AbstractPropertyPermissionTests {
+
+    private static Logger LOGGER = Logger.getLogger(AbstractPPTestsWithLibrary.class);
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    @Override
+    protected void checkJavaHomeProperty(URL webAppURL, int expectedStatus) throws Exception {
+        checkProperty(webAppURL, "java.home", expectedStatus);
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link CallPermissionUtilServlet}.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @throws Exception
+     */
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode) throws Exception {
+        checkProperty(webAppURL, propertyName, expectedCode, null);
+    }
+
+    /**
+     * Checks access to a system property on the server.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + CallPermissionUtilServlet.SERVLET_PATH.substring(1) + "?"
+                + Utils.encodeQueryParam(CallPermissionUtilServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBody != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertEquals("System property value doesn't match the expected one.", expectedBody, respBody);
+        }
+    }
+
+    /**
+     * Create java archive with PropertyReadStaticMethodClass class
+     *
+     * @return created java archive
+     */
+    protected static JavaArchive createLibrary() {
+        final JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "library.jar");
+        lib.addClasses(PermissionUtil.class);
+        return lib;
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPropertyPermissionTests.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/AbstractPropertyPermissionTests.java
@@ -1,0 +1,210 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.jboss.as.testsuite.integration.secman.propertypermission.SystemPropertiesSetup.PROPERTY_NAME;
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.net.URL;
+import java.security.AllPermission;
+import java.util.PropertyPermission;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.testsuite.integration.secman.servlets.JSMCheckServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.container.ClassContainer;
+import org.jboss.shrinkwrap.api.container.ManifestContainer;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Abstract parent for testcases aimed on PropertyPermission.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public abstract class AbstractPropertyPermissionTests {
+
+    public static final Asset ALL_PERMISSIONS_XML = PermissionUtils.createPermissionsXmlAsset(new AllPermission());
+    public static final Asset EMPTY_PERMISSIONS_XML = PermissionUtils.createPermissionsXmlAsset();
+
+    public static final Asset GRANT_PERMISSIONS_XML = PermissionUtils.createPermissionsXmlAsset(new PropertyPermission("*",
+            "read,write"));
+    public static final Asset LIMITED_PERMISSIONS_XML = PermissionUtils.createPermissionsXmlAsset(new PropertyPermission(
+            "java.home", "read"));
+
+    protected static final String APP_GRANT = "read-props-grant";
+    protected static final String APP_LIMITED = "read-props-limited";
+    protected static final String APP_DENY = "read-props-deny";
+
+    private static Logger LOGGER = Logger.getLogger(AbstractPropertyPermissionTests.class);
+
+    /**
+     * Checks if the AS runs with security manager enabled.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testJSMEnabled(@ArquillianResource URL webAppURL) throws Exception {
+        final URI checkJSMuri = new URI(webAppURL.toExternalForm() + JSMCheckServlet.SERVLET_PATH.substring(1));
+        LOGGER.debug("Checking if JSM is enabled: " + checkJSMuri);
+        assertEquals("JSM should be enabled.", Boolean.toString(true), Utils.makeCall(checkJSMuri, 200));
+    }
+
+    /**
+     * Check standard java property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testJavaHomePropertyGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomeProperty(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testJavaHomePropertyLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomeProperty(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check standard java property access in application, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testJavaHomePropertyDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomeProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testASLevelPropertyGrant(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_OK);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testASLevelPropertyLimited(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check AS defined (standalone.xml) property access in application, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testASLevelPropertyDeny(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    protected void checkJavaHomeProperty(URL webAppURL, int expectedStatus) throws Exception {
+        checkProperty(webAppURL, "java.home", expectedStatus, null);
+    }
+
+    /**
+     * Check access to {@value #APP_BASE_NAME} property.
+     */
+    protected void checkTestProperty(URL webAppURL, final int expectedStatus) throws Exception {
+        checkProperty(webAppURL, PROPERTY_NAME, expectedStatus, PROPERTY_NAME);
+    }
+
+    /**
+     * Adds {@link JSMCheckServlet} to the given archive.
+     *
+     * @param archive
+     */
+    protected static void addJSMCheckServlet(final ClassContainer<?> archive) {
+        archive.addClass(JSMCheckServlet.class);
+    }
+
+    /**
+     * Adds {@link JSMCheckServlet} to the given archive.
+     *
+     * @param archive
+     */
+    protected static void addPermissionsXml(final ManifestContainer<?> archive, final Asset permissionsAsset,
+            final Asset jbossPermissionsAsset) {
+        if (permissionsAsset != null) {
+            archive.addAsManifestResource(permissionsAsset, "permissions.xml");
+        }
+        if (jbossPermissionsAsset != null) {
+            archive.addAsManifestResource(jbossPermissionsAsset, "jboss-permissions.xml");
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    protected abstract void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception;
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarLibInWarPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarLibInWarPPTestCase.java
@@ -1,0 +1,92 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to lib in war of deployed ear applications. The applications try to do a
+ * protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class EarLibInWarPPTestCase extends AbstractPPTestsWithLibrary {
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static EnterpriseArchive createDeployment1() {
+        return earDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static EnterpriseArchive createDeployment2() {
+        return earDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static EnterpriseArchive createDeployment3() {
+        return earDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static EnterpriseArchive earDeployment(final String app, Asset permissionsXml) {
+
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, app + ".war");
+        addJSMCheckServlet(war);
+        war.addClasses(CallPermissionUtilServlet.class);
+        war.addAsLibraries(createLibrary());
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, app + ".ear");
+        // override grant-all in permissions.xml by customized jboss-permissions.xm
+        addPermissionsXml(ear, ALL_PERMISSIONS_XML, permissionsXml);
+        ear.addAsModule(war);
+
+        return ear;
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarModulesPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarModulesPPTestCase.java
@@ -1,0 +1,410 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.jboss.as.testsuite.integration.secman.propertypermission.SystemPropertiesSetup.PROPERTY_NAME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.net.URL;
+import java.security.AccessControlException;
+
+import javax.ejb.EJBException;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.servlet.http.HttpServletResponse;
+
+import org.hamcrest.CoreMatchers;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.ejbs.ReadSystemPropertyBean;
+import org.jboss.as.testsuite.integration.secman.ejbs.ReadSystemPropertyRemote;
+import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to sub-deployment of deployed ear applications. The applications try to
+ * do a protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
+
+    private static final String EJBAPP_BASE_NAME = "ejb-module";
+    private static final String WEBAPP_BASE_NAME = "web-module";
+
+    private static final String APP_NO_PERM = "read-props-noperm";
+    private static final String APP_EMPTY_PERM = "read-props-emptyperm";
+
+    private static Logger LOGGER = Logger.getLogger(EarModulesPPTestCase.class);
+
+    @ArquillianResource
+    private InitialContext iniCtx;
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static EnterpriseArchive createDeployment1() {
+        return earDeployment(APP_GRANT, AbstractPropertyPermissionTests.GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static EnterpriseArchive createDeployment2() {
+        return earDeployment(APP_LIMITED, AbstractPropertyPermissionTests.LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static EnterpriseArchive createDeployment3() {
+        return earDeployment(APP_DENY, AbstractPropertyPermissionTests.EMPTY_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_NO_PERM, testable = false)
+    public static EnterpriseArchive createNoPermDeployment() {
+        return earDeployment(APP_NO_PERM, null, ALL_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_EMPTY_PERM, testable = false)
+    public static EnterpriseArchive createEmptyPermDeployment() {
+        return earDeployment(APP_EMPTY_PERM, AbstractPropertyPermissionTests.EMPTY_PERMISSIONS_XML, ALL_PERMISSIONS_XML);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testJavaHomePropertyEjbInJarGrant() throws Exception {
+        checkJavaHomePropertyEjb(APP_GRANT, false);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testJavaHomePropertyEjbInJarLimited() throws Exception {
+        checkJavaHomePropertyEjb(APP_LIMITED, false);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testJavaHomePropertyEjbInJarDeny() throws Exception {
+        checkJavaHomePropertyEjb(APP_DENY, true);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where PropertyPermission for all properties is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_GRANT)
+    public void testASLevelPropertyEjbInJarGrant() throws Exception {
+        checkTestPropertyEjb(APP_GRANT, false);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where not all PropertyPermissions are granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_LIMITED)
+    public void testASLevelPropertyEjbInJarLimited() throws Exception {
+        checkTestPropertyEjb(APP_LIMITED, true);
+    }
+
+    /**
+     * Check standard java property access for EJB in ear, where no PropertyPermission is granted.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    @OperateOnDeployment(APP_DENY)
+    public void testASLevelPropertyEjbInJarDeny() throws Exception {
+        checkTestPropertyEjb(APP_DENY, true);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_NO_PERM)
+    public void testASLevelPropertyEjbInJarNoPerm() throws Exception {
+        checkTestPropertyEjb(APP_NO_PERM, true);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_EMPTY_PERM)
+    public void testASLevelPropertyEjbInJarEmptyPerm() throws Exception {
+        checkTestPropertyEjb(APP_EMPTY_PERM, true);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_NO_PERM)
+    public void testJavaHomePropertyInJSPNoPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_EMPTY_PERM)
+    public void testJavaHomePropertyInJSPEmptyPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_NO_PERM)
+    public void testASLevelPropertyInJSPNoPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_EMPTY_PERM)
+    public void testASLevelPropertyInJSPEmptyPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_NO_PERM)
+    public void testASLevelPropertyNoPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_EMPTY_PERM)
+    public void testASLevelPropertyEmptyPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check access to 'java.home' property.
+     */
+    private void checkJavaHomePropertyEjb(final String moduleNameSuffix, final boolean exceptionExpected) throws Exception {
+        checkPropertyEjb(moduleNameSuffix, "java.home", exceptionExpected, null);
+    }
+
+    /**
+     * Check access to {@value #EARAPP_BASE_NAME} property.
+     */
+    private void checkTestPropertyEjb(final String moduleNameSuffix, final boolean exceptionExpected) throws Exception {
+        checkPropertyEjb(moduleNameSuffix, PROPERTY_NAME, exceptionExpected, PROPERTY_NAME);
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link PrintSystemPropertyServlet}.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + PrintSystemPropertyServlet.SERVLET_PATH.substring(1) + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBody != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertThat("System property value doesn't match the expected one.", respBody,
+                    CoreMatchers.containsString(expectedBody));
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server using <code>readproperty.jsp</code>.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBodyStart expected beginning of response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkPropertyInJSP(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBodyStart) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + "readproperty.jsp" + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBodyStart != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertNotNull("Response from JSP should not be null.", respBody);
+            assertTrue("The readproperty.jsp response doesn't start with the expected value.",
+                    respBody.startsWith(expectedBodyStart));
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server using EJB.
+     *
+     * @param moduleName
+     * @param propertyName
+     * @param exceptionExpected
+     * @param expectedValue
+     * @throws Exception
+     */
+    private void checkPropertyEjb(final String moduleName, final String propertyName, final boolean exceptionExpected,
+            final String expectedValue) throws Exception {
+        LOGGER.debug("Checking if '" + propertyName + "' property is available");
+        ReadSystemPropertyRemote bean = lookupEjb(moduleName, EJBAPP_BASE_NAME + moduleName,
+                ReadSystemPropertyBean.class.getSimpleName(), ReadSystemPropertyRemote.class);
+        assertNotNull(bean);
+
+        Exception ex = null;
+        String propertyValue = null;
+        try {
+            propertyValue = bean.readSystemProperty(propertyName);
+        } catch (Exception e) {
+            ex = e;
+        }
+
+        if (ex instanceof EJBException && ex.getCause() instanceof AccessControlException) {
+            assertTrue("AccessControlException came, but it was not expected", exceptionExpected);
+        } else if (ex != null) {
+            throw ex;
+        } else if (exceptionExpected) {
+            fail("AccessControlException was expected");
+        }
+
+        if (ex == null && expectedValue != null) {
+            assertEquals("System property value doesn't match the expected one.", expectedValue, propertyValue);
+        }
+    }
+
+    private <T> T lookupEjb(final String appName, final String moduleName, final String beanName, final Class<T> interfaceType)
+            throws NamingException {
+        return interfaceType.cast(iniCtx.lookup("ejb:" + appName + "/" + moduleName + "//" + beanName + "!"
+                + interfaceType.getName()));
+    }
+
+    private static EnterpriseArchive earDeployment(final String suffix, final Asset permissionsXml) {
+        return earDeployment(suffix, permissionsXml, null);
+    }
+
+    private static EnterpriseArchive earDeployment(final String suffix, final Asset permissionsXml, final Asset modulesPermXml) {
+        JavaArchive jar = ejbDeployment(suffix);
+        WebArchive war = warDeployment(suffix);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, suffix + ".ear");
+        addPermissionsXml(jar, modulesPermXml, null);
+        addPermissionsXml(war, modulesPermXml, null);
+        ear.addAsModule(jar);
+        ear.addAsModule(war);
+        addPermissionsXml(ear, permissionsXml, null);
+        return ear;
+    }
+
+    private static JavaArchive ejbDeployment(final String suffix) {
+        final JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, EJBAPP_BASE_NAME + suffix + ".jar");
+        ejb.addPackage(ReadSystemPropertyBean.class.getPackage());
+        return ejb;
+    }
+
+    private static WebArchive warDeployment(final String suffix) {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, WEBAPP_BASE_NAME + suffix + ".war");
+        war.addClasses(PrintSystemPropertyServlet.class);
+        war.addAsWebResource(PrintSystemPropertyServlet.class.getPackage(), "readproperty.jsp", "readproperty.jsp");
+        addJSMCheckServlet(war);
+        return war;
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarModulesPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarModulesPPTestCase.java
@@ -55,6 +55,7 @@ import org.jboss.shrinkwrap.api.asset.Asset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -75,6 +76,7 @@ public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
 
     private static final String APP_NO_PERM = "read-props-noperm";
     private static final String APP_EMPTY_PERM = "read-props-emptyperm";
+    private static final String APP_EAR_PERM_MODULE_JBPERM = "read-props-perm-vs-jbperm";
 
     private static Logger LOGGER = Logger.getLogger(EarModulesPPTestCase.class);
 
@@ -129,6 +131,25 @@ public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
     @Deployment(name = APP_EMPTY_PERM, testable = false)
     public static EnterpriseArchive createEmptyPermDeployment() {
         return earDeployment(APP_EMPTY_PERM, AbstractPropertyPermissionTests.EMPTY_PERMISSIONS_XML, ALL_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_EAR_PERM_MODULE_JBPERM, testable = false)
+    public static EnterpriseArchive createEarPermModuleJbPermDeployment() {
+        final String suffix = APP_EAR_PERM_MODULE_JBPERM;
+        JavaArchive jar = ejbDeployment(suffix);
+        WebArchive war = warDeployment(suffix);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, suffix + ".ear");
+        addPermissionsXml(jar, null, ALL_PERMISSIONS_XML);
+        addPermissionsXml(war, null, ALL_PERMISSIONS_XML);
+        ear.addAsModule(jar);
+        ear.addAsModule(war);
+        addPermissionsXml(ear, EMPTY_PERMISSIONS_XML, null);
+        return ear;
     }
 
     /**
@@ -225,6 +246,16 @@ public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
      * Check permission.xml overrides in ear deployments.
      */
     @Test
+    @OperateOnDeployment(APP_EAR_PERM_MODULE_JBPERM)
+    @Ignore("WFLY-4886")
+    public void testASLevelPropertyEjbInJarEmptyPerm2() throws Exception {
+        checkTestPropertyEjb(APP_EAR_PERM_MODULE_JBPERM, true);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
     @OperateOnDeployment(APP_NO_PERM)
     public void testJavaHomePropertyInJSPNoPerm(@ArquillianResource URL webAppURL) throws Exception {
         checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -236,6 +267,16 @@ public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
     @Test
     @OperateOnDeployment(APP_EMPTY_PERM)
     public void testJavaHomePropertyInJSPEmptyPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_EAR_PERM_MODULE_JBPERM)
+    @Ignore("WFLY-4886")
+    public void testJavaHomePropertyInJSPEmptyPerm2(@ArquillianResource URL webAppURL) throws Exception {
         checkJavaHomePropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
 
@@ -261,6 +302,16 @@ public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
      * Check permission.xml overrides in ear deployments.
      */
     @Test
+    @OperateOnDeployment(APP_EAR_PERM_MODULE_JBPERM)
+    @Ignore("WFLY-4886")
+    public void testASLevelPropertyInJSPEmptyPerm2(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestPropertyInJSP(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
     @OperateOnDeployment(APP_NO_PERM)
     public void testASLevelPropertyNoPerm(@ArquillianResource URL webAppURL) throws Exception {
         checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
@@ -272,6 +323,16 @@ public class EarModulesPPTestCase extends AbstractPPTestsWithJSP {
     @Test
     @OperateOnDeployment(APP_EMPTY_PERM)
     public void testASLevelPropertyEmptyPerm(@ArquillianResource URL webAppURL) throws Exception {
+        checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Check permission.xml overrides in ear deployments.
+     */
+    @Test
+    @OperateOnDeployment(APP_EAR_PERM_MODULE_JBPERM)
+    @Ignore("WFLY-4886")
+    public void testASLevelPropertyEmptyPerm2(@ArquillianResource URL webAppURL) throws Exception {
         checkTestProperty(webAppURL, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
 

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarWithLibPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/EarWithLibPPTestCase.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to lib of deployed ear applications. The applications try to do a
+ * protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class EarWithLibPPTestCase extends AbstractPPTestsWithLibrary {
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static EnterpriseArchive createDeployment1() {
+        return earDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static EnterpriseArchive createDeployment2() {
+        return earDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link EnterpriseArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static EnterpriseArchive createDeployment3() {
+        return earDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static EnterpriseArchive earDeployment(final String appName, final Asset permissionsXml) {
+
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, appName + ".war");
+        addJSMCheckServlet(war);
+        war.addClasses(CallPermissionUtilServlet.class);
+
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, appName + ".ear");
+        ear.addAsModule(war);
+        // use just jboss-permissions.xml (and no permissions.xml)
+        addPermissionsXml(ear, null, permissionsXml);
+        ear.addAsLibraries(createLibrary());
+
+        return ear;
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/SystemPropertiesSetup.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/SystemPropertiesSetup.java
@@ -1,0 +1,39 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.as.test.integration.security.common.AbstractSystemPropertiesServerSetupTask;
+
+/**
+ * Server setup task, which adds a custom system property to AS configuration.
+ *
+ * @author Josef Cacek
+ */
+public class SystemPropertiesSetup extends AbstractSystemPropertiesServerSetupTask {
+
+    public static final String PROPERTY_NAME = "custom-test-property";
+
+    @Override
+    protected SystemProperty[] getSystemProperties() {
+        return new SystemProperty[] { new DefaultSystemProperty(PROPERTY_NAME, PROPERTY_NAME) };
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarPPTestCase.java
@@ -1,0 +1,144 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.net.URI;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to deployed web applications. The applications try to do a protected
+ * action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class WarPPTestCase extends AbstractPPTestsWithJSP {
+
+    private static Logger LOGGER = Logger.getLogger(WarPPTestCase.class);
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static WebArchive grantDeployment() {
+        return warDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static WebArchive limitedDeployment() {
+        return warDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static WebArchive denyDeployment() {
+        return warDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static WebArchive warDeployment(final String appName, Asset permissionsXmlAsset) {
+        LOGGER.info("Start WAR deployment");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, appName + ".war");
+        addJSMCheckServlet(war);
+        addPermissionsXml(war, permissionsXmlAsset, null);
+        war.addClasses(PrintSystemPropertyServlet.class);
+        war.addAsWebResource(PrintSystemPropertyServlet.class.getPackage(), "readproperty.jsp", "readproperty.jsp");
+        LOGGER.info(war.toString(true));
+        return war;
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link PrintSystemPropertyServlet}.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBody expected response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkProperty(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBody) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + PrintSystemPropertyServlet.SERVLET_PATH.substring(1) + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBody != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertEquals("System property value doesn't match the expected one.", expectedBody, respBody);
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server using <code>readproperty.jsp</code>.
+     *
+     * @param webAppURL
+     * @param propertyName
+     * @param expectedCode expected HTTP Status code
+     * @param expectedBodyStart expected beginning of response value; if null then response body is not checked
+     * @throws Exception
+     */
+    @Override
+    protected void checkPropertyInJSP(final URL webAppURL, final String propertyName, final int expectedCode,
+            final String expectedBodyStart) throws Exception {
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + "readproperty.jsp" + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+        LOGGER.debug("Checking if '" + propertyName + "' property is available: " + sysPropUri);
+        final String respBody = Utils.makeCall(sysPropUri, expectedCode);
+        if (expectedBodyStart != null && HttpServletResponse.SC_OK == expectedCode) {
+            assertNotNull("Response from JSP should not be null.", respBody);
+            assertTrue("The readproperty.jsp response doesn't start with the expected value.",
+                    respBody.startsWith(expectedBodyStart));
+        }
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarWithLibPPTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/WarWithLibPPTestCase.java
@@ -1,0 +1,85 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.testsuite.integration.secman.servlets.CallPermissionUtilServlet;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case, which checks PropertyPermissions assigned to lib of deployed war applications. The applications try to do a
+ * protected action and it should either complete successfully if {@link java.util.PropertyPermission} is granted, or fail.
+ *
+ * @author Ondrej Lukas
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@ServerSetup(SystemPropertiesSetup.class)
+@RunAsClient
+public class WarWithLibPPTestCase extends AbstractPPTestsWithLibrary {
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_GRANT, testable = false)
+    public static WebArchive createDeployment1() {
+        return warDeployment(APP_GRANT, GRANT_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_LIMITED, testable = false)
+    public static WebArchive createDeployment2() {
+        return warDeployment(APP_LIMITED, LIMITED_PERMISSIONS_XML);
+    }
+
+    /**
+     * Creates archive with a tested application.
+     *
+     * @return {@link WebArchive} instance
+     */
+    @Deployment(name = APP_DENY, testable = false)
+    public static WebArchive createDeployment3() {
+        return warDeployment(APP_DENY, EMPTY_PERMISSIONS_XML);
+    }
+
+    private static WebArchive warDeployment(final String suffix, final Asset permissionsXml) {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, suffix + ".war");
+        war.addClasses(CallPermissionUtilServlet.class);
+        addJSMCheckServlet(war);
+        addPermissionsXml(war, EMPTY_PERMISSIONS_XML, permissionsXml);
+        war.addAsLibraries(createLibrary());
+        return war;
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/package-info.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/propertypermission/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * This package contains tests related to granting java.util.PropertyPermission in AS deployments.
+ * <i>Permissions for the deployments are defined in permissions.xml and/or jboss-permissions.xml</i>
+ */
+package org.jboss.as.testsuite.integration.secman.propertypermission;
+

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/CallPermissionUtilServlet.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/CallPermissionUtilServlet.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.testsuite.integration.secman.PermissionUtil;
+
+/**
+ * Servlet which calls method(s) from {@link PermissionUtil} class usually packaged in a library (i.e. another archive).
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(CallPermissionUtilServlet.SERVLET_PATH)
+public class CallPermissionUtilServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/CallPermissionUtilServlet";
+    public static final String PARAM_PROPERTY_NAME = "property";
+    public static final String DEFAULT_PROPERTY_NAME = "java.home";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        String property = req.getParameter(PARAM_PROPERTY_NAME);
+        if (property == null || property.length() == 0) {
+            property = DEFAULT_PROPERTY_NAME;
+        }
+        final PrintWriter writer = resp.getWriter();
+        writer.write(PermissionUtil.getSystemProperty(property));
+        writer.close();
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/JSMCheckServlet.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/JSMCheckServlet.java
@@ -1,0 +1,61 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet, which checks if the Java Security Manager (JSM) is enabled. Response is a plain text "true" when JSM is enabled or
+ * "false" otherwise.
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(JSMCheckServlet.SERVLET_PATH)
+public class JSMCheckServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/JSMCheckServlet";
+
+    /**
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        final PrintWriter writer = resp.getWriter();
+        writer.write(Boolean.toString(System.getSecurityManager() != null));
+        writer.close();
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/PrintSystemPropertyServlet.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/PrintSystemPropertyServlet.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.servlets;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet, which prints value of system property. By default it prints value of property {@value #DEFAULT_PROPERTY_NAME}, but
+ * you can specify another property name by using request parameter {@value #PARAM_PROPERTY_NAME}.
+ *
+ * @author Josef Cacek
+ */
+@WebServlet(PrintSystemPropertyServlet.SERVLET_PATH)
+public class PrintSystemPropertyServlet extends HttpServlet {
+
+    private static final long serialVersionUID = 1L;
+
+    public static final String SERVLET_PATH = "/SysPropServlet";
+    public static final String PARAM_PROPERTY_NAME = "property";
+    public static final String DEFAULT_PROPERTY_NAME = "java.home";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        String property = req.getParameter(PARAM_PROPERTY_NAME);
+        if (property == null || property.length() == 0) {
+            property = DEFAULT_PROPERTY_NAME;
+        }
+        final PrintWriter writer = resp.getWriter();
+        writer.write(System.getProperty(property, ""));
+        writer.close();
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/package-info.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * Package in which servlets checking JSM permissions are located.
+ */
+package org.jboss.as.testsuite.integration.secman.servlets;

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/readproperty.jsp
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/servlets/readproperty.jsp
@@ -1,0 +1,6 @@
+<%@ page language="java" pageEncoding="UTF-8" contentType="text/plain; charset=UTF-8" session="false"
+%><%!
+private String defaultString(String str, String defVal) {
+    return (str != null && str.length() > 0)?str:defVal;
+}
+%>${(empty param.property)?"java.home":param.property}=<%= System.getProperty(defaultString(request.getParameter("property"),"java.home")) %>

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/MaximumPermissionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/MaximumPermissionsTestCase.java
@@ -1,0 +1,329 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.subsystem;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.net.URI;
+import java.net.URL;
+import java.util.PropertyPermission;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
+import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This class contains test for maximum-permissions attribute in security-manager subsystem. The deployment should failed if the
+ * deployed application asks more permissions than is allowed by the maximum-permissions.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(RemoveDeploymentPermissionsServerSetupTask.class)
+public class MaximumPermissionsTestCase extends ReloadableCliTestBase {
+
+    private static final String DEPLOYMENT_PERM = "deployment-perm";
+    private static final String DEPLOYMENT_JBOSS_PERM = "deployment-jboss-perm";
+    private static final String DEPLOYMENT_NO_PERM = "deployment-no-perm";
+
+    private static Logger LOGGER = Logger.getLogger(MaximumPermissionsTestCase.class);
+    private static final String ADDRESS_WEB = "http://" + TestSuiteEnvironment.getServerAddress() + ":8080/";
+
+    private static final String INDEX_HTML = "OK";
+
+    @ArquillianResource
+    private Deployer deployer;
+
+    /**
+     * Returns Arquillian deployment which defines requested permissions in permissions.xml.
+     */
+    @Deployment(name = DEPLOYMENT_PERM, testable = false, managed = false)
+    public static WebArchive deploymentPerm() {
+        return createDeployment("permissions.xml", DEPLOYMENT_PERM);
+    }
+
+    /**
+     * Returns Arquillian deployment which defines requested permissions in jboss-permissions.xml.
+     */
+    @Deployment(name = DEPLOYMENT_JBOSS_PERM, testable = false, managed = false)
+    public static WebArchive deploymentJBossPerm() {
+        return createDeployment("jboss-permissions.xml", DEPLOYMENT_JBOSS_PERM);
+    }
+
+    /**
+     * Returns Arquillian deployment which doesn't define requested permissions.
+     */
+    @Deployment(name = DEPLOYMENT_NO_PERM, testable = false)
+    public static WebArchive deploymentNoPerm() {
+        return createDeployment(null, DEPLOYMENT_NO_PERM);
+    }
+
+    /**
+     * Tests if deployment fails, when maximum-permissions is not defined and permissions.xml requests some permissions.
+     */
+    @Test
+    @Ignore("WFLY-4882")
+    public void testMaximumPermissionsEmpty() throws Exception {
+        assertNotDeployable(DEPLOYMENT_PERM);
+    }
+
+    /**
+     * Tests if deployment fails, when maximum-permissions is not defined and jboss-permissions.xml requests some permissions.
+     */
+    @Test
+    @Ignore("WFLY-4882")
+    public void testMaximumPermissionsEmptyJBoss() throws Exception {
+        assertNotDeployable(DEPLOYMENT_JBOSS_PERM);
+    }
+
+    /**
+     * Tests if deployment succeeds but doing protected action fails, when maximum-permissions is not defined and requested
+     * permissions declaration is not part of deployment.
+     */
+    @Test
+    public void testNoPermEmptySet() throws Exception {
+        assertPropertyNonReadable(DEPLOYMENT_NO_PERM);
+    }
+
+    /**
+     * Tests if deployment fails, when maximum-permissions is contains another permissions than requested by deployment.
+     */
+    @Test
+    @Ignore("WFLY-4882")
+    public void testFilePerm(@ArquillianResource URL webAppURL) throws Exception {
+        try {
+            doCliOperation(
+                    "/subsystem=security-manager/deployment-permissions=default:add(maximum-permissions=[{class=java.io.FilePermission, actions=read, name=\"/-\"}])");
+            reloadServer();
+
+            assertNotDeployable(DEPLOYMENT_PERM);
+            assertNotDeployable(DEPLOYMENT_JBOSS_PERM);
+            assertPropertyNonReadable(DEPLOYMENT_NO_PERM);
+        } finally {
+            doCliOperationWithoutChecks("/subsystem=security-manager/deployment-permissions=default:remove()");
+            reloadServer();
+        }
+    }
+
+    /**
+     * Tests if deployment succeeds and permissions are granted, when maximum-permissions is contains permissions requested by
+     * deployment.
+     */
+    @Test
+    public void testPropertyPerm(@ArquillianResource URL webAppURL) throws Exception {
+        try {
+            doCliOperation(
+                    "/subsystem=security-manager/deployment-permissions=default:add(maximum-permissions=[{class=java.util.PropertyPermission, actions=read, name=\"*\"}])");
+            reloadServer();
+
+            assertDeployable(DEPLOYMENT_PERM, true);
+            assertDeployable(DEPLOYMENT_JBOSS_PERM, true);
+            assertPropertyNonReadable(DEPLOYMENT_NO_PERM);
+
+        } finally {
+            doCliOperationWithoutChecks("/subsystem=security-manager/deployment-permissions=default:remove()");
+            reloadServer();
+        }
+    }
+
+    /**
+     * Tests if deployments succeeds and permissions are granted, when maximum-permissions contains AllPermission entry.
+     */
+    @Test
+    @Ignore("WFLY-4882")
+    public void testAllPermAndEmptySet(@ArquillianResource URL webAppURL) throws Exception {
+        try {
+            doCliOperation(
+                    "/subsystem=security-manager/deployment-permissions=default:add(maximum-permissions=[{class=java.security.AllPermission}])");
+            reloadServer();
+
+            // check the test apps are deployable and they have requested permissions
+            try {
+                deployer.deploy(DEPLOYMENT_PERM);
+                assertPropertyReadable(DEPLOYMENT_PERM);
+                deployer.deploy(DEPLOYMENT_JBOSS_PERM);
+                assertPropertyReadable(DEPLOYMENT_JBOSS_PERM);
+
+                assertPropertyNonReadable(DEPLOYMENT_NO_PERM);
+                try {
+                    // after removing permissions from maximum-set the deployment which requests non-granted permissions should
+                    // fail.
+                    doCliOperation(
+                            "/subsystem=security-manager/deployment-permissions=default:undefine-attribute(name=maximum-permissions)");
+                    reloadServer();
+
+                    assertNotDeployed(DEPLOYMENT_PERM);
+                    assertNotDeployed(DEPLOYMENT_JBOSS_PERM);
+                    assertDeployed(DEPLOYMENT_NO_PERM);
+                } finally {
+                    // clean-up - undeploy
+                    doCliOperation(
+                            "/subsystem=security-manager/deployment-permissions=default:write-attribute(name=maximum-permissions, value=[{class=java.security.AllPermission}])");
+                    reloadServer();
+                }
+            } finally {
+                deployer.undeploy(DEPLOYMENT_PERM);
+                deployer.undeploy(DEPLOYMENT_JBOSS_PERM);
+            }
+        } finally {
+            doCliOperationWithoutChecks("/subsystem=security-manager/deployment-permissions=default:remove()");
+            reloadServer();
+        }
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link PrintSystemPropertyServlet}.
+     *
+     * @param deploymentName
+     *
+     * @param expectedCode expected HTTP Status code
+     * @throws Exception
+     */
+    protected void checkPropertyAccess(boolean successExpected, String deploymentName) throws Exception {
+        final String propertyName = "java.home";
+
+        final URI sysPropUri = new URI(ADDRESS_WEB + deploymentName + PrintSystemPropertyServlet.SERVLET_PATH + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+
+        Utils.makeCall(sysPropUri, successExpected ? HttpServletResponse.SC_OK : HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Asserts the system property is readable from deployment with given name.
+     *
+     * @param deploymentName
+     * @throws Exception
+     */
+    protected void assertPropertyReadable(String deploymentName) throws Exception {
+        checkPropertyAccess(true, deploymentName);
+    }
+
+    /**
+     * Asserts the system property is not readable from deployment with given name.
+     *
+     * @param deploymentName
+     * @throws Exception
+     */
+    protected void assertPropertyNonReadable(String deploymentName) throws Exception {
+        checkPropertyAccess(false, deploymentName);
+    }
+
+    /**
+     * Asserts the deployment of the application with given name succeeds and checks if system property is
+     * readable/non-readable.
+     *
+     * @param deploymentName
+     * @param expectedPropertyReadable expected "readability" of system property from deployment
+     * @throws Exception
+     */
+    protected void assertDeployable(String deploymentName, boolean expectedPropertyReadable) throws Exception {
+        deployer.deploy(deploymentName);
+        LOGGER.debug("Manually deployed: " + deploymentName);
+        if (expectedPropertyReadable) {
+            assertPropertyReadable(deploymentName);
+        } else {
+            assertPropertyNonReadable(deploymentName);
+        }
+        deployer.undeploy(deploymentName);
+    }
+
+    /**
+     * Asserts the deployment of the application with given name fails.
+     *
+     * @param deploymentName
+     * @throws Exception
+     */
+    protected void assertNotDeployable(String deploymentName) {
+        try {
+            deployer.deploy(deploymentName);
+            deployer.undeploy(deploymentName);
+            fail("Deployment failure expected for deployment: " + deploymentName);
+        } catch (Exception e) {
+            // expected
+        }
+    }
+
+    /**
+     * Asserts the application with given name is deployed.
+     *
+     * @param deploymentName
+     * @throws Exception
+     */
+    protected void assertDeployed(String deploymentName) throws Exception {
+        final URI sysPropUri = new URI(ADDRESS_WEB + deploymentName + "/");
+        final String strBody = Utils.makeCall(sysPropUri, HttpServletResponse.SC_OK);
+        assertEquals("Unexpected message body returned.", INDEX_HTML, strBody);
+    }
+
+    /**
+     * Asserts the application with given name is not-deployed.
+     *
+     * @param deploymentName
+     * @throws Exception
+     */
+    protected void assertNotDeployed(String deploymentName) throws Exception {
+        final URI sysPropUri = new URI(ADDRESS_WEB + deploymentName + "/");
+        Utils.makeCall(sysPropUri, HttpServletResponse.SC_NOT_FOUND);
+    }
+
+    /**
+     * Creates deployment with {@link PrintSystemPropertyServlet} and index.html simple page. If permissionsFilename parameter
+     * is not-<code>null</code>, then permission declaration file with given name is also generated to the deployment.
+     *
+     * @param permissionsFilename filename under META-INF where to store requested permissions (usually permissions.xml,
+     *        jboss-permissions.xml or null to skip requesting permissions)
+     * @param deploymentName
+     * @return
+     */
+    private static WebArchive createDeployment(String permissionsFilename, String deploymentName) {
+        LOGGER.debug("Start WAR deployment");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, deploymentName + ".war");
+        war.addClasses(PrintSystemPropertyServlet.class);
+        war.addAsWebResource(new StringAsset(INDEX_HTML), "index.html");
+        if (permissionsFilename != null) {
+            war.addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(new PropertyPermission("*", "read")),
+                    permissionsFilename);
+        }
+        LOGGER.debug(war.toString(true));
+        return war;
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/MinimumPermissionsTestCase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/MinimumPermissionsTestCase.java
@@ -1,0 +1,172 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.subsystem;
+
+import java.net.URI;
+import java.net.URL;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.testsuite.integration.secman.servlets.PrintSystemPropertyServlet;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * This class contains test for minimum-permissions attribute in security-manager subsystem. The permissions listed in
+ * minimum-permissions should be granted to all deployed applications.
+ *
+ * @author Josef Cacek
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class MinimumPermissionsTestCase extends ReloadableCliTestBase {
+
+    private static final String DEPLOYMENT = "deployment";
+    private static Logger LOGGER = Logger.getLogger(MinimumPermissionsTestCase.class);
+
+    @ArquillianResource
+    private URL webAppURL;
+
+    /**
+     * Test deployment with {@link PrintSystemPropertyServlet} and without any permissions deployment descriptor.
+     *
+     * @return
+     */
+    @Deployment(name = DEPLOYMENT, testable = false)
+    public static WebArchive deployment() {
+        LOGGER.debug("Start WAR deployment");
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war");
+        war.addClasses(PrintSystemPropertyServlet.class);
+        LOGGER.debug(war.toString(true));
+        return war;
+    }
+
+    /**
+     * Tests that permissions are not granted if the minimum-permissions is empty.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testEmptyMinPerm() throws Exception {
+        assertPropertyNonReadable();
+    }
+
+    /**
+     * Tests that property permissions are not granted if the minimum-permissions contains only a {@link java.io.FilePermission}
+     * entry.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testFilePerm(@ArquillianResource URL webAppURL) throws Exception {
+        doCliOperation(
+                "/subsystem=security-manager/deployment-permissions=default:write-attribute(name=minimum-permissions, value=[{class=java.io.FilePermission, actions=read, name=\"/-\"}])");
+        reloadServer();
+
+        assertPropertyNonReadable();
+
+        doCliOperation(
+                "/subsystem=security-manager/deployment-permissions=default:undefine-attribute(name=minimum-permissions)");
+        reloadServer();
+    }
+
+    /**
+     * Tests that permission for reading system property is granted if the minimum-permissions contains PropertyPermission with
+     * wildcard '*'. entry.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testPropertyPerm(@ArquillianResource URL webAppURL) throws Exception {
+        doCliOperation(
+                "/subsystem=security-manager/deployment-permissions=default:write-attribute(name=minimum-permissions, value=[{class=java.util.PropertyPermission, actions=read, name=\"*\"}])");
+        reloadServer();
+
+        assertPropertyReadable();
+
+        doCliOperation(
+                "/subsystem=security-manager/deployment-permissions=default:undefine-attribute(name=minimum-permissions)");
+        reloadServer();
+    }
+
+    /**
+     * Tests that property permissions are granted if the minimum-permissions contains a {@link java.security.AllPermission}
+     * entry.
+     *
+     * @param webAppURL
+     * @throws Exception
+     */
+    @Test
+    public void testAllPerm(@ArquillianResource URL webAppURL) throws Exception {
+        doCliOperation(
+                "/subsystem=security-manager/deployment-permissions=default:write-attribute(name=minimum-permissions, value=[{class=java.security.AllPermission}])");
+        reloadServer();
+
+        assertPropertyReadable();
+
+        doCliOperation(
+                "/subsystem=security-manager/deployment-permissions=default:undefine-attribute(name=minimum-permissions)");
+        reloadServer();
+    }
+
+    /**
+     * Checks access to a system property on the server using {@link PrintSystemPropertyServlet}.
+     *
+     * @param expectedCode expected HTTP Status code
+     * @throws Exception
+     */
+    protected void checkPropertyAccess(boolean successExpected) throws Exception {
+        final String propertyName = "java.home";
+
+        final URI sysPropUri = new URI(webAppURL.toExternalForm() + PrintSystemPropertyServlet.SERVLET_PATH.substring(1) + "?"
+                + Utils.encodeQueryParam(PrintSystemPropertyServlet.PARAM_PROPERTY_NAME, propertyName));
+
+        Utils.makeCall(sysPropUri, successExpected ? HttpServletResponse.SC_OK : HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+    }
+
+    /**
+     * Asserts that a system property is readable from the test deployment.
+     *
+     * @throws Exception
+     */
+    protected void assertPropertyReadable() throws Exception {
+        checkPropertyAccess(true);
+    }
+
+    /**
+     * Asserts that a system property is not readable from the test deployment.
+     *
+     * @throws Exception
+     */
+    protected void assertPropertyNonReadable() throws Exception {
+        checkPropertyAccess(false);
+    }
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/ReloadableCliTestBase.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/ReloadableCliTestBase.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.subsystem;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.base.AbstractCliTestBase;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.logging.Logger;
+
+/**
+ *
+ * @author Josef Cacek
+ */
+public abstract class ReloadableCliTestBase extends AbstractCliTestBase {
+
+    private static Logger LOGGER = Logger.getLogger(ReloadableCliTestBase.class);
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    protected void doCliOperation(final String operation) throws Exception {
+        LOGGER.debugv("Performing CLI operation: {0}", operation);
+        initCLI();
+        cli.sendLine(operation);
+    }
+
+    protected void doCliOperationWithoutChecks(final String operation) throws Exception {
+        LOGGER.debugv("Performing CLI operation without checks: {0}", operation);
+        initCLI();
+        cli.sendLine(operation, true);
+        final CLIOpResult result = cli.readAllAsOpResult();
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debugv("Operation result is: {0}", result.getResponseNode());
+        }
+    }
+
+    protected void reloadServer() {
+        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/RemoveDeploymentPermissionsServerSetupTask.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/RemoveDeploymentPermissionsServerSetupTask.java
@@ -1,0 +1,108 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.testsuite.integration.secman.subsystem;
+
+import static org.junit.Assert.assertTrue;
+
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.util.CLIOpResult;
+import org.jboss.as.test.integration.management.util.CLIWrapper;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.logging.Logger;
+
+/**
+ * Setup task which removes <code>/subsystem=security-manager/deployment-permissions=default</code> node from the domain model.
+ * The {@link #tearDown(ManagementClient, String)} method restores the node with single attribute configured:<br/>
+ * <code>maximum-permissions=[{class=java.security.AllPermission}])</code>.
+ *
+ * @author Josef Cacek
+ */
+public class RemoveDeploymentPermissionsServerSetupTask implements ServerSetupTask {
+
+    private static CLIWrapper cli;
+
+    private static Logger LOGGER = Logger.getLogger(RemoveDeploymentPermissionsServerSetupTask.class);
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.as.arquillian.api.ServerSetupTask#setup(org.jboss.as.arquillian.container.ManagementClient,
+     * java.lang.String)
+     */
+    @Override
+    public final void setup(final ManagementClient managementClient, String containerId) throws Exception {
+        if (cli == null) {
+            cli = new CLIWrapper(true);
+        }
+        CLIOpResult result = null;
+
+        // remove the deployment permissions
+        cli.sendLine("/subsystem=security-manager/deployment-permissions=default:remove()");
+        result = cli.readAllAsOpResult();
+        assertTrue("Removing deployment-permissions by using management API failed", result.isIsOutcomeSuccess());
+
+        // reload the server
+        LOGGER.debug("Reloading the server");
+        reload(managementClient);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jboss.as.arquillian.api.ServerSetupTask#tearDown(org.jboss.as.arquillian.container.ManagementClient,
+     * java.lang.String)
+     */
+    @Override
+    public void tearDown(final ManagementClient managementClient, String containerId) throws Exception {
+        CLIOpResult result = null;
+
+        // remove the deployment permissions configuration if exists
+        cli.sendLine("/subsystem=security-manager/deployment-permissions=default:remove()", true);
+        result = cli.readAllAsOpResult();
+        LOGGER.debug("Just in case. We tried to remove deployment-permissions before adding it. Result of the delete: "
+                + result.getFromResponse(ModelDescriptionConstants.OUTCOME));
+
+        // revert original deployment permissions
+        cli.sendLine(
+                "/subsystem=security-manager/deployment-permissions=default:add(maximum-permissions=[{class=java.security.AllPermission}])");
+        result = cli.readAllAsOpResult();
+        assertTrue("Reverting maximum-permissions by using management API failed", result.isIsOutcomeSuccess());
+
+        // reload the server
+        LOGGER.debug("Reloading the server");
+        reload(managementClient);
+
+    }
+
+    /**
+     * Provide reload operation on the server
+     *
+     * @throws Exception
+     */
+    private static void reload(final ManagementClient managementClient) throws Exception {
+        ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+    }
+
+}

--- a/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/package-info.java
+++ b/testsuite/integration/secman/src/test/java/org/jboss/as/testsuite/integration/secman/subsystem/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+/**
+ * This package contains tests aimed to security-manager subsystem integration testing.
+ */
+package org.jboss.as.testsuite.integration.secman.subsystem;
+

--- a/testsuite/integration/secman/src/test/resources/jboss-ejb-client.properties
+++ b/testsuite/integration/secman/src/test/resources/jboss-ejb-client.properties
@@ -1,0 +1,32 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2011, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=${node0:localhost}
+remote.connection.default.port=8080
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
+remote.connection.default.connect.options.org.xnio.Options.WORKER_TASK_MAX_THREADS=4
+callback.handler.class=org.jboss.as.test.shared.integration.ejb.security.CallbackHandler
+

--- a/testsuite/integration/secman/src/test/resources/logging.properties
+++ b/testsuite/integration/secman/src/test/resources/logging.properties
@@ -1,0 +1,57 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2010, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+# Additional logger names to configure (root logger is always configured)
+loggers=sun.rmi,org.jboss.shrinkwrap,org.jboss.as.test,org.apache.directory
+logger.org.jboss.shrinkwrap.level=INFO
+logger.org.jboss.as.test.level=DEBUG
+logger.org.apache.directory.level=WARNING
+logger.sun.rmi.level=WARNING
+
+# Root logger level
+logger.level=INFO
+
+# Root logger handlers
+logger.handlers=FILE, CONSOLE
+
+# Console handler configuration
+handler.CONSOLE=org.jboss.logmanager.handlers.ConsoleHandler
+handler.CONSOLE.properties=autoFlush
+handler.CONSOLE.level=INFO
+handler.CONSOLE.autoFlush=true
+handler.CONSOLE.formatter=PATTERN
+
+# File handler configuration
+handler.FILE=org.jboss.logmanager.handlers.FileHandler
+handler.FILE.level=DEBUG
+handler.FILE.properties=autoFlush,fileName
+handler.FILE.autoFlush=true
+handler.FILE.fileName=./target/test.log
+handler.FILE.formatter=PATTERN
+
+# Formatter pattern configuration
+formatter.PATTERN=org.jboss.logmanager.formatters.PatternFormatter
+formatter.PATTERN.properties=pattern
+formatter.PATTERN.pattern=%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%e%n
+
+
+logger.sun.rmi

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -36,7 +36,6 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.net.UnknownHostException;
 import java.security.MessageDigest;
-import java.security.Permission;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -46,6 +45,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import javax.security.auth.Subject;
 import javax.security.auth.login.Configuration;
 import javax.security.auth.login.LoginContext;
@@ -761,35 +761,6 @@ public class Utils extends CoreUtils {
             }
         }
         sb.append("\n</dependencies></deployment></jboss-deployment-structure>");
-        return new StringAsset(sb.toString());
-    }
-
-    /**
-     * Creates content of permissions.xml (or jboss-permissions.xml) which placed in META-INF of the deployment specifies
-     * security permissions granted to the deployment.
-     *
-     * @param permissions instances from which are &lt;permission&gt; elements generated
-     * @return not-<code>null</code> content of permissions.xml (version=7)
-     */
-    public static Asset getPermissionsXml(final Permission... permissions) {
-        final StringBuilder sb = new StringBuilder();
-        sb.append("<permissions xmlns='http://xmlns.jcp.org/xml/ns/javaee' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd' version='7'>");
-        if (permissions != null) {
-            for (Permission permission : permissions) {
-                if (permission != null) {
-                    sb.append("\n\t<permission>");
-                    sb.append("\n\t\t<class-name>").append(permission.getClass().getName()).append("</class-name>");
-                    if (permission.getName() != null) {
-                        sb.append("\n\t\t<name>").append(permission.getName()).append("</name>");
-                    }
-                    if (permission.getActions() != null) {
-                        sb.append("\n\t\t<actions>").append(permission.getActions()).append("</actions>");
-                    }
-                    sb.append("\n\t</permission>");
-                }
-            }
-        }
-        sb.append("\n</permissions>");
         return new StringAsset(sb.toString());
     }
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-4858

Added test coverage for testing permissions assignment and handling priorities of related deployment descriptors (`permissions.xml`, `jboss-permissions.xml`).
