### PR TITLE
WFLY-5065 Make build/testsuite work on IBM JDK

### DIFF
--- a/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
+++ b/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
@@ -57,7 +57,7 @@
                         key-alias="${prop.key-alias:test}"
                         password="${prop.password:changeit}"
                         cipher-suite="${prop.cipher-suite:SSL_RSA_WITH_3DES_EDE_CBC_SHA}"
-                        protocol="${prop.native:SSLv3}"
+                        protocol="${prop.native:TLSv1.2}"
                         verify-client="${prop.verify-client:true}"
                         verify-depth="${prop.verify-depth:3}"
                         certificate-file="${prop.certificate-file:certificate-file.ext}"

--- a/pom.xml
+++ b/pom.xml
@@ -2352,6 +2352,12 @@
                 <groupId>org.apache.cxf</groupId>
                 <artifactId>cxf-rt-security-saml</artifactId>
                 <version>${version.org.apache.cxf}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>xalan</groupId>
+                        <artifactId>xalan</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
TX team noticed it: https://developer.jboss.org/message/937285
CI run on IBM JDK passes with this http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=63451&tab=buildResultsDiv&buildTypeId=WF_MasterLinuxIbmJdk
