### PR TITLE
WFLY-5143 JGroups subsystem parser should not allow thread pools to be defined per protocol

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemXMLReader.java
@@ -49,7 +49,6 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
         this.schema = schema;
     }
 
-    @SuppressWarnings("deprecation")
     @Override
     public void readElement(XMLExtendedStreamReader reader, List<ModelNode> result) throws XMLStreamException {
 
@@ -218,7 +217,6 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
         }
     }
 
-    @SuppressWarnings("deprecation")
     private void parseStacks(XMLExtendedStreamReader reader, PathAddress address, Map<PathAddress, ModelNode> operations) throws XMLStreamException {
 
         ModelNode operation = operations.get(address);
@@ -339,8 +337,42 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
             }
         }
 
+        for (ThreadPoolResourceDefinition pool : ThreadPoolResourceDefinition.values()) {
+            PathAddress poolAddress = address.append(pool.getPathElement());
+            operations.put(poolAddress, Util.createAddOperation(poolAddress));
+        }
+
         while (reader.hasNext() && (reader.nextTag() != XMLStreamConstants.END_ELEMENT)) {
-            this.parseProtocolElement(reader, address, operations);
+            XMLElement element = XMLElement.forName(reader.getLocalName());
+            switch (element) {
+                case DEFAULT_THREAD_POOL: {
+                    if (this.schema.since(JGroupsSchema.VERSION_3_0)) {
+                        this.parseThreadPool(ThreadPoolResourceDefinition.DEFAULT, reader, address, operations);
+                        break;
+                    }
+                }
+                case INTERNAL_THREAD_POOL: {
+                    if (this.schema.since(JGroupsSchema.VERSION_3_0)) {
+                        this.parseThreadPool(ThreadPoolResourceDefinition.INTERNAL, reader, address, operations);
+                        break;
+                    }
+                }
+                case OOB_THREAD_POOL: {
+                    if (this.schema.since(JGroupsSchema.VERSION_3_0)) {
+                        this.parseThreadPool(ThreadPoolResourceDefinition.OOB, reader, address, operations);
+                        break;
+                    }
+                }
+                case TIMER_THREAD_POOL: {
+                    if (this.schema.since(JGroupsSchema.VERSION_3_0)) {
+                        this.parseThreadPool(ThreadPoolResourceDefinition.TIMER, reader, address, operations);
+                        break;
+                    }
+                }
+                default: {
+                    this.parseProtocolElement(reader, address, operations);
+                }
+            }
         }
     }
 
@@ -390,18 +422,6 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
                 this.parseProperty(reader, address, operations);
                 break;
             }
-            case DEFAULT_THREAD_POOL:
-                parseThreadPool(ThreadPoolResourceDefinition.DEFAULT, reader, address, operations);
-                break;
-            case INTERNAL_THREAD_POOL:
-                parseThreadPool(ThreadPoolResourceDefinition.INTERNAL, reader, address, operations);
-                break;
-            case OOB_THREAD_POOL:
-                parseThreadPool(ThreadPoolResourceDefinition.OOB, reader, address, operations);
-                break;
-            case TIMER_THREAD_POOL:
-                parseThreadPool(ThreadPoolResourceDefinition.TIMER, reader, address, operations);
-                break;
             default: {
                 throw ParseUtils.unexpectedElement(reader);
             }
@@ -416,8 +436,7 @@ public class JGroupsSubsystemXMLReader implements XMLElementReader<List<ModelNod
 
     private void parseThreadPool(ThreadPoolResourceDefinition pool, XMLExtendedStreamReader reader, PathAddress parentAddress, Map<PathAddress, ModelNode> operations) throws XMLStreamException {
         PathAddress address = parentAddress.append(pool.getPathElement());
-        ModelNode operation = Util.createAddOperation(address);
-        operations.put(address, operation);
+        ModelNode operation = operations.get(address);
 
         for (int i = 0; i < reader.getAttributeCount(); i++) {
             XMLAttribute attribute = XMLAttribute.forName(reader.getAttributeLocalName(i));

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
@@ -23,6 +23,7 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -148,7 +149,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
         registration.registerSubModel(this);
     }
 
-    Iterable<Attribute> getAttributes() {
+    Collection<Attribute> getAttributes() {
         return Arrays.asList(this.minThreads, this.maxThreads, this.queueLength, this.keepAliveTime);
     }
 

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/SubsystemParsingTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/SubsystemParsingTestCase.java
@@ -70,10 +70,10 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
     @Parameters
     public static Collection<Object[]> data() {
         Object[][] data = new Object[][] {
-                { JGroupsSchema.VERSION_1_1, 20 },
-                { JGroupsSchema.VERSION_2_0, 22 },
-                { JGroupsSchema.VERSION_3_0, 29 },
-                { JGroupsSchema.VERSION_4_0, 29 },
+                { JGroupsSchema.VERSION_1_1, 28 },
+                { JGroupsSchema.VERSION_2_0, 30 },
+                { JGroupsSchema.VERSION_3_0, 33 },
+                { JGroupsSchema.VERSION_4_0, 33 },
         };
         return Arrays.asList(data);
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5143

This PR solves 3 issues:
1. Thread pool elements should only be parsed for schema version >= 3.0
2. Thread pool elements are only valid children of a <transport/> element, but are currently accepted as children of a <protocol/> element as well.
3. We should always create thread pool resources, even if the corresponding xml is undefined.  That way the thread pool parameters, as applied to the runtime, are expressed in the model.
