### PR TITLE
Consolidate clustering resource registration logic.

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AbstractResourceDefinition.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AbstractResourceDefinition.java
@@ -1,0 +1,64 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller;
+
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+
+/**
+ * Resource definition for resources that performs all registration via {@link Registration#register(Object)}.
+ * All other registerXXX(...) methods have been made final - to prevent misuse.
+ * @author Paul Ferraro
+ */
+public abstract class AbstractResourceDefinition<R> extends SimpleResourceDefinition implements Registration<R> {
+
+    protected AbstractResourceDefinition(PathElement path, ResourceDescriptionResolver resolver) {
+        super(new Parameters(path, resolver));
+    }
+
+    protected AbstractResourceDefinition(Parameters parameters) {
+        super(parameters);
+    }
+
+    @Override
+    public final void registerOperations(ManagementResourceRegistration resourceRegistration) {
+    }
+
+    @Override
+    public final void registerAttributes(ManagementResourceRegistration resourceRegistration) {
+    }
+
+    @Override
+    public final void registerNotifications(ManagementResourceRegistration resourceRegistration) {
+    }
+
+    @Override
+    public final void registerChildren(ManagementResourceRegistration resourceRegistration) {
+    }
+
+    @Override
+    public final void registerCapabilities(ManagementResourceRegistration resourceRegistration) {
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
@@ -26,7 +26,9 @@ import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -38,19 +40,25 @@ import org.jboss.dmr.ModelNode;
  * Generic add operation step handler that delegates service installation/rollback to a {@link ResourceServiceHandler}.
  * @author Paul Ferraro
  */
-public class AddStepHandler extends AbstractAddStepHandler implements Registration {
+public class AddStepHandler extends AbstractAddStepHandler implements Registration<ManagementResourceRegistration> {
 
     private final AddStepHandlerDescriptor descriptor;
     private final ResourceServiceHandler handler;
+    private final OperationStepHandler writeAttributeHandler;
 
     public AddStepHandler(AddStepHandlerDescriptor descriptor) {
         this(descriptor, null);
     }
 
     public AddStepHandler(AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler) {
+        this(descriptor, handler, new ReloadRequiredWriteAttributeHandler(descriptor.getAttributes()));
+    }
+
+    AddStepHandler(AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler, OperationStepHandler writeAttributeHandler) {
         super(descriptor.getAttributes());
         this.descriptor = descriptor;
         this.handler = handler;
+        this.writeAttributeHandler = writeAttributeHandler;
     }
 
     @Override
@@ -92,13 +100,11 @@ public class AddStepHandler extends AbstractAddStepHandler implements Registrati
     @Override
     public void register(ManagementResourceRegistration registration) {
         SimpleOperationDefinitionBuilder builder = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.ADD, this.descriptor.getDescriptionResolver()).withFlag(OperationEntry.Flag.RESTART_NONE);
-        for (AttributeDefinition attribute : this.descriptor.getAttributes()) {
-            builder.addParameter(attribute);
-        }
-        for (AttributeDefinition parameter : this.descriptor.getExtraParameters()) {
-            builder.addParameter(parameter);
-        }
+        this.descriptor.getAttributes().forEach(attribute -> builder.addParameter(attribute));
+        this.descriptor.getExtraParameters().forEach(attribute -> builder.addParameter(attribute));
         registration.registerOperationHandler(builder.build(), this);
+
+        this.descriptor.getAttributes().forEach(attribute -> registration.registerReadWriteAttribute(attribute, null, this.writeAttributeHandler));
 
         new CapabilityRegistration(this.descriptor.getCapabilities()).register(registration);
     }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/BoottimeAddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/BoottimeAddStepHandler.java
@@ -26,7 +26,9 @@ import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -38,7 +40,7 @@ import org.jboss.dmr.ModelNode;
  * Generic boot-time add step handler that delegates service installation/rollback to a {@link ResourceServiceHandler}.
  * @author Paul Ferraro
  */
-public class BoottimeAddStepHandler extends AbstractBoottimeAddStepHandler implements Registration {
+public class BoottimeAddStepHandler extends AbstractBoottimeAddStepHandler implements Registration<ManagementResourceRegistration> {
 
     private final AddStepHandlerDescriptor descriptor;
     private final ResourceServiceHandler handler;
@@ -91,6 +93,9 @@ public class BoottimeAddStepHandler extends AbstractBoottimeAddStepHandler imple
             builder.addParameter(parameter);
         }
         registration.registerOperationHandler(builder.build(), this);
+
+        OperationStepHandler writeAttributeHandler = new ReloadRequiredWriteAttributeHandler(this.descriptor.getAttributes());
+        this.descriptor.getAttributes().forEach(attribute -> registration.registerReadWriteAttribute(attribute, null, writeAttributeHandler));
 
         new CapabilityRegistration(this.descriptor.getCapabilities()).register(registration);
     }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityRegistration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityRegistration.java
@@ -32,7 +32,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
  * Registration facility for capabilities.
  * @author Paul Ferraro
  */
-public class CapabilityRegistration implements Registration {
+public class CapabilityRegistration implements Registration<ManagementResourceRegistration> {
 
     private final Collection<? extends Capability> capabilities;
 
@@ -48,13 +48,8 @@ public class CapabilityRegistration implements Registration {
         this.capabilities = capabilities;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void register(ManagementResourceRegistration registration) {
-        for (Capability capability : this.capabilities) {
-            registration.registerCapability(capability.getDefinition());
-        }
+        this.capabilities.forEach(capability -> registration.registerCapability(capability.getDefinition()));
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ChildResourceDefinition.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ChildResourceDefinition.java
@@ -22,19 +22,21 @@
 
 package org.jboss.as.clustering.controller;
 
-import java.util.Collection;
-
-import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
 /**
- * Describes the common properties of a remove operation handler.
+ * Resource definition for child resources that performs all registration via {@link #register(ManagementResourceRegistration)}.
  * @author Paul Ferraro
  */
-public interface AddStepHandlerDescriptor extends WriteAttributeStepHandlerDescriptor, RemoveStepHandlerDescriptor {
+public abstract class ChildResourceDefinition extends AbstractResourceDefinition<ManagementResourceRegistration> {
 
-    /**
-     * Extra parameters (not specified by {@link #getAttributes()}) for the add operation.
-     * @return a collection of attributes
-     */
-    Collection<AttributeDefinition> getExtraParameters();
+    protected ChildResourceDefinition(PathElement path, ResourceDescriptionResolver resolver) {
+        super(new Parameters(path, resolver));
+    }
+
+    protected ChildResourceDefinition(Parameters parameters) {
+        super(parameters);
+    }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/MetricHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/MetricHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.controller;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,7 @@ import org.jboss.dmr.ModelNode;
  * Generic {@link org.jboss.as.controller.OperationStepHandler} for runtime metrics.
  * @author Paul Ferraro
  */
-public class MetricHandler<C> extends AbstractRuntimeOnlyHandler implements Registration {
+public class MetricHandler<C> extends AbstractRuntimeOnlyHandler implements Registration<ManagementResourceRegistration> {
 
     private final Map<String, Metric<C>> metrics = new HashMap<>();
     private final MetricExecutor<C> executor;
@@ -50,18 +51,14 @@ public class MetricHandler<C> extends AbstractRuntimeOnlyHandler implements Regi
         this(executor, Arrays.asList(metrics));
     }
 
-    public MetricHandler(MetricExecutor<C> executor, Iterable<? extends Metric<C>> metrics) {
+    public MetricHandler(MetricExecutor<C> executor, Collection<? extends Metric<C>> metrics) {
         this.executor = executor;
-        for (Metric<C> metric : metrics) {
-            this.metrics.put(metric.getDefinition().getName(), metric);
-        }
+        metrics.forEach(metric -> this.metrics.put(metric.getDefinition().getName(), metric));
     }
 
     @Override
     public void register(ManagementResourceRegistration registration) {
-        for (Metric<C> metric : this.metrics.values()) {
-            registration.registerReadOnlyAttribute(metric.getDefinition(), this);
-        }
+        this.metrics.values().forEach(metric -> registration.registerReadOnlyAttribute(metric.getDefinition(), this));
     }
 
     @Override

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/OperationHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/OperationHandler.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.controller;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +38,7 @@ import org.jboss.dmr.ModelNode;
  * Generic {@link org.jboss.as.controller.OperationStepHandler} for runtime operations.
  * @author Paul Ferraro
  */
-public class OperationHandler<C> extends AbstractRuntimeOnlyHandler implements Registration {
+public class OperationHandler<C> extends AbstractRuntimeOnlyHandler implements Registration<ManagementResourceRegistration> {
 
     private final Map<String, Operation<C>> operations = new HashMap<>();
     private final OperationExecutor<C> executor;
@@ -50,18 +51,14 @@ public class OperationHandler<C> extends AbstractRuntimeOnlyHandler implements R
         this(executor, Arrays.asList(operations));
     }
 
-    public OperationHandler(OperationExecutor<C> executor, Iterable<? extends Operation<C>> operations) {
+    public OperationHandler(OperationExecutor<C> executor, Collection<? extends Operation<C>> operations) {
         this.executor = executor;
-        for (Operation<C> operation : operations) {
-            this.operations.put(operation.getDefinition().getName(), operation);
-        }
+        operations.forEach(operation -> this.operations.put(operation.getDefinition().getName(), operation));
     }
 
     @Override
     public void register(ManagementResourceRegistration registration) {
-        for (Operation<C> operation : this.operations.values()) {
-            registration.registerOperationHandler(operation.getDefinition(), this);
-        }
+        this.operations.values().forEach(operation -> registration.registerOperationHandler(operation.getDefinition(), this));
     }
 
     @Override

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/Registration.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/Registration.java
@@ -22,17 +22,15 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
-
 /**
- * Implemented by a resource artifact that can register itself.
- * This allows a resource to encapsulates specific registration details (e.g. resource aliases) from the parent resource.
+ * Implemented by a management artifact that can register itself.
+ * This allows a management object to encapsulates specific registration details (e.g. resource aliases) from the parent resource.
  * @author Paul Ferraro
  */
-public interface Registration {
+public interface Registration<R> {
     /**
      * Registers this object with a resource.
      * @param registration a registration for a management resource
      */
-    void register(ManagementResourceRegistration registration);
+    void register(R registration);
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredWriteAttributeHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredWriteAttributeHandler.java
@@ -22,46 +22,23 @@
 
 package org.jboss.as.clustering.controller;
 
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 
 /**
  * Convenience extension of {@link org.jboss.as.controller.ReloadRequiredWriteAttributeHandler} that can be initialized with an {@link Attribute} set.
  * @author Paul Ferraro
  */
-public class ReloadRequiredWriteAttributeHandler extends org.jboss.as.controller.ReloadRequiredWriteAttributeHandler implements Registration {
+public class ReloadRequiredWriteAttributeHandler extends org.jboss.as.controller.ReloadRequiredWriteAttributeHandler implements Registration<ManagementResourceRegistration> {
 
-    private final Map<String, AttributeDefinition> attributes = new HashMap<>();
+    private final WriteAttributeStepHandlerDescriptor descriptor;
 
-    public <E extends Enum<E> & Attribute> ReloadRequiredWriteAttributeHandler(Class<E> enumClass) {
-        this(EnumSet.allOf(enumClass));
-    }
-
-    public ReloadRequiredWriteAttributeHandler(Attribute... attributes) {
-        this(Arrays.asList(attributes));
-    }
-
-    public ReloadRequiredWriteAttributeHandler(Iterable<? extends Attribute> attributes) {
-        for (Attribute attribute : attributes) {
-            AttributeDefinition definition = attribute.getDefinition();
-            this.attributes.put(definition.getName(), definition);
-        }
-    }
-
-    @Override
-    protected AttributeDefinition getAttributeDefinition(String name) {
-        return this.attributes.get(name);
+    public ReloadRequiredWriteAttributeHandler(WriteAttributeStepHandlerDescriptor descriptor) {
+        super(descriptor.getAttributes());
+        this.descriptor = descriptor;
     }
 
     @Override
     public void register(ManagementResourceRegistration registration) {
-        for (AttributeDefinition attribute : this.attributes.values()) {
-            registration.registerReadWriteAttribute(attribute, null, this);
-        }
+        this.descriptor.getAttributes().forEach(attribute -> registration.registerReadWriteAttribute(attribute, null, this));
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RemoveStepHandler.java
@@ -37,7 +37,7 @@ import org.jboss.dmr.ModelNode;
  * Generic remove operation step handler that delegates service removal/recovery to a dedicated {@link ResourceServiceHandler}.
  * @author Paul Ferraro
  */
-public class RemoveStepHandler extends AbstractRemoveStepHandler implements Registration {
+public class RemoveStepHandler extends AbstractRemoveStepHandler implements Registration<ManagementResourceRegistration> {
 
     private final RemoveStepHandlerDescriptor descriptor;
     private final ResourceServiceHandler handler;

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceDescriptor.java
@@ -76,19 +76,26 @@ public class ResourceDescriptor implements AddStepHandlerDescriptor {
         return this.addAttributes(Arrays.asList(attributes));
     }
 
-    public ResourceDescriptor addAttributes(Iterable<? extends Attribute> attributes) {
-        for (Attribute attribute : attributes) {
-            this.attributes.add(attribute.getDefinition());
-        }
+    public ResourceDescriptor addAttributes(Collection<? extends Attribute> attributes) {
+        attributes.forEach(attribute -> this.attributes.add(attribute.getDefinition()));
+        return this;
+    }
+
+    public <E extends Enum<E> & Attribute> ResourceDescriptor addExtraParameters(Class<E> enumClass) {
+        return this.addExtraParameters(EnumSet.allOf(enumClass));
+    }
+
+    public ResourceDescriptor addExtraParameters(Attribute... parameters) {
+        return this.addExtraParameters(Arrays.asList(parameters));
+    }
+
+    public ResourceDescriptor addExtraParameters(Collection<? extends Attribute> parameters) {
+        parameters.forEach(attribute -> this.parameters.add(attribute.getDefinition()));
         return this;
     }
 
     public ResourceDescriptor addExtraParameters(AttributeDefinition... parameters) {
-        return this.addExtraParameters(Arrays.asList(parameters));
-    }
-
-    public ResourceDescriptor addExtraParameters(Collection<? extends AttributeDefinition> parameters) {
-        this.parameters.addAll(parameters);
+        this.parameters.addAll(Arrays.asList(parameters));
         return this;
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceAddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceAddStepHandler.java
@@ -40,7 +40,7 @@ public class RestartParentResourceAddStepHandler<T> extends AddStepHandler {
     }
 
     public RestartParentResourceAddStepHandler(ResourceServiceBuilderFactory<T> parentFactory, AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler) {
-        super(descriptor, handler);
+        super(descriptor, handler, new RestartParentResourceWriteAttributeHandler<>(parentFactory, descriptor));
         this.handler = new RestartParentResourceStepHandler<>(parentFactory);
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceStepHandler.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.controller;
 
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RestartParentResourceHandlerBase;
 import org.jboss.dmr.ModelNode;
@@ -38,7 +37,7 @@ public class RestartParentResourceStepHandler<T> extends RestartParentResourceHa
 
     private final ResourceServiceBuilderFactory<T> parentFactory;
 
-    public <H extends OperationStepHandler & Registration> RestartParentResourceStepHandler(ResourceServiceBuilderFactory<T> parentFactory) {
+    public RestartParentResourceStepHandler(ResourceServiceBuilderFactory<T> parentFactory) {
         super(null);
         this.parentFactory = parentFactory;
     }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceWriteAttributeHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceWriteAttributeHandler.java
@@ -22,12 +22,6 @@
 
 package org.jboss.as.clustering.controller;
 
-import java.util.Arrays;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -40,41 +34,25 @@ import org.jboss.msc.service.ServiceName;
  * {@link org.jboss.as.controller.RestartParentWriteAttributeHandler} that leverages a {@link ResourceServiceBuilderFactory} for service recreation.
  * @author Paul Ferraro
  */
-public class RestartParentResourceWriteAttributeHandler<T> extends RestartParentWriteAttributeHandler implements Registration {
+public class RestartParentResourceWriteAttributeHandler<T> extends RestartParentWriteAttributeHandler implements Registration<ManagementResourceRegistration> {
 
-    private final ResourceServiceBuilderFactory<T> builderFactory;
-    private final Map<String, AttributeDefinition> attributes = new HashMap<>();
+    private final WriteAttributeStepHandlerDescriptor descriptor;
+    private final ResourceServiceBuilderFactory<T> parentFactory;
 
-    public <E extends Enum<E> & Attribute> RestartParentResourceWriteAttributeHandler(ResourceServiceBuilderFactory<T> builderFactory, Class<E> enumClass) {
-        this(builderFactory, EnumSet.allOf(enumClass));
-    }
-
-    public RestartParentResourceWriteAttributeHandler(ResourceServiceBuilderFactory<T> builderFactory, Attribute... attributes) {
-        this(builderFactory, Arrays.asList(attributes));
-    }
-
-    public RestartParentResourceWriteAttributeHandler(ResourceServiceBuilderFactory<T> builderFactory, Iterable<? extends Attribute> attributes) {
-        super(null);
-        this.builderFactory = builderFactory;
-        for (Attribute attribute : attributes) {
-            AttributeDefinition definition = attribute.getDefinition();
-            this.attributes.put(definition.getName(), definition);
-        }
-    }
-
-    @Override
-    protected AttributeDefinition getAttributeDefinition(String name) {
-        return this.attributes.get(name);
+    public RestartParentResourceWriteAttributeHandler(ResourceServiceBuilderFactory<T> parentFactory, WriteAttributeStepHandlerDescriptor descriptor) {
+        super(null, descriptor.getAttributes());
+        this.descriptor = descriptor;
+        this.parentFactory = parentFactory;
     }
 
     @Override
     protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
-        this.builderFactory.createBuilder(parentAddress).configure(context, parentModel).build(context.getServiceTarget()).install();
+        this.parentFactory.createBuilder(parentAddress).configure(context, parentModel).build(context.getServiceTarget()).install();
     }
 
     @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
-        return this.builderFactory.createBuilder(parentAddress).getServiceName();
+        return this.parentFactory.createBuilder(parentAddress).getServiceName();
     }
 
     @Override
@@ -84,8 +62,6 @@ public class RestartParentResourceWriteAttributeHandler<T> extends RestartParent
 
     @Override
     public void register(ManagementResourceRegistration registration) {
-        for (AttributeDefinition attribute : this.attributes.values()) {
-            registration.registerReadWriteAttribute(attribute, null, this);
-        }
+        this.descriptor.getAttributes().forEach(attribute -> registration.registerReadWriteAttribute(attribute, null, this));
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/SubsystemResourceDefinition.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/SubsystemResourceDefinition.java
@@ -22,19 +22,17 @@
 
 package org.jboss.as.clustering.controller;
 
-import java.util.Collection;
-
-import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.SubsystemRegistration;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 
 /**
- * Describes the common properties of a remove operation handler.
+ * Resource definition for subsystem resources that performs all registration via {@link #register(SubsystemRegistration)}.
  * @author Paul Ferraro
  */
-public interface AddStepHandlerDescriptor extends WriteAttributeStepHandlerDescriptor, RemoveStepHandlerDescriptor {
+public abstract class SubsystemResourceDefinition extends AbstractResourceDefinition<SubsystemRegistration> {
 
-    /**
-     * Extra parameters (not specified by {@link #getAttributes()}) for the add operation.
-     * @return a collection of attributes
-     */
-    Collection<AttributeDefinition> getExtraParameters();
+    protected SubsystemResourceDefinition(PathElement path, ResourceDescriptionResolver resolver) {
+        super(path, resolver);
+    }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/WriteAttributeStepHandlerDescriptor.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/WriteAttributeStepHandlerDescriptor.java
@@ -27,14 +27,14 @@ import java.util.Collection;
 import org.jboss.as.controller.AttributeDefinition;
 
 /**
- * Describes the common properties of a remove operation handler.
  * @author Paul Ferraro
  */
-public interface AddStepHandlerDescriptor extends WriteAttributeStepHandlerDescriptor, RemoveStepHandlerDescriptor {
+@FunctionalInterface
+public interface WriteAttributeStepHandlerDescriptor {
 
     /**
-     * Extra parameters (not specified by {@link #getAttributes()}) for the add operation.
+     * Attributes of the add operation.
      * @return a collection of attributes
      */
-    Collection<AttributeDefinition> getExtraParameters();
+    Collection<AttributeDefinition> getAttributes();
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupForResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupForResourceDefinition.java
@@ -25,7 +25,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import org.infinispan.commons.api.BasicCacheContainer;
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -83,20 +82,13 @@ public class BackupForResourceDefinition extends ComponentResourceDefinition {
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
 
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new BackupForBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupsResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BackupsResourceDefinition.java
@@ -64,20 +64,14 @@ public class BackupsResourceDefinition extends ComponentResourceDefinition {
     }
 
     @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
-        new BackupResourceDefinition(this.builderFactory, this.runtimeRegistration).register(registration);
-    }
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
 
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver());
         ResourceServiceHandler handler = new ParentResourceServiceHandler<>(this.builderFactory);
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
+        new BackupResourceDefinition(this.builderFactory, this.runtimeRegistration).register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryTableResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryTableResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
@@ -75,21 +74,16 @@ public class BinaryTableResourceDefinition extends TableResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(TableResourceDefinition.Attribute.class).addAttributes(TableResourceDefinition.ColumnAttribute.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(TableResourceDefinition.Attribute.class)
+                .addAttributes(TableResourceDefinition.ColumnAttribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new BinaryTableBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerResourceDefinition.java
@@ -21,14 +21,13 @@
  */
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import java.util.stream.Stream;
+import java.util.EnumSet;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.AttributeParsers;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.MetricHandler;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -47,7 +46,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
@@ -67,7 +65,7 @@ import org.jboss.dmr.ModelType;
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  * @author Paul Ferraro
  */
-public class CacheContainerResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class CacheContainerResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -165,7 +163,7 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition i
                 .setAllowNull(true)
                 .setDefaultValue(defaultValue)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        ;
+                ;
     }
 
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
@@ -174,13 +172,13 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition i
         if (InfinispanModel.VERSION_4_0_0.requiresTransformation(version)) {
             builder.discardChildResource(NoTransportResourceDefinition.PATH);
 
-            Stream.of(ThreadPoolResourceDefinition.values()).forEach(pool -> builder.addChildResource(pool.getPathElement(), pool.getDiscardPolicy()));
-            Stream.of(ScheduledThreadPoolResourceDefinition.values()).forEach(pool -> builder.addChildResource(pool.getPathElement(), pool.getDiscardPolicy()));
+            EnumSet.allOf(ThreadPoolResourceDefinition.class).forEach(pool -> builder.addChildResource(pool.getPathElement(), pool.getDiscardPolicy()));
+            EnumSet.allOf(ScheduledThreadPoolResourceDefinition.class).forEach(pool -> builder.addChildResource(pool.getPathElement(), pool.getDiscardPolicy()));
         } else {
             NoTransportResourceDefinition.buildTransformation(version, builder);
 
-            Stream.of(ThreadPoolResourceDefinition.values()).forEach(pool -> pool.buildTransformation(version, parent));
-            Stream.of(ScheduledThreadPoolResourceDefinition.values()).forEach(pool -> pool.buildTransformation(version, parent));
+            EnumSet.allOf(ThreadPoolResourceDefinition.class).forEach(pool -> pool.buildTransformation(version, parent));
+            EnumSet.allOf(ScheduledThreadPoolResourceDefinition.class).forEach(pool -> pool.buildTransformation(version, parent));
         }
 
         if (InfinispanModel.VERSION_3_0_0.requiresTransformation(version)) {
@@ -244,19 +242,14 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition i
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(ExecutorAttribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(DeprecatedAttribute.class).register(registration);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
 
-        if (this.allowRuntimeOnlyRegistration) {
-            new MetricHandler<>(new CacheContainerMetricExecutor(), CacheContainerMetric.class).register(registration);
-        }
-    }
-
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(ExecutorAttribute.class).addAttributes(DeprecatedAttribute.class);
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(ExecutorAttribute.class)
+                .addAttributes(DeprecatedAttribute.class)
+                ;
         ResourceServiceHandler handler = new CacheContainerServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
@@ -282,24 +275,20 @@ public class CacheContainerResourceDefinition extends SimpleResourceDefinition i
             }
         };
         registration.registerOperationHandler(ALIAS_REMOVE, removeAliasHandler);
-    }
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
+        if (this.allowRuntimeOnlyRegistration) {
+            new MetricHandler<>(new CacheContainerMetricExecutor(), CacheContainerMetric.class).register(registration);
+        }
+
         new JGroupsTransportResourceDefinition().register(registration);
         new NoTransportResourceDefinition().register(registration);
 
-        Stream.of(ThreadPoolResourceDefinition.values()).forEach(p -> p.register(registration));
-        Stream.of(ScheduledThreadPoolResourceDefinition.values()).forEach(p -> p.register(registration));
+        EnumSet.allOf(ThreadPoolResourceDefinition.class).forEach(p -> p.register(registration));
+        EnumSet.allOf(ScheduledThreadPoolResourceDefinition.class).forEach(p -> p.register(registration));
 
         new LocalCacheResourceDefinition(this.pathManager, this.allowRuntimeOnlyRegistration).register(registration);
         new InvalidationCacheResourceDefinition(this.pathManager, this.allowRuntimeOnlyRegistration).register(registration);
         new ReplicatedCacheResourceDefinition(this.pathManager, this.allowRuntimeOnlyRegistration).register(registration);
         new DistributedCacheResourceDefinition(this.pathManager, this.allowRuntimeOnlyRegistration).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheResourceDefinition.java
@@ -27,9 +27,8 @@ import java.util.NoSuchElementException;
 import org.infinispan.configuration.cache.Index;
 import org.jboss.as.clustering.controller.AttributeMarshallers;
 import org.jboss.as.clustering.controller.AttributeParsers;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.MetricHandler;
-import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.validation.EnumValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.ModuleIdentifierValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.ParameterValidatorBuilder;
@@ -41,7 +40,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleMapAttributeDefinition;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -59,7 +57,7 @@ import org.jboss.dmr.ModelType;
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class CacheResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class CacheResourceDefinition extends ChildResourceDefinition {
 
     enum Attribute implements org.jboss.as.clustering.controller.Attribute {
         MODULE("module", ModelType.STRING, null, new ModuleIdentifierValidatorBuilder()),
@@ -128,7 +126,7 @@ public class CacheResourceDefinition extends SimpleResourceDefinition implements
                 .setAllowNull(true)
                 .setDefaultValue(defaultValue)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-        ;
+                ;
     }
 
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
@@ -193,17 +191,12 @@ public class CacheResourceDefinition extends SimpleResourceDefinition implements
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(DeprecatedAttribute.class).register(registration);
+    public void register(ManagementResourceRegistration registration) {
 
         if (this.allowRuntimeOnlyRegistration) {
             new MetricHandler<>(new CacheMetricExecutor(), CacheMetric.class).register(registration);
         }
-    }
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new EvictionResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
         new ExpirationResourceDefinition().register(registration);
         new LockingResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
@@ -216,10 +209,5 @@ public class CacheResourceDefinition extends SimpleResourceDefinition implements
         new MixedKeyedJDBCStoreResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
         new StringKeyedJDBCStoreResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
         new RemoteStoreResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ClusteredCacheResourceDefinition.java
@@ -23,7 +23,6 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.MetricHandler;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.validation.EnumValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.ParameterValidatorBuilder;
 import org.jboss.as.controller.AttributeDefinition;
@@ -91,7 +90,7 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
                 .setDefaultValue(defaultValue)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .setMeasurementUnit((type == ModelType.LONG) ? MeasurementUnit.MILLISECONDS : null)
-        ;
+                ;
     }
 
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
@@ -104,13 +103,12 @@ public class ClusteredCacheResourceDefinition extends CacheResourceDefinition {
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(DeprecatedAttribute.class).register(registration);
+    public void register(ManagementResourceRegistration registration) {
 
         if (this.allowRuntimeOnlyRegistration) {
             new MetricHandler<>(new ClusteredCacheMetricExecutor(), ClusteredCacheMetric.class).register(registration);
         }
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ComponentResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ComponentResourceDefinition.java
@@ -21,14 +21,13 @@
  */
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.Registration;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
 
 /**
  * @author Paul Ferraro
  */
-public abstract class ComponentResourceDefinition extends SimpleResourceDefinition implements Registration {
+public abstract class ComponentResourceDefinition extends ChildResourceDefinition {
 
     static PathElement pathElement(String name) {
         return PathElement.pathElement("component", name);

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CustomStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CustomStoreResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -78,21 +77,18 @@ public class CustomStoreResourceDefinition extends StoreResourceDefinition {
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
 
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(StoreResourceDefinition.Attribute.class);
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(StoreResourceDefinition.Attribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new CustomStoreBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/DistributedCacheResourceDefinition.java
@@ -23,9 +23,8 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.validation.DoubleRangeValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.EnumValidatorBuilder;
@@ -83,7 +82,7 @@ public class DistributedCacheResourceDefinition extends SharedStateCacheResource
                     .setDefaultValue(defaultValue)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setMeasurementUnit((type == ModelType.LONG) ? MeasurementUnit.MILLISECONDS : null)
-            ;
+                    ;
         }
 
         @Override
@@ -111,25 +110,22 @@ public class DistributedCacheResourceDefinition extends SharedStateCacheResource
         super(WILDCARD_PATH, pathManager, allowRuntimeOnlyRegistration);
     }
 
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
     @SuppressWarnings("deprecation")
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
                 .addAttributes(Attribute.class)
                 .addAttributes(ClusteredCacheResourceDefinition.Attribute.class)
                 .addAttributes(ClusteredCacheResourceDefinition.DeprecatedAttribute.class)
                 .addAttributes(CacheResourceDefinition.Attribute.class)
                 .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
-        ;
+                ;
         ResourceServiceHandler handler = new DistributedCacheServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionResourceDefinition.java
@@ -26,7 +26,6 @@ import org.infinispan.eviction.EvictionStrategy;
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.MetricHandler;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -74,7 +73,7 @@ public class EvictionResourceDefinition extends ComponentResourceDefinition {
                     .setAllowNull(true)
                     .setDefaultValue(defaultValue)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
-            ;
+                    ;
         }
 
         @Override
@@ -97,24 +96,17 @@ public class EvictionResourceDefinition extends ComponentResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new EvictionBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
 
         if (this.allowRuntimeOnlyRegistration) {
             new MetricHandler<>(new EvictionMetricExecutor(), EvictionMetric.class).register(registration);
         }
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ExpirationResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ExpirationResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -84,20 +83,13 @@ public class ExpirationResourceDefinition extends ComponentResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new ExpirationBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/FileStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/FileStoreResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -87,14 +86,14 @@ public class FileStoreResourceDefinition extends StoreResourceDefinition {
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
 
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(StoreResourceDefinition.Attribute.class);
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(StoreResourceDefinition.Attribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new FileStoreBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
@@ -106,10 +105,7 @@ public class FileStoreResourceDefinition extends StoreResourceDefinition {
                     .build();
             registration.registerOperationHandler(pathHandler.getOperationDefinition(), pathHandler);
         }
-    }
 
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanExtension.java
@@ -48,7 +48,7 @@ public class InfinispanExtension implements Extension {
     public void initialize(ExtensionContext context) {
         SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, InfinispanModel.CURRENT.getVersion());
 
-        registration.registerSubsystemModel(new InfinispanSubsystemResourceDefinition(context.getProcessType().isServer() ? context.getPathManager() : null, context.isRuntimeOnlyRegistrationValid()));
+        new InfinispanSubsystemResourceDefinition(context.getProcessType().isServer() ? context.getPathManager() : null, context.isRuntimeOnlyRegistrationValid()).register(registration);
         registration.registerXMLElementWriter(new InfinispanSubsystemXMLWriter());
 
         if (context.isRegisterTransformers()) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InfinispanSubsystemResourceDefinition.java
@@ -26,9 +26,10 @@ import org.jboss.as.clustering.controller.BoottimeAddStepHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.controller.SubsystemResourceDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -42,7 +43,7 @@ import org.jboss.as.controller.transform.description.TransformationDescriptionBu
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  */
-public class InfinispanSubsystemResourceDefinition extends SimpleResourceDefinition {
+public class InfinispanSubsystemResourceDefinition extends SubsystemResourceDefinition {
 
     static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, InfinispanExtension.SUBSYSTEM_NAME);
 
@@ -64,16 +65,16 @@ public class InfinispanSubsystemResourceDefinition extends SimpleResourceDefinit
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(SubsystemRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubsystemModel(this);
+
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver());
         ResourceServiceHandler handler = new InfinispanSubsystemServiceHandler();
         new BoottimeAddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new CacheContainerResourceDefinition(this.pathManager, this.allowRuntimeOnlyRegistration).register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/InvalidationCacheResourceDefinition.java
@@ -56,15 +56,19 @@ public class InvalidationCacheResourceDefinition extends ClusteredCacheResourceD
 
     @SuppressWarnings("deprecation")
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
                 .addAttributes(ClusteredCacheResourceDefinition.Attribute.class)
                 .addAttributes(ClusteredCacheResourceDefinition.DeprecatedAttribute.class)
                 .addAttributes(CacheResourceDefinition.Attribute.class)
                 .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
-        ;
+                ;
         ResourceServiceHandler handler = new InvalidationCacheServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
@@ -23,7 +23,6 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.infinispan.persistence.jdbc.DatabaseType;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.validation.EnumValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.ParameterValidatorBuilder;
 import org.jboss.as.controller.AttributeDefinition;
@@ -31,7 +30,6 @@ import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
 import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
@@ -87,11 +85,5 @@ public abstract class JDBCStoreResourceDefinition extends StoreResourceDefinitio
 
     JDBCStoreResourceDefinition(PathElement path, InfinispanResourceDescriptionResolver resolver, boolean allowRuntimeOnlyRegistration) {
         super(path, resolver, allowRuntimeOnlyRegistration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JGroupsTransportResourceDefinition.java
@@ -26,7 +26,6 @@ import java.util.Set;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -117,7 +116,7 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
                 .setDefaultValue(defaultValue)
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .setMeasurementUnit((type == ModelType.LONG) ? MeasurementUnit.MILLISECONDS : null)
-        ;
+                ;
     }
 
     @SuppressWarnings("deprecation")
@@ -227,22 +226,17 @@ public class JGroupsTransportResourceDefinition extends TransportResourceDefinit
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(ExecutorAttribute.class).addAttributes(DeprecatedAttribute.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(ExecutorAttribute.class)
+                .addAttributes(DeprecatedAttribute.class)
+                ;
         ResourceServiceHandler handler = new JGroupsTransportServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(ExecutorAttribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(DeprecatedAttribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheResourceDefinition.java
@@ -56,10 +56,17 @@ public class LocalCacheResourceDefinition extends CacheResourceDefinition {
 
     @SuppressWarnings("deprecation")
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(CacheResourceDefinition.Attribute.class).addAttributes(CacheResourceDefinition.DeprecatedAttribute.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(CacheResourceDefinition.Attribute.class)
+                .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
+                ;
         ResourceServiceHandler handler = new LocalCacheServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LockingResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LockingResourceDefinition.java
@@ -26,7 +26,6 @@ import org.infinispan.util.concurrent.IsolationLevel;
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.MetricHandler;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -79,7 +78,7 @@ public class LockingResourceDefinition extends ComponentResourceDefinition {
                     .setDefaultValue(defaultValue)
                     .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                     .setMeasurementUnit((type == ModelType.LONG) ? MeasurementUnit.MILLISECONDS : null)
-            ;
+                    ;
         }
 
         @Override
@@ -104,24 +103,17 @@ public class LockingResourceDefinition extends ComponentResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new LockingBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
 
         if (this.allowRuntimeOnlyRegistration) {
             new MetricHandler<>(new LockingMetricExecutor(), LockingMetric.class).register(registration);
         }
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MixedKeyedJDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MixedKeyedJDBCStoreResourceDefinition.java
@@ -87,8 +87,15 @@ public class MixedKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDefi
     }
 
     @Override
-    public void registerOperations(final ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(JDBCStoreResourceDefinition.Attribute.class).addAttributes(StoreResourceDefinition.Attribute.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(JDBCStoreResourceDefinition.Attribute.class)
+                .addAttributes(StoreResourceDefinition.Attribute.class)
+                .addExtraParameters(DeprecatedAttribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new MixedKeyedJDBCStoreBuilderFactory());
         new AddStepHandler(descriptor, handler) {
             @Override
@@ -112,24 +119,13 @@ public class MixedKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDefi
             }
         }.register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
-        super.registerChildren(registration);
-        new BinaryTableResourceDefinition().register(registration);
-        new StringTableResourceDefinition().register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
         registration.registerReadWriteAttribute(DeprecatedAttribute.BINARY_TABLE.getDefinition(), BinaryKeyedJDBCStoreResourceDefinition.LEGACY_READ_TABLE_HANDLER, BinaryKeyedJDBCStoreResourceDefinition.LEGACY_WRITE_TABLE_HANDLER);
         registration.registerReadWriteAttribute(DeprecatedAttribute.STRING_TABLE.getDefinition(), StringKeyedJDBCStoreResourceDefinition.LEGACY_READ_TABLE_HANDLER, StringKeyedJDBCStoreResourceDefinition.LEGACY_WRITE_TABLE_HANDLER);
-    }
 
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
+        new BinaryTableResourceDefinition().register(registration);
+        new StringTableResourceDefinition().register(registration);
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoStoreResourceDefinition.java
@@ -23,21 +23,20 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
-import org.jboss.as.clustering.controller.Registration;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 
 /**
  * @author Paul Ferraro
  */
-public class NoStoreResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class NoStoreResourceDefinition extends ChildResourceDefinition {
 
     static PathElement PATH = StoreResourceDefinition.pathElement("none");
 
@@ -54,15 +53,12 @@ public class NoStoreResourceDefinition extends SimpleResourceDefinition implemen
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver());
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new NoStoreBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoTransportResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoTransportResourceDefinition.java
@@ -46,15 +46,12 @@ public class NoTransportResourceDefinition extends TransportResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver());
         ResourceServiceHandler handler = new NoTransportServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/PartitionHandlingResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/PartitionHandlingResourceDefinition.java
@@ -25,7 +25,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.MetricHandler;
 import org.jboss.as.clustering.controller.OperationHandler;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -80,16 +79,9 @@ public class PartitionHandlingResourceDefinition extends ComponentResourceDefini
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
 
-        if (this.allowRuntimeOnlyRegistration) {
-            new MetricHandler<>(new PartitionHandlingMetricExecutor(), PartitionHandlingMetric.class).register(registration);
-        }
-    }
-
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new PartitionHandlingBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
@@ -98,10 +90,9 @@ public class PartitionHandlingResourceDefinition extends ComponentResourceDefini
         if (this.allowRuntimeOnlyRegistration) {
             new OperationHandler<>(new PartitionHandlingOperationExecutor(), PartitionHandlingOperation.class).register(registration);
         }
-    }
 
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
+        if (this.allowRuntimeOnlyRegistration) {
+            new MetricHandler<>(new PartitionHandlingMetricExecutor(), PartitionHandlingMetric.class).register(registration);
+        }
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
@@ -27,7 +27,6 @@ import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.AttributeParsers;
 import org.jboss.as.clustering.controller.CapabilityReference;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -124,21 +123,19 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(StoreResourceDefinition.Attribute.class).addCapabilities(Capability.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(StoreResourceDefinition.Attribute.class)
+                .addCapabilities(Capability.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new RemoteStoreBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ReplicatedCacheResourceDefinition.java
@@ -56,15 +56,19 @@ public class ReplicatedCacheResourceDefinition extends SharedStateCacheResourceD
 
     @SuppressWarnings("deprecation")
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
                 .addAttributes(ClusteredCacheResourceDefinition.Attribute.class)
                 .addAttributes(ClusteredCacheResourceDefinition.DeprecatedAttribute.class)
                 .addAttributes(CacheResourceDefinition.Attribute.class)
                 .addAttributes(CacheResourceDefinition.DeprecatedAttribute.class)
-        ;
+                ;
         ResourceServiceHandler handler = new ReplicatedCacheServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScheduledThreadPoolResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScheduledThreadPoolResourceDefinition.java
@@ -23,13 +23,13 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.Attribute;
 import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -67,7 +67,7 @@ import org.wildfly.clustering.infinispan.spi.service.CacheContainerServiceName;
  * @author Radoslav Husar
  * @version Mar 2015
  */
-public enum ScheduledThreadPoolResourceDefinition implements ResourceDefinition, Registration, ScheduledThreadPoolDefinition {
+public enum ScheduledThreadPoolResourceDefinition implements ResourceDefinition, Registration<ManagementResourceRegistration>, ScheduledThreadPoolDefinition {
 
     EXPIRATION("expiration", 1, 60000), // called eviction prior to Infinispan 8
     ;
@@ -121,7 +121,7 @@ public enum ScheduledThreadPoolResourceDefinition implements ResourceDefinition,
 
     @Override
     public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(this.getAttributes()).register(registration);
+        // No-op.
     }
 
     @Override
@@ -169,7 +169,7 @@ public enum ScheduledThreadPoolResourceDefinition implements ResourceDefinition,
         return this.keepAliveTime;
     }
 
-    Iterable<Attribute> getAttributes() {
+    Collection<Attribute> getAttributes() {
         return Arrays.asList(this.maxThreads, this.keepAliveTime);
     }
 
@@ -177,7 +177,7 @@ public enum ScheduledThreadPoolResourceDefinition implements ResourceDefinition,
         // Nothing to transform yet
     }
 
-    public DynamicDiscardPolicy getDiscardPolicy() {
+    DynamicDiscardPolicy getDiscardPolicy() {
         return new UndefinedAttributesDiscardPolicy(this.getAttributes());
     }
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SharedStateCacheResourceDefinition.java
@@ -62,12 +62,13 @@ public class SharedStateCacheResourceDefinition extends ClusteredCacheResourceDe
     }
 
     @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
-        super.registerChildren(registration);
+    public void register(ManagementResourceRegistration registration) {
 
         new PartitionHandlingResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
         new StateTransferResourceDefinition().register(registration);
         new BackupsResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
         new BackupForResourceDefinition().register(registration);
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StateTransferResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -103,21 +102,16 @@ public class StateTransferResourceDefinition extends ComponentResourceDefinition
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(DeprecatedAttribute.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(DeprecatedAttribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new StateTransferBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(DeprecatedAttribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
@@ -23,10 +23,9 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AttributeMarshallers;
 import org.jboss.as.clustering.controller.AttributeParsers;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.MetricHandler;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.transform.OperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleOperationTransformer;
 import org.jboss.as.controller.AttributeDefinition;
@@ -35,7 +34,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleMapAttributeDefinition;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.operations.global.MapOperations;
@@ -51,7 +49,7 @@ import org.jboss.dmr.ModelType;
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  * @author Paul Ferraro
  */
-public abstract class StoreResourceDefinition extends SimpleResourceDefinition implements Registration {
+public abstract class StoreResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -145,18 +143,14 @@ public abstract class StoreResourceDefinition extends SimpleResourceDefinition i
         this.allowRuntimeOnlyRegistration = allowRuntimeOnlyRegistration;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
+    public void register(ManagementResourceRegistration registration) {
 
         if (this.allowRuntimeOnlyRegistration) {
             new MetricHandler<>(new StoreMetricExecutor(), StoreMetric.class).register(registration);
         }
-    }
 
-    @SuppressWarnings("deprecation")
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new StoreWriteBehindResourceDefinition().register(registration);
         new StoreWriteThroughResourceDefinition().register(registration);
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteBehindResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteBehindResourceDefinition.java
@@ -24,7 +24,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -109,21 +108,16 @@ public class StoreWriteBehindResourceDefinition extends StoreWriteResourceDefini
     }
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(DeprecatedAttribute.class).register(registration);
-    }
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
 
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(DeprecatedAttribute.class);
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(DeprecatedAttribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new StoreWriteBehindBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteResourceDefinition.java
@@ -22,14 +22,13 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.Registration;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
 
 /**
  * @author Paul Ferraro
  */
-public abstract class StoreWriteResourceDefinition extends SimpleResourceDefinition implements Registration {
+public abstract class StoreWriteResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreResourceDefinition.java
@@ -29,7 +29,6 @@ import java.util.List;
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -104,34 +103,6 @@ public class StringKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDef
         super(PATH, new InfinispanResourceDescriptionResolver(PATH, pathElement("jdbc"), WILDCARD_PATH), allowRuntimeOnlyRegistration);
     }
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
-        super.registerChildren(registration);
-        new StringTableResourceDefinition().register(registration);
-    }
-
-    @Override
-    public void registerOperations(final ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(JDBCStoreResourceDefinition.Attribute.class).addAttributes(StoreResourceDefinition.Attribute.class);
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new StringKeyedJDBCStoreBuilderFactory());
-        new AddStepHandler(descriptor, handler) {
-            @Override
-            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
-                super.execute(context, operation);
-                if (operation.hasDefined(DeprecatedAttribute.TABLE.getDefinition().getName())) {
-                    // Translate deprecated TABLE attribute into separate add table operation
-                    ModelNode addTableOperation = Util.createAddOperation(context.getCurrentAddress().append(StringTableResourceDefinition.PATH));
-                    ModelNode parameters = operation.get(DeprecatedAttribute.TABLE.getDefinition().getName());
-                    for (Property parameter : parameters.asPropertyList()) {
-                        addTableOperation.get(parameter.getName()).set(parameter.getValue());
-                    }
-                    context.addStep(addTableOperation, registration.getOperationHandler(PathAddress.pathAddress(StringTableResourceDefinition.PATH), ModelDescriptionConstants.ADD), context.getCurrentStage());
-                }
-            }
-        }.register(registration);
-        new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
     static final OperationStepHandler LEGACY_READ_TABLE_HANDLER = new OperationStepHandler() {
         @Override
         public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
@@ -150,20 +121,44 @@ public class StringKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDef
             for (Class<? extends org.jboss.as.clustering.controller.Attribute> attributeClass : Arrays.asList(StringTableResourceDefinition.Attribute.class, TableResourceDefinition.Attribute.class)) {
                 for (org.jboss.as.clustering.controller.Attribute attribute : attributeClass.getEnumConstants()) {
                     ModelNode writeAttributeOperation = Operations.createWriteAttributeOperation(address, attribute, table.get(attribute.getDefinition().getName()));
-                    context.addStep(writeAttributeOperation, new ReloadRequiredWriteAttributeHandler(attribute), context.getCurrentStage());
+                    context.addStep(writeAttributeOperation, context.getResourceRegistration().getAttributeAccess(PathAddress.pathAddress(StringTableResourceDefinition.PATH), attribute.getDefinition().getName()).getWriteHandler(), context.getCurrentStage());
                 }
             }
         }
     };
 
     @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        registration.registerReadWriteAttribute(DeprecatedAttribute.TABLE.getDefinition(), LEGACY_READ_TABLE_HANDLER, LEGACY_WRITE_TABLE_HANDLER);
-    }
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
 
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(JDBCStoreResourceDefinition.Attribute.class)
+                .addAttributes(StoreResourceDefinition.Attribute.class)
+                .addExtraParameters(DeprecatedAttribute.class)
+                ;
+        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new StringKeyedJDBCStoreBuilderFactory());
+        new AddStepHandler(descriptor, handler) {
+            @Override
+            public void execute(OperationContext context, ModelNode operation) throws OperationFailedException {
+                super.execute(context, operation);
+                if (operation.hasDefined(DeprecatedAttribute.TABLE.getDefinition().getName())) {
+                    // Translate deprecated TABLE attribute into separate add table operation
+                    ModelNode addTableOperation = Util.createAddOperation(context.getCurrentAddress().append(StringTableResourceDefinition.PATH));
+                    ModelNode parameters = operation.get(DeprecatedAttribute.TABLE.getDefinition().getName());
+                    for (Property parameter : parameters.asPropertyList()) {
+                        addTableOperation.get(parameter.getName()).set(parameter.getValue());
+                    }
+                    context.addStep(addTableOperation, registration.getOperationHandler(PathAddress.pathAddress(StringTableResourceDefinition.PATH), ModelDescriptionConstants.ADD), context.getCurrentStage());
+                }
+            }
+        }.register(registration);
+        new RemoveStepHandler(descriptor, handler).register(registration);
+
+        registration.registerReadWriteAttribute(DeprecatedAttribute.TABLE.getDefinition(), LEGACY_READ_TABLE_HANDLER, LEGACY_WRITE_TABLE_HANDLER);
+
+        new StringTableResourceDefinition().register(registration);
+
+        super.register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringTableResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringTableResourceDefinition.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
@@ -111,21 +110,16 @@ public class StringTableResourceDefinition extends TableResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(TableResourceDefinition.Attribute.class).addAttributes(TableResourceDefinition.ColumnAttribute.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(TableResourceDefinition.Attribute.class)
+                .addAttributes(TableResourceDefinition.ColumnAttribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new StringTableBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        super.registerAttributes(registration);
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TableResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TableResourceDefinition.java
@@ -22,24 +22,21 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.SimpleAttribute;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.registry.AttributeAccess;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
  * @author Paul Ferraro
  */
-public abstract class TableResourceDefinition extends SimpleResourceDefinition implements Registration {
+public abstract class TableResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
     static PathElement pathElement(String value) {
@@ -111,11 +108,5 @@ public abstract class TableResourceDefinition extends SimpleResourceDefinition i
 
     TableResourceDefinition(PathElement path, ResourceDescriptionResolver resolver) {
         super(path, resolver);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        new ReloadRequiredWriteAttributeHandler(ColumnAttribute.class).register(registration);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolResourceDefinition.java
@@ -23,13 +23,13 @@
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.Attribute;
 import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -66,7 +66,7 @@ import org.wildfly.clustering.infinispan.spi.service.CacheContainerServiceName;
  * @author Radoslav Husar
  * @version February 2015
  */
-public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registration, ThreadPoolDefinition {
+public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registration<ManagementResourceRegistration>, ThreadPoolDefinition {
 
     ASYNC_OPERATIONS("async-operations", 25, 25, 1000, 60000),
     LISTENER("listener", 1, 1, 100000, 60000),
@@ -128,7 +128,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
 
     @Override
     public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(this.getAttributes()).register(registration);
+        // No-op.
     }
 
     @Override
@@ -186,7 +186,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
         return this.keepAliveTime;
     }
 
-    Iterable<Attribute> getAttributes() {
+    Collection<Attribute> getAttributes() {
         return Arrays.asList(this.minThreads, this.maxThreads, this.queueLength, this.keepAliveTime);
     }
 
@@ -194,7 +194,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
         // Nothing to transform yet
     }
 
-    public DynamicDiscardPolicy getDiscardPolicy() {
+    DynamicDiscardPolicy getDiscardPolicy() {
         return new UndefinedAttributesDiscardPolicy(this.getAttributes());
     }
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransactionResourceDefinition.java
@@ -32,7 +32,6 @@ import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.MetricHandler;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
@@ -236,24 +235,17 @@ public class TransactionResourceDefinition extends ComponentResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+        parentRegistration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration));
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new TransactionBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
 
         if (this.allowRuntimeOnlyRegistration) {
             new MetricHandler<>(new TransactionMetricExecutor(), TransactionMetric.class).register(registration);
         }
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerAlias(LEGACY_PATH, new SimpleAliasEntry(registration.registerSubModel(this)));
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/TransportResourceDefinition.java
@@ -22,14 +22,13 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
-import org.jboss.as.clustering.controller.Registration;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
 
 /**
  * @author Paul Ferraro
  */
-public abstract class TransportResourceDefinition extends SimpleResourceDefinition implements Registration {
+public abstract class TransportResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
     static PathElement pathElement(String value) {

--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -127,6 +127,7 @@ infinispan.cache.mixed-keyed-jdbc-store=Alias to the mixed jdbc store configurat
 infinispan.cache.string-keyed-jdbc-store=Alias to the string jdbc store configuration component
 infinispan.cache.write-behind=Alias to the write behind configuration component
 infinispan.cache.backup-for=Alias to the backup-for configuration component
+infinispan.cache.backup=Alias to the backup child of the backups configuration
 
 infinispan.local-cache=A local cache configuration
 infinispan.local-cache.add=Add a local cache to this cache container

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ChannelResourceDefinition.java
@@ -22,9 +22,8 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.MetricHandler;
-import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
@@ -39,7 +38,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
@@ -53,7 +51,7 @@ import org.jboss.dmr.ModelType;
  *
  * @author Paul Ferraro
  */
-public class ChannelResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class ChannelResourceDefinition extends ChildResourceDefinition {
 
     public static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -103,7 +101,9 @@ public class ChannelResourceDefinition extends SimpleResourceDefinition implemen
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new ChannelServiceHandler();
         new AddStepHandler(descriptor, handler) {
@@ -147,24 +147,11 @@ public class ChannelResourceDefinition extends SimpleResourceDefinition implemen
                 super.performRemove(context, operation, model);
             }
         }.register(registration);
-    }
-
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
-        new ForkResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
 
         if (this.allowRuntimeOnlyRegistration) {
             new MetricHandler<>(new ChannelMetricExecutor(), ChannelMetric.class).register(registration);
         }
-    }
 
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
+        new ForkResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkProtocolResourceDefinition.java
@@ -50,12 +50,15 @@ public class ForkProtocolResourceDefinition extends ProtocolResourceDefinition {
         this.allowRuntimeOnlyRegistration = allowRuntimeOnlyRegistration;
     }
 
+    @SuppressWarnings("deprecation")
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
                 .addAttributes(Attribute.class)
                 .addCapabilities(Capability.class)
-        ;
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new ProtocolConfigurationBuilderFactory());
         new RestartParentResourceAddStepHandler<ChannelFactory>(this.parentBuilderFactory, descriptor, handler) {
             @Override
@@ -68,5 +71,11 @@ public class ForkProtocolResourceDefinition extends ProtocolResourceDefinition {
             }
         }.register(registration);
         new RestartParentResourceRemoveStepHandler<>(this.parentBuilderFactory, descriptor, handler).register(registration);
+
+        for (DeprecatedAttribute attribute : DeprecatedAttribute.values()) {
+            registration.registerReadOnlyAttribute(attribute.getDefinition(), null);
+        }
+
+        super.register(registration);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkResourceDefinition.java
@@ -23,7 +23,7 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
-import org.jboss.as.clustering.controller.Registration;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
@@ -33,7 +33,6 @@ import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.RunningMode;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.controller.registry.Resource.ResourceEntry;
@@ -44,7 +43,7 @@ import org.wildfly.clustering.jgroups.spi.ChannelFactory;
  * Definition of a fork resource.
  * @author Paul Ferraro
  */
-public class ForkResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class ForkResourceDefinition extends ChildResourceDefinition {
 
     public static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -61,7 +60,9 @@ public class ForkResourceDefinition extends SimpleResourceDefinition implements 
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver());
         ResourceServiceHandler handler = new ForkServiceHandler(this.builderFactory);
         new AddStepHandler(descriptor, handler).register(registration);
@@ -78,15 +79,7 @@ public class ForkResourceDefinition extends SimpleResourceDefinition implements 
                 }
             }
         }.register(registration);
-    }
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new ForkProtocolResourceDefinition(this.builderFactory, this.allowRuntimeOnlyRegistration).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsExtension.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsExtension.java
@@ -67,7 +67,7 @@ public class JGroupsExtension implements Extension {
     public void initialize(ExtensionContext context) {
         SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, JGroupsModel.CURRENT.getVersion());
 
-        registration.registerSubsystemModel(new JGroupsSubsystemResourceDefinition(context.isRuntimeOnlyRegistrationValid()));
+        new JGroupsSubsystemResourceDefinition(context.isRuntimeOnlyRegistrationValid()).register(registration);
         registration.registerXMLElementWriter(new JGroupsSubsystemXMLWriter());
 
         if (context.isRegisterTransformers()) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemResourceDefinition.java
@@ -22,15 +22,15 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.controller.SubsystemResourceDefinition;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
 import org.jboss.as.controller.registry.AttributeAccess;
@@ -47,7 +47,7 @@ import org.jboss.dmr.ModelType;
  *
  * @author Richard Achmatowicz (c) 2012 Red Hat Inc.
  */
-public class JGroupsSubsystemResourceDefinition extends SimpleResourceDefinition {
+public class JGroupsSubsystemResourceDefinition extends SubsystemResourceDefinition {
 
     public static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, JGroupsExtension.SUBSYSTEM_NAME);
 
@@ -108,22 +108,16 @@ public class JGroupsSubsystemResourceDefinition extends SimpleResourceDefinition
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(SubsystemRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubsystemModel(this);
+
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new JGroupsSubsystemServiceHandler();
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new ChannelResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
         new StackResourceDefinition(this.allowRuntimeOnlyRegistration).register(registration);
     }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -25,16 +25,10 @@ package org.jboss.as.clustering.jgroups.subsystem;
 import org.jboss.as.clustering.controller.AttributeMarshallers;
 import org.jboss.as.clustering.controller.AttributeParsers;
 import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.Operations;
-import org.jboss.as.clustering.controller.Registration;
 import org.jboss.as.clustering.controller.RequiredCapability;
-import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
-import org.jboss.as.clustering.controller.ResourceServiceHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceAddStepHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceRemoveStepHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceWriteAttributeHandler;
-import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.clustering.controller.transform.OperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleAddOperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleOperationTransformer;
@@ -47,7 +41,6 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleMapAttributeDefinition;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
@@ -71,8 +64,9 @@ import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
  * Resource description for /subsystem=jgroups/stack=X/protocol=Y
  *
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+ * @author Paul Ferraro
  */
-public class ProtocolResourceDefinition extends SimpleResourceDefinition implements Registration {
+public abstract class ProtocolResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -257,35 +251,9 @@ public class ProtocolResourceDefinition extends SimpleResourceDefinition impleme
         this.parentBuilderFactory = parentBuilderFactory;
     }
 
-    @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
-                .addAttributes(Attribute.class)
-                .addAttributes(DeprecatedAttribute.class)
-                .addCapabilities(Capability.class)
-        ;
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new ProtocolConfigurationBuilderFactory());
-        new RestartParentResourceAddStepHandler<>(this.parentBuilderFactory, descriptor, handler).register(registration);
-        new RestartParentResourceRemoveStepHandler<>(this.parentBuilderFactory, descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new RestartParentResourceWriteAttributeHandler<>(this.parentBuilderFactory, Attribute.class).register(registration);
-
-        for (DeprecatedAttribute attribute : DeprecatedAttribute.values()) {
-            registration.registerReadOnlyAttribute(attribute.getDefinition(), null);
-        }
-    }
-
     @SuppressWarnings("deprecation")
     @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
-        new PropertyResourceDefinition().register(registration);
-    }
-
-    @Override
     public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
+        new PropertyResourceDefinition().register(registration);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RemoteSiteResourceDefinition.java
@@ -21,20 +21,18 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import org.jboss.as.clustering.controller.Registration;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.RestartParentResourceAddStepHandler;
 import org.jboss.as.clustering.controller.RestartParentResourceRemoveStepHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceWriteAttributeHandler;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.transform.TransformationContext;
@@ -50,7 +48,7 @@ import org.wildfly.clustering.jgroups.spi.RelayConfiguration;
  *
  * @author Paul Ferraro
  */
-public class RemoteSiteResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class RemoteSiteResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -151,21 +149,15 @@ public class RemoteSiteResourceDefinition extends SimpleResourceDefinition imple
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(DeprecatedAttribute.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(DeprecatedAttribute.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new RemoteSiteConfigurationBuilderFactory());
         new RestartParentResourceAddStepHandler<>(this.parentBuilderFactory, descriptor, handler).register(registration);
         new RestartParentResourceRemoveStepHandler<>(this.parentBuilderFactory, descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new RestartParentResourceWriteAttributeHandler<>(this.parentBuilderFactory, Attribute.class).register(registration);
-        new RestartParentResourceWriteAttributeHandler<>(this.parentBuilderFactory, DeprecatedAttribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/StackResourceDefinition.java
@@ -23,8 +23,8 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.OperationHandler;
-import org.jboss.as.clustering.controller.Registration;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
@@ -40,7 +40,6 @@ import org.jboss.as.controller.OperationStepHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -57,7 +56,7 @@ import org.wildfly.clustering.jgroups.spi.ChannelFactory;
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
  * @author Paul Ferraro
  */
-public class StackResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class StackResourceDefinition extends ChildResourceDefinition {
 
     public static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -122,7 +121,9 @@ public class StackResourceDefinition extends SimpleResourceDefinition implements
 
     @SuppressWarnings("deprecation")
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addExtraParameters(TRANSPORT, PROTOCOLS);
         ResourceServiceHandler handler = new StackServiceHandler(this.builderFactory);
         new AddStepHandler(descriptor, handler) {
@@ -211,17 +212,9 @@ public class StackResourceDefinition extends SimpleResourceDefinition implements
         if (this.allowRuntimeOnlyRegistration) {
             new OperationHandler<>(new StackOperationExecutor(), StackOperation.class).register(registration);
         }
-    }
 
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new TransportResourceDefinition(this.builderFactory).register(registration);
-        new ProtocolResourceDefinition(this.builderFactory).register(registration);
+        new StackProtocolResourceDefinition(this.builderFactory).register(registration);
         new RelayResourceDefinition(this.builderFactory).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,7 +33,6 @@ import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.RestartParentResourceAddStepHandler;
 import org.jboss.as.clustering.controller.RestartParentResourceRemoveStepHandler;
-import org.jboss.as.clustering.controller.RestartParentResourceWriteAttributeHandler;
 import org.jboss.as.clustering.controller.SimpleAttribute;
 import org.jboss.as.clustering.controller.validation.IntRangeValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.LongRangeValidatorBuilder;
@@ -59,7 +59,7 @@ import org.wildfly.clustering.jgroups.spi.TransportConfiguration;
  * @author Paul Ferraro
  * @version Aug 2014
  */
-public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registration {
+public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registration<ManagementResourceRegistration> {
 
     DEFAULT("default", "thread_pool", 20, 300, 100, 60L),
     OOB("oob", "oob_thread_pool", 20, 300, 0, 60L),
@@ -99,7 +99,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
                 .setFlags(AttributeAccess.Flag.RESTART_RESOURCE_SERVICES)
                 .setMeasurementUnit((type == ModelType.LONG) ? MeasurementUnit.MILLISECONDS : null)
                 .setValidator(validatorBuilder.allowExpression(true).allowUndefined(true).build())
-        ;
+                ;
     }
 
     @Override
@@ -113,7 +113,9 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
         ResourceDescriptor descriptor = new ResourceDescriptor(this.descriptionResolver).addAttributes(this.getAttributes());
         ResourceServiceBuilderFactory<TransportConfiguration> transportBuilderFactory = new TransportConfigurationBuilderFactory();
         new RestartParentResourceAddStepHandler<>(transportBuilderFactory, descriptor).register(registration);
@@ -122,7 +124,6 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
 
     @Override
     public void registerAttributes(ManagementResourceRegistration registration) {
-        new RestartParentResourceWriteAttributeHandler<>(new TransportConfigurationBuilderFactory(), this.getAttributes()).register(registration);
     }
 
     @Override
@@ -131,6 +132,10 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
 
     @Override
     public void registerChildren(ManagementResourceRegistration registration) {
+    }
+
+    @Override
+    public void registerOperations(ManagementResourceRegistration resourceRegistration) {
     }
 
     @Override
@@ -144,11 +149,11 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
     }
 
     @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
+    public boolean isOrderedChild() {
+        return false;
     }
 
-    Iterable<Attribute> getAttributes() {
+    Collection<Attribute> getAttributes() {
         return Arrays.asList(this.minThreads, this.maxThreads, this.queueLength, this.keepAliveTime);
     }
 
@@ -174,10 +179,5 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
 
     void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         // Nothing to transform yet
-    }
-
-    @Override
-    public boolean isOrderedChild() {
-        return false;
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/ElectionPolicyResourceDefinition.java
@@ -23,25 +23,22 @@
 package org.wildfly.extension.clustering.singleton;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.RequiredCapability;
-import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
-import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.network.OutboundSocketBinding;
 
 /**
  * Definition of an election policy resource.
  * @author Paul Ferraro
  */
-public class ElectionPolicyResourceDefinition extends SimpleResourceDefinition implements Registration {
+public abstract class ElectionPolicyResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -95,21 +92,11 @@ public class ElectionPolicyResourceDefinition extends SimpleResourceDefinition i
                     .setAllowExpression(true)
                     .setAllowNull(true)
                     .setAlternatives(alternative)
-            ;
+                    ;
         }
     }
 
     ElectionPolicyResourceDefinition(PathElement path, ResourceDescriptionResolver resolver) {
         super(path, resolver);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/RandomElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/RandomElectionPolicyResourceDefinition.java
@@ -43,8 +43,13 @@ public class RandomElectionPolicyResourceDefinition extends ElectionPolicyResour
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(ElectionPolicyResourceDefinition.Attribute.class).addCapabilities(ElectionPolicyResourceDefinition.Capability.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(ElectionPolicyResourceDefinition.Attribute.class)
+                .addCapabilities(ElectionPolicyResourceDefinition.Capability.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new RandomElectionPolicyBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SimpleElectionPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SimpleElectionPolicyResourceDefinition.java
@@ -24,7 +24,6 @@ package org.wildfly.extension.clustering.singleton;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
@@ -68,16 +67,16 @@ public class SimpleElectionPolicyResourceDefinition extends ElectionPolicyResour
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addAttributes(ElectionPolicyResourceDefinition.Attribute.class).addCapabilities(ElectionPolicyResourceDefinition.Capability.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addAttributes(ElectionPolicyResourceDefinition.Attribute.class)
+                .addCapabilities(ElectionPolicyResourceDefinition.Capability.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new SimpleElectionPolicyBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
-
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-        super.registerAttributes(registration);
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonExtension.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonExtension.java
@@ -28,7 +28,7 @@ import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.parsing.ExtensionParsingContext;
 
 /**
- * Extension point for singleton deployer subsystem.
+ * Extension point for singleton subsystem.
  * @author Paul Ferraro
  */
 public class SingletonExtension implements Extension {
@@ -38,7 +38,8 @@ public class SingletonExtension implements Extension {
     @Override
     public void initialize(ExtensionContext context) {
         SubsystemRegistration registration = context.registerSubsystem(SUBSYSTEM_NAME, SingletonModel.CURRENT.getVersion());
-        registration.registerSubsystemModel(new SingletonResourceDefinition());
+
+        new SingletonResourceDefinition().register(registration);
         registration.registerXMLElementWriter(new SingletonXMLWriter());
     }
 

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyResourceDefinition.java
@@ -23,17 +23,15 @@
 package org.wildfly.extension.clustering.singleton;
 
 import org.jboss.as.clustering.controller.AddStepHandler;
-import org.jboss.as.clustering.controller.ResourceDescriptor;
-import org.jboss.as.clustering.controller.Registration;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
+import org.jboss.as.clustering.controller.ChildResourceDefinition;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
+import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
@@ -45,7 +43,7 @@ import org.wildfly.clustering.singleton.SingletonPolicy;
  * Definition of a singleton policy resource.
  * @author Paul Ferraro
  */
-public class SingletonPolicyResourceDefinition extends SimpleResourceDefinition implements Registration {
+public class SingletonPolicyResourceDefinition extends ChildResourceDefinition {
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
@@ -99,26 +97,18 @@ public class SingletonPolicyResourceDefinition extends SimpleResourceDefinition 
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
-        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class).addCapabilities(Capability.class);
+    public void register(ManagementResourceRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubModel(this);
+
+        ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver())
+                .addAttributes(Attribute.class)
+                .addCapabilities(Capability.class)
+                ;
         ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new SingletonPolicyBuilderFactory());
         new AddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new RandomElectionPolicyResourceDefinition().register(registration);
         new SimpleElectionPolicyResourceDefinition().register(registration);
-    }
-
-    @Override
-    public void register(ManagementResourceRegistration registration) {
-        registration.registerSubModel(this);
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonResourceDefinition.java
@@ -24,24 +24,24 @@ package org.wildfly.extension.clustering.singleton;
 
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.BoottimeAddStepHandler;
-import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
+import org.jboss.as.clustering.controller.SubsystemResourceDefinition;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
-import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.SubsystemRegistration;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.operations.common.GenericSubsystemDescribeHandler;
-import org.jboss.as.controller.registry.AttributeAccess.Flag;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.AttributeAccess.Flag;
 import org.jboss.dmr.ModelType;
 
 /**
  * Definition of the singleton deployer resource.
  * @author Paul Ferraro
  */
-public class SingletonResourceDefinition extends SimpleResourceDefinition {
+public class SingletonResourceDefinition extends SubsystemResourceDefinition {
 
     static final PathElement PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SingletonExtension.SUBSYSTEM_NAME);
 
@@ -65,22 +65,16 @@ public class SingletonResourceDefinition extends SimpleResourceDefinition {
     }
 
     @Override
-    public void registerOperations(ManagementResourceRegistration registration) {
+    public void register(SubsystemRegistration parentRegistration) {
+        ManagementResourceRegistration registration = parentRegistration.registerSubsystemModel(this);
+
         registration.registerOperationHandler(GenericSubsystemDescribeHandler.DEFINITION, GenericSubsystemDescribeHandler.INSTANCE);
 
         ResourceDescriptor descriptor = new ResourceDescriptor(this.getResourceDescriptionResolver()).addAttributes(Attribute.class);
         ResourceServiceHandler handler = new SingletonServiceHandler();
         new BoottimeAddStepHandler(descriptor, handler).register(registration);
         new RemoveStepHandler(descriptor, handler).register(registration);
-    }
 
-    @Override
-    public void registerAttributes(ManagementResourceRegistration registration) {
-        new ReloadRequiredWriteAttributeHandler(Attribute.class).register(registration);
-    }
-
-    @Override
-    public void registerChildren(ManagementResourceRegistration registration) {
         new SingletonPolicyResourceDefinition().register(registration);
     }
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonServiceHandler.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonServiceHandler.java
@@ -46,9 +46,6 @@ import org.wildfly.extension.clustering.singleton.deployment.SingletonDeployment
  */
 public class SingletonServiceHandler implements ResourceServiceHandler {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void installServices(OperationContext context, ModelNode model) throws OperationFailedException {
 
@@ -71,9 +68,6 @@ public class SingletonServiceHandler implements ResourceServiceHandler {
         new AliasServiceBuilder<>(serviceName, targetServiceName, SingletonPolicy.class).build(context.getServiceTarget()).install();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public void removeServices(OperationContext context, ModelNode model) {
         context.removeService(Capability.POLICY.getDefinition().getCapabilityServiceName());


### PR DESCRIPTION
Allow add operation handlers to also register attributes using the appropriate write handler.  The result is that resources no longer need to register attributes already specified to the add handler.  This is particularly useful for inherited resources.
The intention is to reduce the likelihood of bugs like those addressed by https://github.com/wildfly/wildfly/pull/7907
