### PR TITLE
UseAlias defaults to False now. See WFLY-4954 / JBEAP-221

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterDefinition.java
@@ -162,7 +162,7 @@ public class ModClusterDefinition extends AbstractHandlerDefinition {
 
     public static final SimpleAttributeDefinition USE_ALIAS = new SimpleAttributeDefinitionBuilder(Constants.USE_ALIAS, ModelType.BOOLEAN)
             .setAllowNull(true)
-            .setDefaultValue(new ModelNode(true))
+            .setDefaultValue(new ModelNode(false))
             .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
             .build();
 


### PR DESCRIPTION
Undertow mod_cluster proxy is destined to act as a drop-in replacement for Apache HTTP Server suite of modules called "mod_cluster" that enable users to take advantage of dynamically configured, worker on-site load aware load balancer.

We need to align as many default values and features as possible in order to allow users to try Undertow in place of their current mod_cluster appliances.

_UseAlias_ is one of such values. Apache HTTP Server mod_cluster operates with `UseAlias false` by default, i.e. balancing regardless of worker reported aliases. On the contrary, current Undertow mod_cluster proxy implementation _requires_ one to explicitly and correctly set all aliases, otherwise it doesn't forward any requests.

This commit changes the default to the desired _false_ value.

Related issue: [JBEAP-221](https://issues.jboss.org/browse/JBEAP-221) ([WFLY-4954](https://issues.jboss.org/browse/WFLY-4954),[UNDERTOW-455](https://issues.jboss.org/browse/UNDERTOW-455))
