### PR TITLE
Ignore two clustering tests that commonly fail on windows @pferraro

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
@@ -47,6 +47,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -72,6 +73,7 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Ignore("Intermittently fails")
 public class XSiteSimpleTestCase extends ExtendedClusterAbstractTestCase {
 
     @Deployment(name = DEPLOYMENT_1, managed = false)

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -49,6 +49,7 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.api.Authentication;
@@ -74,6 +75,7 @@ import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNo
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Ignore("Intermittently fails")
 public class EJBClientClusterConfigurationTestCase {
 
     private static final Logger logger = Logger.getLogger(EJBClientClusterConfigurationTestCase.class);


### PR DESCRIPTION
@pferraro looking at stats http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WF_PullRequest&testNameId=-7618144520575484180&tab=testDetails
http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WF_PullRequest&testNameId=1140899232324454378&tab=testDetails
it looks like it always fails on windows with ipv6, with same case:

Caused by: java.io.IOException: Method not implemented! 
java.net.DualStackPlainDatagramSocketImpl.setTimeToLive(DualStackPlainDatagramSocketImpl.java:236)
