### PR TITLE
fix intermittent failures on JMSQueueManagementTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSQueueManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSQueueManagementTestCase.java
@@ -86,7 +86,7 @@ public class JMSQueueManagementTestCase {
     @Before
     public void addQueues() throws Exception {
 
-        adminSupport = JMSOperationsProvider.getInstance(managementClient);
+        adminSupport = JMSOperationsProvider.getInstance(managementClient.getControllerClient());
 
         count++;
         adminSupport.createJmsQueue(getQueueName(), EXPORTED_PREFIX + getQueueJndiName());
@@ -437,11 +437,6 @@ public class JMSQueueManagementTestCase {
 
         // remove the queue
         adminSupport.removeJmsQueue(getQueueName());
-        try {
-            consumer.receive(5000);
-            fail("consumer is not valid after the queue is removed");
-        } catch (javax.jms.IllegalStateException e) {
-        }
         // add the queue back
         adminSupport.createJmsQueue(getQueueName(), EXPORTED_PREFIX + getQueueJndiName());
 


### PR DESCRIPTION
Remove assertion that a consumer can not receive a message after the
queue is closed. There is a time window where the messaging client may not have
been advertised that the queue has been removed and the consumer must be
closed. This assertion is not relevant to the tests. Ensuring that
removing and adding back the same queue removes all stored messages is
enough.
