### PR TITLE
[WFLY-4675] Fix help message for ws tools in bat scripts

### DIFF
--- a/feature-pack/src/main/resources/content/bin/wsconsume.bat
+++ b/feature-pack/src/main/resources/content/bin/wsconsume.bat
@@ -51,7 +51,7 @@ if "x%JBOSS_MODULEPATH%" == "x" (
   set "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
-set JAVA_OPTS = "%JAVA_OPTS% -Dprogram.name=wsconsume.bat"
+set "JAVA_OPTS=%JAVA_OPTS% -Dprogram.name=wsconsume.bat"
 
 "%JAVA%" %JAVA_OPTS% ^
     -classpath "%JAVA_HOME%\lib\tools.jar;%JBOSS_RUNJAR%" ^

--- a/feature-pack/src/main/resources/content/bin/wsprovide.bat
+++ b/feature-pack/src/main/resources/content/bin/wsprovide.bat
@@ -51,7 +51,7 @@ if "x%JBOSS_MODULEPATH%" == "x" (
   set "JBOSS_MODULEPATH=%JBOSS_HOME%\modules"
 )
 
-set JAVA_OPTS = "%JAVA_OPTS% -Dprogram.name=wsprovide.bat"
+set "JAVA_OPTS=%JAVA_OPTS% -Dprogram.name=wsprovide.bat"
 
 "%JAVA%" %JAVA_OPTS% ^
     -jar "%JBOSS_RUNJAR%" ^


### PR DESCRIPTION
Help message in wsconsume.bat and wsprovide.bat contains wrong "usage" section.

Also fixes WFLY-4676
