### PR TITLE
[WFLY-4853] A two cluster test case for EJBClient

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -508,7 +508,89 @@
                 </plugins>
             </build>
         </profile>
-        
+
+        <profile>
+            <id>ts.clustering.two.clusters.profile</id>
+            <activation><property><name>!ts.noClustering</name></property></activation>
+
+            <!--
+                Server configuration executions.
+            -->
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions combine.children="append">
+                            <execution>
+                                <id>ts.config-as.clustering.two.clusters</id>
+                                <phase>process-test-resources</phase>
+                                <goals><goal>run</goal></goals>
+                                <configuration>
+                                    <target>
+                                        <echo>Creating two clusters configurations</echo>
+                                        <!-- Build the UDP server configs in target/ . -->
+                                        <!-- this configuration uses one interface and port offsets -->
+                                        <ant antfile="${basedir}/../src/test/scripts/clustering-build.xml">
+                                            <property name="node0" value="${node0}"/>
+                                            <property name="node1" value="${node1}"/>
+                                            <property name="node2" value="${node2}"/>
+                                            <property name="node3" value="${node3}"/>
+                                            <property name="mcast-clusterA" value="${mcast}"/>
+                                            <property name="mcast-clusterB" value="${mcast1}"/>
+                                            <property name="mcast-mping" value="${mcast2}"/>
+                                            <property name="mcast.ttl" value="${mcast.ttl}"/>
+                                            <target name="build-clustering-two-clusters"/>
+                                        </ant>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!--
+                       Surefire test executions.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions combine.children="append">
+
+                            <!-- Disable default-test execution. -->
+                            <execution>
+                                <id>default-test</id>
+                                <goals><goal>test</goal></goals>
+                                <phase>none</phase>
+                            </execution>
+
+                            <!-- Single node clustering tests. -->
+                            <execution>
+                                <id>ts.surefire.clustering.two.clusters</id>
+                                <phase>test</phase>
+                                <goals><goal>test</goal></goals>
+                                <configuration>
+                                    <!-- Tests to execute. -->
+                                    <includes>
+                                        <include>org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java</include>
+                                    </includes>
+
+                                    <!-- Parameters to test cases. -->
+                                    <systemPropertyVariables combine.children="append">
+                                        <arquillian.launch>clustering-two-clusters</arquillian.launch>
+                                        <jboss.server.config.file.name>standalone-ha.xml</jboss.server.config.file.name>
+                                        <stack>udp</stack>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+
+
         <profile>
             <id>ts.clustering.session-db-persistence.profile</id>
             <activation>

--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -511,7 +511,7 @@
 
         <profile>
             <id>ts.clustering.two.clusters.profile</id>
-            <activation><property><name>!ts.noClustering</name></property></activation>
+            <activation><property><name>extendedTests</name></property></activation>
 
             <!--
                 Server configuration executions.

--- a/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/clustering/src/test/config/arq/arquillian.xml
@@ -248,4 +248,63 @@
             </configuration>
         </container>
     </group>
+
+    <group qualifier="clustering-two-clusters">
+
+        <container qualifier="container-0" mode="custom" managed="false" default="true">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clusterA-node0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clusterA-node0 -Djboss.node.name=clusterA-node0</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node0}</property>
+                <property name="managementPort">${as.managementPort:9990}</property>
+
+                <property name="waitForPorts">${as.debug.port:8787} ${as.managementPort:9999}</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-1" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clusterA-node1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clusterA-node1 -Djboss.node.name=clusterA-node1 -Djboss.port.offset=100</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node1}</property>
+                <property name="managementPort">10090</property>
+
+                <property name="waitForPorts">${as.debug.port.node1} 10099</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-2" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clusterB-node0</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clusterB-node0 -Djboss.node.name=clusterB-node0 -Djboss.port.offset=200</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node2}</property>
+                <property name="managementPort">10190</property>
+
+                <property name="waitForPorts">${as.debug.port.node2} 10199</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+
+        <container qualifier="container-3" mode="custom" managed="false">
+            <configuration>
+                <property name="jbossHome">${basedir}/target/wildfly-clusterB-node1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/wildfly-clusterB-node1 -Djboss.node.name=clusterB-node1 -Djboss.port.offset=300</property>
+                <property name="serverConfig">${jboss.server.config.file.name}</property>
+                <property name="jbossArguments">${jboss.args}</property>
+                <property name="managementAddress">${node3}</property>
+                <property name="managementPort">10290</property>
+
+                <property name="waitForPorts">${as.debug.port.node3} 10299</property>
+                <property name="waitForPortsTimeoutInSeconds">8</property>
+            </configuration>
+        </container>
+    </group>
 </arquillian>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ExtendedClusteringTestConstants.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ExtendedClusteringTestConstants.java
@@ -36,26 +36,26 @@ public interface ExtendedClusteringTestConstants extends ClusteringTestConstants
      */
     String CONTAINER_3 = "container-2";
     String CONTAINER_4 = "container-3";
-    String[] XSITE_CONTAINERS = new String[] { CONTAINER_1, CONTAINER_2, CONTAINER_3, CONTAINER_4 };
+    String[] EXTENDED_CONTAINERS = new String[] { CONTAINER_1, CONTAINER_2, CONTAINER_3, CONTAINER_4 };
 
     /**
      * Deployment names.
      */
     String DEPLOYMENT_3 = "deployment-2";
     String DEPLOYMENT_4 = "deployment-3";
-    String[] XSITE_DEPLOYMENTS = new String[] { DEPLOYMENT_1, DEPLOYMENT_2, DEPLOYMENT_3, DEPLOYMENT_4 };
+    String[] EXTENDED_DEPLOYMENTS = new String[] { DEPLOYMENT_1, DEPLOYMENT_2, DEPLOYMENT_3, DEPLOYMENT_4 };
 
     /**
      * Some helper deployment names.
      */
     String DEPLOYMENT_HELPER_3 = "deployment-helper-2";
     String DEPLOYMENT_HELPER_4 = "deployment-helper-3";
-    String[] XSITE_DEPLOYMENT_HELPERS = new String[] { DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2, DEPLOYMENT_HELPER_3, DEPLOYMENT_HELPER_4 };
+    String[] EXTENDED_DEPLOYMENT_HELPERS = new String[] { DEPLOYMENT_HELPER_1, DEPLOYMENT_HELPER_2, DEPLOYMENT_HELPER_3, DEPLOYMENT_HELPER_4 };
 
     /**
      * Node names passed in arquillian.xml via -Djboss.node.name property.
      */
     String NODE_3 = "node-2";
     String NODE_4 = "node-3";
