### PR TITLE
Undertow CLI IllegalArgumentException, WFLY-5045 JBEAP-562 volume-2

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterNodeDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterNodeDefinition.java
@@ -144,7 +144,7 @@ public class ModClusterNodeDefinition extends SimpleResourceDefinition {
 
 
     ModClusterNodeDefinition() {
-        super(UndertowExtension.NODE, UndertowExtension.getResolver("handler","mod-cluster", "balancer", "node"), null, null, true);
+        super(UndertowExtension.NODE, UndertowExtension.getResolver("handler", "mod-cluster", "balancer", "node"), null, null, true);
     }
 
     @Override
@@ -158,7 +158,7 @@ public class ModClusterNodeDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerOperationHandler(ENABLE, new AbstractNodeOperation() {
             @Override
             protected void handleNode(OperationContext context, ModClusterStatus.Node ctx, ModelNode operation) throws OperationFailedException {
-                for(ModClusterStatus.Context n : ctx.getContexts()) {
+                for (ModClusterStatus.Context n : ctx.getContexts()) {
                     n.enable();
                 }
             }
@@ -166,7 +166,7 @@ public class ModClusterNodeDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerOperationHandler(DISABLE, new AbstractNodeOperation() {
             @Override
             protected void handleNode(OperationContext context, ModClusterStatus.Node ctx, ModelNode operation) throws OperationFailedException {
-                for(ModClusterStatus.Context n : ctx.getContexts()) {
+                for (ModClusterStatus.Context n : ctx.getContexts()) {
                     n.disable();
                 }
             }
@@ -174,7 +174,7 @@ public class ModClusterNodeDefinition extends SimpleResourceDefinition {
         resourceRegistration.registerOperationHandler(STOP, new AbstractNodeOperation() {
             @Override
             protected void handleNode(OperationContext context, ModClusterStatus.Node ctx, ModelNode operation) throws OperationFailedException {
-                for(ModClusterStatus.Context n : ctx.getContexts()) {
+                for (ModClusterStatus.Context n : ctx.getContexts()) {
                     n.stop();
                 }
             }
@@ -203,7 +203,7 @@ public class ModClusterNodeDefinition extends SimpleResourceDefinition {
             @Override
             protected void handleNode(OperationContext context, ModClusterStatus.Node ctx, ModelNode operation) throws OperationFailedException {
                 final String domain = ctx.getDomain();
-                if(domain == null) {
+                if (domain == null) {
                     context.getResult().set(new ModelNode());
                 } else {
                     context.getResult().set(new ModelNode(domain));
@@ -345,7 +345,7 @@ public class ModClusterNodeDefinition extends SimpleResourceDefinition {
             handleNode(context, node, operation);
         }
 
-        protected abstract void handleNode(OperationContext context, ModClusterStatus.Node ctx, ModelNode operation) throws OperationFailedException ;
+        protected abstract void handleNode(OperationContext context, ModClusterStatus.Node ctx, ModelNode operation) throws OperationFailedException;
     }
 
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterNodeDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterNodeDefinition.java
@@ -39,6 +39,7 @@ import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.extension.undertow.Constants;
 import org.wildfly.extension.undertow.UndertowExtension;
+import org.wildfly.extension.undertow.logging.UndertowLogger;
 
 /**
  * Runtime representation of a mod_cluster node
@@ -297,11 +298,12 @@ public class ModClusterNodeDefinition extends SimpleResourceDefinition {
 
             @Override
             protected void handleNode(OperationContext context, ModClusterStatus.Node ctx, ModelNode operation) throws OperationFailedException {
-                ModelNode list = new ModelNode(ModelType.LIST);
-                for(String alias : ctx.getAliases()) {
-                    list.add(alias);
+                final ModelNode result = new ModelNode();
+                for (String alias : ctx.getAliases()) {
+                    UndertowLogger.ROOT_LOGGER.tracef("Adding alias %s", alias);
+                    result.add(alias);
                 }
-                context.getResult().set(list);
+                context.getResult().set(result);
             }
         });
         resourceRegistration.registerReadOnlyAttribute(ELECTED, new AbstractNodeOperation() {


### PR DESCRIPTION
See [WFLY-5045](https://issues.jboss.org/browse/WFLY-5045) for more details.
The former blocking error:

```
11:42:36,292 ERROR [org.jboss.as.controller.management-operation] (management-handler-thread - 3) WFLYCTL0013: Operation ("read-attribute") failed - address: ([
    ("subsystem" => "undertow"),
    ("configuration" => "filter"),
    ("mod-cluster" => "modcluster"),
    ("balancer" => "mycluster"),
    ("node" => "jboss-eap-7.0-2")
]): java.lang.IllegalArgumentException
  at org.jboss.dmr.ModelValue.addChild(ModelValue.java:128)
  at org.jboss.dmr.ModelNode.add(ModelNode.java:1239)
  at org.jboss.dmr.ModelNode.add(ModelNode.java:1016)
  at org.wildfly.extension.undertow.filters.ModClusterNodeDefinition$19.handleNode(ModClusterNodeDefinition.java:302)
  at org.wildfly.extension.undertow.filters.ModClusterNodeDefinition$AbstractNodeOperation.execute(ModClusterNodeDefinition.java:343)
  at org.jboss.as.controller.operations.global.ReadAttributeHandler.doExecuteInternal(ReadAttributeHandler.java:174)
  at org.jboss.as.controller.operations.global.ReadAttributeHandler.doExecute(ReadAttributeHandler.java:137)
  at org.jboss.as.controller.operations.global.GlobalOperationHandlers$AbstractMultiTargetHandler.execute(GlobalOperationHandlers.java:248)
  at org.jboss.as.controller.operations.global.GlobalOperationHandlers$AvailableResponseWrapper.execute(GlobalOperationHandlers.java:701)
  at org.jboss.as.controller.AbstractOperationContext.executeStep(AbstractOperationContext.java:846)
  at org.jboss.as.controller.AbstractOperationContext.processStages(AbstractOperationContext.java:637)
  at org.jboss.as.controller.AbstractOperationContext.executeOperation(AbstractOperationContext.java:362)
  at org.jboss.as.controller.OperationContextImpl.executeOperation(OperationContextImpl.java:1272)
  at org.jboss.as.controller.ModelControllerImpl.internalExecute(ModelControllerImpl.java:394)
  at org.jboss.as.controller.ModelControllerImpl.execute(ModelControllerImpl.java:225)
  at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler.doExecute(ModelControllerClientOperationHandler.java:207)
  at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler.access$300(ModelControllerClientOperationHandler.java:129)
  at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler$1$1.run(ModelControllerClientOperationHandler.java:151)
  at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler$1$1.run(ModelControllerClientOperationHandler.java:147)
  at java.security.AccessController.doPrivileged(Native Method)
  at javax.security.auth.Subject.doAs(Subject.java:422)
  at org.jboss.as.controller.AccessAuditContext.doAs(AccessAuditContext.java:92)
  at org.jboss.as.controller.remote.ModelControllerClientOperationHandler$ExecuteRequestHandler$1.execute(ModelControllerClientOperationHandler.java:147)
  at org.jboss.as.protocol.mgmt.AbstractMessageHandler$2$1.doExecute(AbstractMessageHandler.java:298)
  at org.jboss.as.protocol.mgmt.AbstractMessageHandler$AsyncTaskRunner.run(AbstractMessageHandler.java:518)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
  at java.lang.Thread.run(Thread.java:745)
  at org.jboss.threads.JBossThread.run(JBossThread.java:320)
```

is fixed now:

```
"node" => {
  "jboss-eap-7.0" => {
      "aliases" => [
          "default-host",
          "localhost"
      ],
      "cache-connections" => 5,
      "elected" => 0,
      "flush-packets" => false,
      "load" => 14,
      "load-balancing-group" => undefined,
      "max-connections" => 10,
      "open-connections" => 1,
      "ping" => 10,
      "queue-new-requests" => true,
      "read" => 0L,
      "request-queue-size" => 10,
      "status" => "NODE_UP",
      "timeout" => 0,
      "ttl" => 60L,
      "uri" => "ajp://192.168.122.172:8009/?#",
      "written" => 0L,
      "context" => {"/clusterbench" => {
          "requests" => 0,
          "status" => "enabled"
      }}
}
```

Cheers
