### PR TITLE
WFLY-5038 Update MutableDetector to include immutable classes from Java 8

### DIFF
--- a/clustering/web/infinispan/pom.xml
+++ b/clustering/web/infinispan/pom.xml
@@ -39,6 +39,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>net.jcip</groupId>
+            <artifactId>jcip-annotations</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.wildfly</groupId>
             <artifactId>wildfly-clustering-api</artifactId>
         </dependency>

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/MutableDetector.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/MutableDetector.java
@@ -25,17 +25,46 @@ import java.io.File;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.MathContext;
-import java.net.InetAddress;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.security.Permission;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.MonthDay;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.chrono.ChronoLocalDate;
+import java.time.chrono.Chronology;
+import java.time.chrono.Era;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DecimalStyle;
+import java.time.temporal.TemporalField;
+import java.time.temporal.TemporalUnit;
+import java.time.temporal.ValueRange;
+import java.time.temporal.WeekFields;
+import java.time.zone.ZoneOffsetTransition;
+import java.time.zone.ZoneOffsetTransitionRule;
+import java.time.zone.ZoneRules;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Currency;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 
@@ -47,49 +76,94 @@ import org.wildfly.clustering.web.annotation.Immutable;
  */
 public class MutableDetector {
 
-    private static List<Object> IMMUTABLE_VALUES = Arrays.asList(
+    // Singleton immutable objects detectable via reference equality test
+    private static final Set<Object> IMMUTABLE_OBJECTS = createIdentitySet(Arrays.asList(
             null,
             Collections.EMPTY_LIST,
             Collections.EMPTY_MAP,
             Collections.EMPTY_SET
-    );
+    ));
 
-    private static List<Class<?>> IMMUTABLE_TYPES = Arrays.<Class<?>>asList(
+    // Concrete immutable classes detectable via reference equality test
+    private static final Set<Class<?>> IMMUTABLE_CLASSES = createIdentitySet(Arrays.asList(
             BigDecimal.class,
             BigInteger.class,
             Boolean.class,
             Byte.class,
             Character.class,
+            Class.class,
             Currency.class,
+            DateTimeFormatter.class,
+            DecimalStyle.class,
             Double.class,
-            Enum.class, // Strictly speaking, one could implement a mutable enum, but that would just be weird.
+            Duration.class,
             File.class,
             Float.class,
-            InetAddress.class,
+            Inet4Address.class,
+            Inet6Address.class,
             InetSocketAddress.class,
+            Instant.class,
             Integer.class,
             Locale.class,
+            LocalDate.class,
+            LocalDateTime.class,
+            LocalTime.class,
             Long.class,
             MathContext.class,
-            Path.class,
-            Permission.class,
+            MonthDay.class,
+            Period.class,
             Short.class,
             StackTraceElement.class,
             String.class,
-            TimeZone.class, // Strictly speaking, this class is mutable, although in practice it is never mutated.
             URI.class,
             URL.class,
-            UUID.class
+            UUID.class,
+            ValueRange.class,
+            WeekFields.class,
+            Year.class,
+            YearMonth.class,
+            ZoneOffset.class,
+            ZoneOffsetTransition.class,
+            ZoneOffsetTransitionRule.class,
+            ZoneRules.class,
+            ZonedDateTime.class
+    ));
+
+    // Interfaces and abstract classes documented to be immutable, but only detectable via instanceof tests
+    private static final List<Class<?>> IMMUTABLE_ABSTRACT_CLASSES = Arrays.asList(
+            Chronology.class,
+            ChronoLocalDate.class,
+            Clock.class,
+            Enum.class, // In theory, one could implement a mutable enum, but that would just be weird.
+            Era.class,
+            Path.class,
+            Permission.class,
+            TemporalField.class,
+            TemporalUnit.class,
+            TimeZone.class, // Strictly speaking, this class is mutable, although in practice it is never mutated.
+            ZoneId.class
     );
 
-    public static boolean isMutable(Object object) {
-        for (Object value: IMMUTABLE_VALUES) {
-            if (object == value) return false;
+    private static <T> Set<T> createIdentitySet(List<T> list) {
+        Map<T, Void> result = new IdentityHashMap<>(list.size());
+        for (T element : list) {
+            result.put(element, null);
         }
-        for (Class<?> immutableClass: IMMUTABLE_TYPES) {
+        return Collections.unmodifiableSet(result.keySet());
+    }
+
+    public static boolean isMutable(Object object) {
+
+        if (IMMUTABLE_OBJECTS.contains(object)) return false;
+
+        Class<?> objectClass = object.getClass();
+        if (IMMUTABLE_CLASSES.contains(objectClass)) return false;
+
+        for (Class<?> immutableClass: IMMUTABLE_ABSTRACT_CLASSES) {
             if (immutableClass.isInstance(object)) return false;
         }
-        return !object.getClass().isAnnotationPresent(Immutable.class);
+
+        return !objectClass.isAnnotationPresent(Immutable.class) && !objectClass.isAnnotationPresent(net.jcip.annotations.Immutable.class);
     }
 
     private MutableDetector() {

--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/MutableDetectorTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/session/MutableDetectorTestCase.java
@@ -35,6 +35,26 @@ import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.nio.file.FileSystems;
 import java.security.AllPermission;
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.MonthDay;
+import java.time.Period;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DecimalStyle;
+import java.time.temporal.ValueRange;
+import java.time.temporal.WeekFields;
+import java.time.zone.ZoneOffsetTransitionRule;
+import java.time.zone.ZoneOffsetTransitionRule.TimeDefinition;
+import java.time.zone.ZoneRules;
 import java.util.Collections;
 import java.util.Currency;
 import java.util.Date;
@@ -66,8 +86,8 @@ public class MutableDetectorTestCase {
         assertFalse(MutableDetector.isMutable(Collections.EMPTY_SET));
         assertFalse(MutableDetector.isMutable(Boolean.TRUE));
         assertFalse(MutableDetector.isMutable(Character.valueOf('a')));
+        assertFalse(MutableDetector.isMutable(this.getClass()));
         assertFalse(MutableDetector.isMutable(Currency.getInstance(Locale.US)));
-        assertFalse(MutableDetector.isMutable(TimeUnit.DAYS));
         assertFalse(MutableDetector.isMutable(Locale.getDefault()));
         assertFalse(MutableDetector.isMutable(Byte.valueOf(Integer.valueOf(1).byteValue())));
         assertFalse(MutableDetector.isMutable(Short.valueOf(Integer.valueOf(1).shortValue())));
@@ -83,6 +103,7 @@ public class MutableDetectorTestCase {
         assertFalse(MutableDetector.isMutable("test"));
         assertFalse(MutableDetector.isMutable(TimeZone.getDefault()));
         assertFalse(MutableDetector.isMutable(UUID.randomUUID()));
+        assertFalse(MutableDetector.isMutable(TimeUnit.DAYS));
         File file = new File(System.getProperty("user.home"));
         assertFalse(MutableDetector.isMutable(file));
         assertFalse(MutableDetector.isMutable(file.toURI()));
@@ -90,9 +111,33 @@ public class MutableDetectorTestCase {
         assertFalse(MutableDetector.isMutable(FileSystems.getDefault().getRootDirectories().iterator().next()));
         assertFalse(MutableDetector.isMutable(new AllPermission()));
         assertFalse(MutableDetector.isMutable(new ImmutableObject()));
+
+        assertFalse(MutableDetector.isMutable(DateTimeFormatter.BASIC_ISO_DATE));
+        assertFalse(MutableDetector.isMutable(DecimalStyle.STANDARD));
+        assertFalse(MutableDetector.isMutable(Duration.ZERO));
+        assertFalse(MutableDetector.isMutable(Instant.now()));
+        assertFalse(MutableDetector.isMutable(LocalDate.now()));
+        assertFalse(MutableDetector.isMutable(LocalDateTime.now()));
+        assertFalse(MutableDetector.isMutable(LocalTime.now()));
+        assertFalse(MutableDetector.isMutable(MonthDay.now()));
+        assertFalse(MutableDetector.isMutable(Period.ZERO));
+        assertFalse(MutableDetector.isMutable(ValueRange.of(0L, 10L)));
+        assertFalse(MutableDetector.isMutable(WeekFields.ISO));
+        assertFalse(MutableDetector.isMutable(Year.now()));
+        assertFalse(MutableDetector.isMutable(YearMonth.now()));
+        assertFalse(MutableDetector.isMutable(ZoneOffset.UTC));
+        assertFalse(MutableDetector.isMutable(ZoneRules.of(ZoneOffset.UTC).nextTransition(Instant.now())));
+        assertFalse(MutableDetector.isMutable(ZoneOffsetTransitionRule.of(Month.JANUARY, 1, DayOfWeek.SUNDAY, LocalTime.MIDNIGHT, true, TimeDefinition.STANDARD, ZoneOffset.UTC, ZoneOffset.ofHours(1), ZoneOffset.ofHours(2))));
+        assertFalse(MutableDetector.isMutable(ZoneRules.of(ZoneOffset.UTC)));
+        assertFalse(MutableDetector.isMutable(ZonedDateTime.now()));
+        assertFalse(MutableDetector.isMutable(new JCIPImmutableObject()));
     }
 
     @Immutable
     static class ImmutableObject {
+    }
+
+    @net.jcip.annotations.Immutable
+    static class JCIPImmutableObject {
     }
 }

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/web/infinispan/main/module.xml
@@ -38,6 +38,7 @@
     <dependencies>
         <module name="javax.servlet.api"/>
 
+        <module name="net.jcip"/>
         <module name="org.infinispan"/>
         <module name="org.infinispan.commons"/>
         <module name="org.jboss.logging"/>


### PR DESCRIPTION
Also detect @Immutable from JCIP, to be leveraged by modules external to WildFly.

https://issues.jboss.org/browse/WFLY-5038
