### PR TITLE
[WFLY-5085][WFLY-5088] migrate generic messaging transport

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingXMLWriter.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MessagingXMLWriter.java
@@ -215,11 +215,12 @@ public class MessagingXMLWriter implements XMLElementWriter<SubsystemMarshalling
                 for(final Property property : node.get(CONNECTOR).asPropertyList()) {
                     writer.writeStartElement(Element.CONNECTOR.getLocalName());
                     writer.writeAttribute(Attribute.NAME.getLocalName(), property.getName());
+                    GenericTransportDefinition.SOCKET_BINDING.marshallAsAttribute(property.getValue(), writer);
 
                     writeTransportParam(writer, property.getValue().get(PARAM));
 
-                    GenericTransportDefinition.SOCKET_BINDING.marshallAsElement(property.getValue(), writer);
                     CommonAttributes.FACTORY_CLASS.marshallAsElement(property.getValue(), writer);
+
                     writer.writeEndElement();
                 }
             }


### PR DESCRIPTION
If the (legacy) generic acceptor or connector are using the default
HornetQ-based Netty factory classes, migrate them to use instead the
Artemis-based classes.

Also fix the persistence of the generic connector resources (that must
marshall their socket-binding as a XML attribute).

JIRA: https://issues.jboss.org/browse/WFLY-5085
JIRA: https://issues.jboss.org/browse/WFLY-5088