-    String[] XSITE_NODES = new String[] { NODE_1, NODE_2 , NODE_3, NODE_4};
+    String[] EXTENDED_NODES = new String[] { NODE_1, NODE_2 , NODE_3, NODE_4};
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ExtendedClusterAbstractTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ExtendedClusterAbstractTestCase.java
@@ -38,7 +38,8 @@ public abstract class ExtendedClusterAbstractTestCase extends ClusterAbstractTes
     }
 
     @Override
-    public void afterTestMethod() {
+    public void afterTestMethod()
+    {
         this.start(EXTENDED_CONTAINERS);
         this.undeploy(EXTENDED_DEPLOYMENTS);
     }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ExtendedClusterAbstractTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ExtendedClusterAbstractTestCase.java
@@ -33,14 +33,14 @@ public abstract class ExtendedClusterAbstractTestCase extends ClusterAbstractTes
 
     @Override
     public void beforeTestMethod() {
-        this.start(XSITE_CONTAINERS);
-        this.deploy(XSITE_DEPLOYMENTS);
+        this.start(EXTENDED_CONTAINERS);
+        this.deploy(EXTENDED_DEPLOYMENTS);
     }
 
     @Override
     public void afterTestMethod() {
-        this.start(XSITE_CONTAINERS);
-        this.undeploy(XSITE_DEPLOYMENTS);
+        this.start(EXTENDED_CONTAINERS);
+        this.undeploy(EXTENDED_DEPLOYMENTS);
     }
 }
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
@@ -187,7 +187,6 @@ public class RemoteEJBTwoClusterTestCase extends ExtendedClusterAbstractTestCase
     /*
      * Tests concurrent fail-over with a managed transaction context on the forwarder.
      */
