### PR TITLE
[WFLY-4819][WFLY-4981] Upgrade to JBossWS 5.1.0.Beta1 / Apache CXF 3.1.2

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -493,6 +493,11 @@
 
         <dependency>
             <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-security-saml</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-transports-http</artifactId>
         </dependency>
 
@@ -514,6 +519,12 @@
         <dependency>
             <groupId>org.apache.cxf</groupId>
             <artifactId>cxf-rt-wsdl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -1346,8 +1357,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.opensaml</groupId>
-            <artifactId>opensaml</artifactId>
+            <groupId>org.cryptacular</groupId>
+            <artifactId>cryptacular</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -1358,7 +1369,7 @@
 
         <dependency>
             <groupId>org.opensaml</groupId>
-            <artifactId>openws</artifactId>
+            <artifactId>opensaml-core</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>
@@ -1369,7 +1380,139 @@
 
         <dependency>
             <groupId>org.opensaml</groupId>
-            <artifactId>xmltooling</artifactId>
+            <artifactId>opensaml-profile-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-saml-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-saml-impl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-security-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-security-impl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-soap-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xacml-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xacml-impl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xacml-saml-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xacml-saml-impl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xmlsec-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.opensaml</groupId>
+            <artifactId>opensaml-xmlsec-impl</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>net.shibboleth.utilities</groupId>
+            <artifactId>java-support</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/impl/main/module.xml
@@ -39,6 +39,7 @@
         <artifact name="${org.apache.cxf:cxf-rt-frontend-simple}"/>
         <artifact name="${org.apache.cxf:cxf-rt-management}"/>
         <artifact name="${org.apache.cxf:cxf-rt-security?jandex}"/>
+        <artifact name="${org.apache.cxf:cxf-rt-security-saml}"/>
         <artifact name="${org.apache.cxf:cxf-rt-transports-http}"/>
         <artifact name="${org.apache.cxf:cxf-rt-transports-http-hc}"/>
         <artifact name="${org.apache.cxf:cxf-rt-transports-jms}"/>
@@ -88,11 +89,6 @@
         <module name="org.codehaus.woodstox" />
         <module name="org.joda.time" />
         <module name="org.opensaml" />
-        <module name="org.springframework.spring" optional="true">
-          <imports>
-            <include path="META-INF"/>
-          </imports>
-        </module>
         <module name="org.apache.cxf" export="true">
           <imports>
             <include path="META-INF/cxf"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
@@ -52,10 +52,5 @@
         <module name="org.apache.ws.xmlschema" />
         <module name="org.codehaus.woodstox" />
         <module name="org.apache.xml-resolver" />
-        <module name="org.springframework.spring" optional="true">
-            <imports>
-                <include path="META-INF"/>
-            </imports>
-        </module>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/server/integration/main/module.xml
@@ -89,14 +89,6 @@
         <module name="org.apache.ws.security" export="true"/>
         <module name="org.apache.santuario.xmlsec" export="true"/>
         <module name="org.bouncycastle" export="true"/>
-        <module name="org.springframework.spring" optional="true" export="true">
-          <imports>
-            <include path="META-INF"/>
-          </imports>
-          <exports>
-            <include path="META-INF"/>
-          </exports>
-        </module>
         <module name="org.jboss.xts">
           <imports>
             <include path="com.arjuna.mw.wst11.client"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/cxf/jbossws-cxf-server/main/module.xml
@@ -68,10 +68,5 @@
         <module name="org.jboss.logging" />
         <module name="org.apache.ws.security" />
         <module name="org.picketbox" />
-        <module name="org.springframework.spring" optional="true">
-          <imports>
-            <include path="META-INF"/>
-          </imports>
-        </module>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/jaxws-client/main/module.xml
@@ -69,11 +69,6 @@
         <module name="org.jboss.logging" />
         <module name="org.picketbox"/>
         <module name="org.apache.commons.beanutils"/>
-        <module name="org.springframework.spring" optional="true">
-          <imports>
-            <include path="META-INF"/>
-          </imports>
-        </module>
         <module name="javax.wsdl4j.api" />
         <module name="org.bouncycastle" />
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/opensaml/main/module.xml
@@ -25,9 +25,21 @@
 <module xmlns="urn:jboss:module:1.3" name="org.opensaml">
 
     <resources>
