### PR TITLE
Prepare for WFCORE-808

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
@@ -154,7 +154,7 @@ public class CacheAddHandler extends AbstractAddStepHandler {
         }
     }
 
-    void removeRuntimeServices(OperationContext context, ModelNode operation, ModelNode containerModel, ModelNode cacheModel) {
+    void removeRuntimeServices(OperationContext context, ModelNode operation) {
         PathAddress address = Operations.getPathAddress(operation);
         String containerName = address.getElement(address.size() - 2).getValue();
         String cacheName = address.getElement(address.size() - 1).getValue();

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemoveHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerRemoveHandler.java
@@ -48,7 +48,7 @@ public class CacheContainerRemoveHandler extends AbstractRemoveStepHandler {
             if (model.hasDefined(type.pathElement().getKey())) {
                 for (Property property: model.get(type.pathElement().getKey()).asPropertyList()) {
                     ModelNode removeOperation = Util.createRemoveOperation(address.append(type.pathElement(property.getName())));
-                    addHandler.removeRuntimeServices(context, removeOperation, model, property.getValue());
+                    addHandler.removeRuntimeServices(context, removeOperation);
                 }
             }
         }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemoveHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheRemoveHandler.java
@@ -36,14 +36,9 @@ public class CacheRemoveHandler extends AbstractRemoveStepHandler {
     @Override
     protected void performRuntime(OperationContext context, ModelNode operation, ModelNode model) throws OperationFailedException {
 
-        // we also need the containerModel to re-install cache services
         PathAddress address = context.getCurrentAddress();
         CacheType type = CacheType.forName(address.getLastElement().getKey());
-
-        PathAddress containerAddress = address.subAddress(0, address.size() - 1);
-        ModelNode containerModel = context.readResourceFromRoot(containerAddress).getModel();
-
-        type.getAddHandler().removeRuntimeServices(context, operation, containerModel, model);
+        type.getAddHandler().removeRuntimeServices(context, operation);
     }
 
     @Override

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationSequencesTestCase.java
@@ -44,23 +44,23 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // add a cache container
         ModelNode result = servicesA.executeOperation(addContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // add a local cache
         result = servicesA.executeOperation(addCacheOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // remove the cache container
         result = servicesA.executeOperation(removeContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // add the same cache container
         result = servicesA.executeOperation(addContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // add the same local cache
         result = servicesA.executeOperation(addCacheOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
     }
 
     @Test
@@ -76,19 +76,19 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // add a cache container
         ModelNode result = servicesA.executeOperation(addContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // add a local cache
         result = servicesA.executeOperation(addCacheOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // remove the cache container
         result = servicesA.executeOperation(removeContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // remove the cache container again
         result = servicesA.executeOperation(removeContainerOp);
-        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), FAILED, result.get(OUTCOME).asString());
     }
 
     @Test
@@ -108,17 +108,17 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // add a cache container
         ModelNode result = servicesA.executeOperation(addContainerOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // add a local cache
         result = servicesA.executeOperation(addCacheOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // remove the cache container
         // the remove has OperationContext.setRollbackOnly() injected
         // and so is expected to fail
         result = servicesA.executeOperation(removeContainerOp);
-        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), FAILED, result.get(OUTCOME).asString());
 
         // need to check that all services are correctly re-installed
         ServiceName containerServiceName = CacheContainerServiceName.CACHE_CONTAINER.getServiceName("maximal2");
@@ -143,15 +143,15 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // add a local cache
         ModelNode result = servicesA.executeOperation(addOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // remove the local cache
         result = servicesA.executeOperation(removeOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // add the same local cache
         result = servicesA.executeOperation(addOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
     }
 
     @Test
@@ -166,14 +166,14 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
 
         // add a local cache
         ModelNode result = servicesA.executeOperation(addOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // remove the local cache
         result = servicesA.executeOperation(removeOp);
-        Assert.assertEquals(SUCCESS, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), SUCCESS, result.get(OUTCOME).asString());
 
         // remove the same local cache
         result = servicesA.executeOperation(removeOp);
-        Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
+        Assert.assertEquals(result.toString(), FAILED, result.get(OUTCOME).asString());
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemRemoveHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemRemoveHandler.java
@@ -26,6 +26,7 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
@@ -42,37 +43,44 @@ public class JGroupsSubsystemRemoveHandler extends AbstractRemoveStepHandler {
     JGroupsSubsystemRemoveHandler(boolean allowRuntimeOnlyRegistration) {
         this.allowRuntimeOnlyRegistration = allowRuntimeOnlyRegistration;
     }
+    /**
+     * TODO remove this and the performRemove override once a core release
+     * with WFCORE-808 is merged.
+     */
+    protected boolean removeChildRecursively(PathElement child) {
+        return false;
+    }
 
     @Override
     protected void performRemove(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
         PathAddress address = context.getCurrentAddress();
-
-        if (model.hasDefined(ChannelResourceDefinition.WILDCARD_PATH.getKey())) {
-            ModelNode channels = model.get(ChannelResourceDefinition.WILDCARD_PATH.getKey());
-            if (channels.isDefined()) {
-                for (Property channel: channels.asPropertyList()) {
-                    PathAddress channelAddress = address.append(ChannelResourceDefinition.pathElement(channel.getName()));
-                    context.addStep(Util.createRemoveOperation(channelAddress), new ChannelRemoveHandler(this.allowRuntimeOnlyRegistration), OperationContext.Stage.MODEL);
-                }
-            }
-        }
-
-        if (model.hasDefined(StackResourceDefinition.WILDCARD_PATH.getKey())) {
-            ModelNode stacks = model.get(StackResourceDefinition.WILDCARD_PATH.getKey());
-            if (stacks.isDefined()) {
-                for (Property stack: stacks.asPropertyList()) {
-                    PathAddress stackAddress = address.append(StackResourceDefinition.pathElement(stack.getName()));
-                    context.addStep(Util.createRemoveOperation(stackAddress), new StackRemoveHandler(), OperationContext.Stage.MODEL);
-                }
-            }
-        }
 
         context.addStep(operation, new OperationStepHandler() {
             @Override
             public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
                 JGroupsSubsystemRemoveHandler.super.performRemove(context, operation, model);
             }
-        }, OperationContext.Stage.MODEL);
+        }, OperationContext.Stage.MODEL, true);
+
+        if (model.hasDefined(StackResourceDefinition.WILDCARD_PATH.getKey())) {
+            ModelNode stacks = model.get(StackResourceDefinition.WILDCARD_PATH.getKey());
+            if (stacks.isDefined()) {
+                for (Property stack: stacks.asPropertyList()) {
+                    PathAddress stackAddress = address.append(StackResourceDefinition.pathElement(stack.getName()));
+                    context.addStep(Util.createRemoveOperation(stackAddress), new StackRemoveHandler(), OperationContext.Stage.MODEL, true);
+                }
+            }
+        }
+
+        if (model.hasDefined(ChannelResourceDefinition.WILDCARD_PATH.getKey())) {
+            ModelNode channels = model.get(ChannelResourceDefinition.WILDCARD_PATH.getKey());
+            if (channels.isDefined()) {
+                for (Property channel: channels.asPropertyList()) {
+                    PathAddress channelAddress = address.append(ChannelResourceDefinition.pathElement(channel.getName()));
+                    context.addStep(Util.createRemoveOperation(channelAddress), new ChannelRemoveHandler(this.allowRuntimeOnlyRegistration), OperationContext.Stage.MODEL, true);
+                }
+            }
+        }
     }
 
     @Override

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRemove.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRemove.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.txn.subsystem;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
+
+/**
+ * Removes the transaction subsystem root resource.
+ *
+ * @author Brian Stansberry
+ */
+class TransactionSubsystemRemove extends ReloadRequiredRemoveStepHandler {
+
+    static final TransactionSubsystemRemove INSTANCE = new TransactionSubsystemRemove();
+
+    /**
+     * Suppresses removal of the log-store=log-store child, as that remove op handler is a no-op.
+     */
+    //@Override
+    protected boolean removeChildRecursively(PathElement child) {
+        return !TransactionExtension.LOG_STORE_PATH.equals(child);
+    }
+}

--- a/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
+++ b/transactions/src/main/java/org/jboss/as/txn/subsystem/TransactionSubsystemRootResourceDefinition.java
@@ -34,7 +34,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -237,7 +236,7 @@ public class TransactionSubsystemRootResourceDefinition extends SimpleResourceDe
     TransactionSubsystemRootResourceDefinition(boolean registerRuntimeOnly) {
         super(TransactionExtension.SUBSYSTEM_PATH,
                 TransactionExtension.getResourceDescriptionResolver(),
-                TransactionSubsystemAdd.INSTANCE, ReloadRequiredRemoveStepHandler.INSTANCE,
+                TransactionSubsystemAdd.INSTANCE, TransactionSubsystemRemove.INSTANCE,
                 OperationEntry.Flag.RESTART_ALL_SERVICES, OperationEntry.Flag.RESTART_ALL_SERVICES);
         this.registerRuntimeOnly = registerRuntimeOnly;
     }


### PR DESCRIPTION
Commits to allow WFCORE-808 to work by tweaking some resource remove handling such that a parent removing a child will work.

The jgroups and infinispan changes are valid regardless of WFCORE-808.
