### PR TITLE
fix intermittent failures on JMSTopicManagementTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSTopicManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSTopicManagementTestCase.java
@@ -28,7 +28,6 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.VALUE;
 import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.operations.common.Util.getEmptyOperation;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.IOException;
 
@@ -90,7 +89,7 @@ public class JMSTopicManagementTestCase {
     public void before() throws Exception {
         cf = (ConnectionFactory) remoteContext.lookup("jms/RemoteConnectionFactory");
 
-        adminSupport = JMSOperationsProvider.getInstance(managementClient);
+        adminSupport = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
         count++;
 
         adminSupport.createJmsTopic(getTopicName(), EXPORTED_PREFIX + getTopicJndiName());
@@ -417,11 +416,6 @@ public class JMSTopicManagementTestCase {
 
         // remove the topic
         adminSupport.removeJmsTopic(getTopicName());
-        try {
-            consumer.receive(5000);
-            fail("consumer is not valid after the queue is removed");
-        } catch (javax.jms.IllegalStateException e) {
-        }
         // add the topic
         adminSupport.createJmsTopic(getTopicName(), getTopicJndiName());
         // and recreate the durable subscriber to check all the messages have


### PR DESCRIPTION
Remove assertion that a consumer can not receive a message after the
topic is closed. There is a time window where the messaging client may
not have been advertised that the topic has been removed and the
consumer must be closed.
This assertion is not relevant to the tests. Ensuring that removing and
adding back the same topic removes all stored messages is enough
