### PR TITLE
WFLY-4997 Upgrade jboss-transaction-spi

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
         <version.org.jboss.genericjms>1.0.7.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.2.5.Final</version.org.jboss.ironjacamar>
-        <version.org.jboss.jboss-transaction-spi>7.1.1.Final</version.org.jboss.jboss-transaction-spi>
+        <version.org.jboss.jboss-transaction-spi>7.3.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>10.0.0.Beta2</version.org.jboss.metadata>
         <version.org.jboss.narayana>5.2.0.Final</version.org.jboss.narayana>
         <version.org.jboss.mod_cluster>1.3.1.Final</version.org.jboss.mod_cluster>


### PR DESCRIPTION
The upgrade introduces 2 changes:
- a locator method for obtaining an implementation of the TransactionListenerRegistry interface that JPA uses to monitor thread to transaction association changes. The functionality is already present but JPA was having to make an ugly cast of the transaction manager to TransactionListenerRegistry;
- ServerVMClientUserTransaction now implements javax.naming.Referenceable (so that it can be looked up via JNDI). This was an issue raised by support (JBTM-2449)
