### PR TITLE
[WFLY-4628] Add ability to start, stop and restart batch jobs on a deployment

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtension.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemExtension.java
@@ -25,10 +25,10 @@ package org.wildfly.extension.batch.jberet;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.wildfly.extension.batch.jberet.deployment.BatchDeploymentResourceDefinition;
 import org.wildfly.extension.batch.jberet.deployment.BatchJobExecutionResourceDefinition;
 import org.wildfly.extension.batch.jberet.deployment.BatchJobResourceDefinition;
 
@@ -58,10 +58,7 @@ public class BatchSubsystemExtension implements Extension {
         subsystem.registerXMLElementWriter(new BatchSubsystemWriter());
         // Register the deployment resources
         if (context.isRuntimeOnlyRegistrationValid()) {
-            final SimpleResourceDefinition deploymentResource = new SimpleResourceDefinition(
-                    BatchSubsystemDefinition.SUBSYSTEM_PATH,
-                    BatchResourceDescriptionResolver.getResourceDescriptionResolver("deployment"));
-            final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(deploymentResource);
+            final ManagementResourceRegistration deployments = subsystem.registerDeploymentModel(new BatchDeploymentResourceDefinition());
             final ManagementResourceRegistration jobRegistration = deployments.registerSubModel(BatchJobResourceDefinition.INSTANCE);
             jobRegistration.registerSubModel(new BatchJobExecutionResourceDefinition()).setRuntimeOnly(true);
         }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDeploymentResourceDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDeploymentResourceDefinition.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.jberet.deployment;
+
+import javax.batch.operations.JobExecutionAlreadyCompleteException;
+import javax.batch.operations.JobExecutionNotMostRecentException;
+import javax.batch.operations.JobExecutionNotRunningException;
+import javax.batch.operations.JobOperator;
+import javax.batch.operations.JobRestartException;
+import javax.batch.operations.JobSecurityException;
+import javax.batch.operations.JobStartException;
+import javax.batch.operations.NoSuchJobExecutionException;
+import java.util.Properties;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.SimpleAttributeDefinition;
+import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleMapAttributeDefinition;
+import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.operations.validation.LongRangeValidator;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
+import org.wildfly.extension.batch.jberet.BatchResourceDescriptionResolver;
+import org.wildfly.extension.batch.jberet.BatchSubsystemDefinition;
+
+/**
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchDeploymentResourceDefinition extends SimpleResourceDefinition {
+
+    private static final ResourceDescriptionResolver DEFAULT_RESOLVER = BatchResourceDescriptionResolver.getResourceDescriptionResolver("deployment");
+
+    private static final SimpleAttributeDefinition EXECUTION_ID = SimpleAttributeDefinitionBuilder.create("execution-id", ModelType.LONG, false)
+            .setValidator(new LongRangeValidator(1L, false))
+            .build();
+
+    private static final SimpleAttributeDefinition JOB_XML_NAME = SimpleAttributeDefinitionBuilder.create("job-xml-name", ModelType.STRING, false)
+            .build();
+
+    private static final SimpleMapAttributeDefinition PROPERTIES = new SimpleMapAttributeDefinition.Builder("properties", ModelType.STRING, true)
+            .build();
+
+    private static final SimpleOperationDefinition START_JOB = new SimpleOperationDefinitionBuilder("start-job", DEFAULT_RESOLVER)
+            .setParameters(JOB_XML_NAME, PROPERTIES)
+            .setReplyType(ModelType.LONG)
+            .setRuntimeOnly()
+            .build();
+
+    private static final SimpleOperationDefinition RESTART_JOB = new SimpleOperationDefinitionBuilder("restart-job", DEFAULT_RESOLVER)
+            .setParameters(EXECUTION_ID, PROPERTIES)
+            .setReplyType(ModelType.LONG)
+            .setRuntimeOnly()
+            .build();
+
+    private static final SimpleOperationDefinition STOP_JOB = new SimpleOperationDefinitionBuilder("stop-job", DEFAULT_RESOLVER)
+            .setParameters(EXECUTION_ID)
+            .setRuntimeOnly()
+            .build();
+
+    public BatchDeploymentResourceDefinition() {
+        super(new Parameters(BatchSubsystemDefinition.SUBSYSTEM_PATH, DEFAULT_RESOLVER).setRuntime());
+    }
+
+    @Override
+    public void registerOperations(final ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(START_JOB, new JobOperationStepHandler() {
+            @Override
+            protected void execute(final OperationContext context, final ModelNode operation, final JobOperator jobOperator) throws OperationFailedException {
+                // Resolve the job XML name
+                final String jobName = resolveValue(context, operation, JOB_XML_NAME).asString();
+                final Properties properties = resolvePropertyValue(context, operation, PROPERTIES);
+                try {
+                    final long executionId = jobOperator.start(jobName, properties);
+                    context.getResult().set(executionId);
+                } catch (JobStartException | JobSecurityException e) {
+                    throw createOperationFailure(e);
+                }
+            }
+        });
+
+        resourceRegistration.registerOperationHandler(STOP_JOB, new JobOperationStepHandler() {
+            @Override
+            protected void execute(final OperationContext context, final ModelNode operation, final JobOperator jobOperator) throws OperationFailedException {
+                // Resolve the execution id
+                final long executionId = resolveValue(context, operation, EXECUTION_ID).asLong();
+                try {
+                    jobOperator.stop(executionId);
+                } catch (NoSuchJobExecutionException | JobExecutionNotRunningException | JobSecurityException e) {
+                    throw createOperationFailure(e);
+                }
+            }
+        });
+
+        resourceRegistration.registerOperationHandler(RESTART_JOB, new JobOperationStepHandler() {
+            @Override
+            protected void execute(final OperationContext context, final ModelNode operation, final JobOperator jobOperator) throws OperationFailedException {
+                // Resolve the execution id
+                final long executionId = resolveValue(context, operation, EXECUTION_ID).asLong();
+                final Properties properties = resolvePropertyValue(context, operation, PROPERTIES);
+                try {
+                    final long newExecutionId = jobOperator.restart(executionId, properties);
+                    context.getResult().set(newExecutionId);
+                } catch (JobExecutionAlreadyCompleteException | NoSuchJobExecutionException | JobExecutionNotMostRecentException | JobRestartException | JobSecurityException e) {
+                    throw createOperationFailure(e);
+                }
+            }
+        });
+    }
+}

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchJobExecutionResourceDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchJobExecutionResourceDefinition.java
@@ -24,7 +24,14 @@ package org.wildfly.extension.batch.jberet.deployment;
 
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Properties;
+import javax.batch.operations.JobExecutionAlreadyCompleteException;
+import javax.batch.operations.JobExecutionNotMostRecentException;
+import javax.batch.operations.JobExecutionNotRunningException;
 import javax.batch.operations.JobOperator;
+import javax.batch.operations.JobRestartException;
+import javax.batch.operations.JobSecurityException;
+import javax.batch.operations.NoSuchJobExecutionException;
 import javax.batch.runtime.BatchStatus;
 import javax.batch.runtime.JobExecution;
 import javax.batch.runtime.JobInstance;
@@ -34,7 +41,11 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
+import org.jboss.as.controller.SimpleMapAttributeDefinition;
+import org.jboss.as.controller.SimpleOperationDefinition;
+import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
@@ -78,13 +89,28 @@ public class BatchJobExecutionResourceDefinition extends SimpleResourceDefinitio
 
     static final String ISO_8601_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
+    private static final ResourceDescriptionResolver DEFAULT_RESOLVER = BatchResourceDescriptionResolver.getResourceDescriptionResolver("deployment", "job", "execution");
+
+    private static final SimpleMapAttributeDefinition PROPERTIES = new SimpleMapAttributeDefinition.Builder("properties", ModelType.STRING, true)
+            .build();
+
+    private static final SimpleOperationDefinition RESTART_JOB = new SimpleOperationDefinitionBuilder("restart-job", DEFAULT_RESOLVER)
+            .setParameters(PROPERTIES)
+            .setReplyType(ModelType.LONG)
+            .setRuntimeOnly()
+            .build();
+
+    private static final SimpleOperationDefinition STOP_JOB = new SimpleOperationDefinitionBuilder("stop-job", DEFAULT_RESOLVER)
+            .setRuntimeOnly()
+            .build();
+
     public BatchJobExecutionResourceDefinition() {
-        super(PathElement.pathElement(EXECUTION), BatchResourceDescriptionResolver.getResourceDescriptionResolver("deployment", "job", "execution"));
+        super(new Parameters(PathElement.pathElement(EXECUTION), DEFAULT_RESOLVER).setRuntime());
     }
 
     @Override
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadOnlyAttribute(INSTANCE_ID, new JobOperationStepHandler() {
+        resourceRegistration.registerReadOnlyAttribute(INSTANCE_ID, new JobOperationUpdateStepHandler() {
             @Override
             protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
                 final JobInstance jobInstance = jobOperator.getJobInstance(Long.parseLong(context.getCurrentAddressValue()));
@@ -135,7 +161,41 @@ public class BatchJobExecutionResourceDefinition extends SimpleResourceDefinitio
         });
     }
 
-    abstract static class JobExecutionOperationStepHandler extends JobOperationStepHandler {
+    @Override
+    public void registerOperations(final ManagementResourceRegistration resourceRegistration) {
+        super.registerOperations(resourceRegistration);
+
+        resourceRegistration.registerOperationHandler(STOP_JOB, new JobOperationStepHandler() {
+            @Override
+            protected void execute(final OperationContext context, final ModelNode operation, final JobOperator jobOperator) throws OperationFailedException {
+                // Resolve the execution id
+                final long executionId = Long.parseLong(context.getCurrentAddressValue());
+                try {
+                    jobOperator.stop(executionId);
+                } catch (NoSuchJobExecutionException | JobExecutionNotRunningException | JobSecurityException e) {
+                    throw createOperationFailure(e);
+                }
+            }
+        });
+
+        resourceRegistration.registerOperationHandler(RESTART_JOB, new JobOperationStepHandler() {
+            @Override
+            protected void execute(final OperationContext context, final ModelNode operation, final JobOperator jobOperator) throws OperationFailedException {
+                // Resolve the execution id
+                final long executionId = Long.parseLong(context.getCurrentAddressValue());
+                // Get the properties
+                final Properties properties = resolvePropertyValue(context, operation, PROPERTIES);
+                try {
+                    final long newExecutionId = jobOperator.restart(executionId, properties);
+                    context.getResult().set(newExecutionId);
+                } catch (JobExecutionAlreadyCompleteException | NoSuchJobExecutionException | JobExecutionNotMostRecentException | JobRestartException | JobSecurityException e) {
+                    throw createOperationFailure(e);
+                }
+            }
+        });
+    }
+
+    abstract static class JobExecutionOperationStepHandler extends JobOperationUpdateStepHandler {
         @Override
         protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
             final JobExecution jobExecution = jobOperator.getJobExecution(Long.parseLong(context.getCurrentAddressValue()));

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchJobResourceDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchJobResourceDefinition.java
@@ -59,13 +59,13 @@ public class BatchJobResourceDefinition extends SimpleResourceDefinition {
 
     @Override
     public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
-        resourceRegistration.registerReadOnlyAttribute(RUNNING_EXECUTIONS, new JobOperationStepHandler() {
+        resourceRegistration.registerReadOnlyAttribute(RUNNING_EXECUTIONS, new JobOperationUpdateStepHandler() {
             @Override
             protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
                 model.set(jobOperator.getRunningExecutions(jobName).size());
             }
         });
-        resourceRegistration.registerReadOnlyAttribute(INSTANCE_COUNT, new JobOperationStepHandler() {
+        resourceRegistration.registerReadOnlyAttribute(INSTANCE_COUNT, new JobOperationUpdateStepHandler() {
             @Override
             protected void updateModel(final OperationContext context, final ModelNode model, final JobOperator jobOperator, final String jobName) throws OperationFailedException {
                 model.set(jobOperator.getJobInstanceCount(jobName));

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperationUpdateStepHandler.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobOperationUpdateStepHandler.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.jberet.deployment;
+
+import javax.batch.operations.JobOperator;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A handler to assist with updating the dynamic batch job resources.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+abstract class JobOperationUpdateStepHandler extends JobOperationStepHandler {
+    @Override
+    protected void execute(final OperationContext context, final ModelNode operation, final JobOperator jobOperator) throws OperationFailedException {
+        updateModel(context, context.getResult(), jobOperator, context.getCurrentAddressValue());
+    }
+
+    /**
+     * Updates the model with information from the {@link javax.batch.operations.JobOperator JobOperator}.
+     *
+     * @param context     the operation context used
+     * @param model       the model to update
+     * @param jobOperator the job operator
+     * @param jobName     the name of the job
+     *
+     * @throws OperationFailedException if an update failure occurs
+     */
+    protected abstract void updateModel(OperationContext context, ModelNode model, JobOperator jobOperator, String jobName) throws OperationFailedException;
+}

