### PR TITLE
WFLY-3518 Add null check to JASPI mechanism

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPIAuthenticationMechanism.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPIAuthenticationMechanism.java
@@ -101,11 +101,13 @@ public class JASPIAuthenticationMechanism implements AuthenticationMechanism {
 
         if (sessionManager != null) {
             AuthenticatedSessionManager.AuthenticatedSession authSession = sessionManager.lookupSession(exchange);
-            cachedAccount = authSession.getAccount();
-            // if there is a cached account we set it in the security context so that the principal is available to
-            // SAM modules via request.getUserPrincipal().
-            if (cachedAccount !=  null) {
-                jaspicSecurityContext.setCachedAuthenticatedAccount(cachedAccount);
+            if(authSession != null) {
+                cachedAccount = authSession.getAccount();
+                // if there is a cached account we set it in the security context so that the principal is available to
+                // SAM modules via request.getUserPrincipal().
+                if (cachedAccount != null) {
+                    jaspicSecurityContext.setCachedAuthenticatedAccount(cachedAccount);
+                }
             }
         }
 


### PR DESCRIPTION
This check should be back-ported it should also allow session less JASPIC modules to work.
