### PR TITLE
[WFLY-5014] jms-bridge context properties can not be parsed

### DIFF
--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -456,14 +456,32 @@
 
     <hornetq-server name="empty"/>
 
-    <jms-bridge>
+    <jms-bridge  module="org.another.mq.broker">
         <source>
             <connection-factory name="/cf/sourceCF" />
             <destination name="/topic/anotherSourceTopic" />
+            <user>${jms-bridge.source.user:foo}</user>
+            <password>${jms-bridge.source.password:bar}</password>
+            <context>
+                <property key="java.naming.factory.initial"  value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
+                <property key="java.naming.provider.url"     value="${java.naming.provider.url:jnp://localhost:1099}" />
+                <property key="java.naming.factory.url.pkgs" value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
+                <property key="jnp.timeout"                  value="${jnp.timeout:5000}"/>
+                <property key="jnp.sotimeout"                value="${jnp.sotimeout:5000}"/>
+            </context>
         </source>
         <target>
             <connection-factory name="/cf/targetCF" />
             <destination name="anotherMQ/jms/queue/anotherTargetQueue" />
+            <user>${jms-bridge.target.user:foo}</user>
+            <password>${jms-bridge.target.password:bar}</password>
+            <context>
+                <property key="java.naming.factory.initial"  value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
+                <property key="java.naming.provider.url"     value="${java.naming.provider.url:jnp://localhost:1099}" />
+                <property key="java.naming.factory.url.pkgs" value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
+                <property key="jnp.timeout"                  value="${jnp.timeout:5000}"/>
+                <property key="jnp.sotimeout"                value="${jnp.sotimeout:5000}"/>
+            </context>
         </target>
         <quality-of-service>${quality.of.service:AT_MOST_ONCE}</quality-of-service>
         <failure-retry-interval>${failure.retry.interval:45678}</failure-retry-interval>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeDefinition.java
@@ -40,6 +40,8 @@ import java.util.Collection;
 
 import org.apache.activemq.artemis.jms.bridge.QualityOfServiceMode;
 import org.jboss.as.controller.AttributeDefinition;
+import org.jboss.as.controller.AttributeMarshallers;
+import org.jboss.as.controller.AttributeParsers;
 import org.jboss.as.controller.PersistentResourceDefinition;
 import org.jboss.as.controller.PropertiesAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinition;
@@ -94,12 +96,10 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
             .build();
 
-    // FIXME Attribute can not be parsed https://issues.jboss.org/browse/WFCORE-691
     public static final PropertiesAttributeDefinition SOURCE_CONTEXT = new PropertiesAttributeDefinition.Builder("source-context", true)
             .setAttributeGroup(SOURCE)
-            .setWrapXmlElement(true)
-            .setWrapperElement("context")
-            .setXmlName("property")
+            .setAttributeParser(new AttributeParsers.PropertiesParser())
+            .setAttributeMarshaller(new AttributeMarshallers.PropertiesAttributeMarshaller())
             .setAllowExpression(true)
             .build();
 