--- a/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
+++ b/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
@@ -47,8 +47,21 @@ batch.jberet.thread-pool=The thread pool used for batch jobs.
 # Thread factory
 batch.jberet.thread-factory=The thread factory used for the thread-pool.
 
-# Batch job information
+# Batch deployment resource
 batch.jberet.deployment=Information about the batch subsystem for the deployment.
+# Batch deployment operations
+batch.jberet.deployment.start-job=Starts a batch job.
+batch.jberet.deployment.start-job.job-xml-name=The name of the job XML file to use when starting the job.
+batch.jberet.deployment.start-job.properties=Optional properties to use when starting the batch job.
+
+batch.jberet.deployment.stop-job=Stops a running batch job.
+batch.jberet.deployment.stop-job.execution-id=The execution id of the job to be stopped.
+
+batch.jberet.deployment.restart-job=Restarts a batch job. Only jobs in a STOPPED or FAILED state can be restarted.
+batch.jberet.deployment.restart-job.execution-id=The execution id of the job to restart. This must be the most recent job execution id.
+batch.jberet.deployment.restart-job.properties=Optional properties to use when restarting the batch job.
+
+# Batch job information
 batch.jberet.deployment.job=Information about a specific batch job.
 batch.jberet.deployment.job.running-executions=The number of currently running executions for the job.
 batch.jberet.deployment.job.instance-count=The number of instances for the job.
