### PR TITLE
Adjustment required due to AESH Upgrade in wildfly-core

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/perimeter/CLISecurityTestCase.java
@@ -62,7 +62,7 @@ public class CLISecurityTestCase {
     public static class UnauthentizedCLI extends CLIWrapper {
 
         public UnauthentizedCLI() throws Exception {
-            super(false, null, createConsoleInput());
+            super(false);
         }
 
         @Override
@@ -70,23 +70,6 @@ public class CLISecurityTestCase {
             return null;
         }
 
-        private static InputStream createConsoleInput() {
-            return new InputStream() {
-                private final byte[] bytes = (Authentication.USERNAME + '\n').getBytes();
-                private int i = 0;
-                @Override
-                public int read() throws IOException {
-                    if(i >= bytes.length) {
-                        return -1;
-                    }
-                    return bytes[i++];
-                }
-                @Override
-                public int available() {
-                    return bytes.length - i;
-                }
-            };
-        }
         public synchronized void shutdown(){
             this.quit();
         }


### PR DESCRIPTION
The CLI behavior is changing and it seems that pre-loading the inputstream for the CLI doesn't work the same way anymore. Instead of waiting for the console to request the input, the console is reading the input before the CLI completes the startup or can do anything with the input line.

Adjusted test passes locally with and without the AESH upgrade in core, so inputting the username seems to be unrelated to verifying the CLI authentication message anyway.

Related AESH upgrade in core: https://github.com/wildfly/wildfly-core/pull/904
