### PR TITLE
[WFLY-5041] Added ReuseAuthenticatedSubjectTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/CounterServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/CounterServlet.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.context;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.jboss.as.test.integration.security.loginmodules.common.CounterLoginModule;
+
+/**
+ * Servlet which prints counter from CounterLoginModule. It can also reset this counter when reset parameter is set to true.
+ *
+ * @author olukas
+ */
+@WebServlet(urlPatterns = {CounterServlet.SERVLET_PATH})
+public class CounterServlet extends HttpServlet {
+
+    public static final String SERVLET_PATH = "/CounterServlet";
+
+    public static final String RESET_PARAM = "reset";
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        final PrintWriter writer = resp.getWriter();
+        if (Boolean.parseBoolean(req.getParameter(RESET_PARAM))) {
+            CounterLoginModule.resetCounter();
+        }
+        writer.write(Integer.toString(CounterLoginModule.getCounter()));
+        writer.close();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbOwnSecurityDomain.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbOwnSecurityDomain.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.context;
+
+/**
+ *
+ * @author olukas
+ */
+public interface EjbOwnSecurityDomain {
+
+    public String sayHello();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbOwnSecurityDomainImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbOwnSecurityDomainImpl.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.context;
+
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Stateless;
+import static org.jboss.as.test.integration.security.context.EjbOwnSecurityDomainImpl.SECURITY_DOMAIN;
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * EJB which does not use the same security-domain as deployment from ReuseAuthenticatedSubjectTestCase.
+ *
+ * @author olukas
+ */
+@Stateless
+@DeclareRoles(EjbOwnSecurityDomainImpl.AUTHORIZED_ROLE)
+@SecurityDomain(SECURITY_DOMAIN)
+public class EjbOwnSecurityDomainImpl implements EjbOwnSecurityDomain {
+
+    public static final String AUTHORIZED_ROLE = "admin";
+    public static final String SECURITY_DOMAIN = "ejbOwnSecurityDomain";
+
+    public static final String SAY_HELLO = "Hello from EjbOwnSecurityDomain";
+
+    @Override
+    @RolesAllowed(AUTHORIZED_ROLE)
+    public String sayHello() {
+        return SAY_HELLO;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbSecurityDomainAsServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbSecurityDomainAsServlet.java
@@ -1,0 +1,31 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.context;
+
+/**
+ *
+ * @author olukas
+ */
+public interface EjbSecurityDomainAsServlet {
+
+    public String sayHello();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbSecurityDomainAsServletImpl.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/EjbSecurityDomainAsServletImpl.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.context;
+
+import javax.annotation.security.DeclareRoles;
+import javax.annotation.security.RolesAllowed;
+import javax.ejb.Stateless;
+import static org.jboss.as.test.integration.security.context.EjbSecurityDomainAsServletImpl.SECURITY_DOMAIN;
+import org.jboss.ejb3.annotation.SecurityDomain;
+
+/**
+ * EJB which uses the same security-domain as deployment from ReuseAuthenticatedSubjectTestCase.
+ *
+ * @author olukas
+ */
+@Stateless
+@DeclareRoles(EjbSecurityDomainAsServletImpl.AUTHORIZED_ROLE)
+@SecurityDomain(SECURITY_DOMAIN)
+public class EjbSecurityDomainAsServletImpl implements EjbSecurityDomainAsServlet {
+
+    public static final String AUTHORIZED_ROLE = "admin";
+    public static final String SECURITY_DOMAIN = "ejbSecurityDomainAsServlet";
+
+    public static final String SAY_HELLO = "Hello from EjbSecurityDomainAsServlet";
+
+    @Override
+    @RolesAllowed(AUTHORIZED_ROLE)
+    public String sayHello() {
+        return SAY_HELLO;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/ReuseAuthenticatedSubjectServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/ReuseAuthenticatedSubjectServlet.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.context;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.annotation.security.DeclareRoles;
+import javax.ejb.EJB;
+import javax.servlet.ServletException;
+import javax.servlet.annotation.HttpConstraint;
+import javax.servlet.annotation.ServletSecurity;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Servlet for invocation EjbSecurityDomainAsServlet or EjbOwnSecurityDomain EJB.
+ *
+ * @author olukas
+ */
+@WebServlet(urlPatterns = {ReuseAuthenticatedSubjectServlet.SERVLET_PATH})
+@DeclareRoles({ReuseAuthenticatedSubjectServlet.AUTHORIZED_ROLE})
+@ServletSecurity(
+        @HttpConstraint(rolesAllowed = {ReuseAuthenticatedSubjectServlet.AUTHORIZED_ROLE}))
+public class ReuseAuthenticatedSubjectServlet extends HttpServlet {
+
+    public static final String SERVLET_PATH = "/ReuseAuthenticatedSubjectServlet";
+
+    public static final String SAME_SECURITY_DOMAIN_PARAM = "sameSecuriryDomain";
+
+    public static final String AUTHORIZED_ROLE = "admin";
+
+    @EJB
+    EjbSecurityDomainAsServlet ejbSecurityDomainAsServlet;
+
+    @EJB
+    EjbOwnSecurityDomain ejbOwnSecurityDomain;
+
+    /**
+     * Invoke EJB and write its output. If sameSecuriryDomain parameter is set to true, then EjbSecurityDomainAsServlet is used.
+     * Otherwise EjbOwnSecurityDomain is used.
+     *
+     * @param req
+     * @param resp
+     * @throws ServletException
+     * @throws IOException
+     * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+     */
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType("text/plain");
+        final PrintWriter writer = resp.getWriter();
+        if (Boolean.parseBoolean(req.getParameter(SAME_SECURITY_DOMAIN_PARAM))) {
+            writer.write(ejbSecurityDomainAsServlet.sayHello());
+        } else {
+            writer.write(ejbOwnSecurityDomain.sayHello());
+        }
+        writer.close();
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/ReuseAuthenticatedSubjectTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/ReuseAuthenticatedSubjectTestCase.java
@@ -1,0 +1,183 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.context;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainsServerSetupTask;
+import org.jboss.as.test.integration.security.common.Utils;
+import org.jboss.as.test.integration.security.common.config.SecurityDomain;
+import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.integration.security.loginmodules.common.CounterLoginModule;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test whether if web app and EJB belong to the same security domain then the user is not unnecessarily reauthenticated when
+ * the web app invokes an EJB.
+ *
+ * @author olukas
+ */
+@RunWith(Arquillian.class)
+@ServerSetup({ReuseAuthenticatedSubjectTestCase.SecurityDomainsSetup.class})
+@RunAsClient
+public class ReuseAuthenticatedSubjectTestCase {
+
+    private static final Logger LOGGER = Logger.getLogger(ReuseAuthenticatedSubjectTestCase.class);
+
+    private static final String USER = "user";
+    private static final String PASSWORD = "password";
+    private static final String ROLE = "admin";
+
+    private static final String USERS_PROPERTIES_CONTENT = USER + "=" + PASSWORD;
+    private static final String ROLES_PROPERTIES_CONTENT = USER + "=" + ROLE;
+
+    private static final String DEPLOYMENT_NAME = "dep";
+
+    /**
+     * Test whether if web app and EJB belong to the same security domain then the user is not unnecessarily reauthenticated
+     * when the web app invokes an EJB.
+     *
+     * @param url
+     * @throws Exception
+     */
+    @OperateOnDeployment(DEPLOYMENT_NAME)
+    @Test
+    public void testEjbInSameSecurityDomain(@ArquillianResource URL url) throws Exception {
+        resetCounter(url);
+
+        final URL servletUrl = new URL(url.toExternalForm() + ReuseAuthenticatedSubjectServlet.SERVLET_PATH.substring(1) + "?"
+                + ReuseAuthenticatedSubjectServlet.SAME_SECURITY_DOMAIN_PARAM + "=true");
+        String servletOutput = Utils.makeCallWithBasicAuthn(servletUrl, USER, PASSWORD, 200);
+        Assert.assertEquals("Unexpected servlet output after EJB call", EjbSecurityDomainAsServletImpl.SAY_HELLO, servletOutput);
+
+        Assert.assertEquals("Authenticated subject was not reused for EJB from the same security domain", "1", getCounter(url));
+    }
+
+    /**
+     * Test whether if web app and EJB belong to the different security domain then the user is authenticated for both web app
+     * and EJB invoked from that app.
+     *
+     * @param url
+     * @throws Exception
+     */
+    @OperateOnDeployment(DEPLOYMENT_NAME)
+    @Test
+    public void testEjbInDifferentSecurityDomain(@ArquillianResource URL url) throws Exception {
+        resetCounter(url);
+
+        final URL servletUrl = new URL(url.toExternalForm() + ReuseAuthenticatedSubjectServlet.SERVLET_PATH.substring(1) + "?"
+                + ReuseAuthenticatedSubjectServlet.SAME_SECURITY_DOMAIN_PARAM + "=false");
+        String servletOutput = Utils.makeCallWithBasicAuthn(servletUrl, USER, PASSWORD, 200);
+        Assert.assertEquals("Unexpected servlet output after EJB call", EjbOwnSecurityDomainImpl.SAY_HELLO, servletOutput);
+
+        Assert.assertEquals("Authenticated subject was reused for EJB from the different security domain", "2", getCounter(url));
+    }
+
+    /**
+     * Creates {@link WebArchive} (WAR) for given deployment name.
+     *
+     * @return
+     */
+    @Deployment(name = DEPLOYMENT_NAME)
+    public static WebArchive deployment() {
+        LOGGER.info("Starting deployment " + DEPLOYMENT_NAME);
+
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT_NAME + ".war");
+        war.addClasses(ReuseAuthenticatedSubjectServlet.class,
+                EjbOwnSecurityDomain.class,
+                EjbOwnSecurityDomainImpl.class,
+                EjbSecurityDomainAsServlet.class,
+                EjbSecurityDomainAsServletImpl.class,
+                CounterLoginModule.class,
+                CounterServlet.class
+        );
+        war.addAsWebInfResource(ReuseAuthenticatedSubjectTestCase.class.getPackage(), "web-basic-authn.xml", "web.xml");
+        war.addAsResource(new StringAsset(USERS_PROPERTIES_CONTENT), "users.properties");
+        war.addAsResource(new StringAsset(ROLES_PROPERTIES_CONTENT), "roles.properties");
+        war.addAsWebInfResource(new StringAsset("<jboss-web>" + //
+                "<security-domain>" + EjbSecurityDomainAsServletImpl.SECURITY_DOMAIN + "</security-domain>" + //
+                "</jboss-web>"), "jboss-web.xml");
+
+        return war;
+    }
+
+    private void resetCounter(URL url) throws Exception {
+        final URL servletUrl = new URL(url.toExternalForm() + CounterServlet.SERVLET_PATH.substring(1) + "?"
+                + CounterServlet.RESET_PARAM + "=true");
+        String counter = Utils.makeCall(servletUrl.toURI(), 200);
+        Assert.assertEquals("Counter in CounterLoginModule was not successfully reset", "0", counter);
+    }
+
+    private String getCounter(URL url) throws Exception, MalformedURLException {
+        final URL counterServletUrl = new URL(url.toExternalForm() + CounterServlet.SERVLET_PATH.substring(1) + "?"
+                + CounterServlet.RESET_PARAM);
+        String counter = Utils.makeCall(counterServletUrl.toURI(), 200);
+        return counter;
+    }
+
+    static class SecurityDomainsSetup extends AbstractSecurityDomainsServerSetupTask {
+
+        @Override
+        protected SecurityDomain[] getSecurityDomains() throws Exception {
+
+            final Map<String, String> lmOptions = new HashMap<String, String>();
+            final SecurityModule.Builder usersRolesLoginModuleBuilder = new SecurityModule.Builder()
+                    .name("UsersRoles")
+                    .options(lmOptions);
+
+            final SecurityModule.Builder counterLoginModule = new SecurityModule.Builder()
+                    .name(CounterLoginModule.class.getName());
+
+            final SecurityDomain sd1 = new SecurityDomain.Builder()
+                    .name(EjbSecurityDomainAsServletImpl.SECURITY_DOMAIN)
+                    .loginModules(
+                            usersRolesLoginModuleBuilder.build(),
+                            counterLoginModule.build())
+                    .build();
+
+            final SecurityDomain sd2 = new SecurityDomain.Builder()
+                    .name(EjbOwnSecurityDomainImpl.SECURITY_DOMAIN)
+                    .loginModules(
+                            usersRolesLoginModuleBuilder.build(),
+                            counterLoginModule.build())
+                    .build();
+
+            return new SecurityDomain[]{sd1, sd2};
+        }
+
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/web-basic-authn.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/context/web-basic-authn.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+    version="3.0">  
+
+  <login-config>
+    <auth-method>BASIC</auth-method>
+    <realm-name>Test realm</realm-name>
+  </login-config>
+  
+</web-app>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/CounterLoginModule.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/common/CounterLoginModule.java
@@ -1,0 +1,72 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.security.loginmodules.common;
+
+import java.util.Map;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.LoginException;
+import javax.security.auth.spi.LoginModule;
+
+/**
+ * Simple Login Module which only increase counter when login method is called.
+ *
+ * @author olukas
+ */
+public class CounterLoginModule implements LoginModule {
+
+    private static int counter = 0;
+
+    @Override
+    public void initialize(Subject subject, CallbackHandler callbackHandler, Map<String, ?> sharedState, Map<String, ?> options) {
+    }
+
+    @Override
+    public boolean login() throws LoginException {
+        counter++;
+        return true;
+    }
+
+    @Override
+    public boolean commit() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean abort() throws LoginException {
+        return true;
+    }
+
+    @Override
+    public boolean logout() throws LoginException {
+        return true;
+    }
+
+    public static int getCounter() {
+        return counter;
+    }
+
+    public static void resetCounter() {
+        counter = 0;
+    }
+
+}


### PR DESCRIPTION
Test case for Reuse authenticated subject from incoming context when security domains match. This functionality was fixed in https://github.com/wildfly/wildfly/pull/7470.

Jira: https://issues.jboss.org/browse/WFLY-5041
