### PR TITLE
WFLY-4923 closing of container managed persistence context should guard against background threads that are also using the persistence context

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -42,6 +42,7 @@ import org.jboss.logging.Logger;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.modules.ModuleIdentifier;
+import org.jboss.msc.inject.InjectionException;
 import org.jboss.vfs.VirtualFile;
 
 /**
@@ -753,4 +754,12 @@ public interface JpaLogger extends BasicLogger {
     @Message(id = 70, value = "A container-managed extended persistence context can only be initiated within the scope of a stateful session bean (persistence unit '%s').")
     IllegalStateException xpcOnlyFromSFSB(String scopedPuName);
 
+    /**
+     * Likely means that the transaction manager does not implement the org.jboss.tm.listener.TransactionListenerRegistry class.
+     *
+     * @param cause the cause of the error.
+     * @return
+     */
+    @Message(id = 71, value = "Could not obtain TransactionListenerRegistry from transaction manager")
+    InjectionException errorGettingTransactionListenerRegistry(@Cause Throwable cause);
 }


### PR DESCRIPTION
I included the commit from https://github.com/wildfly/wildfly/pull/7820 (need access to TransactionListenerRegistry), after pr#7820 is merged, I will update this pr.
