### PR TITLE
[WFLY-5039] Safe copy the job names to avoid ConcurrentModificationEx…

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobXmlResolverService.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/JobXmlResolverService.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -178,7 +179,7 @@ class JobXmlResolverService implements Service<JobXmlResolver>, JobXmlResolver {
 
     @Override
     public synchronized Collection<String> getJobXmlNames(final ClassLoader classLoader) {
-        return cachedJobInfo.keySet();
+        return new ArrayList<>(cachedJobInfo.keySet());
     }
 
     @Override

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobXmlResolverService.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/JobXmlResolverService.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -159,7 +160,7 @@ class JobXmlResolverService implements Service<JobXmlResolver>, JobXmlResolver {
 
     @Override
     public synchronized Collection<String> getJobXmlNames(final ClassLoader classLoader) {
-        return cachedJobInfo.keySet();
+        return new ArrayList<>(cachedJobInfo.keySet());
     }
 
     @Override


### PR DESCRIPTION
…ception's.

`ConcurrentModificationException` errors are being thrown in the batch TCK. This corrects what should have been done with a safe copy.
https://issues.jboss.org/browse/WFLY-5039