-    @Ignore("See EJBCLIENT-137")
     @Test
     @InSequence(2)
     public void testConcurrentFailoverOverWithTransactions() throws Exception {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/RemoteEJBTwoClusterTestCase.java
@@ -1,0 +1,347 @@
+package org.jboss.as.test.clustering.twoclusters;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.as.test.clustering.EJBClientContextSelector;
+import org.jboss.as.test.clustering.ejb.EJBDirectory;
+import org.jboss.as.test.clustering.ejb.RemoteEJBDirectory;
+import org.jboss.as.test.clustering.cluster.ExtendedClusterAbstractTestCase;
+import org.jboss.as.test.clustering.twoclusters.bean.SerialBean;
+import org.jboss.as.test.clustering.twoclusters.bean.common.CommonStatefulSB;
+import org.jboss.as.test.clustering.twoclusters.bean.forwarding.AbstractForwardingStatefulSBImpl;
+import org.jboss.as.test.clustering.twoclusters.bean.forwarding.ForwardingStatefulSBImpl;
+import org.jboss.as.test.clustering.twoclusters.bean.forwarding.NonTxForwardingStatefulSBImpl;
+import org.jboss.as.test.clustering.twoclusters.bean.stateful.RemoteStatefulSB;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.ejb.client.ContextSelector;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.naming.NamingException;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Test EJBClient functionality across two clusters with fail-over.
+ * <p/>
+ * A client makes an invocation on one clustered app (on cluster A) which in turn
+ * forwards the invocation on a second clustered app (on cluster B).
+ * <p/>
+ * cluster A = {node0, node1}
+ * cluster B = {node2, node3}
+ * <p/>
+ * Under constant client load, we stop and then restart individual servers.
+ * <p/>
+ * We expect that client invocations will not be affected.
+ *
+ * @author Richard Achmatowicz
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class RemoteEJBTwoClusterTestCase extends ExtendedClusterAbstractTestCase {
+
+    private static final Logger logger = Logger.getLogger(RemoteEJBTwoClusterTestCase.class);
+    private static final String FORWARDER_MODULE_NAME = "clusterbench-ee6-ejb-forwarder";
+    private static final String RECEIVER_MODULE_NAME = "clusterbench-ee6-ejb";
+    // EJBClient configuartion to cluster A
+    private static final String FORWARDER_CLIENT_PROPERTIES = "org/jboss/as/test/clustering/twoclusters/forwarder-jboss-ejb-client.properties";
+
+    private static long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
+    private static long FAILURE_FREE_TIME = TimeoutUtil.adjust(5000);
+    // 200 ms keeps the test stable
+    private static long INVOCATION_WAIT = TimeoutUtil.adjust(200);
+    private static long SERVER_DOWN_TIME = TimeoutUtil.adjust(5000);
+    // allowed percentage of exceptions (exceptions / invocations)
+    private static double EXCEPTION_PERCENTAGE = 0.1;
+    private static boolean useTransactions = true;
+
+    private static EJBDirectory directory;
+
+    @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_1)
+    public static Archive<?> deployment0() {
+        if (useTransactions)
+            return getTxForwardingDeployment();
+        else
+            return getNonTxForwardingDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_2, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_2)
+    public static Archive<?> deployment1() {
+        if (useTransactions)
+            return getTxForwardingDeployment();
+        else
+            return getNonTxForwardingDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_3, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_3)
+    public static Archive<?> deployment2() {
+        return getNonForwardingDeployment();
+    }
+
+    @Deployment(name = DEPLOYMENT_4, managed = false, testable = false)
+    @TargetsContainer(CONTAINER_4)
+    public static Archive<?> deployment3() {
+        return getNonForwardingDeployment();
+    }
+
+    private static Archive<?> getTxForwardingDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, FORWARDER_MODULE_NAME + ".jar");
+        ejbJar.addPackage(CommonStatefulSB.class.getPackage());
+        ejbJar.addPackage(RemoteStatefulSB.class.getPackage());
+        ejbJar.addClass(SerialBean.class.getName());
+        // the forwarding classes
+        ejbJar.addClass(AbstractForwardingStatefulSBImpl.class.getName());
+        ejbJar.addPackage(ForwardingStatefulSBImpl.class.getPackage());
+        // remote outbound connection configuration
+        ejbJar.addAsManifestResource(RemoteEJBTwoClusterTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        log.info(ejbJar.toString(true));
+        return ejbJar;
+    }
+
+    private static Archive<?> getNonTxForwardingDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, FORWARDER_MODULE_NAME + ".jar");
+        ejbJar.addPackage(CommonStatefulSB.class.getPackage());
+        ejbJar.addPackage(RemoteStatefulSB.class.getPackage());
+        ejbJar.addClass(SerialBean.class.getName());
+        // the forwarding classes
+        ejbJar.addClass(AbstractForwardingStatefulSBImpl.class.getName());
+        ejbJar.addClass(NonTxForwardingStatefulSBImpl.class.getName());
+        // remote outbound connection configuration
+        ejbJar.addAsManifestResource(RemoteEJBTwoClusterTestCase.class.getPackage(), "jboss-ejb-client.xml", "jboss-ejb-client.xml");
+        log.info(ejbJar.toString(true));
+        return ejbJar;
+    }
+
+    private static Archive<?> getNonForwardingDeployment() {
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, RECEIVER_MODULE_NAME + ".jar");
+        ejbJar.addPackage(CommonStatefulSB.class.getPackage());
+        ejbJar.addPackage(RemoteStatefulSB.class.getPackage());
+        ejbJar.addClass(SerialBean.class.getName());
+        log.info(ejbJar.toString(true));
+        return ejbJar;
+    }
+
+    /*
+     * In the test case framework:
+     * - containers are deployed by the framework before any test runs
+     * - containers are undeployed by the test case itself
+     * - deployments are deployed by the test case itself
+     * - deployments are undeployed by the test case itself
+     */
+
+    @BeforeClass
+    public static void beforeTest() throws NamingException {
+
+        directory = new RemoteEJBDirectory(FORWARDER_MODULE_NAME);
+    }
+
+    @AfterClass
+    public static void destroy() throws NamingException {
+        directory.close();
+    }
+
+    @After
+    public void afterTest() throws Exception {
+    }
+
+    /*
+     * Tests that EJBClient invocations on stateful session beans can still successfully be processed
+     * as long as one node in each cluster is available.
+     *
+     */
+    @Test
+    @InSequence(1)
+    public void testConcurrentFailoverOverTwoClusters() throws Exception {
+        ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(FORWARDER_CLIENT_PROPERTIES);
+
+        try {
+            try {
+                // get the forwarder deployment on cluster A
+                RemoteStatefulSB bean = null;
+                if (useTransactions)
+                    bean = directory.lookupStateful(ForwardingStatefulSBImpl.class, RemoteStatefulSB.class);
+                else
+                    bean = directory.lookupStateful(NonTxForwardingStatefulSBImpl.class, RemoteStatefulSB.class);
+
+                AtomicInteger count = new AtomicInteger();
+
+                // Allow sufficient time for client to receive full topology
+                logger.info("Waiting for clusters to form:");
+                Thread.sleep(CLIENT_TOPOLOGY_UPDATE_WAIT);
+
+                int newSerialValue = bean.getSerialAndIncrement();
+                int newCountValue = count.getAndIncrement();
+                logger.info("First invocation: count = " + newCountValue + ", serial = " + newSerialValue);
+
+                //
+                ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+                CountDownLatch latch = new CountDownLatch(1);
+                ClientInvocationTask client = new ClientInvocationTask(bean, latch, count);
+
+                try {
+                    // set up the client invocations
+                    Future<?> future = executor.scheduleWithFixedDelay(client, 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
+                    latch.await();
+
+                    // a few seconds of non-failure behaviour
+                    Thread.sleep(FAILURE_FREE_TIME);
+
+                    logger.info("------ Shutdown clusterA-node0 -----");
+                    // stop cluster A node 0
+                    stop(CONTAINER_1);
+                    // Let the server stay down for a while
+                    Thread.sleep(SERVER_DOWN_TIME);
+                    logger.info("------ Startup clusterA-node0 -----");
+                    start(CONTAINER_1);
+
+                    // a few seconds of non-failure behaviour
+                    Thread.sleep(FAILURE_FREE_TIME);
+
+                    logger.info("----- Shutdown clusterA-node1 -----");
+                    // stop cluster A node 1
+                    stop(CONTAINER_2);
+                    // Let the server stay down for a while
+                    Thread.sleep(SERVER_DOWN_TIME);
+                    logger.info("------ Startup clusterA-node1 -----");
+                    start(CONTAINER_2);
+
+                    // a few seconds of non-failure behaviour
+                    Thread.sleep(FAILURE_FREE_TIME);
+
+                    logger.info("----- Shutdown clusterB-node0 -----");
+                    // stop cluster B node 0
+                    stop(CONTAINER_3);
+                    // Let the server stay down for a while
+                    Thread.sleep(SERVER_DOWN_TIME);
+                    logger.info("------ Startup clusterB-node0 -----");
+                    start(CONTAINER_3);
+
+                    // a few seconds of non-failure behaviour
+                    Thread.sleep(FAILURE_FREE_TIME);
+
+                    logger.info("----- Shutdown clusterB-node1 -----");
+                    // stop cluster B node 1
+                    stop(CONTAINER_4);
+                    // Let the server stay down for a while
+                    Thread.sleep(SERVER_DOWN_TIME);
+                    logger.info("------ Startup clusterB-node1 -----");
+                    start(CONTAINER_4);
+
+                    // a few seconds of non-failure behaviour
+                    Thread.sleep(FAILURE_FREE_TIME);
+
+                    // cancel the executor and wait for it to complete
+                    future.cancel(false);
+                    try {
+                        future.get();
+                    } catch (CancellationException e) {
+                        logger.info("Could not cancel future: " + e.toString());
+                    }
+
+                    // test is completed, report results
+                    double invocations = client.getInvocationCount();
+                    double exceptions = client.getExceptionCount();
+                    logger.info("Total invocations = " + invocations + ", total exceptions = " + exceptions);
+                    Assert.assertTrue("Too many exceptions! percentage = " + 100 * (exceptions/invocations), (exceptions/invocations) < EXCEPTION_PERCENTAGE);
+
+                } catch (Exception e) {
+                    Assert.fail("Exception occurred on client: " + e.getMessage() + ", test did not complete successfully (inner)");
+
+                } finally {
+                    logger.info("Shutting down executor");
+                    executor.shutdownNow();
+                }
+
+            } catch (Exception e) {
+                Assert.fail("Exception occurred on client: " + e.getMessage() + ", test did not complete successfully (outer)");
+
+            }
+        } finally {
+            // reset the EJBClient context to the original instance
+            EJBClientContext.setSelector(selector);
+        }
+    }
+
+    private class ClientInvocationTask implements Runnable {
+        private final RemoteStatefulSB bean;
+        private final CountDownLatch latch;
+        private final AtomicInteger count;
+        // count of exceptional responses
+        private int invocationCount;
+        private int exceptionCount;
+        // true of the last invocation resulted in an exception
+        private boolean lastWasException;
+        private boolean firstTime;
+
+        ClientInvocationTask(RemoteStatefulSB bean, CountDownLatch latch, AtomicInteger count) {
+            this.bean = bean;
+            this.latch = latch;
+            this.count = count;
+            this.invocationCount = 0;
+            this.exceptionCount = 0;
+
+            this.lastWasException = false;
+            this.firstTime = true;
+        }
+
+        public int getExceptionCount() {
+            return exceptionCount;
+        }
+
+        public int getInvocationCount() {
+            return invocationCount;
+        }
+
+        @Override
+        public void run() {
+            try {
+                // make an invocation on the remote SFSB
+                this.invocationCount++;
+                logger.info("CLIENT: start invocation (" + this.invocationCount + ")");
+                int value = this.bean.getSerialAndIncrement();
+
+                // check to see if the previous invocation was exceptional
+                if (this.lastWasException) {
+                    // reset the value of the counter
+                    this.count.set(value+1);
+                    this.lastWasException = false;
+                    logger.info("CLIENT: made invocation (" + this.invocationCount + ") on bean, resetting count = " + (value+1));
+                } else {
+                    int count = this.count.getAndIncrement();
+                    logger.info("CLIENT: made invocation (" + this.invocationCount + ") on bean, count = " + count + ", value = " + value);
+                }
+            } catch (Exception e) {
+                // log the occurrence of the exception
+                logger.info("CLIENT: Exception invoking (" + this.invocationCount + ") on bean from client: " + e.getMessage());
+                this.exceptionCount++;
+                this.lastWasException = true;
+            } finally {
+                if (firstTime) {
+                    this.firstTime = false;
+                    this.latch.countDown();
+                }
+            }
+        }
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/SerialBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/SerialBean.java
@@ -1,0 +1,39 @@
+package org.jboss.as.test.clustering.twoclusters.bean;
+
+import java.io.Serializable;
+import java.util.Random;
+
+public class SerialBean implements Serializable {
+
+    private int serial;
+    private byte[] cargo;
+
+    public SerialBean() {
+        this.serial = 0;
+        this.cargo = new byte[4 * 1024];
+        Random rand = new Random();
+        rand.nextBytes(cargo);
+    }
+
+    public byte[] getCargo() {
+        return cargo;
+    }
+
+    public void setCargo(byte[] cargo) {
+        this.cargo = cargo;
+    }
+
+    public int getSerial() {
+        return serial;
+    }
+
+    public int getSerialAndIncrement() {
+        int retVal = this.getSerial();
+        serial++;
+        return retVal;
+    }
+
+    public void setSerial(int serial) {
+        this.serial = serial;
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/common/CommonStatefulSB.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/common/CommonStatefulSB.java
@@ -1,0 +1,11 @@
+package org.jboss.as.test.clustering.twoclusters.bean.common;
+
+
+public interface CommonStatefulSB {
+
+    int getSerial();
+
+    int getSerialAndIncrement();
+
+    byte[] getCargo();
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/common/CommonStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/common/CommonStatefulSBImpl.java
@@ -1,0 +1,47 @@
+package org.jboss.as.test.clustering.twoclusters.bean.common;
+
+import org.jboss.as.test.clustering.twoclusters.bean.SerialBean;
+
+import javax.annotation.PostConstruct;
+import javax.ejb.Remove;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class CommonStatefulSBImpl implements CommonStatefulSB {
+
+    private SerialBean bean;
+    private static final Logger log = Logger.getLogger(CommonStatefulSBImpl.class.getName());
+
+    @PostConstruct
+    private void init() {
+        bean = new SerialBean();
+        log.log(Level.INFO, "New SFSB created: {0}.", this);
+    }
+
+    @Override
+    public int getSerial() {
+        log.log(Level.INFO, "getSerial() called on non-forwarding node " + getCurrentNode());
+        return bean.getSerial();
+    }
+
+    @Override
+    public int getSerialAndIncrement() {
+        log.log(Level.INFO, "getSerialAndIncrement() called on non-forwarding node " + getCurrentNode());
+        return bean.getSerialAndIncrement();
+    }
+
+    @Override
+    public byte[] getCargo() {
+        log.log(Level.INFO, "getCargo() called on non-forwarding node " + getCurrentNode());
+        return bean.getCargo();
+    }
+
+    @Remove
+    private void destroy() {
+        // Let the container do the work.
+    }
+
+    private String getCurrentNode() {
+        return System.getProperty("jboss.node.name", "unknown");
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/common/CommonStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/common/CommonStatefulSBImpl.java
@@ -4,9 +4,12 @@ import org.jboss.as.test.clustering.twoclusters.bean.SerialBean;
 
 import javax.annotation.PostConstruct;
 import javax.ejb.Remove;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
 public class CommonStatefulSBImpl implements CommonStatefulSB {
 
     private SerialBean bean;

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/AbstractForwardingStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/AbstractForwardingStatefulSBImpl.java
@@ -1,0 +1,63 @@
+package org.jboss.as.test.clustering.twoclusters.bean.forwarding;
+
+import org.jboss.as.test.clustering.twoclusters.bean.stateful.RemoteStatefulSB;
+import org.jboss.as.test.clustering.twoclusters.bean.stateful.RemoteStatefulSBImpl;
+
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import java.util.Hashtable;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@TransactionAttribute(TransactionAttributeType.NOT_SUPPORTED)
+public class AbstractForwardingStatefulSBImpl {
+
+    private static final Logger log = Logger.getLogger(AbstractForwardingStatefulSBImpl.class.getName());
+
+    private RemoteStatefulSB bean;
+
+    private final String appName = "";
+    private final String moduleName = "clusterbench-ee6-ejb";
+    private final String distinctName = "" ;
+    private final String beanName = RemoteStatefulSBImpl.class.getSimpleName();
+    private final String viewClassName = RemoteStatefulSB.class.getName() ;
+
+    private final String EJB_NAME = "ejb:" + appName + "/" + moduleName + "/" + distinctName + "/" + beanName +  "!" + viewClassName + "?stateful";
+
+    @SuppressWarnings("unchecked")
+    private RemoteStatefulSB forward() {
+        if (bean == null) {
+            try {
+                Hashtable props = new Hashtable();
+                props.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+                Context context = new InitialContext(props);
+                bean = (RemoteStatefulSB) context.lookup(EJB_NAME);
+            } catch (Exception e) {
+                log.log(Level.INFO, "exception occurred looking up name " + EJB_NAME + " on forwarding node " + getCurrentNode());
+                throw new RuntimeException(e);
+            }
+        }
+        return bean;
+    }
+
+    public int getSerial() {
+        log.log(Level.INFO, "getSerial() called on forwarding node " + getCurrentNode());
+        return forward().getSerial();
+    }
+
+    public int getSerialAndIncrement() {
+        log.log(Level.INFO, "getSerialAndIncrement() called on forwarding node " + getCurrentNode());
+        return forward().getSerialAndIncrement();
+    }
+
+    public byte[] getCargo() {
+        log.log(Level.INFO, "getCargo() called on forwarding node " + getCurrentNode());
+        return forward().getCargo();
+    }
+
+    private String getCurrentNode() {
+        return System.getProperty("jboss.node.name", "unknown");
+    }
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/ForwardingStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/ForwardingStatefulSBImpl.java
@@ -11,4 +11,24 @@ import javax.ejb.TransactionAttributeType;
 @Clustered
 @TransactionAttribute(TransactionAttributeType.REQUIRED) // this is the default anyway
 public class ForwardingStatefulSBImpl extends AbstractForwardingStatefulSBImpl implements RemoteStatefulSB {
+
+    // we need to override these methods so that the TransactionAttribute gets processed on this class!
+
+    @Override
+    public int getSerial()
+    {
+        return super.getSerial();
+    }
+
+    @Override
+    public int getSerialAndIncrement()
+    {
+        return super.getSerialAndIncrement();
+    }
+
+    @Override
+    public byte[] getCargo()
+    {
+        return super.getCargo();
+    }
 }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/ForwardingStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/ForwardingStatefulSBImpl.java
@@ -1,0 +1,14 @@
+package org.jboss.as.test.clustering.twoclusters.bean.forwarding;
+
+import org.jboss.as.test.clustering.twoclusters.bean.stateful.RemoteStatefulSB;
+import org.jboss.ejb3.annotation.Clustered;
+
+import javax.ejb.Stateful;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+
+@Stateful
+@Clustered
+@TransactionAttribute(TransactionAttributeType.REQUIRED) // this is the default anyway
+public class ForwardingStatefulSBImpl extends AbstractForwardingStatefulSBImpl implements RemoteStatefulSB {
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/NonTxForwardingStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/forwarding/NonTxForwardingStatefulSBImpl.java
@@ -1,0 +1,11 @@
+package org.jboss.as.test.clustering.twoclusters.bean.forwarding;
+
+import org.jboss.as.test.clustering.twoclusters.bean.stateful.RemoteStatefulSB;
+import org.jboss.ejb3.annotation.Clustered;
+
+import javax.ejb.Stateful;
+
+@Stateful
+@Clustered
+public class NonTxForwardingStatefulSBImpl extends AbstractForwardingStatefulSBImpl implements RemoteStatefulSB {
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/stateful/LocalStatefulSB.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/stateful/LocalStatefulSB.java
@@ -1,0 +1,20 @@
+package org.jboss.as.test.clustering.twoclusters.bean.stateful;
+
+import org.jboss.as.test.clustering.twoclusters.bean.common.CommonStatefulSBImpl;
+import org.jboss.ejb3.annotation.Clustered;
+
+import javax.ejb.LocalBean;
+import javax.ejb.Stateful;
+import javax.enterprise.context.SessionScoped;
+
+/**
+ * @author Radoslav Husar
+ * @version Dec 2011
+ */
+@Stateful
+@LocalBean
+@SessionScoped
+@Clustered
+public class LocalStatefulSB extends CommonStatefulSBImpl {
+    // Inherit.
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/stateful/RemoteStatefulSB.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/stateful/RemoteStatefulSB.java
@@ -1,0 +1,16 @@
+package org.jboss.as.test.clustering.twoclusters.bean.stateful;
+
+import org.jboss.as.test.clustering.twoclusters.bean.common.CommonStatefulSB;
+
+import javax.ejb.Remote;
+/**
+ * The enterprise bean must implement a business interface. That is, remote clients may not access an enterprise bean through a
+ * no-interface view.
+ *
+ * @author Radoslav Husar
+ * @version Dec 2011
+ */
+@Remote
+public interface RemoteStatefulSB extends CommonStatefulSB {
+    // Inherit.
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/stateful/RemoteStatefulSBImpl.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/bean/stateful/RemoteStatefulSBImpl.java
@@ -1,0 +1,16 @@
+package org.jboss.as.test.clustering.twoclusters.bean.stateful;
+
+import org.jboss.as.test.clustering.twoclusters.bean.common.CommonStatefulSBImpl;
+import org.jboss.ejb3.annotation.Clustered;
+
+import javax.ejb.Stateful;
+
+/**
+ * @author Radoslav Husar
+ * @version Dec 2011
+ */
+@Stateful
+@Clustered
+public class RemoteStatefulSBImpl extends CommonStatefulSBImpl implements RemoteStatefulSB {
+    // Inherit.
+}

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/forwarder-jboss-ejb-client.properties
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/forwarder-jboss-ejb-client.properties
@@ -1,0 +1,37 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=default
+
+remote.connection.default.host=${node0:localhost}
+remote.connection.default.port=8080
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.connection.default.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
+remote.connection.default.connect.options.org.xnio.Options.WORKER_TASK_MAX_THREADS=4
+callback.handler.class=org.jboss.as.test.shared.integration.ejb.security.CallbackHandler
+
+remote.clusters=ejb-forwarder
+
+remote.cluster.ejb-forwarder.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false
+remote.cluster.ejb-forwarder.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT=false
+remote.cluster.ejb-forwarder.connect.options.org.xnio.Options.WORKER_TASK_MAX_THREADS=4

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/jboss-ejb-client.xml
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/twoclusters/jboss-ejb-client.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss-ejb-client xmlns="urn:jboss:ejb-client:1.2">
+    <client-context>
+        <ejb-receivers>
+            <remoting-ejb-receiver outbound-connection-ref="remote-ejb-connection"/>
+        </ejb-receivers>
+        <clusters>
+            <cluster name="ejb" max-allowed-connected-nodes="20" security-realm="PasswordRealm" username="remoteejbuser">
+                <connection-creation-options>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="true"/>
+                </connection-creation-options>
+            </cluster>
+            <cluster name="ejb-forwarder" max-allowed-connected-nodes="20" security-realm="PasswordRealm" username="remoteejbuser">
+                <connection-creation-options>
+                    <property name="org.xnio.Options.SSL_ENABLED" value="false"/>
+                    <property name="org.xnio.Options.SASL_POLICY_NOANONYMOUS" value="true"/>
+                </connection-creation-options>
+            </cluster>
+        </clusters>
+   </client-context>
+</jboss-ejb-client>

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -299,4 +299,72 @@
                                                  router-inet-address="${node0}"/>
     </target>
 
+    <!-- two cluster test deployment:
+         4 nodes: ${node0}, ${node1}, ${node2}, ${node3}
+         clusters: clusterA (node0, node1), clusterB (node2, node3)
+     -->
+    <target name="build-clustering-two-clusters" description="Builds server configurations for EJBClient testing on two clusters">
+
+        <echo>Building two cluster configs with clusters clusterA, clusterB</echo>
+
+        <!-- clusterA, node 0, mcast 0 -->
+        <echo message="Building config clustering-two-clusters clusterA-node0"/>
+        <copy todir="target/wildfly-clusterA-node0" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
+        </copy>
+        <ts.config-as.ip-with-multicast-longform name="wildfly-clusterA-node0"
+                                                 managementIPAddress="${node0}" publicIPAddress="${node0}"
+                                                 udpMcastAddress="${mcast-clusterA}" diagnosticsMcastAddress="${mcast-clusterA}" mpingMcastAddress="${mcast-mping}" modclusterMcastAddress="${mcast-clusterA}"/>
+        <ts.config-as.add-port-offset name="wildfly-clusterA-node0"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-clusterA-node0" mcast.ttl="${mcast.ttl}"/>
+        <!--ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node0" node="${node2}" remotePort="8280" protocol="http-remoting"/-->
+        <ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node0" node="${node2}" remotePort="8280" protocol="http-remoting" securityRealm="PasswordRealm" userName="remoteejbuser"/>
+        <ts.config-as.add-identity-realm name="wildfly-clusterA-node0" realmName="PasswordRealm" secret="cmVtQHRlZWpicGFzc3dkMQ=="/>
+
+        <ts.config-as.change-cache-container-name name="wildfly-clusterA-node0" container="ejb" newName="ejb-forwarder"/>
+        <ts.config-as.change-passivation-store-cache-container-name name="wildfly-clusterA-node0" storeName="infinispan" newContainerName="ejb-forwarder"/>
+        <ts.config-as.change-ejb-remote-connector-cluster-name name="wildfly-clusterA-node0" cluster="ejb-forwarder"/>
+
+        <!-- clusterA, node 1, mcast 0 -->
+        <echo message="Building config clustering-two-clusters clusterA-node1"/>
+        <copy todir="target/wildfly-clusterA-node1" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
+        </copy>
+        <ts.config-as.ip-with-multicast-longform name="wildfly-clusterA-node1"
+                                                 managementIPAddress="${node1}" publicIPAddress="${node1}"
+                                                 udpMcastAddress="${mcast-clusterA}" diagnosticsMcastAddress="${mcast-clusterA}" mpingMcastAddress="${mcast-mping}" modclusterMcastAddress="${mcast-clusterA}"/>
+        <ts.config-as.add-port-offset name="wildfly-clusterA-node1" offset="100" nativePort="9999" httpPort="9990"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-clusterA-node1" mcast.ttl="${mcast.ttl}"/>
+        <ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node1" node="${node2}" remotePort="8280" protocol="http-remoting" securityRealm="PasswordRealm" userName="remoteejbuser" />
+        <ts.config-as.add-identity-realm name="wildfly-clusterA-node1" realmName="PasswordRealm" secret="cmVtQHRlZWpicGFzc3dkMQ=="/>
+
+        <ts.config-as.change-cache-container-name name="wildfly-clusterA-node1" container="ejb" newName="ejb-forwarder"/>
+        <ts.config-as.change-passivation-store-cache-container-name name="wildfly-clusterA-node1" storeName="infinispan" newContainerName="ejb-forwarder"/>
+        <ts.config-as.change-ejb-remote-connector-cluster-name name="wildfly-clusterA-node1" cluster="ejb-forwarder"/>
+
+
+        <!-- clusterB, node 2, mcast 1 -->
+        <echo message="Building config clustering-two-clusters clusterB-node0"/>
+        <copy todir="target/wildfly-clusterB-node0" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
+        </copy>
+        <ts.config-as.ip-with-multicast-longform name="wildfly-clusterB-node0"
+                                                 managementIPAddress="${node2}" publicIPAddress="${node2}"
+                                                 udpMcastAddress="${mcast-clusterB}" diagnosticsMcastAddress="${mcast-clusterB}" mpingMcastAddress="${mcast-mping}" modclusterMcastAddress="${mcast-clusterB}"/>
+        <ts.config-as.add-port-offset name="wildfly-clusterB-node0" offset="200" nativePort="9999" httpPort="9990"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-clusterB-node0" mcast.ttl="${mcast.ttl}"/>
+
+        <!-- clusterB, node 3, mcast 1 -->
+        <echo message="Building config clustering-two-clusters-clusterB-node1"/>
+        <copy todir="target/wildfly-clusterB-node1" overwrite="true">
+            <fileset dir="${basedir}/target/jbossas"/>
+        </copy>
+        <ts.config-as.ip-with-multicast-longform name="wildfly-clusterB-node1"
+                                                 managementIPAddress="${node3}" publicIPAddress="${node3}"
+                                                 udpMcastAddress="${mcast-clusterB}" diagnosticsMcastAddress="${mcast-clusterB}" mpingMcastAddress="${mcast-mping}" modclusterMcastAddress="${mcast-clusterB}"/>
+        <ts.config-as.add-port-offset name="wildfly-clusterB-node1" offset="300" nativePort="9999" httpPort="9990"/>
+        <ts.config-as.configure-multicast-ttl name="wildfly-clusterB-node1" mcast.ttl="${mcast.ttl}"/>
+
+    </target>
+
 </project>

--- a/testsuite/integration/src/test/scripts/clustering-common-targets.xml
+++ b/testsuite/integration/src/test/scripts/clustering-common-targets.xml
@@ -533,6 +533,122 @@
     </macrodef>
 
     <!--
+        Change the name used by an Infinispan cache container.
+    -->
+    <macrodef name="ts.config-as.change-cache-container-name" description="Change the name associated with the cache container">
+
+        <attribute name="name" default="wildfly"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+
+        <attribute name="container" default="ejb"/>
+        <attribute name="newName" default="ejb"/>
+
+        <sequential>
+            <echo message="Changing name to @{cluster} for the container @{container} in Infinispan subsystem for config @{name}"/>
+
+            <execute-xslt-transform transform="changeCacheContainerName.xsl" name="@{name}" output.dir="@{output.dir}" config.dir.name="@{config.dir.name}">
+                <transform-params>
+                    <param name="container" expression="@{container}"/>
+                    <param name="newName" expression="@{newName}"/>
+                </transform-params>
+            </execute-xslt-transform>
+        </sequential>
+    </macrodef>
+
+    <!--
+       Change the name used by an Infinispan cache container in a passivation store.
+   -->
+    <macrodef name="ts.config-as.change-passivation-store-cache-container-name" description="Change the cache container name associated with the passivation store">
+
+        <attribute name="name" default="wildfly"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+
+        <attribute name="storeName" default="infinispan"/>
+        <attribute name="newContainerName" default="ejb"/>
+
+        <sequential>
+            <echo message="Changing cache container name to @{newContainerName} for the passivation store @{storeName} in EJB3 subsystem for config @{name}"/>
+
+            <execute-xslt-transform transform="changePassivationStoreCacheContainerName.xsl" name="@{name}" output.dir="@{output.dir}" config.dir.name="@{config.dir.name}">
+                <transform-params>
+                    <param name="storeName" expression="@{storeName}"/>
+                    <param name="newContainerName" expression="@{newContainerName}"/>
+                </transform-params>
+            </execute-xslt-transform>
+        </sequential>
+    </macrodef>
+
+    <!--
+         Change the cluster name for the channel used by an Infinispan cache container.
+     -->
+    <macrodef name="ts.config-as.change-cache-container-channel-name" description="Change the channel name associated with the cache container">
+
+        <attribute name="name" default="wildfly"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+
+        <attribute name="container" default="ejb"/>
+        <attribute name="channel" default="ee"/>
+
+        <sequential>
+            <echo message="Changing cluster name to @{cluster} for the container @{container} in Infinispan subsystem for config @{name}"/>
+
+            <execute-xslt-transform transform="changeCacheContainerChannelName.xsl" name="@{name}" output.dir="@{output.dir}" config.dir.name="@{config.dir.name}">
+                <transform-params>
+                    <param name="container" expression="@{container}"/>
+                    <param name="channel" expression="@{channel}"/>
+                </transform-params>
+            </execute-xslt-transform>
+        </sequential>
+    </macrodef>
+
+    <!--
+         Change the cluster name for the remote connector used by the EJB subsystem.
+     -->
+    <macrodef name="ts.config-as.change-ejb-remote-connector-cluster-name" description="Change the cluster name associated with the EJB remote connector">
+
+        <attribute name="name" default="wildfly"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+
+        <attribute name="cluster" default="ejb"/>
+
+        <sequential>
+            <echo message="Changing cluster name to @{cluster} for the remote connector in the EJB subsystem for config @{name}"/>
+
+            <execute-xslt-transform transform="changeEJBRemoteConnectorClusterName.xsl" name="@{name}" output.dir="@{output.dir}" config.dir.name="@{config.dir.name}">
+                <transform-params>
+                    <param name="cluster" expression="@{cluster}"/>
+                </transform-params>
+            </execute-xslt-transform>
+        </sequential>
+    </macrodef>
+
+    <!--
+        Change the cluster name for the channel used by an Infinispan cache container.
+    -->
+    <macrodef name="ts.config-as.add-channel" description="Add a channel to the set of JGroups channel instances">
+
+        <attribute name="name" default="wildfly"/>
+        <attribute name="output.dir" default="${project.build.directory}"/>
+        <attribute name="config.dir.name" default="standalone/configuration"/>
+
+        <attribute name="channel" default="ee"/>
+
+        <sequential>
+            <echo message="Add channel named @{channel} for the set of channels in JGroups subsystem for config @{name}"/>
+
+            <execute-xslt-transform transform="addChannel.xsl" name="@{name}" output.dir="@{output.dir}" config.dir.name="@{config.dir.name}">
+                <transform-params>
+                    <param name="channel" expression="@{channel}"/>
+                </transform-params>
+            </execute-xslt-transform>
+        </sequential>
+    </macrodef>
+
+    <!--
         Execute an XSLT transform in place.
     -->
     <macrodef name="execute-xslt-transform" description="Execute an XSLT transform on an xml file (in place)">

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -117,6 +117,7 @@
         <attribute name="name" default="jbossas"/>
         <attribute name="output.dir" default="${project.build.directory}"/>
         <attribute name="config.dir.name" default="standalone/configuration"/>
+
         <attribute name="offset" default="0"/>
         <attribute name="nativePort" default="9999"/>
         <attribute name="httpPort" default="9990"/>

--- a/testsuite/integration/src/test/xslt/addChannel.xsl
+++ b/testsuite/integration/src/test/xslt/addChannel.xsl
@@ -1,0 +1,30 @@
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:param name="channel"/>
+
+    <xsl:variable name="jgroupsns" select="'urn:jboss:domain:jgroups:'"/>
+
+    <!-- traverse the whole tree, so that all elements and attributes are eventually current node -->
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Prevent duplicates -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $jgroupsns)]
+   						  /*[local-name()='channels']
+   						  /*[local-name()='channel' and @name=$channel]"/>
+
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $jgroupsns)]
+   						  /*[local-name()='channels']">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>            
+            <xsl:element name="channel" namespace="{namespace-uri()}">
+                <xsl:attribute name="name"><xsl:value-of select="$channel"/></xsl:attribute>
+            </xsl:element>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/changeCacheContainerChannelName.xsl
+++ b/testsuite/integration/src/test/xslt/changeCacheContainerChannelName.xsl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Author: Radoslav Husar rhusar@redhat.com, Version: Dec 2011 -->
+
+<xsl:stylesheet
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:variable name="nsInf" select="'urn:jboss:domain:infinispan:'"/>
+
+    <!-- User params. -->
+    <xsl:param name="name" select="'ejb'"/>
+    <xsl:param name="channel" select="'ee'"/>
+
+    <xsl:template match="node()|@*" name="identity">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- add or modify cluster=* attribute on cache container transport. -->
+
+    <!-- attribute exists - change its value in the transport element -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsInf)]
+   /*[local-name()='cache-container' and starts-with(namespace-uri(), $nsInf) and @name=$name]
+   /*[local-name()='transport' and starts-with(namespace-uri(), $nsInf)]/@channel">
+        <xsl:attribute name="channel">
+            <xsl:value-of select="$channel"/>
+        </xsl:attribute>
+    </xsl:template>
+
+    <!-- attribute does not exist - add it to the transport element -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsInf)]
+   /*[local-name()='cache-container' and starts-with(namespace-uri(), $nsInf) and @name=$name]
+   /*[local-name()='transport' and starts-with(namespace-uri(), $nsInf)]">
+        <xsl:copy>
+            <xsl:for-each select="@*">
+                <xsl:attribute name="{name(.)}">
+                    <xsl:value-of select="."/>
+                </xsl:attribute>
+            </xsl:for-each>
+            <xsl:attribute name="channel">
+                <xsl:value-of select="$channel"/>
+            </xsl:attribute>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Copy everything else untouched. -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/changeCacheContainerName.xsl
+++ b/testsuite/integration/src/test/xslt/changeCacheContainerName.xsl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Author: Radoslav Husar rhusar@redhat.com, Version: Dec 2011 -->
+
+<xsl:stylesheet
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:variable name="nsInf" select="'urn:jboss:domain:infinispan:'"/>
+
+    <!-- User params. -->
+    <xsl:param name="name" select="'ejb'"/>
+    <xsl:param name="newName" select="'ejb'"/>
+
+    <xsl:template match="node()|@*" name="identity">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- change the name attribute on the container, if it matches the name parameter value $name  -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsInf)]
+   /*[local-name()='cache-container' and starts-with(namespace-uri(), $nsInf)]/@name[.=$name]">
+        <xsl:attribute name="name">
+            <xsl:value-of select="$newName"/>
+        </xsl:attribute>
+    </xsl:template>
+
+    <!-- Copy everything else untouched. -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/changeEJBRemoteConnectorClusterName.xsl
+++ b/testsuite/integration/src/test/xslt/changeEJBRemoteConnectorClusterName.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Author: Radoslav Husar rhusar@redhat.com, Version: Dec 2011 -->
+
+<xsl:stylesheet
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:variable name="nsEjb3" select="'urn:jboss:domain:ejb3:'"/>
+
+    <!-- User params. -->
+    <xsl:param name="cluster" select="'ejb'"/>
+
+    <xsl:template match="node()|@*" name="identity">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- add or modify cache-container=* attribute on passivation store named $cache. -->
+
+    <!-- attribute exists - change its value in the passivation-store element -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsEjb3)]
+   /*[local-name()='remote' and starts-with(namespace-uri(), $nsEjb3)]/@cluster">
+        <xsl:attribute name="cluster">
+            <xsl:value-of select="$cluster"/>
+        </xsl:attribute>
+    </xsl:template>
+
+    <!-- attribute does not exist - add it to the passivation-store element -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsEjb3)]
+   /*[local-name()='remote' and starts-with(namespace-uri(), $nsEjb3)]">
+        <xsl:copy>
+            <xsl:for-each select="@*">
+                <xsl:attribute name="{name(.)}">
+                    <xsl:value-of select="."/>
+                </xsl:attribute>
+            </xsl:for-each>
+            <xsl:attribute name="cluster">
+                <xsl:value-of select="$cluster"/>
+            </xsl:attribute>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Copy everything else untouched. -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testsuite/integration/src/test/xslt/changePassivationStoreCacheContainerName.xsl
+++ b/testsuite/integration/src/test/xslt/changePassivationStoreCacheContainerName.xsl
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Author: Radoslav Husar rhusar@redhat.com, Version: Dec 2011 -->
+
+<xsl:stylesheet
+        xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        version="1.0">
+
+    <xsl:output method="xml" indent="yes"/>
+
+    <xsl:variable name="nsEjb3" select="'urn:jboss:domain:ejb3:'"/>
+
+    <!-- User params. -->
+    <xsl:param name="store" select="'infinispan'"/>
+    <xsl:param name="newContainerName" select="'ejb'"/>
+
+    <xsl:template match="node()|@*" name="identity">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- add or modify cache-container=* attribute on passivation store named $cache. -->
+
+    <!-- attribute exists - change its value in the passivation-store element -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsEjb3)]
+   /*[local-name()='passivation-stores' and starts-with(namespace-uri(), $nsEjb3)]
+   /*[local-name()='passivation-store' and starts-with(namespace-uri(), $nsEjb3) and @name=$store]/@cache-container">
+        <xsl:attribute name="cache-container">
+            <xsl:value-of select="$newContainerName"/>
+        </xsl:attribute>
+    </xsl:template>
+
+    <!-- attribute does not exist - add it to the passivation-store element -->
+    <xsl:template match="//*[local-name()='subsystem' and starts-with(namespace-uri(), $nsEjb3)]
+   /*[local-name()='passivation-stores' and starts-with(namespace-uri(), $nsEjb3)]
+   /*[local-name()='passivation-store' and starts-with(namespace-uri(), $nsEjb3)]">
+        <xsl:copy>
+            <xsl:for-each select="@*">
+                <xsl:attribute name="{name(.)}">
+                    <xsl:value-of select="."/>
+                </xsl:attribute>
+            </xsl:for-each>
+            <xsl:attribute name="cache-container">
+                <xsl:value-of select="$newContainerName"/>
+            </xsl:attribute>
+        </xsl:copy>
+    </xsl:template>
+
+    <!-- Copy everything else untouched. -->
+    <xsl:template match="@*|node()">
+        <xsl:copy>
+            <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+    </xsl:template>
+
+</xsl:stylesheet>

--- a/testsuite/shared/src/main/resources/application-users.properties
+++ b/testsuite/shared/src/main/resources/application-users.properties
@@ -1,6 +1,8 @@
 # guest=guest
 # user1=password1
 # user2=password2
+#remoteejbuser=rem@teejbpasswd1
 guest=b5d048a237bfd2874b6928e1f37ee15e
 user1=23624d2f74dfcb9688651a066d90b97e
 user2=ab3f9e12039435236d89de9023a304b7
+remoteejbuser=d37cd830cc282510807b82c4b861256d


### PR DESCRIPTION
This PR does the following:
- provides a two cluster test case for testing remote EJBCLient invocations from both a non-transactional context and a managed transactional-context (see https://issues.jboss.org/browse/WFLY-4853)
- provides a fix for the problem of not being able to rename (from an EJBClient point of view) the name of a custer (see https://issues.jboss.org/browse/WFLY-3290)

This test replicates in the Wildfly testsuite a significant EAP test which up to now existed only as a SmartFrog test.
- 
