### PR TITLE
WFLY-4515 JGroupsModel#VERSION1_3_0 is missing; no transformations ha…

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsModel.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsModel.java
@@ -30,6 +30,7 @@ import org.jboss.as.controller.ModelVersion;
 public enum JGroupsModel {
 
     VERSION_1_2_0(1, 2, 0),
+    VERSION_1_3_0(1, 3, 0),
     VERSION_2_0_0(2, 0, 0),
     VERSION_3_0_0(3, 0, 0),
     ;
@@ -37,7 +38,7 @@ public enum JGroupsModel {
 
     private final ModelVersion version;
 
-    private JGroupsModel(int major, int minor, int micro) {
+    JGroupsModel(int major, int minor, int micro) {
         this.version = ModelVersion.create(major, minor, micro);
     }
 


### PR DESCRIPTION
…ppen for EAP 6.4.x

https://github.com/jbossas/jboss-eap/blob/EAP_6.4.3.CR2-dev/clustering/jgroups/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsExtension.java#L63

> [17:09] James R Perkins: IIRC that value-type didn't need a transformer because it was a read-only attribute. Something like that at least.

So should be good to go as is.
