### PR TITLE
Testcase for WFLY-4864 JSP in web application doesn't get VFS-based security permissions

### DIFF
--- a/testsuite/integration/web/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/web/src/test/config/arq/arquillian.xml
@@ -7,7 +7,7 @@
     <container qualifier="jboss" default="true">
         <configuration>
             <property name="jbossHome">${basedir}/target/jbossas</property>
-            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0}</property>
+            <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas -Dtest.bind.address=${node0} -Djava.security.policy==${basedir}/target/test-classes/security.policy</property>
             <property name="serverConfig">${jboss.server.config.file.name:standalone.xml}</property>
             <property name="jbossArguments">${jboss.args}</property>
             <!-- -Djboss.inst is not necessarily needed, only in case the test case neeeds path to the instance it runs in.

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/JspSecurityManagerTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/jsp/JspSecurityManagerTestCase.java
@@ -1,0 +1,52 @@
+package org.jboss.as.test.integration.web.jsp;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.common.HttpRequest;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+
+@RunWith(Arquillian.class)
+@RunAsClient
+public class JspSecurityManagerTestCase {
+    private static final StringAsset WEB_XML = new StringAsset(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+                    "<web-app xmlns=\"http://java.sun.com/xml/ns/javaee\"\n" +
+                    "         xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n" +
+                    "         xsi:schemaLocation=\"http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_1.xsd\"\n" +
+                    "         version=\"3.1\">\n" +
+                    "</web-app>");
+
+    private static final StringAsset INDEX_JSP = new StringAsset(
+            "<%@ page contentType=\"text/html;charset=UTF-8\" language=\"java\" %>\n" +
+                    "<html>\n" +
+                    "  <head>\n" +
+                    "    <title></title>\n" +
+                    "  </head>\n" +
+                    "  <body>\n" +
+                    "<%= System.getProperty(\"java.home\") %>" +
+                    "  </body>\n" +
+                    "</html>");
+
+    @Deployment
+    public static WebArchive deploy() {
+        return ShrinkWrap.create(WebArchive.class, "read-props.war")
+                .addAsWebInfResource(WEB_XML, "web.xml")
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsWebResource(INDEX_JSP, "index.jsp");
+    }
+
+    @Test
+    public void shouldReadProperties(@ArquillianResource URL url) throws Exception {
+        HttpRequest.get(url + "index.jsp", 10, TimeUnit.SECONDS);
+    }
+}

--- a/testsuite/integration/web/src/test/resources/security.policy
+++ b/testsuite/integration/web/src/test/resources/security.policy
@@ -1,0 +1,21 @@
+grant codeBase "file:${jboss.home.dir}/jboss-modules.jar" {
+  permission java.security.AllPermission;
+};
+
+grant codeBase "file:${jboss.home.dir}/standalone/tmp/read-props.war/-" {
+  permission java.io.FilePermission "*", "read,write,delete";
+};
+
+grant codeBase "file:${{java.ext.dirs}}/*" {
+    permission java.security.AllPermission;
+};
+
+// Grant read PropertyPermission for all properties to test application
+grant codeBase "vfs:/content/read-props.war/-" {
+  permission java.util.PropertyPermission "*", "read";
+};
+
+// workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1075045
+grant {
+  permission java.lang.RuntimePermission "getClassLoader";
+};

--- a/testsuite/integration/web/src/test/resources/security.policy
+++ b/testsuite/integration/web/src/test/resources/security.policy
@@ -18,3 +18,8 @@ grant codeBase "vfs:/content/read-props.war/-" {
 grant codeBase "vfs:/${user.dir}/content/read-props.war/-" {
   permission java.util.PropertyPermission "*", "read";
 };
+
+//add permisions for WebSocket tests
+grant{
+  permission java.net.SocketPermission "*", "listen,resolve";
+};

--- a/testsuite/integration/web/src/test/resources/security.policy
+++ b/testsuite/integration/web/src/test/resources/security.policy
@@ -14,8 +14,7 @@ grant codeBase "file:${{java.ext.dirs}}/*" {
 grant codeBase "vfs:/content/read-props.war/-" {
   permission java.util.PropertyPermission "*", "read";
 };
-
-// workaround for https://bugzilla.redhat.com/show_bug.cgi?id=1075045
-grant {
-  permission java.lang.RuntimePermission "getClassLoader";
+//workaround for vfs on windows https://bugzilla.redhat.com/show_bug.cgi?id=1082518
+grant codeBase "vfs:/${user.dir}/content/read-props.war/-" {
+  permission java.util.PropertyPermission "*", "read";
 };


### PR DESCRIPTION
incorporates #7697 
this just adds test, the fix was the jastow upgrade, done in: https://github.com/wildfly/wildfly/pull/7738
