### PR TITLE
Replace direct use of JMX subsystem with a capability-based usage in a couple cases

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
@@ -38,7 +38,6 @@
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.ee"/>
         <module name="org.jboss.as.ejb3"/>
-        <module name="org.jboss.as.jmx"/>
         <module name="org.jboss.as.naming"/>
         <module name="org.wildfly.security.elytron"/>
         <module name="org.jboss.as.server"/>

--- a/jsr77/pom.xml
+++ b/jsr77/pom.xml
@@ -52,10 +52,6 @@
         </dependency>
         <dependency>
             <groupId>org.wildfly.core</groupId>
-            <artifactId>wildfly-jmx</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-server</artifactId>
         </dependency>
         <dependency>

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementRootResource.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementRootResource.java
@@ -23,6 +23,7 @@ package org.jboss.as.jsr77.subsystem;
 
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 
 /**
@@ -30,6 +31,11 @@ import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class JSR77ManagementRootResource extends SimpleResourceDefinition {
+
+    static final String JMX_CAPABILITY = "org.wildfly.management.jmx";
+    static final RuntimeCapability<Void> JSR77_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.jsr77")
+            .addRequirements(JMX_CAPABILITY)
+            .build();
 
     static JSR77ManagementRootResource INSTANCE = new JSR77ManagementRootResource();
 

--- a/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemRemove.java
+++ b/jsr77/src/main/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemRemove.java
@@ -38,6 +38,7 @@ class JSR77ManagementSubsystemRemove extends AbstractRemoveStepHandler {
     static JSR77ManagementSubsystemRemove INSTANCE = new JSR77ManagementSubsystemRemove();
 
     private JSR77ManagementSubsystemRemove() {
+        super(JSR77ManagementRootResource.JSR77_CAPABILITY);
     }
 
     @Override

--- a/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
+++ b/jsr77/src/test/java/org/jboss/as/jsr77/subsystem/JSR77ManagementSubsystemTestCase.java
@@ -38,6 +38,8 @@ import org.junit.Test;
  */
 public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest {
 
+    private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities(JSR77ManagementRootResource.JMX_CAPABILITY);
+
     public JSR77ManagementSubsystemTestCase() {
         super(JSR77ManagementExtension.SUBSYSTEM_NAME, new JSR77ManagementExtension());
     }
@@ -45,6 +47,11 @@ public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest 
     @Override
     protected String getSubsystemXml() throws IOException {
         return "<subsystem xmlns=\"urn:jboss:domain:jsr77:1.0\"/>";
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return ADDITIONAL_INITIALIZATION;
     }
 
     @Override
@@ -98,12 +105,13 @@ public class JSR77ManagementSubsystemTestCase extends AbstractSubsystemBaseTest 
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion) throws Exception {
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+        KernelServicesBuilder builder = createKernelServicesBuilder(ADDITIONAL_INITIALIZATION)
                 .setSubsystemXml(getSubsystemXml());
 
         // Add legacy subsystems
         builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-jsr77:" + controllerVersion.getMavenGavVersion());
+                .addMavenResourceURL("org.jboss.as:jboss-as-jsr77:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(ADDITIONAL_INITIALIZATION, null);
 
         KernelServices mainServices = builder.build();
         KernelServices legacyServices = mainServices.getLegacyServices(modelVersion);

--- a/sar/src/main/java/org/jboss/as/service/MBeanServices.java
+++ b/sar/src/main/java/org/jboss/as/service/MBeanServices.java
@@ -28,7 +28,6 @@ import java.util.List;
 import javax.management.MBeanServer;
 
 import org.jboss.as.jmx.MBeanRegistrationService;
-import org.jboss.as.jmx.MBeanServerService;
 import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.SetupAction;
 import org.jboss.as.server.deployment.reflect.ClassReflectionIndex;
@@ -61,21 +60,23 @@ final class MBeanServices {
     private final ServiceBuilder<?> createDestroyServiceBuilder;
     private final ServiceBuilder<?> startStopServiceBuilder;
     private final ServiceTarget target;
+    private final ServiceName mbeanServerServiceName;
     private boolean installed;
 
     private final List<SetupAction> setupActions;
 
     /**
-     *
      * @param mBeanName
      * @param mBeanInstance
      * @param mBeanClassHierarchy
      * @param target
      * @param componentInstantiator
      * @param setupActions the deployment unit's service name
+     * @param mbeanServerServiceName
      */
-    MBeanServices(final String mBeanName, final Object mBeanInstance, final List<ClassReflectionIndex> mBeanClassHierarchy, final ServiceTarget target,ServiceComponentInstantiator componentInstantiator,
-                  final List<SetupAction> setupActions, final ClassLoader mbeanContextClassLoader) {
+    MBeanServices(final String mBeanName, final Object mBeanInstance, final List<ClassReflectionIndex> mBeanClassHierarchy,
+                  final ServiceTarget target, final ServiceComponentInstantiator componentInstantiator,
+                  final List<SetupAction> setupActions, final ClassLoader mbeanContextClassLoader, final ServiceName mbeanServerServiceName) {
         if (mBeanClassHierarchy == null) {
             throw SarLogger.ROOT_LOGGER.nullVar("mBeanName");
         }
@@ -84,6 +85,9 @@ final class MBeanServices {
         }
         if (target == null) {
             throw SarLogger.ROOT_LOGGER.nullVar("target");
+        }
+        if (mbeanServerServiceName == null) {
+            throw SarLogger.ROOT_LOGGER.nullVar("mbeanServerServiceName");
         }
 
         final Method createMethod = ReflectionUtils.getMethod(mBeanClassHierarchy, CREATE_METHOD_NAME, NO_ARGS, false);
@@ -108,6 +112,7 @@ final class MBeanServices {
         this.mBeanName = mBeanName;
         this.target = target;
         this.setupActions = setupActions;
+        this.mbeanServerServiceName = mbeanServerServiceName;
     }
 
     Service<Object> getCreateDestroyService() {
@@ -150,7 +155,7 @@ final class MBeanServices {
         // Add service to register the mbean in the mbean server
         final MBeanRegistrationService<Object> mbeanRegistrationService = new MBeanRegistrationService<Object>(mBeanName, setupActions);
         target.addService(MBeanRegistrationService.SERVICE_NAME.append(mBeanName), mbeanRegistrationService)
-            .addDependency(MBeanServerService.SERVICE_NAME, MBeanServer.class, mbeanRegistrationService.getMBeanServerInjector())
+            .addDependency(mbeanServerServiceName, MBeanServer.class, mbeanRegistrationService.getMBeanServerInjector())
             .addDependency(startStopServiceName, Object.class, mbeanRegistrationService.getValueInjector())
             .install();
 

--- a/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
+++ b/sar/src/main/java/org/jboss/as/service/ParsedServiceDeploymentProcessor.java
@@ -59,6 +59,7 @@ import org.jboss.modules.Module;
 import org.jboss.msc.inject.Injector;
 import org.jboss.msc.inject.MethodInjector;
 import org.jboss.msc.service.Service;
+import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.ImmediateValue;
 import org.jboss.msc.value.MethodValue;
@@ -75,6 +76,13 @@ import org.wildfly.security.manager.WildFlySecurityManager;
  * @author Eduardo Martins
  */
 public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor {
+
+    private final ServiceName mbeanServerServiceName;
+
+    ParsedServiceDeploymentProcessor(ServiceName mbeanServerServiceName) {
+
+        this.mbeanServerServiceName = mbeanServerServiceName;
+    }
 
     /**
      * Process a deployment for JbossService configuration.  Will install a {@code JBossService} for each configured service.
@@ -122,7 +130,7 @@ public class ParsedServiceDeploymentProcessor implements DeploymentUnitProcessor
         final String mBeanName = mBeanConfig.getName();
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
 
-        final MBeanServices mBeanServices = new MBeanServices(mBeanName, mBeanInstance, mBeanClassHierarchy, target, componentInstantiator, deploymentUnit.getAttachmentList(Attachments.SETUP_ACTIONS), classLoader);
+        final MBeanServices mBeanServices = new MBeanServices(mBeanName, mBeanInstance, mBeanClassHierarchy, target, componentInstantiator, deploymentUnit.getAttachmentList(Attachments.SETUP_ACTIONS), classLoader, mbeanServerServiceName);
 
         final JBossServiceDependencyConfig[] dependencyConfigs = mBeanConfig.getDependencyConfigs();
         addDependencies(dependencyConfigs, mBeanClassHierarchy, mBeanServices);

--- a/sar/src/main/java/org/jboss/as/service/SarExtension.java
+++ b/sar/src/main/java/org/jboss/as/service/SarExtension.java
@@ -40,6 +40,7 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
@@ -71,8 +72,14 @@ public class SarExtension implements Extension {
     private static final String RESOURCE_NAME = SarExtension.class.getPackage().getName() + ".LocalDescriptions";
     private static final ResourceDescriptionResolver RESOLVER = new StandardResourceDescriptionResolver("sar", RESOURCE_NAME, SarExtension.class.getClassLoader());
     private static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SarExtension.SUBSYSTEM_NAME);
+
+    static final String JMX_CAPABILITY = "org.wildfly.management.jmx";
+    static final RuntimeCapability<Void> SAR_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.extension.sar-deployment")
+            .addRequirements(JMX_CAPABILITY)
+            .build();
+
     private static final ResourceDefinition RESOURCE_DEFINITION = new SimpleResourceDefinition(PATH, RESOLVER,
-                            SarSubsystemAdd.INSTANCE, ReloadRequiredRemoveStepHandler.INSTANCE,
+                            SarSubsystemAdd.INSTANCE, new ReloadRequiredRemoveStepHandler(SAR_CAPABILITY),
                             OperationEntry.Flag.RESTART_ALL_SERVICES, OperationEntry.Flag.RESTART_ALL_SERVICES);
 
     private static final ModelVersion CURRENT_MODEL_VERSION = ModelVersion.create(1, 0, 0);

--- a/sar/src/main/java/org/jboss/as/service/SarSubsystemAdd.java
+++ b/sar/src/main/java/org/jboss/as/service/SarSubsystemAdd.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.service;
 
+import javax.management.MBeanServer;
+
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.server.AbstractDeploymentChainStep;
@@ -29,6 +31,7 @@ import org.jboss.as.server.DeploymentProcessorTarget;
 import org.jboss.as.server.deployment.Phase;
 import org.jboss.as.service.component.ServiceComponentProcessor;
 import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * @author Emanuel Muckenhuber
@@ -38,22 +41,26 @@ public class SarSubsystemAdd extends AbstractBoottimeAddStepHandler {
     static final SarSubsystemAdd INSTANCE = new SarSubsystemAdd();
 
     private SarSubsystemAdd() {
+        super(SarExtension.SAR_CAPABILITY);
     }
 
     protected void populateModel(ModelNode operation, ModelNode model) {
         model.setEmptyObject();
     }
 
-    protected void performBoottime(OperationContext context, ModelNode operation, ModelNode model) {
+    protected void performBoottime(final OperationContext context, ModelNode operation, ModelNode model) {
 
         context.addStep(new AbstractDeploymentChainStep() {
             public void execute(DeploymentProcessorTarget processorTarget) {
+
+                ServiceName jmxCapability = context.getCapabilityServiceName(SarExtension.JMX_CAPABILITY, MBeanServer.class);
+
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_SAR_SUB_DEPLOY_CHECK, new SarSubDeploymentProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.STRUCTURE, Phase.STRUCTURE_SAR, new SarStructureProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.DEPENDENCIES, Phase.DEPENDENCIES_SAR_MODULE, new SarModuleDependencyProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.PARSE, Phase.PARSE_SERVICE_DEPLOYMENT, new ServiceDeploymentParsingProcessor());
                 processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_SAR_SERVICE_COMPONENT, new ServiceComponentProcessor());
-                processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_SERVICE_DEPLOYMENT, new ParsedServiceDeploymentProcessor());
+                processorTarget.addDeploymentProcessor(SarExtension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_SERVICE_DEPLOYMENT, new ParsedServiceDeploymentProcessor(jmxCapability));
             }
         }, OperationContext.Stage.RUNTIME);
 

--- a/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
+++ b/sar/src/test/java/org/jboss/as/service/SarSubsystemTestCase.java
@@ -39,8 +39,15 @@ import org.junit.Test;
  */
 public class SarSubsystemTestCase extends AbstractSubsystemBaseTest {
 
+    private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities("org.wildfly.management.jmx");
+
     public SarSubsystemTestCase() {
         super(SarExtension.SUBSYSTEM_NAME, new SarExtension());
+    }
+
+    @Override
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return ADDITIONAL_INITIALIZATION;
     }
 
     @Override
@@ -98,12 +105,13 @@ public class SarSubsystemTestCase extends AbstractSubsystemBaseTest {
     private void testTransformers_1_0_0(ModelTestControllerVersion controllerVersion, String commonBeansVersion) throws Exception {
         ModelVersion modelVersion = ModelVersion.create(1, 0, 0);
         //Use the non-runtime version of the extension which will happen on the HC
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT)
+        KernelServicesBuilder builder = createKernelServicesBuilder(ADDITIONAL_INITIALIZATION)
                 .setSubsystemXml(getSubsystemXml());
 
         // Add legacy subsystems
         LegacyKernelServicesInitializer initializer = builder.createLegacyKernelServicesBuilder(null, controllerVersion, modelVersion)
-                .addMavenResourceURL("org.jboss.as:jboss-as-sar:" + controllerVersion.getMavenGavVersion());
+                .addMavenResourceURL("org.jboss.as:jboss-as-sar:" + controllerVersion.getMavenGavVersion())
+                .configureReverseControllerCheck(ADDITIONAL_INITIALIZATION, null);
         if (commonBeansVersion != null) {
             initializer.addMavenResourceURL("org.jboss.common:jboss-common-beans:" + commonBeansVersion);
         }

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -631,6 +631,7 @@
             </subsystem>
         </profile>
         <profile name="ignored">
+            <subsystem xmlns="urn:jboss:domain:jmx:1.0"/>
             <subsystem xmlns="urn:jboss:domain:sar:1.0"/>
         </profile>
         <profile name="minimal">


### PR DESCRIPTION
Commits to use the org.wildfly.management.jmx capability instead of tight coupling for a couple simple subsystems.

There are other subsystems that still use the tightly couple approach, but for those more work is needed.

1) Transactions, webservices: we need to figure out what the dependent capabilities are, as part of a proper design of the contracts exposed by those extensions.
2) Messaging-artemis. Same, but there Jeff Mesnil and I had a pretty good understanding from the HornetQ subsystem and I just need to port the work over to artemis.
3) JGroups and infinispan are complicated as those subsystems do a lot of stuff in custom ways.
