### PR TITLE
This test originally only failed on Windows, but now seems to be inte…

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -48,11 +48,10 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.wildfly.security.manager.WildFlySecurityManager;
 import org.wildfly.test.api.Authentication;
 
 import javax.naming.Context;
@@ -62,7 +61,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.Locale;
 import java.util.Properties;
 
 import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
@@ -77,6 +75,7 @@ import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNo
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Ignore("WFLY-4421")
 public class EJBClientClusterConfigurationTestCase {
 
     private static final Logger logger = Logger.getLogger(EJBClientClusterConfigurationTestCase.class);
@@ -92,12 +91,6 @@ public class EJBClientClusterConfigurationTestCase {
     // These should match what's configured in arquillian.xml for -Djboss.node.name of each server instance
     private static final String DEFAULT_JBOSSAS_NODE_NAME = "default-jbossas";
     private static final String JBOSSAS_WITH_OUTBOUND_CONNECTION_NODE_NAME = "jbossas-with-remote-outbound-connection";
-
-    private static final boolean IS_WINDOWS;
-
-    static {
-        IS_WINDOWS = WildFlySecurityManager.getPropertyPrivileged("os.name", "").toLowerCase(Locale.ROOT).contains("windows");
-    }
 
     @ArquillianResource
     private ContainerController container;
@@ -157,8 +150,6 @@ public class EJBClientClusterConfigurationTestCase {
      */
     @Test
     public void testServerToServerClusterFormation() throws Exception {
-        // Ignore on Windows, see WFLY-4421
-        Assume.assumeFalse(IS_WINDOWS);
 
         // First start the default server
         this.container.start(DEFAULT_JBOSSAS);


### PR DESCRIPTION
…rmittently failing on Linux as well. See WFLY-4421 for more details.

@pferraro This is now failing on Linux as well as Windows. http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WF_PullRequest&buildTypeId=&tab=testDetails&testNameId=-7618144520575484180&order=TEST_STATUS_DESC&branch_WF_PullRequest=__all_branches__&itemsCount=50