-        <artifact name="${org.opensaml:opensaml}"/>
-        <artifact name="${org.opensaml:openws}"/>
-        <artifact name="${org.opensaml:xmltooling}"/>
+        <artifact name="${org.opensaml:opensaml-core}"/>
+        <artifact name="${org.opensaml:opensaml-profile-api}"/>
+        <artifact name="${org.opensaml:opensaml-saml-api}"/>
+        <artifact name="${org.opensaml:opensaml-saml-impl}"/>
+        <artifact name="${org.opensaml:opensaml-security-api}"/>
+        <artifact name="${org.opensaml:opensaml-security-impl}"/>
+        <artifact name="${org.opensaml:opensaml-soap-api}"/>
+        <artifact name="${org.opensaml:opensaml-xacml-api}"/>
+        <artifact name="${org.opensaml:opensaml-xacml-impl}"/>
+        <artifact name="${org.opensaml:opensaml-xacml-saml-api}"/>
+        <artifact name="${org.opensaml:opensaml-xacml-saml-impl}"/>
+        <artifact name="${org.opensaml:opensaml-xmlsec-api}"/>
+        <artifact name="${org.opensaml:opensaml-xmlsec-impl}"/>
+        <artifact name="${org.cryptacular:cryptacular}"/>
+        <artifact name="${net.shibboleth.utilities:java-support}"/>
     </resources>
 
     <dependencies>
@@ -36,5 +48,8 @@
       <module name="org.apache.santuario.xmlsec"/>
       <module name="org.apache.ws.security" />
       <module name="org.joda.time"/>
+      <module name="com.google.guava"/>
+      <module name="org.bouncycastle"/>
+      <module name="org.apache.commons.codec"/>
     </dependencies>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -113,10 +113,11 @@
         <version.joda-time>2.7</version.joda-time>
         <version.jsoup>1.8.1</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
+        <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
         <version.org.antlr-34>3.4</version.org.antlr-34>
         <version.org.apache.activemq.artemis>1.0.0</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
-        <version.org.apache.cxf>3.0.5</version.org.apache.cxf>
+        <version.org.apache.cxf>3.1.2</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.3</version.org.apache.cxf.xjcplugins>
         <version.org.apache.ds>2.0.0-M20</version.org.apache.ds>
         <version.org.apache.httpcomponents.httpclient>4.3.6</version.org.apache.httpcomponents.httpclient>
@@ -127,15 +128,16 @@
         <version.org.apache.myfaces.core>2.1.17</version.org.apache.myfaces.core>
         <version.org.apache.neethi>3.0.3</version.org.apache.neethi>
         <version.org.apache.qpid.proton>0.8</version.org.apache.qpid.proton>
-        <version.org.apache.santuario>2.0.4</version.org.apache.santuario>
+        <version.org.apache.santuario>2.0.5</version.org.apache.santuario>
         <version.org.apache.velocity>1.7</version.org.apache.velocity>
-        <version.org.apache.ws.security>2.0.4</version.org.apache.ws.security>
+        <version.org.apache.ws.security>2.1.2</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.0.2</version.org.apache.ws.xmlschema>
         <version.org.apache.xalan>2.7.1.jbossorg-1</version.org.apache.xalan>
         <version.org.bouncycastle>1.52</version.org.bouncycastle>
         <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.3.3</version.org.codehaus.jettison>
         <version.org.codehaus.plexus.plexus-utils>3.0.21</version.org.codehaus.plexus.plexus-utils>
+        <version.org.cryptacular>1.0</version.org.cryptacular>
         <version.org.eclipse.jdt.core.compiler>4.4.2</version.org.eclipse.jdt.core.compiler>
         <version.org.glassfish.javax.el>3.0.1-b08-jbossorg-1</version.org.glassfish.javax.el>
         <version.org.glassfish.javax.enterprise.concurrent>1.0</version.org.glassfish.javax.enterprise.concurrent>
@@ -201,16 +203,14 @@
         <version.org.jboss.weld.weld>2.3.0.Beta3</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.3.Beta2</version.org.jboss.weld.weld-api>
         <version.org.jboss.ws.api>1.0.3.Final</version.org.jboss.ws.api>
