### PR TITLE
Use thread pools' specific resource descriptions (/subsystem=infinisp…

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScheduledThreadPoolResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScheduledThreadPoolResourceDefinition.java
@@ -85,7 +85,7 @@ public enum ScheduledThreadPoolResourceDefinition implements ResourceDefinition,
 
     ScheduledThreadPoolResourceDefinition(String name, int defaultMaxThreads, long defaultKeepaliveTime) {
         this.name = name;
-        this.descriptionResolver = new InfinispanResourceDescriptionResolver(pathElement(PathElement.WILDCARD_VALUE));
+        this.descriptionResolver = new InfinispanResourceDescriptionResolver(pathElement(name), pathElement(PathElement.WILDCARD_VALUE));
         this.maxThreads = new SimpleAttribute(createBuilder("max-threads", ModelType.INT, new ModelNode(defaultMaxThreads), new IntRangeValidatorBuilder().min(0)).build());
         this.keepAliveTime = new SimpleAttribute(createBuilder("keepalive-time", ModelType.LONG, new ModelNode(defaultKeepaliveTime), new LongRangeValidatorBuilder().min(0)).build());
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolResourceDefinition.java
@@ -91,7 +91,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
 
     ThreadPoolResourceDefinition(String name, int defaultMinThreads, int defaultMaxThreads, int defaultQueueLength, long defaultKeepaliveTime) {
         this.name = name;
-        this.descriptionResolver = new InfinispanResourceDescriptionResolver(pathElement(PathElement.WILDCARD_VALUE));
+        this.descriptionResolver = new InfinispanResourceDescriptionResolver(pathElement(name), pathElement(PathElement.WILDCARD_VALUE));
         this.minThreads = new SimpleAttribute(createBuilder("min-threads", ModelType.INT, new ModelNode(defaultMinThreads), new IntRangeValidatorBuilder().min(0)).build());
         this.maxThreads = new SimpleAttribute(createBuilder("max-threads", ModelType.INT, new ModelNode(defaultMaxThreads), new IntRangeValidatorBuilder().min(0)).build());
         this.queueLength = new SimpleAttribute(createBuilder("queue-length", ModelType.INT, new ModelNode(defaultQueueLength), new IntRangeValidatorBuilder().min(0)).build());

--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -42,11 +42,13 @@ infinispan.cache-container.invalidation-cache=An invalidation cache child of the
 infinispan.cache-container.replicated-cache=A replicated cache child of the cache container.
 infinispan.cache-container.distributed-cache=A distributed cache child of the cache container.
 # thread-pool resources
-infinispan.thread-pool.transport=Defines a thread pool used for asynchronous transport communication.
-infinispan.thread-pool.expiration=Defines a thread pool used for for evictions.
+infinispan.thread-pool.async-operations=Defines a thread pool used for asynchronous operations.
 infinispan.thread-pool.listener=Defines a thread pool used for asynchronous cache listener notifications.
 infinispan.thread-pool.persistence=Defines a thread pool used for interacting with the persistent store.
-infinispan.thread-pool=A thread pool executor.
+infinispan.thread-pool.remote-command=Defines a thread pool used to execute remote commands.
+infinispan.thread-pool.state-transfer=Defines a thread pool used for for state transfer.
+infinispan.thread-pool.transport=Defines a thread pool used for asynchronous transport communication.
+infinispan.thread-pool.expiration=Defines a thread pool used for for evictions.
 infinispan.thread-pool.add=Adds a thread pool executor.
 infinispan.thread-pool.remove=Removes a thread pool executor.
 infinispan.thread-pool.min-threads=The core thread pool size which is smaller than the maximum pool size. If undefined, the core thread pool size is the same as the maximum thread pool size.


### PR DESCRIPTION
…an/cache-container=_/thread-pool=_:read-resource-description())

by searching on multiple paths to allow reusing of attribute descriptions

```
[standalone@localhost:9990 /] /subsystem=infinispan/cache-container=web/thread-pool=listener/:read-resource-description
{
    "outcome" => "success",
    "result" => {
        "description" => "Defines a thread pool used for asynchronous cache listener notifications.",
...
```

instead of 

```
...
        "description" => "A thread pool executor.",
...
```
