### PR TITLE
Xml / xml api usage cleanup

### DIFF
--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/XMLSanitizer.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/util/XMLSanitizer.java
@@ -21,11 +21,11 @@
  */
 package org.jboss.as.jdr.util;
 
-import org.apache.commons.io.IOUtils;
-import org.jboss.vfs.VirtualFileFilter;
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
+import static org.jboss.as.jdr.logger.JdrLogger.ROOT_LOGGER;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
@@ -36,11 +36,11 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathFactory;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
 
-import static org.jboss.as.jdr.logger.JdrLogger.ROOT_LOGGER;
+import org.apache.commons.io.IOUtils;
+import org.jboss.vfs.VirtualFileFilter;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
 
 /**
  * {@link Sanitizer} subclass that removes the contents of the matched xpath expression
@@ -63,8 +63,9 @@ public class XMLSanitizer extends AbstractSanitizer {
         builder = DBfactory.newDocumentBuilder();
         builder.setErrorHandler(null);
 
-        TransformerFactory transformerFactory = TransformerFactory.newInstance("org.apache.xalan.processor.TransformerFactoryImpl", null);
+        TransformerFactory transformerFactory = TransformerFactory.newInstance();
         transformer = transformerFactory.newTransformer();
+
     }
 
     public InputStream sanitize(InputStream in) throws Exception {
@@ -72,6 +73,7 @@ public class XMLSanitizer extends AbstractSanitizer {
         try {
             // storing the entire file in memory in case we need to bail.
             Document doc = builder.parse(new ByteArrayInputStream(content));
+            doc.setXmlStandalone(true);
             Object result = expression.evaluate(doc, XPathConstants.NODESET);
             NodeList nodes = (NodeList) result;
             for (int i = 0; i < nodes.getLength(); i++) {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/altdd/alt-ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/altdd/alt-ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/altdd/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/altdd/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/async/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/descriptor/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/descriptor/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/descriptor/jboss-ejb3-md-complete.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/descriptor/jboss-ejb3-md-complete.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/descriptor/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/descriptor/jboss-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb2.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb2.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                   xmlns="http://java.sun.com/xml/ns/javaee"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/eararchive/jboss-ejb3-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                   xmlns="http://java.sun.com/xml/ns/javaee"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/global/jboss-ejb3-global.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/ejb2/reference/global/jboss-ejb3-global.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                   xmlns="http://java.sun.com/xml/ns/javaee"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/bmp/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/entity/exceptions/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2015, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/invocationcontext/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/invocationcontext/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/destroy/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/interceptor/lifecycle/destroy/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/jndi/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/jndi/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/cmt/notsupported/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-20-message-selector.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-20-message-selector.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2014, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-20-topic.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-20-topic.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2014, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-20.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-20.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2014, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-21.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/ejb-jar-21.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2014, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/jboss-ejb3-topic.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/jboss-ejb3-topic.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/jboss-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedestination/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedestination/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedestination/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagedestination/jboss-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                   xmlns="http://java.sun.com/xml/ns/javaee"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/entity/bmp/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/entity/bmp/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/callerprincipal/GetCallerPrincipalTestCase.java
@@ -37,7 +37,7 @@ import javax.jms.TextMessage;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
 
-import junit.framework.Assert;
+import org.junit.Assert;
 
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/partial-ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/partial-ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/concurrency/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/singleton/concurrency/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/database/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/database/jboss-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                   xmlns="http://java.sun.com/xml/ns/javaee"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/entity/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/entity/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/jboss-ejb3-default-timeout.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/jboss-ejb3-default-timeout.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/cmt/timeout/jboss-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/duplicateview/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/view/duplicateview/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestPersistenceProvider.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/classtransformer/TestPersistenceProvider.java
@@ -23,17 +23,13 @@
 package org.jboss.as.test.integration.jpa.mockprovider.classtransformer;
 
 import java.lang.reflect.Proxy;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.spi.PersistenceProvider;
 import javax.persistence.spi.PersistenceUnitInfo;
 import javax.persistence.spi.ProviderUtil;
-
-import org.jboss.as.jpa.container.EntityManagerUnwrappedTargetInvocationHandler;
 
 /**
  * TestPersistenceProvider

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-one.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-one.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2013, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-two.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/shared/ejb-jar-two.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2013, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/context/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/jacc/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ejb-jar xmlns="http://java.sun.com/xml/ns/javaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/testobjects/config/jboss-ejb3.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/xacml/testobjects/config/jboss-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
 	xmlns="http://java.sun.com/xml/ns/javaee" xmlns:s="urn:security"
 	version="3.1" impl-version="2.0">

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jndi/ejb-jar.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/weld/jndi/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/ejb-jar.xml
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/basic/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/security/ejb-jar.xml
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/security/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/ejb-jar.xml
+++ b/testsuite/integration/iiop/src/test/java/org/jboss/as/test/iiop/transaction/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/jboss-ejb3.xml
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/jboss-ejb3.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
                xmlns="http://java.sun.com/xml/ns/javaee"
                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ejb3/dd/ejb-jar.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/ejb3/dd/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/property/ejb-jar.xml
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/property/ejb-jar.xml
@@ -1,4 +1,4 @@
-<?xml version="1.1" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2010, Red Hat, Inc., and individual contributors

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/AbstractValidationUnitTest.java
@@ -35,7 +35,8 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.apache.xerces.dom.DOMInputImpl;
+import org.w3c.dom.bootstrap.DOMImplementationRegistry;
+import org.w3c.dom.ls.DOMImplementationLS;
 import org.w3c.dom.ls.LSInput;
 import org.w3c.dom.ls.LSResourceResolver;
 import org.xml.sax.EntityResolver;
@@ -153,7 +154,13 @@ public class AbstractValidationUnitTest {
     static final LSResourceResolver DEFAULT_RESOURCE_RESOLVER = new LSResourceResolver() {
         @Override
         public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
-            LSInput input = new DOMInputImpl();
+            final DOMImplementationLS impl;
+            try {
+                impl = (DOMImplementationLS) DOMImplementationRegistry.newInstance().getDOMImplementation("LS");
+            } catch (ClassNotFoundException | InstantiationException | IllegalAccessException e) {
+                throw new RuntimeException("could not create LS input" ,e);
+            }
+            LSInput input = impl.createLSInput();
 
             final URL url;
             if (NAMESPACE_MAP.containsKey(systemId)) {


### PR DESCRIPTION
workaround for JDK-8029437 if we ever use JDK xml parsers. Only change is to use xml 1.0 instead of 1.1.
and fix api usage to use standard api for obtaining parsers instead of impl specific one