-        <version.org.jboss.ws.spi>3.0.0.Final</version.org.jboss.ws.spi>
-        <version.org.jboss.ws.common>3.0.0.Final</version.org.jboss.ws.common>
+        <version.org.jboss.ws.spi>3.1.0.Beta1</version.org.jboss.ws.spi>
+        <version.org.jboss.ws.common>3.1.0.Beta1</version.org.jboss.ws.common>
         <version.org.jboss.ws.common.tools>1.2.1.Final</version.org.jboss.ws.common.tools>
-        <version.org.jboss.ws.cxf>5.0.0.Final</version.org.jboss.ws.cxf>
+        <version.org.jboss.ws.cxf>5.1.0.Beta1</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
         <version.org.jgroups>3.6.4.Final</version.org.jgroups>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
-        <version.org.opensaml.opensaml>2.6.1</version.org.opensaml.opensaml>
-        <version.org.opensaml.openws>1.5.1</version.org.opensaml.openws>
-        <version.org.opensaml.xmltooling>1.4.1</version.org.opensaml.xmltooling>
+        <version.org.opensaml.opensaml>3.1.1</version.org.opensaml.opensaml>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
         <version.org.picketlink>2.7.0.Final</version.org.picketlink>
         <version.org.scannotation>1.0.3</version.org.scannotation>
@@ -2335,6 +2335,12 @@
 
             <dependency>
                 <groupId>org.apache.cxf</groupId>
+                <artifactId>cxf-rt-security-saml</artifactId>
+                <version>${version.org.apache.cxf}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-transports-http</artifactId>
                 <version>${version.org.apache.cxf}</version>
                 <exclusions>
@@ -3244,127 +3250,93 @@
             </dependency>
 
             <dependency>
+                <groupId>org.cryptacular</groupId>
+                <artifactId>cryptacular</artifactId>
+                <version>${version.org.cryptacular}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.opensaml</groupId>
-                <artifactId>opensaml</artifactId>
+                <artifactId>opensaml-core</artifactId>
                 <version>${version.org.opensaml.opensaml}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.opensaml</groupId>
-                        <artifactId>openws</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>velocity</groupId>
-                        <artifactId>velocity</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.owasp.esapi</groupId>
-                        <artifactId>esapi</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>log4j-over-slf4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jcl-over-slf4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jul-to-slf4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-ext-jdk15</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>ca.juliusdavies</groupId>
-                        <artifactId>not-yet-commons-ssl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>net.jcip</groupId>
-                        <artifactId>jcip-annotations</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-resolver</groupId>
-                        <artifactId>xml-resolver</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xerces</groupId>
-                        <artifactId>xercesImpl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xalan</groupId>
-                        <artifactId>xalan</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-codec</groupId>
-                        <artifactId>commons-codec</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-httpclient</groupId>
-                        <artifactId>commons-httpclient</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-lang</groupId>
-                        <artifactId>commons-lang</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>commons-collections</groupId>
-                        <artifactId>commons-collections</artifactId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
-                <artifactId>openws</artifactId>
-                <version>${version.org.opensaml.openws}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>commons-httpclient</groupId>
-                        <artifactId>commons-httpclient</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis</artifactId>
-                    </exclusion>
-                </exclusions>
+                <artifactId>opensaml-profile-api</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
             </dependency>
 
             <dependency>
                 <groupId>org.opensaml</groupId>
-                <artifactId>xmltooling</artifactId>
-                <version>${version.org.opensaml.xmltooling}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>log4j-over-slf4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.slf4j</groupId>
-                        <artifactId>jul-to-slf4j</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.bouncycastle</groupId>
-                        <artifactId>bcprov-jdk15</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>ca.juliusdavies</groupId>
-                        <artifactId>not-yet-commons-ssl</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>xml-apis</groupId>
-                        <artifactId>xml-apis</artifactId>
-                    </exclusion>
-                </exclusions>
+                <artifactId>opensaml-saml-api</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-saml-impl</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-security-api</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-security-impl</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-soap-api</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-xacml-api</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-xacml-impl</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-xacml-saml-api</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-xacml-saml-impl</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-xmlsec-api</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.opensaml</groupId>
+                <artifactId>opensaml-xmlsec-impl</artifactId>
+                <version>${version.org.opensaml.opensaml}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.shibboleth.utilities</groupId>
+                <artifactId>java-support</artifactId>
+                <version>${version.net.shibboleth.utilities.java-support}</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,6 +161,7 @@
         <version.org.jboss.genericjms>1.0.7.Final</version.org.jboss.genericjms>
         <version.org.jboss.iiop-client>1.0.0.Final</version.org.jboss.iiop-client>
         <version.org.jboss.ironjacamar>1.2.5.Final</version.org.jboss.ironjacamar>
