### PR TITLE
[WFLY-3355] MDB fails to deploy on reload

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
@@ -63,6 +63,7 @@ import org.jboss.jca.common.api.metadata.spec.Connector;
 import org.jboss.jca.common.api.metadata.spec.XsdString;
 import org.jboss.jca.core.api.connectionmanager.ccm.CachedConnectionManager;
 import org.jboss.jca.core.api.management.ManagementRepository;
+import org.jboss.jca.core.bootstrapcontext.BootstrapContextCoordinator;
 import org.jboss.jca.core.connectionmanager.ConnectionManager;
 import org.jboss.jca.core.security.picketbox.PicketBoxSubjectFactory;
 import org.jboss.jca.core.spi.mdr.AlreadyExistsException;
@@ -200,6 +201,10 @@ public abstract class AbstractResourceAdapterDeploymentService {
                     WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(old);
                 }
             }
+
+            if (value.getDeployment() != null && value.getDeployment().getBootstrapContextIdentifier() != null) {
+                BootstrapContextCoordinator.getInstance().removeBootstrapContext(value.getDeployment().getBootstrapContextIdentifier());
+            }
         }
         if (raRepositoryRegistrationId != null  && raRepository != null && raRepository.getValue() != null) {
             try {
@@ -222,7 +227,6 @@ public abstract class AbstractResourceAdapterDeploymentService {
                 DEPLOYMENT_CONNECTOR_LOGGER.debug("Failed to unregister RA from MDR", e);
             }
         }
-
     }
 
     public Injector<AS7MetadataRepository> getMdrInjector() {

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/PooledConnectionFactoryService.java
@@ -100,7 +100,6 @@ import org.jboss.jca.common.metadata.spec.RequiredConfigPropertyImpl;
 import org.jboss.jca.common.metadata.spec.ResourceAdapterImpl;
 import org.jboss.jca.core.api.connectionmanager.ccm.CachedConnectionManager;
 import org.jboss.jca.core.api.management.ManagementRepository;
-import org.jboss.jca.core.bootstrapcontext.BootstrapContextCoordinator;
 import org.jboss.jca.core.spi.rar.ResourceAdapterRepository;
 import org.jboss.jca.core.spi.transaction.TransactionIntegration;
 import org.jboss.msc.inject.Injector;
@@ -177,7 +176,6 @@ public class PooledConnectionFactoryService implements Service<Void> {
     private String serverName;
     private final String jgroupsChannelName;
     private final boolean createBinderService;
-    private ResourceAdapterActivatorService activator;
 
    public PooledConnectionFactoryService(String name, List<String> connectors, String discoveryGroupName, String serverName, String jgroupsChannelName, List<PooledConnectionFactoryConfigProperties> adapterParams, List<String> jndiNames, String txSupport, int minPoolSize, int maxPoolSize) {
         this.name = name;
@@ -381,7 +379,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
             ConnectionDefinition common = createConnDef(transactionSupport, bindInfo.getBindName(), minPoolSize, maxPoolSize);
             Activation activation = createActivation(common, transactionSupport);
 
-            activator = new ResourceAdapterActivatorService(cmd, activation,
+            ResourceAdapterActivatorService activator = new ResourceAdapterActivatorService(cmd, activation,
                     PooledConnectionFactoryService.class.getClassLoader(), name);
             activator.setBindInfo(bindInfo);
             activator.setCreateBinderService(createBinderService);
@@ -517,11 +515,7 @@ public class PooledConnectionFactoryService implements Service<Void> {
 
 
     public void stop(StopContext context) {
-        // https://issues.jboss.org/browse/WFLY-3355
-        if (activator != null) {
-            String bootstrapContextIdentifier = activator.getDeploymentMD().getBootstrapContextIdentifier();
-            BootstrapContextCoordinator.getInstance().removeBootstrapContext(bootstrapContextIdentifier);
-        }
+        // Service context takes care of this
     }
 
     public Injector<Object> getTransactionManager() {


### PR DESCRIPTION
Removal of the RA's bootstrap context must be performed in
AbstractResourceAdapterDeploymentService#stop() method.

JIRA: https://issues.jboss.org/browse/WFLY-3355
