### PR TITLE
WFLY-4996 Add org.jboss.common-core to modcluster subsystem

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/mod_cluster/main/module.xml
@@ -33,6 +33,7 @@
 
     <dependencies>
         <module name="javax.api"/>
+        <module name="org.jboss.common-core"/>
         <module name="org.jboss.as.clustering.common"/>
         <module name="org.jboss.as.controller"/>
         <module name="org.jboss.as.network"/>


### PR DESCRIPTION
ModClusterSubsystemAdd class uses org.jboss.util.propertyeditor.PropertyEditors class which is located in org.jboss.common-core module. Reference to this module is not specified in modcluster subsystem module configuration. 
