### PR TITLE
Ignore ParseAndMarshalModelsTestCase until we can turn it into someth…

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -62,6 +62,7 @@ import org.junit.runner.RunWith;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 @RunWith(Arquillian.class)
+@Ignore("WFLY-5138")
 public class ParseAndMarshalModelsTestCase {
 
     @Deployment(name = "test", managed = false, testable = true)


### PR DESCRIPTION
…ing reasonably useful

See https://issues.jboss.org/browse/WFLY-5138 for details of why they are currently not useful.
