### PR TITLE
Display warnings and errors on migration

### DIFF
--- a/legacy/web/src/main/java/org/jboss/as/web/WebLogger.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebLogger.java
@@ -5,11 +5,8 @@ import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
-import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-
-import static org.jboss.logging.Logger.Level.WARN;
 
 /**
  * Logger for new messages in the legacy extension, used only for the migrate operation,
@@ -26,14 +23,15 @@ public interface WebLogger extends BasicLogger {
     @Message(id = 1, value = "Migrate operation only allowed in admin only mode")
     OperationFailedException migrateOperationAllowedOnlyInAdminOnly();
 
-    @LogMessage(level = WARN)
     @Message(id = 2, value = "Could not migrate resource %s")
-    void couldNotMigrateResource(ModelNode node);
+    String couldNotMigrateResource(ModelNode node);
 
-    @LogMessage(level = WARN)
     @Message(id = 3, value = "Could not migrate attribute %s from resource %s")
-    void couldNotMigrateResource(String attribute, PathAddress node);
+    String couldNotMigrateResource(String attribute, PathAddress node);
 
     @Message(id = 4, value = "Could not migrate SSL connector as no SSL config is defined")
     OperationFailedException noSslConfig();
+
+    @Message(id = 5, value = "Migration failed, see results for more details.")
+    String migrationFailed();
 }

--- a/legacy/web/src/main/resources/org/jboss/as/web/LocalDescriptions.properties
+++ b/legacy/web/src/main/resources/org/jboss/as/web/LocalDescriptions.properties
@@ -8,6 +8,10 @@ web.remove=Operation removing the web subsystem.
 web.deprecated=The Web subsystem is deprecated and may be removed or limited to managed domain legacy server use in future versions.
 web.describe-migration=Describes the steps that will be taken to migrate this configuration to Undertow
 web.migrate=Migrates this web subsystem config to Undertow
+web.describe-migration.migration-warnings=Any warnings about resources that could not be migrated
+web.migrate.migration-warnings=Any warnings about resources that could not be migrated
+web.migrate.migration-error=The error that occured during migration
+
 
 web.container=Common container configuration
 web.container.add=Adds web container


### PR DESCRIPTION
Output is:

Standard EAP config (no warnings or errors):

```
[standalone@localhost:9999 /] /subsystem=web:migrate
{
    "outcome" => "success",
    "result" => {"migration-warnings" => []}
}
```

Success with a warning (in this case due to an invalid protocol attribute on a connector):

```
[standalone@localhost:9999 /] /subsystem=web:migrate
{
    "outcome" => "success",
    "result" => {"migration-warnings" => ["WFLYWEB0002: Could not migrate resource {
    \"protocol\" => \"INVALID\",
    \"scheme\" => \"http\",
    \"socket-binding\" => \"ajp\",
    \"enable-lookups\" => undefined,
    \"proxy-binding\" => undefined,
    \"proxy-name\" => undefined,
    \"proxy-port\" => undefined,
    \"redirect-binding\" => undefined,
    \"redirect-port\" => undefined,
    \"secure\" => undefined,
    \"max-post-size\" => undefined,
    \"max-save-post-size\" => undefined,
    \"enabled\" => undefined,
    \"executor\" => undefined,
    \"max-connections\" => undefined,
    \"virtual-server\" => undefined,
    \"name\" => \"ajp\",
    \"operation\" => \"add\",
    \"address\" => [
        (\"subsystem\" => \"web\"),
        (\"connector\" => \"ajp\")
    ]
}"]}
}
```

Failed OP:

```
[standalone@localhost:9999 /] /subsystem=web:migrate
{
    "outcome" => "failed",
    "result" => {
        "migration-warnings" => [],
        "migration-error" => {
            "operation" => {
                "operation" => "add",
                "address" => [
                    ("subsystem" => "undertow"),
                    ("server" => "default-server"),
                    ("ajp-listener" => "ajp")
                ],
                "socket-binding" => "ajp",
                "secure" => undefined,
                "redirect-socket" => undefined,
                "enabled" => undefined,
                "resolve-peer-address" => undefined,
                "max-post-size" => undefined,
                "max-connections" => "sadfadsfasdgasdfg",
                "operation-headers" => {
                    "caller-type" => "user",
                    "access-mechanism" => "NATIVE"
                },
                "worker" => undefined,
                "buffer-pool" => undefined,
                "disallowed-methods" => undefined,
                "max-header-size" => undefined,
                "buffer-pipelined-data" => undefined,
                "max-parameters" => undefined,
                "max-headers" => undefined,
                "max-cookies" => undefined,
                "allow-encoded-slash" => undefined,
                "decode-url" => undefined,
                "url-charset" => undefined,
                "always-set-keep-alive" => undefined,
                "max-buffered-request-size" => undefined,
                "record-request-start-time" => undefined,
                "allow-equals-in-cookie-value" => undefined,
                "no-request-timeout" => undefined,
                "request-parse-timeout" => undefined,
                "tcp-backlog" => undefined,
                "receive-buffer" => undefined,
                "send-buffer" => undefined,
                "tcp-keep-alive" => undefined,
                "read-timeout" => undefined,
                "write-timeout" => undefined
            },
            "result" => {
                "outcome" => "failed",
                "failure-description" => "WFLYCTL0097: Wrong type for max-connections. Expected [INT] but was STRING",
                "rolled-back" => true
            }
        }
    },
    "rolled-back" => true
}
```

Note that there can only ever be one migration error, as the rest of the operations will not be attempted after the first failure.