@@ -131,12 +131,10 @@ public class JMSBridgeDefinition extends PersistentResourceDefinition {
             .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
             .build();
 
-    // FIXME Attribute can not be parsed https://issues.jboss.org/browse/WFCORE-691
     public static final PropertiesAttributeDefinition TARGET_CONTEXT = new PropertiesAttributeDefinition.Builder("target-context", true)
             .setAttributeGroup(TARGET)
-            .setWrapXmlElement(true)
-            .setWrapperElement("context")
-            .setXmlName("property")
+            .setAttributeParser(new AttributeParsers.PropertiesParser())
+            .setAttributeMarshaller(new AttributeMarshallers.PropertiesAttributeMarshaller())
             .setAllowExpression(true)
             .build();
 

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
@@ -703,8 +703,28 @@
 
     <xs:complexType name="jms-bridgeType">
         <xs:sequence>
-            <xs:element name="source" type="jms-bridgeParticipantType" minOccurs="0" maxOccurs="1" />
-            <xs:element name="target" type="jms-bridgeParticipantType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="source" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="source-context" type="contextType" minOccurs="0" maxOccurs="1" />
+                    </xs:sequence>
+                    <xs:attribute name="connection-factory" type="xs:string" use="required" />
+                    <xs:attribute name="destination" type="xs:string" use="required" />
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="target" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="target-context" type="contextType" minOccurs="0" maxOccurs="1" />
+                    </xs:sequence>
+                    <xs:attribute name="connection-factory" type="xs:string" use="required" />
+                    <xs:attribute name="destination" type="xs:string" use="required" />
+                    <xs:attribute name="user" type="xs:string" use="optional" />
+                    <xs:attribute name="password" type="xs:string" use="optional" />
+                </xs:complexType>
+            </xs:element>
         </xs:sequence>
 
         <xs:attribute name="name" type="xs:string" use="required" />
@@ -729,26 +749,15 @@
         <xs:attribute name="add-messageID-in-header" type="xs:boolean" use="optional" />
     </xs:complexType>
 
-    <xs:complexType name="jms-bridgeParticipantType">
-        <xs:sequence >
-            <xs:element name="context" minOccurs="0" maxOccurs="1">
+    <xs:complexType name="contextType">
+        <xs:sequence>
+            <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
-                            <xs:complexType>
-                                <xs:attribute name="name" type="xs:string" use="required" />
-                                <xs:attribute name="value" type="xs:string" use="required" />
-                            </xs:complexType>
-                        </xs:element>
-                    </xs:sequence>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="value" type="xs:string" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
-        <xs:attribute name="connection-factory" type="xs:string" use="required" />
-        <xs:attribute name="destination" type="xs:string" use="required" />
-
-        <xs:attribute name="user" type="xs:string" use="optional" />
-        <xs:attribute name="password" type="xs:string" use="optional" />
     </xs:complexType>
 
 </xs:schema>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
@@ -411,8 +411,6 @@
 
     <server name="empty"/>
 
-    <!--
-
     <jms-bridge name="default"
                 module="com.foo.bar"
                 quality-of-service="${quality.of.service:AT_MOST_ONCE}"
@@ -423,7 +421,8 @@
         <source connection-factory="/cf/sourceCF"
                 destination="/topic/anotherSourceTopic"
                 user="myUser"
-                password="myPassword" />
+                password="myPassword"/>
+
         <target connection-factory="/cf/targetCF"
                 destination="anotherMQ/jms/queue/anotherTargetQueue"
                 user="myUser"
@@ -445,28 +444,27 @@
                 destination="/topic/sourceTopic"
                 user="myUser"
                 password="myPassword">
-            <context>
+            <source-context>
                 <property name="java.naming.factory.initial"
                           value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
                 <property name="java.naming.provider.url"
                           value="${java.naming.provider.url:jnp://localhost:1099}" />
                 <property name="java.naming.factory.url.pkgs"
                           value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
-            </context>
+            </source-context>
         </source>
         <target connection-factory="anotherAS7/jms/cf/targetCF"
                 destination="anotherAS7/jms/queue/targetQueue"
                 user="${userInExpression:user}"
                 password="${passwordInExpression:password}">
-            <context>
+            <target-context>
                 <property name="java.naming.factory.initial"
                           value="${java.naming.factory.initial:org.jnp.interfaces.NamingContextFactory}" />
                 <property name="java.naming.provider.url"
                           value="${java.naming.provider.url:jnp://localhost:1099}" />
                 <property name="java.naming.factory.url.pkgs"
                           value="${java.naming.factory.url.pkgs:org.jboss.naming:org.jnp.interfaces}"/>
-            </context>
+            </target-context>
         </target>
     </jms-bridge>
-    -->
 </subsystem>


### PR DESCRIPTION
- fix jms-bridge's source-context and target-contex attribute
  definitions.
- add a jms-bridge element to the legacy messaging configuration test
  used to check its migration

JIRA: https://issues.jboss.org/browse/WFLY-5014