@@ -60,3 +73,8 @@ batch.jberet.deployment.job.execution.create-time=The time the execution was cre
 batch.jberet.deployment.job.execution.start-time=The time the execution entered the STARTED status in ISO 8601 format.
 batch.jberet.deployment.job.execution.last-updated-time=The time the execution was last updated in ISO 8601 format.
 batch.jberet.deployment.job.execution.end-time=The time, in ISO 8601 format, the execution entered a status of: COMPLETED, STOPPED or FAILED
+# Batch deployment executed jobs operations
+batch.jberet.deployment.job.execution.stop-job=Stops a running batch job.
+
+batch.jberet.deployment.job.execution.restart-job=Restarts a batch job. Only jobs in a STOPPED or FAILED state can be restarted. This must also be the most recent job execution.
+batch.jberet.deployment.job.execution.restart-job.properties=Optional properties to use when restarting the batch job.

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/Counter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/Counter.java
@@ -22,53 +22,29 @@
 
 package org.jboss.as.test.integration.batch.common;
 
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import javax.batch.api.BatchProperty;
-import javax.batch.api.chunk.ItemWriter;
-import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Singleton;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 @Named
-//@Singleton
-public class CountingItemWriter implements ItemWriter {
+@Singleton
+public class Counter implements Serializable {
 
-    @Inject
-    private Counter counter;
+    private final AtomicInteger counter = new AtomicInteger(0);
 
-    @Inject
-    @BatchProperty(name = "writer.sleep.time")
-    private long sleep;
-
-    @Override
-    public void open(final Serializable checkpoint) throws Exception {
+    public int increment() {
+        return counter.incrementAndGet();
     }
 
-    @Override
-    public void close() throws Exception {
+    public int increment(final int i) {
+        return counter.addAndGet(i);
     }
 
-    @Override
-    public void writeItems(final List<Object> items) throws Exception {
-        counter.increment(items.size());
-        if (sleep > 0) {
-            TimeUnit.MILLISECONDS.sleep(sleep);
-        }
-    }
-
-    @Override
-    public Serializable checkpointInfo() throws Exception {
-        return counter;
-    }
-
-    public int getWrittenItemSize() {
+    public int get() {
         return counter.get();
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/deployment/JobControlTestCase.java
@@ -1,0 +1,300 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.batch.deployment;
+
+import javax.batch.operations.JobOperator;
+import javax.batch.runtime.BatchRuntime;
+import javax.batch.runtime.BatchStatus;
+import javax.batch.runtime.JobExecution;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.Operations;
+import org.jboss.as.test.integration.batch.common.AbstractBatchTestCase;
+import org.jboss.as.test.integration.batch.common.CountingItemReader;
+import org.jboss.as.test.integration.batch.common.CountingItemWriter;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests the start, stop and restart functionality for deployments.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+@RunWith(Arquillian.class)
+public class JobControlTestCase extends AbstractBatchTestCase {
+
+    private static final String DEPLOYMENT_NAME = "test-batch.war";
+
+    @ArquillianResource
+    private ManagementClient managementClient;
+
+    @Inject
+    private CountingItemWriter countingItemWriter;
+
+    private int currentCount = 0;
+
+    @Deployment(name = DEPLOYMENT_NAME)
+    public static WebArchive createNamedInMemoryDeployment() {
+        return createDefaultWar(DEPLOYMENT_NAME, DeploymentDescriptorTestCase.class.getPackage(), "test-chunk.xml")
+                .addClasses(CountingItemReader.class, CountingItemWriter.class)
+                .addClass(Operations.class)
+                .addAsResource(new StringAsset("Dependencies: org.jboss.dmr, org.jboss.as.controller\n"), "META-INF/MANIFEST.MF");
+    }
+
+    @Test
+    public void testStart() throws Exception {
+        final ModelNode address = Operations.createAddress("deployment", DEPLOYMENT_NAME, "subsystem", "batch-jberet");
+        final ModelNode op = Operations.createOperation("start-job", address);
+        op.get("job-xml-name").set("test-chunk");
+        final ModelNode properties = op.get("properties");
+        properties.get("reader.end").set("5");
+        final ModelNode result = executeOperation(op);
+        currentCount += 5;
+        final long executionId = result.asLong();
+        Assert.assertTrue("Execution id should be greater than 0", executionId > 0L);
+
+        // Validate that the job as executed
+        final JobOperator jobOperator = BatchRuntime.getJobOperator();
+        final JobExecution execution = jobOperator.getJobExecution(executionId);
+        Assert.assertNotNull(execution);
+
+        // Wait for 3 seconds max for the execution to finish.
+        waitForTermination(execution, 3);
+
+        // Check that we have 5 items
+        Assert.assertEquals(currentCount, countingItemWriter.getWrittenItemSize());
+    }
+
+    @Test
+    public void testStop() throws Exception {
+        final ModelNode address = Operations.createAddress("deployment", DEPLOYMENT_NAME, "subsystem", "batch-jberet");
+        ModelNode op = Operations.createOperation("start-job", address);
+        op.get("job-xml-name").set("test-chunk");
+        final ModelNode properties = op.get("properties");
+        properties.get("reader.end").set("20");
+        // We're adding a long wait time to ensure we can stop, 1 seconds should be okay
+        properties.get("writer.sleep.time").set(Integer.toString(TimeoutUtil.adjust(1000)));
+        final ModelNode result = executeOperation(op);
+        final long executionId = result.asLong();
+        Assert.assertTrue("Execution id should be greater than 0", executionId > 0L);
+
+        // Test the stop operation
+        op = Operations.createOperation("stop-job", address);
+        op.get("execution-id").set(executionId);
+        executeOperation(op);
+
+        // Validate that the job as executed
+        final JobOperator jobOperator = BatchRuntime.getJobOperator();
+        final JobExecution execution = jobOperator.getJobExecution(executionId);
+        Assert.assertNotNull(execution);
+
+        // Wait for 1 seconds max for the execution to finish.
+        waitForTermination(execution, 3);
+
+        // Reset the counter as we're not sure how many were actually written
+        currentCount = countingItemWriter.getWrittenItemSize();
+
+        // Check that the status is stopped
+        Assert.assertEquals(BatchStatus.STOPPED, execution.getBatchStatus());
+    }
+
+    @Test
+    public void testStopOnExecutionResource() throws Exception {
+        final ModelNode address = Operations.createAddress("deployment", DEPLOYMENT_NAME, "subsystem", "batch-jberet");
+        ModelNode op = Operations.createOperation("start-job", address);
+        op.get("job-xml-name").set("test-chunk");
+        final ModelNode properties = op.get("properties");
+        properties.get("reader.end").set("20");
+        // We're adding a long wait time to ensure we can stop, 1 seconds should be okay
+        properties.get("writer.sleep.time").set(Integer.toString(TimeoutUtil.adjust(1000)));
+        final ModelNode result = executeOperation(op);
+        final long executionId = result.asLong();
+        Assert.assertTrue("Execution id should be greater than 0", executionId > 0L);
+
+        // Test the stop operation
+        final ModelNode executionAddress = Operations.createAddress("deployment", DEPLOYMENT_NAME, "subsystem", "batch-jberet", "job", "test-chunk", "execution", Long.toString(executionId));
+        executeOperation(Operations.createOperation("stop-job", executionAddress));
+
+        // Validate that the job as executed
+        final JobOperator jobOperator = BatchRuntime.getJobOperator();
+        final JobExecution execution = jobOperator.getJobExecution(executionId);
+        Assert.assertNotNull(execution);
+
+        // Wait for 1 seconds max for the execution to finish.
+        waitForTermination(execution, 3);
+
+        // Reset the counter as we're not sure how many were actually written
+        currentCount = countingItemWriter.getWrittenItemSize();
+
+        // Check that the status is stopped
+        Assert.assertEquals(BatchStatus.STOPPED, execution.getBatchStatus());
+    }
+
+    @Test
+    public void testRestart() throws Exception {
+        final ModelNode address = Operations.createAddress("deployment", DEPLOYMENT_NAME, "subsystem", "batch-jberet");
+        ModelNode op = Operations.createOperation("start-job", address);
+        op.get("job-xml-name").set("test-chunk");
+        ModelNode properties = op.get("properties");
+        properties.get("reader.end").set("20");
+        // We're adding a long wait time to ensure we can stop, 1 seconds should be okay
+        properties.get("writer.sleep.time").set(Integer.toString(TimeoutUtil.adjust(1000)));
+        ModelNode result = executeOperation(op);
+        long executionId = result.asLong();
+        Assert.assertTrue("Execution id should be greater than 0", executionId > 0L);
+
+        // Test the stop operation
+        op = Operations.createOperation("stop-job", address);
+        op.get("execution-id").set(executionId);
+        executeOperation(op);
+
+        // Validate that the job as executed
+        final JobOperator jobOperator = BatchRuntime.getJobOperator();
+        JobExecution execution = jobOperator.getJobExecution(executionId);
+        Assert.assertNotNull(execution);
+
+        // Wait for 3 seconds max for the execution to finish.
+        waitForTermination(execution, 3);
+
+        // Reset the counter as we're not sure how many were actually written
+        currentCount = countingItemWriter.getWrittenItemSize();
+
+        // Check that the status is stopped
+        Assert.assertEquals(BatchStatus.STOPPED, execution.getBatchStatus());
+
+        // Restart the execution
+        op = Operations.createOperation("restart-job", address);
+        op.get("execution-id").set(executionId);
+        properties = op.get("properties");
+        properties.get("reader.end").set("10");
+        properties.get("writer.sleep.time").set("0");
+        result = executeOperation(op);
+        executionId = result.asLong();
+        Assert.assertTrue("Execution id should be greater than 0", executionId > 0L);
+        execution = jobOperator.getJobExecution(executionId);
+        Assert.assertNotNull(execution);
+
+        // Wait for 3 seconds max for the execution to finish.
+        waitForTermination(execution, 3);
+
+        // Check that the status is stopped
+        Assert.assertEquals(BatchStatus.COMPLETED, execution.getBatchStatus());
+    }
+
+    @Test
+    public void testRestartOnExecutionResource() throws Exception {
+        final ModelNode address = Operations.createAddress("deployment", DEPLOYMENT_NAME, "subsystem", "batch-jberet");
+        ModelNode op = Operations.createOperation("start-job", address);
+        op.get("job-xml-name").set("test-chunk");
+        ModelNode properties = op.get("properties");
+        properties.get("reader.end").set("20");
+        // We're adding a long wait time to ensure we can stop, 1 seconds should be okay
+        properties.get("writer.sleep.time").set(Integer.toString(TimeoutUtil.adjust(1000)));
+        ModelNode result = executeOperation(op);
+        long executionId = result.asLong();
+        Assert.assertTrue("Execution id should be greater than 0", executionId > 0L);
+
+        // Test the stop operation
+        final ModelNode executionAddress = Operations.createAddress("deployment", DEPLOYMENT_NAME, "subsystem", "batch-jberet", "job", "test-chunk", "execution", Long.toString(executionId));
+        executeOperation(Operations.createOperation("stop-job", executionAddress));
+
+        // Validate that the job as executed
+        final JobOperator jobOperator = BatchRuntime.getJobOperator();
+        JobExecution execution = jobOperator.getJobExecution(executionId);
+        Assert.assertNotNull(execution);
+
+        // Wait for 1 seconds max for the execution to finish.
+        waitForTermination(execution, 3);
+
+        // Reset the counter as we're not sure how many were actually written
+        currentCount = countingItemWriter.getWrittenItemSize();
+
+        // Check that the status is stopped
+        Assert.assertEquals(BatchStatus.STOPPED, execution.getBatchStatus());
+
+        // Restart the execution
+        op = Operations.createOperation("restart-job", executionAddress);
+        properties = op.get("properties");
+        properties.get("reader.end").set("10");
+        properties.get("writer.sleep.time").set("0");
+        result = executeOperation(op);
+        executionId = result.asLong();
+        Assert.assertTrue("Execution id should be greater than 0", executionId > 0L);
+        execution = jobOperator.getJobExecution(executionId);
+        Assert.assertNotNull(execution);
+
+        // Wait for 3 seconds max for the execution to finish.
+        waitForTermination(execution, 3);
+
+        // Check that the status is stopped
+        Assert.assertEquals(BatchStatus.COMPLETED, execution.getBatchStatus());
+    }
+
+    private ModelNode executeOperation(final ModelNode op) throws IOException {
+        final ModelControllerClient client = managementClient.getControllerClient();
+        final ModelNode result = client.execute(op);
+        if (Operations.isSuccessfulOutcome(result)) {
+            return Operations.readResult(result);
+        }
+        Assert.fail(Operations.getFailureDescription(result).asString());
+        // Should never be reached
+        return new ModelNode();
+    }
+
+    private static void waitForTermination(final JobExecution jobExecution, final int timeout) {
+        long waitTimeout = TimeoutUtil.adjust(timeout * 1000);
+        long sleep = 100L;
+        while (true) {
+            switch (jobExecution.getBatchStatus()) {
+                case STARTED:
+                case STARTING:
+                case STOPPING:
+                    try {
+                        TimeUnit.MILLISECONDS.sleep(sleep);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                    waitTimeout -= sleep;
+                    sleep = Math.max(sleep / 2, 100L);
+                    break;
+                default:
+                    return;
+            }
+            if (waitTimeout <= 0) {
+                throw new IllegalStateException("Batch job did not complete within allotted time.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
Three new operations were added to the deployment resource, `deployment=example.war`. All three exist on the `subsystem=batch-jberet` sub-resource of a deployment. The `stop` and `restart` also exist on the `subsystem=batch-jberet/job=job-name/execution=1` sub-resource.

The job-name name may not be known to a user attempting to stop or restart a batch job. The job name is defined by an attribute in a job XML file. There's no way to determine which job XML file contains which job and it's possible more than on job XML file defines the same job name. This is the main reason for the `stop` and `restart` operations to be located on two resources.
