### PR TITLE
WFLY-5006 support for extended persistence context with SynchronizationType.UNSYNCHRONIZED

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/injectors/PersistenceContextInjectionSource.java
@@ -172,7 +172,12 @@ public class PersistenceContextInjectionSource extends InjectionSource {
                 }
 
                 if (entityManager1 == null) {
-                    entityManager1 = new ExtendedEntityManager(unitName, emf.createEntityManager(properties), synchronizationType);
+                    if (SynchronizationType.UNSYNCHRONIZED.equals(synchronizationType)) {
+                        entityManager1 = new ExtendedEntityManager(unitName, emf.createEntityManager(synchronizationType, properties), synchronizationType);
+                    }
+                    else {
+                        entityManager1 = new ExtendedEntityManager(unitName, emf.createEntityManager(properties), synchronizationType);
+                    }
                     createdNewExtendedPersistence = true;
                     if (ROOT_LOGGER.isDebugEnabled())
                         ROOT_LOGGER.debugf("created new ExtendedEntityManager for unit name=%s, useDeepInheritance = %b", unitName, useDeepInheritance);


### PR DESCRIPTION
I'm not sure why I only saw failures in our org.jboss.as.test.integration.jpa.transaction.TransactionTestCase after Hibernate ORM (5.0) fixed the HHH-9927 bug, but am happy to catch this (JPA 2.1 bug) finally.  
