### PR TITLE
Weld Probe module - add javax.api dependency

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/probe/main/module.xml
@@ -35,6 +35,7 @@
     <dependencies>
         <module name="ch.qos.cal10n" />
         <module name="com.google.guava"/>
+        <module name="javax.api"/>
         <module name="javax.annotation.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.inject.api"/>


### PR DESCRIPTION
`org.jboss.weld.probe.ProbeExtension` will have some `javax.management` imports in near future.
