### PR TITLE
[WFLY-5192] HOST attribute should allow null

### DIFF
--- a/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
+++ b/xts/src/main/java/org/jboss/as/xts/XTSSubsystemDefinition.java
@@ -47,6 +47,7 @@ public class XTSSubsystemDefinition extends SimpleResourceDefinition {
 
     protected static final SimpleAttributeDefinition HOST_NAME =
             new SimpleAttributeDefinitionBuilder(CommonAttributes.HOST, ModelType.STRING)
+                    .setAllowNull(true)
                     .setDefaultValue(new ModelNode("default-host"))
                     .setAllowExpression(true)
                     .setXmlName(Attribute.NAME.getLocalName())


### PR DESCRIPTION
The already present default value will ensure that the runtime service never sees null.

This change allows configs that are legal per the xsd to boot. In particular they allow legal EAP 6 configs to boot.

@gytis Please approve.
