### PR TITLE
Prepare wildfly codebase for new improved parser coming to core

### DIFF
--- a/iiop-openjdk/src/main/resources/schema/jboss-as-iiop-openjdk_1_0.xsd
+++ b/iiop-openjdk/src/main/resources/schema/jboss-as-iiop-openjdk_1_0.xsd
@@ -46,15 +46,16 @@
             </xs:documentation>
         </xs:annotation>
         <xs:sequence>
+            <xs:element name="properties" minOccurs="0" maxOccurs="1" type="genericPropertiesType"/>
             <xs:element name="orb" minOccurs="0" maxOccurs="1" type="orbConfigType"/>
             <xs:element name="tcp" minOccurs="0" maxOccurs="1" type="tcpConfigType"/>
             <xs:element name="initializers" minOccurs="0" maxOccurs="1" type="initializersConfigType"/>
             <xs:element name="naming" minOccurs="0" maxOccurs="1" type="namingConfigType"/>
             <xs:element name="security" minOccurs="0" maxOccurs="1" type="securityConfigType"/>
             <xs:element name="client-transport" minOccurs="0" maxOccurs="1" type="iorClientTransportConfigType"/>
+            <xs:element name="transport-config" type="iorTransportConfigType" minOccurs="0" maxOccurs="1"/>
             <xs:element name="as-context" minOccurs="0" maxOccurs="1" type="iorASContextType"/>
             <xs:element name="sas-context" minOccurs="0" maxOccurs="1" type="iorSASContextType"/>
-            <xs:element name="properties" minOccurs="0" maxOccurs="1" type="genericPropertiesType"/>
         </xs:sequence>
     </xs:complexType>
 
@@ -71,6 +72,7 @@
         <xs:attribute name="giop-version" type="xs:string" use="optional" default="1.2"/>
         <xs:attribute name="socket-binding" type="xs:string" use="optional" default="iiop"/>
         <xs:attribute name="ssl-socket-binding" type="xs:string" use="optional" default="iiop-ssl"/>
+        <xs:attribute name="persistent-server-id" type="xs:string" use="optional" default="1"/>
     </xs:complexType>
 
     <xs:complexType name="tcpConfigType">

--- a/iiop-openjdk/src/main/resources/subsystem-templates/iiop-openjdk.xml
+++ b/iiop-openjdk/src/main/resources/subsystem-templates/iiop-openjdk.xml
@@ -3,7 +3,6 @@
 <config>
    <extension-module>org.wildfly.iiop-openjdk</extension-module>
    <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-       <orb socket-binding="iiop" ssl-socket-binding="iiop-ssl"/>
        <initializers transactions="spec" security="identity"/>
    </subsystem>
    <socket-binding name="iiop" interface="unsecure" port="3528"/>

--- a/iiop-openjdk/src/test/java/org/wildfly/iiop/openjdk/IIOPSubsystemTestCase.java
+++ b/iiop-openjdk/src/test/java/org/wildfly/iiop/openjdk/IIOPSubsystemTestCase.java
@@ -74,6 +74,18 @@ public class IIOPSubsystemTestCase extends AbstractSubsystemBaseTest {
         standardSubsystemTest("expressions-1.0.xml");
     }
 
