### PR TITLE
WFLY-4923 closing of container managed persistence context should guard against background threads that are also using the persistence context

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/container/TransactionScopedEntityManager.java
@@ -159,7 +159,7 @@ public class TransactionScopedEntityManager extends AbstractEntityManager implem
                 ROOT_LOGGER.debugf("%s: created entity manager session %s", TransactionUtil.getEntityManagerDetails(entityManager, scopedPuName),
                         TransactionUtil.getTransaction(transactionManager).toString());
             }
-            TransactionUtil.registerSynchronization(entityManager, scopedPuName, transactionSynchronizationRegistry);
+            TransactionUtil.registerSynchronization(entityManager, scopedPuName, transactionSynchronizationRegistry, transactionManager);
             TransactionUtil.putEntityManagerInTransactionRegistry(scopedPuName, entityManager, transactionSynchronizationRegistry);
         }
         else {

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -755,4 +755,14 @@ public interface JpaLogger extends BasicLogger {
 
     @Message(id = 71, value = "Deployment '%s' specified more than one Hibernate Search module name ('%s','%s')")
     DeploymentUnitProcessingException differentSearchModuleDependencies(String deployment, String searchModuleName1, String searchModuleName2);
+
+    /**
+     * Likely means that the transaction manager does not implement the org.jboss.tm.listener.TransactionListenerRegistry class.
+     *
+     * @param cause the cause of the error.
+     * @return
+     */
+    @Message(id = 72, value = "Could not obtain TransactionListenerRegistry from transaction manager")
+    IllegalStateException errorGettingTransactionListenerRegistry(@Cause Throwable cause);
+
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/JPAService.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/service/JPAService.java
@@ -97,8 +97,6 @@ public class JPAService implements Service<Void> {
         JPAService jpaService = new JPAService();
         setDefaultDataSourceName(defaultDataSourceName);
         setDefaultExtendedPersistenceInheritance(defaultExtendedPersistenceInheritance);
-
-
         target.addService(SERVICE_NAME, jpaService)
             .setInitialMode(ServiceController.Mode.ACTIVE)
             .addDependency(JPAUserTransactionListenerService.SERVICE_NAME)

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/transaction/TransactionUtil.java
@@ -24,8 +24,9 @@ package org.jboss.as.jpa.transaction;
 
 import static org.jboss.as.jpa.messages.JpaLogger.ROOT_LOGGER;
 
+import java.util.EnumSet;
+
 import javax.persistence.EntityManager;
-import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
@@ -35,6 +36,12 @@ import javax.transaction.TransactionSynchronizationRegistry;
 import org.jboss.as.jpa.container.ExtendedEntityManager;
 import org.jboss.as.jpa.messages.JpaLogger;
 import org.jboss.tm.TxUtils;
+import org.jboss.tm.listener.EventType;
+import org.jboss.tm.listener.TransactionEvent;
+import org.jboss.tm.listener.TransactionListener;
+import org.jboss.tm.listener.TransactionListenerRegistry;
+import org.jboss.tm.listener.TransactionListenerRegistryUnavailableException;
+import org.jboss.tm.listener.TransactionTypeNotSupported;
 
 /**
  * Transaction utilities for JPA
@@ -42,6 +49,8 @@ import org.jboss.tm.TxUtils;
  * @author Scott Marlow (forked from code by Gavin King)
  */
 public class TransactionUtil {
+
+    private static final EnumSet<EventType> eventTypes = EnumSet.of(EventType.ASSOCIATED, EventType.DISASSOCIATING);
 
     public static boolean isInTx(TransactionManager transactionManager) {
         Transaction tx = getTransaction(transactionManager);
@@ -60,8 +69,23 @@ public class TransactionUtil {
         return getEntityManagerInTransactionRegistry(puScopedName, tsr);
     }
 
-    public static void registerSynchronization(EntityManager entityManager, String puScopedName, TransactionSynchronizationRegistry tsr) {
-        tsr.registerInterposedSynchronization(new SessionSynchronization(entityManager, puScopedName));
+    public static void registerSynchronization(EntityManager entityManager, String puScopedName, TransactionSynchronizationRegistry tsr, TransactionManager transactionManager) {
+        SessionSynchronization sessionSynchronization = new SessionSynchronization(entityManager, puScopedName);
+        tsr.registerInterposedSynchronization(sessionSynchronization);
+        try {
+            getTransactionListenerRegistry(transactionManager).addListener(getTransaction(transactionManager), sessionSynchronization, eventTypes);
+        } catch (TransactionTypeNotSupported transactionTypeNotSupported) {
+            throw JpaLogger.ROOT_LOGGER.errorGettingTransaction(transactionTypeNotSupported);
+        }
+    }
+
+    private static TransactionListenerRegistry getTransactionListenerRegistry(TransactionManager transactionManager) {
+        if (transactionManager instanceof TransactionListenerRegistry) {
+            return (TransactionListenerRegistry)transactionManager;
+        }
+        else {
+            throw JpaLogger.ROOT_LOGGER.errorGettingTransactionListenerRegistry(new TransactionListenerRegistryUnavailableException());
+        }
     }
 
     public static Transaction getTransaction(TransactionManager transactionManager) {
@@ -103,9 +127,27 @@ public class TransactionUtil {
         tsr.putResource(scopedPuName, entityManager);
     }
 
-    private static class SessionSynchronization implements Synchronization {
+    /**
+     * Using the TransactionListener, we can detect Synchronization.afterCompletion() being called from a
+     * background thread, while the application may still be actively using the EntityManager.
+     * We need to ensure that the background thread does not close the EntityManager while the application thread
+     * is actively using it.
+     *
+     * We know when the application thread is associated with the transaction and can defer closing the EntityManager
+     * until both conditions are met:
+     *
+     *   1. application is disassociated from transaction
+     *   2. Synchronization.afterCompletion has been called
+     *
+     * See discussions for more details about how we arrived at using the TransactionListener:
+     *     https://developer.jboss.org/message/919807
+     *     https://developer.jboss.org/thread/252572
+     */
+    private static class SessionSynchronization implements Synchronization, TransactionListener {
         private EntityManager manager;  // the underlying entity manager
         private String scopedPuName;
+        private transient boolean transactionDisassociatedFromApplication = false;
+        private transient boolean afterCompletionCalled = false;
 
         public SessionSynchronization(EntityManager session, String scopedPuName) {
             this.manager = session;
@@ -113,47 +155,47 @@ public class TransactionUtil {
         }
 
         public void beforeCompletion() {
+            afterCompletionCalled = false;
         }
 
-        public void afterCompletion(int status) {
+        public synchronized void afterCompletion(int status) {
             /**
-             * If its not safe (safeToClose returns false) to close the EntityManager now,
-             * any connections joined to the JTA transaction
-             * will be released by the JCA connection pool manager.  When the JTA Transaction is no longer
-             * referencing the EntityManager, it will be eligible for garbage collection.
-             * See AS7-6586 for more details.
+             * Note: synchronization is to protect against two concurrent threads from closing the EntityManager (manager)
+             * at the same time.
              */
-            if (safeToClose(status)) {
-                try {
-                    if (ROOT_LOGGER.isDebugEnabled())
-                        ROOT_LOGGER.debugf("%s: closing entity managersession", getEntityManagerDetails(manager, scopedPuName));
-                    manager.close();
-                } catch (Exception ignored) {
-                    if (ROOT_LOGGER.isDebugEnabled())
-                        ROOT_LOGGER.debugf(ignored, "ignoring error that occurred while closing EntityManager for %s (", scopedPuName);
-                }
-            }
-            // The TX reference to the entity manager, should be cleared by the TM
-
+            afterCompletionCalled = true;
+            safeCloseEntityManager();
         }
 
         /**
-         * AS7-6586 requires that the container avoid closing the EntityManager while the application
-         * may be using the EntityManager in a different thread.  If the transaction has been rolled
-         * back, will check if the current thread is the Arjuna transaction manager Reaper thread.  It is not
-         * safe to call EntityManager.close from the Reaper thread, so false is returned.
-         *
-         * TODO: switch to depend on JBTM-1556 instead of checking the current thread name.
-         *
-         * @param status of transaction.
-         * @return
+         * After the JTA transaction is ended (Synchronization.afterCompletion has been called) and
+         * the JTA transaction is no longer associated with application thread (application thread called
+         * transaction.rollback/commit/suspend), the entity manager can safely be closed.
          */
-        private boolean safeToClose(int status) {
-            if (Status.STATUS_COMMITTED != status) {
-                return !TxUtils.isTransactionManagerTimeoutThread();
+        private void safeCloseEntityManager() {
+            if ( afterCompletionCalled == true && transactionDisassociatedFromApplication == true) {
+                if (manager != null) {
+                    try {
+                        if (ROOT_LOGGER.isDebugEnabled())
+                            ROOT_LOGGER.debugf("%s: closing entity managersession", getEntityManagerDetails(manager, scopedPuName));
+                        manager.close();
+                    } catch (Exception ignored) {
+                        if (ROOT_LOGGER.isDebugEnabled())
+                            ROOT_LOGGER.debugf(ignored, "ignoring error that occurred while closing EntityManager for %s (", scopedPuName);
+                    }
+                    manager = null;
+                }
             }
+        }
 
-            return true;
+        @Override
+        public synchronized void onEvent(TransactionEvent transactionEvent) {
+            // set to true if application thread is no longer associated with JTA transaction
+            // (EventType.DISASSOCIATING in progress).  We are tracking when the application thread
+            // is no longer associated with the transaction, as that indicates that it is safe to
+            // close the entity manager (since the application is no longer using the entity manager).
+            transactionDisassociatedFromApplication = transactionEvent.getTypes().contains(EventType.DISASSOCIATING);
+            safeCloseEntityManager();
         }
     }
 


### PR DESCRIPTION
This update of https://github.com/wildfly/wildfly/pull/7837 does not use org.jboss.tm.listener.TransactionListenerRegistryLocator, instead we do a similar check to what TransactionListenerRegistryLocator does, only we already have the TM to use:

```
    public static void setTransactionListenerRegistry() throws TransactionListenerRegistryUnavailableException {
        if (transactionManager instanceof TransactionListenerRegistry) {
            transactionListenerRegistry = (TransactionListenerRegistry)transactionManager;
        }
        else {
            throw new TransactionListenerRegistryUnavailableException();
        }
    }
```
