### PR TITLE
Leverage capability API for socket binding dependencies.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/capability/Capability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/capability/Capability.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -20,41 +20,25 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.clustering.jgroups.subsystem;
+package org.jboss.as.clustering.controller.capability;
 
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
-import org.jboss.modules.ModuleIdentifier;
-import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
+import org.jboss.msc.service.ServiceName;
 
 /**
  * @author Paul Ferraro
  */
-public class ProtocolConfigurationBuilder extends AbstractProtocolConfigurationBuilder<ProtocolConfiguration> {
+public enum Capability {
+    OUTBOUND_SOCKET_BINDING("org.wildfly.network.outbound-socket-binding"),
+    SOCKET_BINDING("org.wildfly.network.socket-binding"),
+    ;
+    private final String baseName;
 
-    public ProtocolConfigurationBuilder(CapabilityServiceSupport support, String stackName, String name) {
-        super(support, stackName, name);
+    Capability(String baseName) {
+        this.baseName = baseName;
     }
 
-    @Override
-    public ProtocolConfigurationBuilder setModule(ModuleIdentifier module) {
-        super.setModule(module);
-        return this;
-    }
-
-    @Override
-    public ProtocolConfigurationBuilder setSocketBinding(String socketBindingName) {
-        super.setSocketBinding(socketBindingName);
-        return this;
-    }
-
-    @Override
-    public ProtocolConfigurationBuilder addProperty(String name, String value) {
-        super.addProperty(name, value);
-        return this;
-    }
-
-    @Override
-    public ProtocolConfiguration getValue() {
-        return this;
+    public ServiceName getServiceName(CapabilityServiceSupport support, String name) {
+        return support.getCapabilityServiceName(this.baseName, name);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheAddHandler.java
@@ -47,6 +47,7 @@ import org.infinispan.persistence.remote.configuration.RemoteStoreConfigurationB
 import org.infinispan.transaction.LockingMode;
 import org.infinispan.util.concurrent.IsolationLevel;
 import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.clustering.controller.capability.Capability;
 import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.clustering.infinispan.InfinispanLogger;
 import org.jboss.as.clustering.naming.BinderServiceBuilder;
@@ -391,7 +392,7 @@ public class CacheAddHandler extends AbstractAddStepHandler {
                             // Do nothing
                         }
                     };
-                    configBuilder.addDependency(OutboundSocketBinding.OUTBOUND_SOCKET_BINDING_BASE_SERVICE_NAME.append(outboundSocketBinding), OutboundSocketBinding.class, injector);
+                    configBuilder.addDependency(Capability.OUTBOUND_SOCKET_BINDING.getServiceName(context.getCapabilityServiceSupport(), outboundSocketBinding), OutboundSocketBinding.class, injector);
                 }
                 builder.remoteCacheName(RemoteStoreResourceDefinition.CACHE.resolveModelAttribute(context, store).asString());
                 builder.socketTimeout(RemoteStoreResourceDefinition.SOCKET_TIMEOUT.resolveModelAttribute(context, store).asLong());

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
@@ -112,6 +112,7 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition {
             .setDeprecated(InfinispanModel.VERSION_3_0_0.getVersion())
             .build();
 
+    @Deprecated
     static final SimpleAttributeDefinition START = new SimpleAttributeDefinitionBuilder(ModelKeys.START, ModelType.STRING, true)
             .setXmlName(Attribute.START.getLocalName())
             .setAllowExpression(true)

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
@@ -107,6 +107,7 @@ public class StoreResourceDefinition extends SimpleResourceDefinition {
 
     private final boolean allowRuntimeOnlyRegistration;
 
+    @SuppressWarnings("deprecation")
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
         if (InfinispanModel.VERSION_3_0_0.requiresTransformation(version)) {
             OperationTransformer putPropertyTransformer = new OperationTransformer() {
@@ -161,6 +162,7 @@ public class StoreResourceDefinition extends SimpleResourceDefinition {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void registerChildren(ManagementResourceRegistration registration) {
         // child resources

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionResourceDefinition.java
@@ -99,6 +99,7 @@ public class TransactionResourceDefinition extends SimpleResourceDefinition {
 
     private final boolean allowRuntimeOnlyRegistration;
 
+    @SuppressWarnings("deprecation")
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder builder = parent.addChildResource(PATH);
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolConfigurationBuilder.java
@@ -25,6 +25,8 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jboss.as.clustering.controller.capability.Capability;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceBuilder;
@@ -44,6 +46,7 @@ import org.wildfly.clustering.service.ValueDependency;
  */
 public abstract class AbstractProtocolConfigurationBuilder<P extends ProtocolConfiguration> implements Builder<P>, Value<P>, ProtocolConfiguration {
 
+    final CapabilityServiceSupport support;
     final String stackName;
     final String name;
 
@@ -51,7 +54,8 @@ public abstract class AbstractProtocolConfigurationBuilder<P extends ProtocolCon
     private ModuleIdentifier module = ProtocolConfiguration.DEFAULT_MODULE;
     private ValueDependency<SocketBinding> socketBinding;
 
-    public AbstractProtocolConfigurationBuilder(String stackName, String name) {
+    public AbstractProtocolConfigurationBuilder(CapabilityServiceSupport support, String stackName, String name) {
+        this.support = support;
         this.stackName = stackName;
         this.name = name;
     }
@@ -77,7 +81,7 @@ public abstract class AbstractProtocolConfigurationBuilder<P extends ProtocolCon
 
     public AbstractProtocolConfigurationBuilder<P> setSocketBinding(String socketBindingName) {
         if (socketBindingName != null) {
-            this.socketBinding = new InjectedValueDependency<>(SocketBinding.JBOSS_BINDING_NAME.append(socketBindingName), SocketBinding.class);
+            this.socketBinding = new InjectedValueDependency<>(Capability.SOCKET_BINDING.getServiceName(this.support, socketBindingName), SocketBinding.class);
         }
         return this;
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelAddHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelAddHandler.java
@@ -106,7 +106,7 @@ public class ChannelAddHandler extends AbstractAddStepHandler {
         new BinderServiceBuilder<>(JGroupsBindingFactory.createChannelBinding(name), ChannelServiceName.CHANNEL.getServiceName(name), Channel.class).build(target).install();
 
         // Install fork channel factory
-        new ForkChannelFactoryBuilder(name).build(target).install();
+        new ForkChannelFactoryBuilder(context.getCapabilityServiceSupport(), name).build(target).install();
 
         // Install fork channel factory jndi binding
         new BinderServiceBuilder<>(JGroupsBindingFactory.createChannelFactoryBinding(name), ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(name), ChannelFactory.class).build(target).install();

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkAddHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkAddHandler.java
@@ -66,7 +66,7 @@ public class ForkAddHandler extends AbstractAddStepHandler {
 
         ServiceTarget target = context.getServiceTarget();
 
-        ForkChannelFactoryBuilder builder = new ForkChannelFactoryBuilder(name);
+        ForkChannelFactoryBuilder builder = new ForkChannelFactoryBuilder(context.getCapabilityServiceSupport(), name);
 
         if (model.hasDefined(ProtocolResourceDefinition.WILDCARD_PATH.getKey())) {
             for (Property property : model.get(ProtocolResourceDefinition.WILDCARD_PATH.getKey()).asPropertyList()) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkChannelFactoryBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkChannelFactoryBuilder.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.jboss.as.clustering.jgroups.ForkChannelFactory;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
@@ -48,12 +49,14 @@ import org.wildfly.clustering.service.ValueDependency;
  */
 public class ForkChannelFactoryBuilder implements Builder<ChannelFactory>, Value<ChannelFactory> {
 
+    private final CapabilityServiceSupport support;
     private final String channelName;
     private final InjectedValue<Channel> parentChannel = new InjectedValue<>();
     private final InjectedValue<ChannelFactory> parentFactory = new InjectedValue<>();
     private final List<ValueDependency<ProtocolConfiguration>> protocols = new LinkedList<>();
 
-    public ForkChannelFactoryBuilder(String channelName) {
+    public ForkChannelFactoryBuilder(CapabilityServiceSupport support, String channelName) {
+        this.support = support;
         this.channelName = channelName;
     }
 
@@ -81,7 +84,7 @@ public class ForkChannelFactoryBuilder implements Builder<ChannelFactory>, Value
     }
 
     public ProtocolConfigurationBuilder addProtocol(String type) {
-        ProtocolConfigurationBuilder builder = new ProtocolConfigurationBuilder(this.channelName, type);
+        ProtocolConfigurationBuilder builder = new ProtocolConfigurationBuilder(this.support, this.channelName, type);
         this.protocols.add(new InjectedValueDependency<>(builder, ProtocolConfiguration.class));
         return builder;
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JChannelFactoryBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JChannelFactoryBuilder.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.jboss.as.clustering.jgroups.JChannelFactory;
 import org.jboss.as.clustering.jgroups.ProtocolDefaults;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.as.server.ServerEnvironmentService;
 import org.jboss.as.server.Services;
@@ -57,6 +58,7 @@ import org.wildfly.clustering.service.ValueDependency;
  */
 public class JChannelFactoryBuilder implements Builder<ChannelFactory>, Value<ChannelFactory>, ProtocolStackConfiguration {
 
+    private final CapabilityServiceSupport support;
     private final InjectedValue<ProtocolDefaults> defaults = new InjectedValue<>();
     private final InjectedValue<ServerEnvironment> environment = new InjectedValue<>();
     private final InjectedValue<ModuleLoader> loader = new InjectedValue<>();
@@ -65,7 +67,8 @@ public class JChannelFactoryBuilder implements Builder<ChannelFactory>, Value<Ch
     private final List<ValueDependency<ProtocolConfiguration>> protocols = new LinkedList<>();
     private ValueDependency<RelayConfiguration> relay = null;
 
-    public JChannelFactoryBuilder(String name) {
+    public JChannelFactoryBuilder(CapabilityServiceSupport support, String name) {
+        this.support = support;
         this.name = name;
     }
 
@@ -99,19 +102,19 @@ public class JChannelFactoryBuilder implements Builder<ChannelFactory>, Value<Ch
     }
 
     public TransportConfigurationBuilder setTransport(String type) {
-        TransportConfigurationBuilder builder = new TransportConfigurationBuilder(this.name, type);
+        TransportConfigurationBuilder builder = new TransportConfigurationBuilder(this.support, this.name, type);
         this.transport = new InjectedValueDependency<>(builder, TransportConfiguration.class);
         return builder;
     }
 
     public ProtocolConfigurationBuilder addProtocol(String type) {
-        ProtocolConfigurationBuilder builder = new ProtocolConfigurationBuilder(this.name, type);
+        ProtocolConfigurationBuilder builder = new ProtocolConfigurationBuilder(this.support, this.name, type);
         this.protocols.add(new InjectedValueDependency<>(builder, ProtocolConfiguration.class));
         return builder;
     }
 
     public RelayConfigurationBuilder setRelay(String site) {
-        RelayConfigurationBuilder builder = new RelayConfigurationBuilder(this.name).setSiteName(site);
+        RelayConfigurationBuilder builder = new RelayConfigurationBuilder(this.support, this.name).setSiteName(site);
         this.relay = new InjectedValueDependency<>(builder, RelayConfiguration.class);
         return builder;
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
@@ -265,6 +265,7 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void parseTransport(XMLExtendedStreamReader reader, PathAddress stackAddress, Map<PathAddress, ModelNode> operations) throws XMLStreamException {
 
         String type = require(reader, Attribute.TYPE);
@@ -470,6 +471,7 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
         }
     }
 
+    @SuppressWarnings("deprecation")
     private void parseRemoteSite(XMLExtendedStreamReader reader, PathAddress relayAddress, Map<PathAddress, ModelNode> operations) throws XMLStreamException {
         String site = require(reader, Attribute.NAME);
         PathAddress address = relayAddress.append(RemoteSiteResourceDefinition.pathElement(site));

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLWriter.java
@@ -100,6 +100,7 @@ public class JGroupsSubsystemXMLWriter implements XMLElementWriter<SubsystemMars
         writer.writeEndElement();
     }
 
+    @SuppressWarnings("deprecation")
     private static void writeTransport(XMLExtendedStreamWriter writer, Property property) throws XMLStreamException {
         writer.writeStartElement(Element.TRANSPORT.getLocalName());
         writeProtocolAttributes(writer, property);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -99,6 +99,7 @@ public class ProtocolResourceDefinition extends SimpleResourceDefinition {
 
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { TYPE, MODULE, SOCKET_BINDING, PROPERTIES };
 
+    @SuppressWarnings("deprecation")
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder builder = parent.addChildResource(WILDCARD_PATH);
 
@@ -107,7 +108,6 @@ public class ProtocolResourceDefinition extends SimpleResourceDefinition {
         if (JGroupsModel.VERSION_3_0_0.requiresTransformation(version)) {
             // Translate /subsystem=jgroups/stack=*/protocol=*:add() -> /subsystem=jgroups/stack=*:add-protocol()
             OperationTransformer addTransformer = new OperationTransformer() {
-                @SuppressWarnings("deprecation")
                 @Override
                 public ModelNode transformOperation(ModelNode operation) {
                     PathAddress address = Operations.getPathAddress(operation);
@@ -119,7 +119,6 @@ public class ProtocolResourceDefinition extends SimpleResourceDefinition {
 
             // Translate /subsystem=jgroups/stack=*/protocol=*:remove() -> /subsystem=jgroups/stack=*:remove-protocol()
             OperationTransformer removeTransformer = new OperationTransformer() {
-                @SuppressWarnings("deprecation")
                 @Override
                 public ModelNode transformOperation(ModelNode operation) {
                     PathAddress address = Operations.getPathAddress(operation);
@@ -139,6 +138,7 @@ public class ProtocolResourceDefinition extends SimpleResourceDefinition {
     /*
      * Builds transformations common to both protocols and transport.
      */
+    @SuppressWarnings("deprecation")
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
 
         if (JGroupsModel.VERSION_3_0_0.requiresTransformation(version)) {
@@ -207,6 +207,7 @@ public class ProtocolResourceDefinition extends SimpleResourceDefinition {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void registerChildren(ManagementResourceRegistration registration) {
         registration.registerSubModel(new PropertyResourceDefinition());

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RelayConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RelayConfigurationBuilder.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
@@ -45,8 +46,8 @@ public class RelayConfigurationBuilder extends AbstractProtocolConfigurationBuil
     private final List<ValueDependency<RemoteSiteConfiguration>> sites = new LinkedList<>();
     private String siteName = null;
 
-    public RelayConfigurationBuilder(String stackName) {
-        super(stackName, RelayConfiguration.PROTOCOL_NAME);
+    public RelayConfigurationBuilder(CapabilityServiceSupport support, String stackName) {
+        super(support, stackName, RelayConfiguration.PROTOCOL_NAME);
     }
 
     @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RelayResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RelayResourceDefinition.java
@@ -53,6 +53,7 @@ public class RelayResourceDefinition extends SimpleResourceDefinition {
 
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] { SITE, ProtocolResourceDefinition.PROPERTIES };
 
+    @SuppressWarnings("deprecation")
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder builder = parent.addChildResource(PATH);
 
@@ -72,6 +73,7 @@ public class RelayResourceDefinition extends SimpleResourceDefinition {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void registerChildren(ManagementResourceRegistration registration) {
         registration.registerSubModel(new RemoteSiteResourceDefinition());

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackAddHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackAddHandler.java
@@ -66,7 +66,7 @@ public class StackAddHandler extends AbstractAddStepHandler {
         String rack = ModelNodes.asString(TransportResourceDefinition.RACK.resolveModelAttribute(context, transport));
         String site = ModelNodes.asString(TransportResourceDefinition.SITE.resolveModelAttribute(context, transport));
 
-        JChannelFactoryBuilder builder = new JChannelFactoryBuilder(name);
+        JChannelFactoryBuilder builder = new JChannelFactoryBuilder(context.getCapabilityServiceSupport(), name);
         TransportConfigurationBuilder transportBuilder = builder.setTransport(type)
                 .setModule(ModelNodes.asModuleIdentifier(ProtocolResourceDefinition.MODULE.resolveModelAttribute(context, transport)))
                 .setShared(TransportResourceDefinition.SHARED.resolveModelAttribute(context, transport).asBoolean())
@@ -121,16 +121,16 @@ public class StackAddHandler extends AbstractAddStepHandler {
         context.removeService(ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(name));
 
         Property transport = model.get(TransportResourceDefinition.WILDCARD_PATH.getKey()).asProperty();
-        context.removeService(new TransportConfigurationBuilder(name, transport.getName()).getServiceName());
+        context.removeService(new TransportConfigurationBuilder(context.getCapabilityServiceSupport(), name, transport.getName()).getServiceName());
 
         if (model.hasDefined(ProtocolResourceDefinition.WILDCARD_PATH.getKey())) {
             for (Property protocol : model.get(ProtocolResourceDefinition.WILDCARD_PATH.getKey()).asPropertyList()) {
-                context.removeService(new ProtocolConfigurationBuilder(name, protocol.getName()).getServiceName());
+                context.removeService(new ProtocolConfigurationBuilder(context.getCapabilityServiceSupport(), name, protocol.getName()).getServiceName());
             }
         }
 
         if (model.hasDefined(RelayResourceDefinition.PATH.getKey())) {
-            context.removeService(new RelayConfigurationBuilder(name).getServiceName());
+            context.removeService(new RelayConfigurationBuilder(context.getCapabilityServiceSupport(), name).getServiceName());
             ModelNode relay = model.get(RelayResourceDefinition.PATH.getKeyValuePair());
             if (relay.hasDefined(RemoteSiteResourceDefinition.WILDCARD_PATH.getKey())) {
                 for (Property remoteSite: relay.get(RemoteSiteResourceDefinition.WILDCARD_PATH.getKey()).asPropertyList()) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
@@ -117,6 +117,7 @@ public class StackResourceDefinition extends SimpleResourceDefinition {
         this.allowRuntimeOnlyRegistration = allowRuntimeOnlyRegistration;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void registerOperations(ManagementResourceRegistration registration) {
         super.registerOperations(registration);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import org.jboss.as.clustering.controller.capability.Capability;
+import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.modules.ModuleIdentifier;
 import org.jboss.msc.service.ServiceBuilder;
@@ -39,8 +41,8 @@ public class TransportConfigurationBuilder extends AbstractProtocolConfiguration
     private boolean shared = TransportResourceDefinition.SHARED.getDefaultValue().asBoolean();
     private Topology topology = null;
 
-    public TransportConfigurationBuilder(String stackName, String name) {
-        super(stackName, name);
+    public TransportConfigurationBuilder(CapabilityServiceSupport support, String stackName, String name) {
+        super(support, stackName, name);
     }
 
     @Override
@@ -77,7 +79,7 @@ public class TransportConfigurationBuilder extends AbstractProtocolConfiguration
 
     public TransportConfigurationBuilder setDiagnosticsSocket(String socketBindingName) {
         if (socketBindingName != null) {
-            this.diagnosticsSocketBinding = new InjectedValueDependency<>(SocketBinding.JBOSS_BINDING_NAME.append(socketBindingName), SocketBinding.class);
+            this.diagnosticsSocketBinding = new InjectedValueDependency<>(Capability.SOCKET_BINDING.getServiceName(this.support, socketBindingName), SocketBinding.class);
         }
         return this;
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -128,11 +128,13 @@ public class TransportResourceDefinition extends SimpleResourceDefinition {
             .build();
 
     // the list of attributes used by the transport resource
+    @SuppressWarnings("deprecation")
     static final AttributeDefinition[] ATTRIBUTES = new AttributeDefinition[] {
             ProtocolResourceDefinition.TYPE, ProtocolResourceDefinition.MODULE, SHARED, ProtocolResourceDefinition.SOCKET_BINDING, DIAGNOSTICS_SOCKET_BINDING,
             ProtocolResourceDefinition.PROPERTIES, DEFAULT_EXECUTOR, OOB_EXECUTOR, TIMER_EXECUTOR, THREAD_FACTORY, SITE, RACK, MACHINE
     };
 
+    @SuppressWarnings("deprecation")
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder builder = parent.addChildResource(WILDCARD_PATH);
 
@@ -184,6 +186,7 @@ public class TransportResourceDefinition extends SimpleResourceDefinition {
         }
     }
 
+    @SuppressWarnings("deprecation")
     @Override
     public void registerChildren(ManagementResourceRegistration registration) {
         registration.registerSubModel(new PropertyResourceDefinition());


### PR DESCRIPTION
Eliminate usage of deprecated API where possible.  Suppress warnings where applicable.
