### PR TITLE
Ignore test that sends a content body with a 204 response

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/ResponseCodeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/headers/ResponseCodeTestCase.java
@@ -76,13 +76,6 @@ public class ResponseCodeTestCase {
     }
 
     @Test
-    public void test204() throws Exception {
-        final HttpGet get = new HttpGet(url.toExternalForm() + "jaxrs/test/returnCode/204");
-        final HttpResponse response = HTTP_CLIENT.execute(get);
-        doContentTypeChecks(response, 204,false);
-    }
-
-    @Test
     public void test300() throws Exception {
         final HttpGet get = new HttpGet(url.toExternalForm() + "jaxrs/test/returnCode/300");
         final HttpResponse response = HTTP_CLIENT.execute(get);


### PR DESCRIPTION
204 means 'No Content' so this obviously violates the RFC
