### PR TITLE
Propagate the initial view

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
@@ -88,6 +88,7 @@ public class ChannelCommandDispatcherFactory implements CommandDispatcherFactory
         this.dispatcher.setRequestHandler(this);
         this.dispatcher.setMembershipListener(this);
         this.dispatcher.start();
+        viewAccepted(this.dispatcher.getChannel().getView());
     }
 
     @Override


### PR DESCRIPTION
If the jgroups view is already determined by the time the CommandDispatcherFactory is created, no viewAccepted is triggered, so the CDF does not have an up-to-date view of the view.

By grabbing the initial view, the CDF can stay up-to-date.
