### PR TITLE
WFLY-4871 Upgrade to Hibernate Search 5.3.0.Final

### DIFF
--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -115,8 +115,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-infinispan</artifactId>
+            <groupId>org.infinispan</groupId>
+            <artifactId>infinispan-directory-provider</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1801,17 +1801,6 @@
         
         <dependency>
             <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-search-infinispan</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        
-        <dependency>
-            <groupId>org.hibernate</groupId>
             <artifactId>hibernate-search-orm</artifactId>
             <exclusions>
                 <exclusion>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-search/directory-provider/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/infinispan/hibernate-search/directory-provider/main/module.xml
@@ -25,7 +25,7 @@
         <property name="jboss.api" value="private"/>
     </properties>
     <resources>
-        <artifact name="${org.hibernate:hibernate-search-infinispan}"/>
+        <artifact name="${org.infinispan:infinispan-directory-provider}"/>
     </resources>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <version.org.hibernate.validator>5.1.3.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.hql>1.1.0.Final</version.org.hibernate.hql>
-        <version.org.hibernate.search>5.2.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>5.3.0.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
         <version.org.infinispan>7.2.3.Final</version.org.infinispan>
         <version.org.jasypt>1.9.1</version.org.jasypt>
@@ -4033,12 +4033,6 @@
 
             <dependency>
                 <groupId>org.hibernate</groupId>
-                <artifactId>hibernate-search-infinispan</artifactId>
-                <version>${version.org.hibernate.search}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.hibernate</groupId>
                 <artifactId>hibernate-search-backend-jms</artifactId>
                 <version>${version.org.hibernate.search}</version>
             </dependency>
@@ -4255,10 +4249,6 @@
                     <exclusion>
                         <groupId>org.hibernate</groupId>
                         <artifactId>hibernate-search-engine</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.hibernate</groupId>
-                        <artifactId>hibernate-search-infinispan</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.hibernate</groupId>


### PR DESCRIPTION
This is blocking the Hibernate ORM 5 upgrade, however that will need an additional HS upgrade.

Already discussed with @scottmarlow .
