### PR TITLE
[master] [WFLY-4340] use-try-lock exposed for <connection-definition>

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonAttributes.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/CommonAttributes.java
@@ -67,7 +67,6 @@ import static org.jboss.as.connector.subsystems.resourceadapters.Constants.SHARA
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.STATISTICS_ENABLED;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRANSACTION_SUPPORT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.TRACKING;
-import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USETRYLOCK;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_CCM;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.USE_JAVA_CONTEXT;
 import static org.jboss.as.connector.subsystems.resourceadapters.Constants.WM_SECURITY;
@@ -121,7 +120,6 @@ public class CommonAttributes {
             BLOCKING_TIMEOUT_WAIT_MILLIS,
             IDLETIMEOUTMINUTES,
             XA_RESOURCE_TIMEOUT,
-            USETRYLOCK,
             BACKGROUNDVALIDATIONMILLIS,
             BACKGROUNDVALIDATION,
             USE_FAST_FAIL, VALIDATE_ON_MATCH, USE_CCM,


### PR DESCRIPTION
Copy'n'paste bug from datasources.
- No default value
- Never marshalled/unmarshalled
- Never in XSDs
- Never used in resource adapter deployments
