### PR TITLE
WFLY-4931/JBEAP-437 for backward compatability check for legacy Hibernate persistence provider name as alias for Hibernate ORM 5.0 or greater

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/PersistenceUnitServiceHandler.java
@@ -985,7 +985,11 @@ public class PersistenceUnitServiceHandler {
     private static PersistenceProvider getProviderByName(PersistenceUnitMetadata pu, List<PersistenceProvider> providers) {
         String providerName = pu.getPersistenceProviderClassName();
         for (PersistenceProvider provider : providers) {
-            if (provider.getClass().getName().equals(providerName)) {
+            if (providerName == null ||
+                    provider.getClass().getName().equals(providerName) ||
+                    // WFLY-4931 allow legacy Hibernate persistence provider name org.hibernate.ejb.HibernatePersistence to be used.
+                    (provider.getClass().getName().equals(Configuration.PROVIDER_CLASS_DEFAULT) && providerName.equals(Configuration.PROVIDER_CLASS_HIBERNATE4_1))
+                    ) {
                 return provider;                    // return the provider that matched classname
             }
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/cfgfile/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/cfgfile/persistence.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" version="1.0">
     <persistence-unit name="mypc">
+        <provider>org.hibernate.ejb.HibernatePersistence</provider>
         <properties>
             <property name="hibernate.ejb.cfgfile" value="hibernate.cfg.xml"/>
         </properties>


### PR DESCRIPTION
This will help applications migrating from older versions of WildFly/AS