+    @Override
+    protected String getSubsystemXsdPath() throws Exception {
+        return "schema/jboss-as-iiop-openjdk_1_0.xsd";
+    }
+
+    @Override
+    protected String[] getSubsystemTemplatePaths() throws IOException {
+        return new String[] {
+                "/subsystem-templates/iiop-openjdk.xml"
+        };
+    }
+
     @Test
     public void testParseEmptySubsystem() throws Exception {
         // parse the subsystem xml into operations.
@@ -140,6 +152,7 @@ public class IIOPSubsystemTestCase extends AbstractSubsystemBaseTest {
         // parse the subsystem xml and install into the first controller.
         String subsystemXml =
                 "<subsystem xmlns=\"" + Namespace.CURRENT.getUriString() + "\">" +
+                "<orb socket-binding=\"iiop\" ssl-socket-binding=\"iiop-ssl\"/>"+
                 "</subsystem>";
 
         AdditionalInitialization additionalInit = new AdditionalInitialization(){

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/expressions-1.0.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/expressions-1.0.xml
@@ -1,11 +1,11 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-    <orb giop-version ="${test.exp:1.2}" socket-binding="iiop" ssl-socket-binding="iiop-ssl"/>
+    <properties>
+        <property name="${test.exp:some_property}" value="${test.exp:some_value}"/>
+    </properties>
+    <orb giop-version="${test.exp:1.2}" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2"/>
     <tcp high-water-mark="${test.exp:100}" number-to-reclaim="${test.exp:30}"/>
     <initializers security="${test.exp:off}" transactions="${test.exp:spec}"/>
     <naming root-context="${test.exp:JBoss/Naming/root}" export-corbaloc="${test.exp:false}"/>
     <security support-ssl="${test.exp:false}" add-component-via-interceptor="${test.exp:true}" client-supports="${test.exp:MutualAuth}"
-        client-requires="${test.exp:None}" server-supports="${test.exp:MutualAuth}" server-requires="${test.exp:None}"/>
-    <properties>
-        <property name="${test.exp:some_property}" value="${test.exp:some_value}"/>
-    </properties>
+              client-requires="${test.exp:None}" server-supports="${test.exp:MutualAuth}" server-requires="${test.exp:None}"/>
 </subsystem>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/expressions-1.0.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/expressions-1.0.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-    <properties>
+    <!--<properties>
         <property name="${test.exp:some_property}" value="${test.exp:some_value}"/>
-    </properties>
+    </properties>-->
     <orb giop-version="${test.exp:1.2}" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2"/>
     <tcp high-water-mark="${test.exp:100}" number-to-reclaim="${test.exp:30}"/>
     <initializers security="${test.exp:off}" transactions="${test.exp:spec}"/>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-client.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-client.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-    <properties>
+    <!--<properties>
         <property name="some_property" value="some_value"/>
-    </properties>
+    </properties>-->
     <tcp high-water-mark="500" number-to-reclaim="30"/>
     <initializers security="client" transactions="spec"/>
 </subsystem>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-client.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-client.xml
@@ -1,11 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-    <orb giop-version="1.2" socket-binding="iiop" ssl-socket-binding="iiop-ssl"/>
-    <tcp high-water-mark="500" number-to-reclaim="30" />
-    <initializers security="client" transactions="spec"/>
-    <naming root-context="JBoss/Naming/root" export-corbaloc="true"/>
-    <security support-ssl="false" add-component-via-interceptor="true" client-supports="MutualAuth"
-        client-requires="None" server-supports="MutualAuth" server-requires="None"/>
     <properties>
         <property name="some_property" value="some_value"/>
     </properties>
+    <tcp high-water-mark="500" number-to-reclaim="30"/>
+    <initializers security="client" transactions="spec"/>
 </subsystem>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-identity.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-identity.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-    <properties>
+    <!--<properties>
         <property name="some_property" value="some_value"/>
-    </properties>
+    </properties>-->
     <orb giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2"/>
     <tcp high-water-mark="500" number-to-reclaim="30"/>
     <initializers security="client" transactions="spec"/>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-identity.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0-security-identity.xml
@@ -1,11 +1,8 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-    <orb giop-version="1.2" socket-binding="iiop" ssl-socket-binding="iiop-ssl"/>
-    <tcp high-water-mark="500" number-to-reclaim="30"/>
-    <initializers security="client" transactions="spec"/>
-    <naming root-context="JBoss/Naming/root" export-corbaloc="true"/>
-    <security support-ssl="false" add-component-via-interceptor="true" client-supports="MutualAuth"
-              client-requires="None" server-supports="MutualAuth" server-requires="None"/>
     <properties>
         <property name="some_property" value="some_value"/>
     </properties>
+    <orb giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2"/>
+    <tcp high-water-mark="500" number-to-reclaim="30"/>
+    <initializers security="client" transactions="spec"/>
 </subsystem>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0.xml
@@ -1,7 +1,7 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-   <properties>
+   <!--properties>
         <property name="some_property" value="some_value"/>
-    </properties>
+    </properties-->
    <orb persistent-server-id="wildfly" giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2" />
     <tcp high-water-mark="500" number-to-reclaim="30"/>
     <initializers security="client" transactions="spec"/>

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0.xml
@@ -1,17 +1,17 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-   <orb persistent-server-id="wildfly" giop-version="1.2" socket-binding="iiop" ssl-socket-binding="iiop-ssl" />
-    <tcp high-water-mark="500" number-to-reclaim="30"/>
-    <initializers security="client" transactions="spec"/>
-    <naming root-context="JBoss/Naming/root" export-corbaloc="true"/>
-    <security support-ssl="false" add-component-via-interceptor="true" client-supports="MutualAuth"
-              client-requires="None"
-              server-supports="MutualAuth" server-requires="None"/>
-    <transport-config integrity="required" confidentiality="required" detect-replay="supported"
-                      detect-misordering="supported"
-                      trust-in-client="none" trust-in-target="none"/>
-    <as-context auth-method="username_password" realm="test_realm" required="true"/>
-    <sas-context caller-propagation="supported"/>
-    <properties>
+   <properties>
         <property name="some_property" value="some_value"/>
     </properties>
+   <orb persistent-server-id="wildfly" giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2" />
+    <tcp high-water-mark="500" number-to-reclaim="30"/>
+    <initializers security="client" transactions="spec"/>
+    <naming root-context="JBoss/Naming/root2" export-corbaloc="false"/>
+    <security support-ssl="true" add-component-via-interceptor="false" client-supports="None"
+              client-requires="MutualAuth"
+              server-supports="None" server-requires="MutualAuth"/>
+    <transport-config integrity="required" confidentiality="required" detect-replay="supported"
+                      detect-misordering="supported"
+                      trust-in-client="supported" trust-in-target="supported"/>
+    <as-context auth-method="none" realm="test_realm2" required="true"/>
+    <sas-context caller-propagation="supported"/>
 </subsystem>

--- a/legacy/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-ior-settings.xml
+++ b/legacy/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem-ior-settings.xml
@@ -10,8 +10,8 @@
     </properties>
     <ior-settings>
         <transport-config integrity="required" confidentiality="required" detect-replay="supported" detect-misordering="supported"
-                          trust-in-client="none" trust-in-target="none"/>
-        <as-context auth-method="username_password" realm="test_realm" required="true"/>
+                          trust-in-client="supported" trust-in-target="supported"/>
+        <as-context auth-method="none" realm="test_realm" required="false"/>
         <sas-context caller-propagation="supported"/>
     </ior-settings>
 </subsystem>

--- a/legacy/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem.xml
+++ b/legacy/jacorb/src/test/resources/org/jboss/as/jacorb/subsystem.xml
@@ -10,8 +10,8 @@
     </properties>
     <ior-settings>
         <transport-config integrity="required" confidentiality="required" detect-replay="supported" detect-misordering="supported"
-                          trust-in-client="none" trust-in-target="none"/>
-        <as-context auth-method="username_password" realm="test_realm" required="true"/>
+                          trust-in-client="supported" trust-in-target="supported"/>
+        <as-context auth-method="none" realm="test_realm" required="false"/>
         <sas-context caller-propagation="supported"/>
     </ior-settings>
 </subsystem>

--- a/legacy/web/src/main/java/org/jboss/as/web/WebContainerDefinition.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebContainerDefinition.java
@@ -52,6 +52,7 @@ public class WebContainerDefinition extends ModelOnlyResourceDefinition {
     protected static final PropertiesAttributeDefinition MIME_MAPPINGS = new PropertiesAttributeDefinition.Builder(Constants.MIME_MAPPING, true)
             .setAllowExpression(true)
             .setWrapXmlElement(false)
+            .setXmlName(Constants.MIME_MAPPING)
             .build();
     protected static final AttributeDefinition[] CONTAINER_ATTRIBUTES = {
             WELCOME_FILES,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InVMTransportDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/InVMTransportDefinition.java
@@ -42,7 +42,6 @@ import org.jboss.dmr.ModelNode;
 public class InVMTransportDefinition extends AbstractTransportDefinition {
 
     public static final SimpleAttributeDefinition SERVER_ID = create("server-id", INT)
-            .setDefaultValue(new ModelNode(0))
             .setAllowExpression(true)
             .setAttributeMarshaller(new AttributeMarshaller() {
                 public void marshallAsAttribute(AttributeDefinition attribute, ModelNode resourceModel, boolean marshallDefault, XMLStreamWriter writer) throws XMLStreamException {

--- a/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.0.xml
+++ b/undertow/src/test/resources/org/wildfly/extension/undertow/undertow-3.0.xml
@@ -86,7 +86,7 @@
                         http-only="true"
                         max-age="1000"/>
         <!--<persistent-sessions relative-to="${server.data.dir}" path="web-sessions"/>-->
-        <websockets dispatch-to-worker="true" buffer-pool="default" worker="default" />
+        <websockets dispatch-to-worker="false" />
         <mime-mappings>
             <mime-mapping name="txt" value="text/plain" />
         </mime-mappings>


### PR DESCRIPTION
Prepare full for wildfly/wildfly-core/pull/908

Mostly just changes to our testing templates to make sure we don't use default values.

extra commit https://github.com/wildfly/wildfly/commit/55d4f9e2c6a98883e8b0580a35a3e16ebe769f6a temporary disables testing properties attribute in IIOP subsystem as new parser differently (properly) orders writing of PropertiesAttributes and that causes failures in our subsystems tests.

Once Wildfly core with said PR is integrated to full, the second commit can and should be reverted.
https://issues.jboss.org/browse/WFLY-4987 is there to revert this commit.