+        <version.org.jboss.jandex>2.0.0.Beta3</version.org.jboss.jandex>
         <version.org.jboss.jboss-transaction-spi>7.3.0.Final</version.org.jboss.jboss-transaction-spi>
         <version.org.jboss.metadata>10.0.0.Beta2</version.org.jboss.metadata>
         <version.org.jboss.narayana>5.2.0.Final</version.org.jboss.narayana>
@@ -803,11 +804,25 @@
                     <groupId>org.wildfly.build</groupId>
                     <artifactId>wildfly-feature-pack-build-maven-plugin</artifactId>
                     <version>${version.org.wildfly.build-tools}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss</groupId>
+                            <artifactId>jandex</artifactId>
+                            <version>${version.org.jboss.jandex}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.wildfly.build</groupId>
                     <artifactId>wildfly-server-provisioning-maven-plugin</artifactId>
                     <version>${version.org.wildfly.build-tools}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jboss</groupId>
+                            <artifactId>jandex</artifactId>
+                            <version>${version.org.jboss.jandex}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -4181,6 +4196,12 @@
                 <groupId>org.infinispan</groupId>
                 <artifactId>infinispan-lucene-directory</artifactId>
                 <version>${version.org.infinispan}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss</groupId>
+                <artifactId>jandex</artifactId>
+                <version>${version.org.jboss.jandex}</version>
             </dependency>
 
             <dependency>

--- a/webservices/server-integration/src/test/java/org/jboss/as/webservices/config/ServerConfigImplTestCase.java
+++ b/webservices/server-integration/src/test/java/org/jboss/as/webservices/config/ServerConfigImplTestCase.java
@@ -236,5 +236,9 @@ public class ServerConfigImplTestCase {
         public String getImplementationVersion() {
             return null;
         }
+
+        public void validatePathRewriteRule(String rule) {
+            //NOOP
+        }
     }
 }

--- a/webservices/server-integration/src/test/java/org/jboss/as/webservices/dmr/WebservicesSubsystemRuntimeTestCase.java
+++ b/webservices/server-integration/src/test/java/org/jboss/as/webservices/dmr/WebservicesSubsystemRuntimeTestCase.java
@@ -118,7 +118,6 @@ public class WebservicesSubsystemRuntimeTestCase extends AbstractSubsystemBaseTe
         Assert.assertEquals(9895, serverConfig.getWebServicePort());
         Assert.assertEquals(9944, serverConfig.getWebServiceSecurePort());
         Assert.assertEquals("https", serverConfig.getWebServiceUriScheme());
-        Assert.assertEquals("s/jaxws-jbws2150-codefirst/xx\\/jaxws-jbws2150-codefirst/g", serverConfig.getWebServicePathRewriteRule());
 
         //Client & Endpoint predefined configuration tests
         //HACK: we need to manually reload the client/endpoint configs as the ServerConfigService is actually not starting in this test;

--- a/webservices/server-integration/src/test/resources/org/jboss/as/webservices/dmr/ws-subsystem20-rt.xml
+++ b/webservices/server-integration/src/test/resources/org/jboss/as/webservices/dmr/ws-subsystem20-rt.xml
@@ -4,7 +4,6 @@
     <wsdl-port>9895</wsdl-port>
     <wsdl-secure-port>9944</wsdl-secure-port>
     <wsdl-uri-scheme>https</wsdl-uri-scheme>
-    <wsdl-path-rewrite-rule>s/jaxws-jbws2150-codefirst/xx\/jaxws-jbws2150-codefirst/g</wsdl-path-rewrite-rule>
     <endpoint-config name="Standard-Endpoint-Config"/>
     <endpoint-config name="Recording-Endpoint-Config">
         <pre-handler-chain name="recording-handlers" protocol-bindings="##SOAP11_HTTP ##SOAP11_HTTP_MTOM ##SOAP12_HTTP ##SOAP12_HTTP_MTOM">


### PR DESCRIPTION
.. also ensure the same jandex version is used for dependencies and plugin dependencies, otherwise we end up with a version shipped in the distro that's not the same used for generating -jandex jars.
