### PR TITLE
[WFLY-3290] Add cluster attribute to EJB3 subsystem remote element to allow specifying EJBClient cluster name.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemotingConnectorClientMappingsEntryProviderService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemotingConnectorClientMappingsEntryProviderService.java
@@ -36,7 +36,6 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.InjectedValue;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
 import org.wildfly.clustering.registry.RegistryEntryProvider;
 import org.wildfly.clustering.spi.CacheGroupServiceName;
 
@@ -49,8 +48,8 @@ public class EJBRemotingConnectorClientMappingsEntryProviderService extends Abst
     private final InjectedValue<ServerEnvironment> serverEnvironment = new InjectedValue<>();
     private final InjectedValue<RemotingConnectorBindingInfoService.RemotingConnectorInfo> remotingConnectorInfo = new InjectedValue<>();
 
-    public ServiceBuilder<RegistryEntryProvider<String, List<ClientMapping>>> build(ServiceTarget target, ServiceName remotingServerInfoServiceName) {
-        return target.addService(CacheGroupServiceName.REGISTRY_ENTRY.getServiceName(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME), this)
+    public ServiceBuilder<RegistryEntryProvider<String, List<ClientMapping>>> build(ServiceTarget target, String clientMappingsClusterName, ServiceName remotingServerInfoServiceName) {
+        return target.addService(CacheGroupServiceName.REGISTRY_ENTRY.getServiceName(clientMappingsClusterName), this)
                 .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, this.serverEnvironment)
                 .addDependency(remotingServerInfoServiceName, RemotingConnectorBindingInfoService.RemotingConnectorInfo.class, this.remotingConnectorInfo)
         ;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RegistryInstallerService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RegistryInstallerService.java
@@ -28,7 +28,6 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
 import org.wildfly.clustering.registry.Registry;
 import org.wildfly.clustering.spi.CacheGroupServiceName;
 
@@ -36,15 +35,20 @@ public class RegistryInstallerService implements Service<Void> {
 
     public static final ServiceName SERVICE_NAME = ServiceName.JBOSS.append("ejb", "remoting", "connector", "client-mappings", "installer");
 
+    private final String clientMappingsClusterName;
     @SuppressWarnings("rawtypes")
     private final InjectedValue<RegistryCollector> collector = new InjectedValue<>();
     @SuppressWarnings("rawtypes")
     private final InjectedValue<Registry> registry = new InjectedValue<>();
 
+    public RegistryInstallerService(String clientMappingsClusterName) {
+        this.clientMappingsClusterName = clientMappingsClusterName;
+    }
+
     public ServiceBuilder<Void> build(ServiceTarget target) {
         return target.addService(SERVICE_NAME, this)
                 .addDependency(RegistryCollectorService.SERVICE_NAME, RegistryCollector.class, this.collector)
-                .addDependency(CacheGroupServiceName.REGISTRY.getServiceName(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME), Registry.class, this.registry)
+                .addDependency(CacheGroupServiceName.REGISTRY.getServiceName(this.clientMappingsClusterName), Registry.class, this.registry)
         ;
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Extension.java
@@ -58,7 +58,7 @@ public class EJB3Extension implements Extension {
     public static final String NAMESPACE_1_5 = EJB3SubsystemNamespace.EJB3_1_5.getUriString();
     public static final String NAMESPACE_2_0 = EJB3SubsystemNamespace.EJB3_2_0.getUriString();
     public static final String NAMESPACE_3_0 = EJB3SubsystemNamespace.EJB3_3_0.getUriString();
-    public static final String NAMESPACE_3_1 = EJB3SubsystemNamespace.EJB3_3_1.getUriString();
+    public static final String NAMESPACE_4_0 = EJB3SubsystemNamespace.EJB3_4_0.getUriString();
 
     static final PathElement SUBSYSTEM_PATH = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, SUBSYSTEM_NAME);
 
@@ -115,6 +115,6 @@ public class EJB3Extension implements Extension {
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_1_5, EJB3Subsystem15Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_2_0, EJB3Subsystem20Parser.INSTANCE);
         context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_3_0, EJB3Subsystem30Parser.INSTANCE);
-        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_3_1, EJB3Subsystem31Parser.INSTANCE);
+        context.setSubsystemXmlMapping(SUBSYSTEM_NAME, NAMESPACE_4_0, EJB3Subsystem40Parser.INSTANCE);
     }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -34,8 +34,12 @@ import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
+import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
 
 /**
  * A {@link org.jboss.as.controller.ResourceDefinition} for the EJB remote service
@@ -45,6 +49,13 @@ import org.jboss.dmr.ModelType;
 public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
 
     public static final EJB3RemoteResourceDefinition INSTANCE = new EJB3RemoteResourceDefinition();
+
+    static final SimpleAttributeDefinition CLIENT_MAPPINGS_CLUSTER_NAME =
+            new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME, ModelType.STRING, true)
+                    .setAllowExpression(true)
+                    .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
+                    .setDefaultValue(new ModelNode(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME))
+                    .build();
 
     static final SimpleAttributeDefinition CONNECTOR_REF =
             new SimpleAttributeDefinitionBuilder(EJB3SubsystemModel.CONNECTOR_REF, ModelType.STRING, true)
@@ -63,6 +74,7 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
 
     static {
         Map<String, AttributeDefinition> map = new LinkedHashMap<String, AttributeDefinition>();
+        map.put(CLIENT_MAPPINGS_CLUSTER_NAME.getName(), CLIENT_MAPPINGS_CLUSTER_NAME);
         map.put(CONNECTOR_REF.getName(), CONNECTOR_REF);
         map.put(THREAD_POOL_NAME.getName(), THREAD_POOL_NAME);
 
@@ -96,4 +108,21 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
     static void registerTransformers_1_1_0(ResourceTransformationDescriptionBuilder builder) {
         RemoteConnectorChannelCreationOptionResource.registerTransformers_1_1_0(builder.addChildResource(EJB3SubsystemModel.REMOTE_SERVICE_PATH));
     }
+
+    static void registerTransformers_1_2_0(ResourceTransformationDescriptionBuilder parent) {
+        ResourceTransformationDescriptionBuilder remoteService = parent.addChildResource(EJB3SubsystemModel.REMOTE_SERVICE_PATH);
+        remoteService.getAttributeBuilder()
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME)),CLIENT_MAPPINGS_CLUSTER_NAME)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, CLIENT_MAPPINGS_CLUSTER_NAME)
+                .end();
+    }
+
+    static void registerTransformers_3_0(ResourceTransformationDescriptionBuilder parent) {
+        ResourceTransformationDescriptionBuilder remoteService = parent.addChildResource(EJB3SubsystemModel.REMOTE_SERVICE_PATH);
+        remoteService.getAttributeBuilder()
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME)),CLIENT_MAPPINGS_CLUSTER_NAME)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, CLIENT_MAPPINGS_CLUSTER_NAME)
+                .end();
+    }
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteResourceDefinition.java
@@ -109,7 +109,7 @@ public class EJB3RemoteResourceDefinition extends SimpleResourceDefinition {
         RemoteConnectorChannelCreationOptionResource.registerTransformers_1_1_0(builder.addChildResource(EJB3SubsystemModel.REMOTE_SERVICE_PATH));
     }
 
-    static void registerTransformers_1_2_0(ResourceTransformationDescriptionBuilder parent) {
+    static void registerTransformers_1_2_0_and_1_3_0(ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder remoteService = parent.addChildResource(EJB3SubsystemModel.REMOTE_SERVICE_PATH);
         remoteService.getAttributeBuilder()
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME)),CLIENT_MAPPINGS_CLUSTER_NAME)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3RemoteServiceAdd.java
@@ -60,7 +60,6 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.jboss.remoting3.RemotingOptions;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
 import org.wildfly.clustering.service.Builder;
 import org.wildfly.clustering.service.SubGroupServiceNameFactory;
 import org.wildfly.clustering.spi.CacheGroupBuilderProvider;
@@ -106,32 +105,32 @@ public class EJB3RemoteServiceAdd extends AbstractAddStepHandler {
     }
 
     void installRuntimeServices(final OperationContext context, final ModelNode model) throws OperationFailedException {
+        final String clientMappingsClusterName = EJB3RemoteResourceDefinition.CLIENT_MAPPINGS_CLUSTER_NAME.resolveModelAttribute(context, model).asString();
         final String connectorName = EJB3RemoteResourceDefinition.CONNECTOR_REF.resolveModelAttribute(context, model).asString();
         final String threadPoolName = EJB3RemoteResourceDefinition.THREAD_POOL_NAME.resolveModelAttribute(context, model).asString();
         final ServiceName remotingServerInfoServiceName = RemotingConnectorBindingInfoService.serviceName(connectorName);
 
         final ServiceTarget target = context.getServiceTarget();
-
         // Install the client-mapping service for the remoting connector
-        new EJBRemotingConnectorClientMappingsEntryProviderService().build(target, remotingServerInfoServiceName)
+        new EJBRemotingConnectorClientMappingsEntryProviderService().build(target, clientMappingsClusterName, remotingServerInfoServiceName)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
                 .install();
 
-        new RegistryInstallerService().build(target).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
+        new RegistryInstallerService(clientMappingsClusterName).build(target).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
 
         // Handle case where no infinispan subsystem exists or does not define an ejb cache-container
         Resource rootResource = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS);
         PathElement infinispanPath = PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "infinispan");
-        if (!rootResource.hasChild(infinispanPath) || !rootResource.getChild(infinispanPath).hasChild(PathElement.pathElement("cache-container", BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME))) {
+        if (!rootResource.hasChild(infinispanPath) || !rootResource.getChild(infinispanPath).hasChild(PathElement.pathElement("cache-container", clientMappingsClusterName))) {
             // Install services that would normally be installed by this container/cache
             ModuleIdentifier module = Module.forClass(this.getClass()).getIdentifier();
             for (GroupBuilderProvider provider : ServiceLoader.load(LocalGroupBuilderProvider.class, LocalGroupBuilderProvider.class.getClassLoader())) {
-                for (Builder<?> builder : provider.getBuilders(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME, module)) {
+                for (Builder<?> builder : provider.getBuilders(clientMappingsClusterName, module)) {
                     builder.build(target).install();
                 }
             }
             for (CacheGroupBuilderProvider provider : ServiceLoader.load(LocalCacheGroupBuilderProvider.class, LocalCacheGroupBuilderProvider.class.getClassLoader())) {
-                for (Builder<?> builder : provider.getBuilders(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME, SubGroupServiceNameFactory.DEFAULT_SUB_GROUP)) {
+                for (Builder<?> builder : provider.getBuilders(clientMappingsClusterName, SubGroupServiceNameFactory.DEFAULT_SUB_GROUP)) {
                     builder.build(target).install();
                 }
             }
@@ -161,6 +160,7 @@ public class EJB3RemoteServiceAdd extends AbstractAddStepHandler {
 
     @Override
     protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {
+        EJB3RemoteResourceDefinition.CLIENT_MAPPINGS_CLUSTER_NAME.validateAndSet(operation, model);
         EJB3RemoteResourceDefinition.CONNECTOR_REF.validateAndSet(operation, model);
         EJB3RemoteResourceDefinition.THREAD_POOL_NAME.validateAndSet(operation, model);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem40Parser.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3Subsystem40Parser.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2015, Red Hat, Inc., and individual contributors
+ * Copyright 2012, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -30,7 +30,10 @@ import org.jboss.staxmapper.XMLExtendedStreamReader;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
 import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.parsing.ParseUtils.missingRequired;
@@ -40,22 +43,77 @@ import static org.jboss.as.controller.parsing.ParseUtils.requireNoContent;
 import static org.jboss.as.controller.parsing.ParseUtils.requireNoNamespaceAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedAttribute;
 import static org.jboss.as.controller.parsing.ParseUtils.unexpectedElement;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.REMOTE;
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemModel.SERVICE;
 
 /**
- * Parser for ejb3:3.1 namespace.
- *
- * @author Flavia Rainone
+ * @author <a href="mailto:rachmato@redhat.com">Richard Achmatowicz</a>
  */
-public class EJB3Subsystem31Parser extends EJB3Subsystem30Parser {
+public class EJB3Subsystem40Parser extends EJB3Subsystem30Parser {
 
-    public static final EJB3Subsystem31Parser INSTANCE = new EJB3Subsystem31Parser();
+    public static final EJB3Subsystem40Parser INSTANCE = new EJB3Subsystem40Parser();
 
-    protected EJB3Subsystem31Parser() {
+    protected EJB3Subsystem40Parser() {
     }
 
     @Override
     protected EJB3SubsystemNamespace getExpectedNamespace() {
-        return EJB3SubsystemNamespace.EJB3_3_1;
+        return EJB3SubsystemNamespace.EJB3_4_0;
+    }
+
+
+    protected void parseRemote(final XMLExtendedStreamReader reader, List<ModelNode> operations) throws XMLStreamException {
+        final int count = reader.getAttributeCount();
+        final PathAddress ejb3RemoteServiceAddress = SUBSYSTEM_PATH.append(SERVICE, REMOTE);
+        ModelNode operation = Util.createAddOperation(ejb3RemoteServiceAddress);
+        final EnumSet<EJB3SubsystemXMLAttribute> required = EnumSet.of(EJB3SubsystemXMLAttribute.CONNECTOR_REF,
+                EJB3SubsystemXMLAttribute.THREAD_POOL_NAME);
+        for (int i = 0; i < count; i++) {
+            requireNoNamespaceAttribute(reader, i);
+            final String value = reader.getAttributeValue(i);
+            final EJB3SubsystemXMLAttribute attribute = EJB3SubsystemXMLAttribute.forName(reader.getAttributeLocalName(i));
+            required.remove(attribute);
+            switch (attribute) {
+                case CLIENT_MAPPINGS_CLUSTER_NAME:
+                    EJB3RemoteResourceDefinition.CLIENT_MAPPINGS_CLUSTER_NAME.parseAndSetParameter(value, operation, reader);
+                    break;
+                case CONNECTOR_REF:
+                    EJB3RemoteResourceDefinition.CONNECTOR_REF.parseAndSetParameter(value, operation, reader);
+                    break;
+                case THREAD_POOL_NAME:
+                    EJB3RemoteResourceDefinition.THREAD_POOL_NAME.parseAndSetParameter(value, operation, reader);
+                    break;
+                default:
+                    throw unexpectedAttribute(reader, i);
+            }
+        }
+        if (!required.isEmpty()) {
+            throw missingRequired(reader, required);
+        }
+        // each profile adds it's own operation
+        operations.add(operation);
+
+        final Set<EJB3SubsystemXMLElement> parsedElements = new HashSet<EJB3SubsystemXMLElement>();
+        while (reader.hasNext() && reader.nextTag() != XMLStreamConstants.END_ELEMENT) {
+            EJB3SubsystemXMLElement element = EJB3SubsystemXMLElement.forName(reader.getLocalName());
+            switch (element) {
+                case CHANNEL_CREATION_OPTIONS: {
+                    if (parsedElements.contains(EJB3SubsystemXMLElement.CHANNEL_CREATION_OPTIONS)) {
+                        throw unexpectedElement(reader);
+                    }
+                    parsedElements.add(EJB3SubsystemXMLElement.CHANNEL_CREATION_OPTIONS);
+                    this.parseChannelCreationOptions(reader, ejb3RemoteServiceAddress, operations);
+                    break;
+                }
+                case PROFILES: {
+                    parseProfiles(reader, operations);
+                    break;
+                }
+                default: {
+                    throw unexpectedElement(reader);
+                }
+            }
+        }
     }
 
     @Override
@@ -128,4 +186,5 @@ public class EJB3Subsystem31Parser extends EJB3Subsystem30Parser {
             }
         }
     }
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemModel.java
@@ -83,6 +83,7 @@ public interface EJB3SubsystemModel {
     String REMOTING_EJB_RECEIVER = "remoting-ejb-receiver";
     String OUTBOUND_CONNECTION_REF= "outbound-connection-ref";
     String CONNECT_TIMEOUT= "connect-timeout";
+    String CLIENT_MAPPINGS_CLUSTER_NAME = "cluster";
 
     String TIMER = "timer";
     String TIMER_SERVICE = "timer-service";

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemNamespace.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemNamespace.java
@@ -42,8 +42,7 @@ public enum EJB3SubsystemNamespace {
     EJB3_1_5("urn:jboss:domain:ejb3:1.5"),
     EJB3_2_0("urn:jboss:domain:ejb3:2.0"),
     EJB3_3_0("urn:jboss:domain:ejb3:3.0"),
-    EJB3_3_1("urn:jboss:domain:ejb3:3.1"),
-    ;
+    EJB3_4_0("urn:jboss:domain:ejb3:4.0");
 
 
     private final String name;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -308,19 +308,18 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         builder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE));
         if (version.equals(VERSION_1_2_1)) {
             TimerServiceResourceDefinition.registerTransformers_1_2_0(builder);
+            EJB3RemoteResourceDefinition.registerTransformers_1_2_0(builder);
         } else if (version.equals(VERSION_1_3_0)) {
             TimerServiceResourceDefinition.registerTransformers_1_3_0(builder);
-
         }
-
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, version);
     }
 
     private static void registerTransformers_3_0_0(SubsystemRegistration subsystemRegistration) {
         final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
-        builder.getAttributeBuilder()
-                .setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME)
-                .end();
+        builder.getAttributeBuilder().setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME)
+        .end();
+        EJB3RemoteResourceDefinition.registerTransformers_3_0(builder);
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_3_0_0);
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -305,11 +305,11 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         //builder.getAttributeBuilder().setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME);
 
         PassivationStoreResourceDefinition.registerTransformers_1_2_1_and_1_3_0(builder);
+        EJB3RemoteResourceDefinition.registerTransformers_1_2_0_and_1_3_0(builder);
+        MdbDeliveryGroupResourceDefinition.registerTransformers_1_2_0_and_1_3_0(builder);
         builder.rejectChildResource(PathElement.pathElement(EJB3SubsystemModel.REMOTING_PROFILE));
         if (version.equals(VERSION_1_2_1)) {
             TimerServiceResourceDefinition.registerTransformers_1_2_0(builder);
-            EJB3RemoteResourceDefinition.registerTransformers_1_2_0(builder);
-            MdbDeliveryGroupResourceDefinition.registerTransformers_1_2_0(builder);
         } else if (version.equals(VERSION_1_3_0)) {
             TimerServiceResourceDefinition.registerTransformers_1_3_0(builder);
         }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRootResourceDefinition.java
@@ -309,6 +309,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         if (version.equals(VERSION_1_2_1)) {
             TimerServiceResourceDefinition.registerTransformers_1_2_0(builder);
             EJB3RemoteResourceDefinition.registerTransformers_1_2_0(builder);
+            MdbDeliveryGroupResourceDefinition.registerTransformers_1_2_0(builder);
         } else if (version.equals(VERSION_1_3_0)) {
             TimerServiceResourceDefinition.registerTransformers_1_3_0(builder);
         }
@@ -319,6 +320,7 @@ public class EJB3SubsystemRootResourceDefinition extends SimpleResourceDefinitio
         final ResourceTransformationDescriptionBuilder builder = TransformationDescriptionBuilder.Factory.createSubsystemInstance();
         builder.getAttributeBuilder().setValueConverter(AttributeConverter.Factory.createHardCoded(new ModelNode("hornetq-ra"), true), EJB3SubsystemRootResourceDefinition.DEFAULT_RESOURCE_ADAPTER_NAME)
         .end();
+        MdbDeliveryGroupResourceDefinition.registerTransformers_3_0(builder);
         EJB3RemoteResourceDefinition.registerTransformers_3_0(builder);
         TransformationDescription.Tools.register(builder.build(), subsystemRegistration, VERSION_3_0_0);
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLAttribute.java
@@ -38,6 +38,7 @@ public enum EJB3SubsystemXMLAttribute {
 
     CACHE_CONTAINER("cache-container"),
     CACHE_REF("cache-ref"),
+    CLIENT_MAPPINGS_CLUSTER_NAME("cluster"),
     @Deprecated CLIENT_MAPPINGS_CACHE("client-mappings-cache"),
     @Deprecated CLUSTERED_CACHE_REF("clustered-cache-ref"),
     CONNECT_TIMEOUT("connect-timeout"),

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemXMLPersister.java
@@ -53,10 +53,8 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
     @Override
     public void writeContent(final XMLExtendedStreamWriter writer, final SubsystemMarshallingContext context) throws XMLStreamException {
 
-        context.startSubsystemElement(EJB3SubsystemNamespace.EJB3_3_1.getUriString(), false);
-
-        writeElements(writer,  context);
-
+        context.startSubsystemElement(EJB3SubsystemNamespace.EJB3_4_0.getUriString(), false);
+        writeElements(writer, context);
         // write the subsystem end element
         writer.writeEndElement();
     }
@@ -276,6 +274,10 @@ public class EJB3SubsystemXMLPersister implements XMLElementWriter<SubsystemMars
 
 
     protected void writeRemote(final XMLExtendedStreamWriter writer, final ModelNode model) throws XMLStreamException {
+        // only write if non-default value?
+        if (model.hasDefined(EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME)) {
+            writer.writeAttribute(EJB3SubsystemXMLAttribute.CLIENT_MAPPINGS_CLUSTER_NAME.getLocalName(), model.require(EJB3SubsystemModel.CLIENT_MAPPINGS_CLUSTER_NAME).asString());
+        }
         writer.writeAttribute(EJB3SubsystemXMLAttribute.CONNECTOR_REF.getLocalName(), model.require(EJB3SubsystemModel.CONNECTOR_REF).asString());
         writer.writeAttribute(EJB3SubsystemXMLAttribute.THREAD_POOL_NAME.getLocalName(), model.require(EJB3SubsystemModel.THREAD_POOL_NAME).asString());
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
@@ -68,15 +68,17 @@ public class MdbDeliveryGroupResourceDefinition extends SimpleResourceDefinition
     public void registerAttributes(ManagementResourceRegistration resourceRegistration) {
         resourceRegistration.registerReadWriteAttribute(ACTIVE, null,
                 new AbstractWriteAttributeHandler<Void>() {
-                    @Override protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation,
-                            String attributeName, ModelNode resolvedValue, ModelNode currentValue,
-                            HandbackHolder<Void> handbackHolder) throws OperationFailedException {
+                    @Override
+                    protected boolean applyUpdateToRuntime(OperationContext context, ModelNode operation,
+                                                           String attributeName, ModelNode resolvedValue, ModelNode currentValue,
+                                                           HandbackHolder<Void> handbackHolder) throws OperationFailedException {
                         updateDeliveryGroup(context, currentValue, resolvedValue);
                         return false;
                     }
 
-                    @Override protected void revertUpdateToRuntime(OperationContext context, ModelNode operation,
-                            String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Void handback)
+                    @Override
+                    protected void revertUpdateToRuntime(OperationContext context, ModelNode operation,
+                                                         String attributeName, ModelNode valueToRestore, ModelNode valueToRevert, Void handback)
                             throws OperationFailedException {
                         updateDeliveryGroup(context, valueToRevert, valueToRestore);
                     }
@@ -92,7 +94,7 @@ public class MdbDeliveryGroupResourceDefinition extends SimpleResourceDefinition
                 });
     }
 
-    static void registerTransformers_1_2_0(ResourceTransformationDescriptionBuilder parent) {
+    static void registerTransformers_1_2_0_and_1_3_0(ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder mdbDeliveryGroup = parent.addChildResource(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP));
         mdbDeliveryGroup.getAttributeBuilder()
                 .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(true)), ACTIVE)

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/MdbDeliveryGroupResourceDefinition.java
@@ -31,6 +31,9 @@ import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.transform.description.DiscardAttributeChecker;
+import org.jboss.as.controller.transform.description.RejectAttributeChecker;
+import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
@@ -89,4 +92,19 @@ public class MdbDeliveryGroupResourceDefinition extends SimpleResourceDefinition
                 });
     }
 
+    static void registerTransformers_1_2_0(ResourceTransformationDescriptionBuilder parent) {
+        ResourceTransformationDescriptionBuilder mdbDeliveryGroup = parent.addChildResource(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP));
+        mdbDeliveryGroup.getAttributeBuilder()
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(true)), ACTIVE)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ACTIVE)
+                .end();
+    }
+
+    static void registerTransformers_3_0(ResourceTransformationDescriptionBuilder parent) {
+        ResourceTransformationDescriptionBuilder mdbDeliveryGroup = parent.addChildResource(PathElement.pathElement(EJB3SubsystemModel.MDB_DELIVERY_GROUP));
+        mdbDeliveryGroup.getAttributeBuilder()
+                .setDiscard(new DiscardAttributeChecker.DiscardAttributeValueChecker(new ModelNode(true)), ACTIVE)
+                .addRejectCheck(RejectAttributeChecker.DEFINED, ACTIVE)
+                .end();
+    }
 }

--- a/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
+++ b/ejb3/src/main/resources/org/jboss/as/ejb3/subsystem/LocalDescriptions.properties
@@ -226,6 +226,7 @@ stateless-session-bean.wait-time=Time spend waiting to obtain an instance.
 remote=The EJB3 Remote Service
 remote.add=Adds the EJB3 remote service
 remote.remove=Removes the EJB3 remote service
+remote.cluster= The name of the clustered cache container which will be used to store/access the client-mappings of the EJB remoting connector's socket-binding on each node, in the cluster
 remote.connector-ref=The name of the connector on which the EJB3 remoting channel is registered
 remote.thread-pool-name=The name of the thread pool that handles remote invocations
 remote.client-mappings-cache-container-ref=The name of the clustered cache container which will be used to store/access the client-mappings of the EJB remoting connector's socket-binding on each node, in the cluster

--- a/ejb3/src/main/resources/schema/wildfly-ejb4_0_0.xsd
+++ b/ejb3/src/main/resources/schema/wildfly-ejb4_0_0.xsd
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ Copyright 2014, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -23,8 +23,8 @@
   -->
 
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
-           targetNamespace="urn:jboss:domain:ejb3:3.1"
-           xmlns="urn:jboss:domain:ejb3:3.1"
+           targetNamespace="urn:jboss:domain:ejb3:4.0"
+           xmlns="urn:jboss:domain:ejb3:4.0"
            xmlns:threads="urn:jboss:domain:threads:1.1"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
@@ -91,6 +91,7 @@
         </xs:all>
         <xs:attribute name="connector-ref" type="xs:string" use="required"/>
         <xs:attribute name="thread-pool-name" type="xs:token" use="required"/>
+        <xs:attribute name="cluster" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:complexType name="profilesType">

--- a/ejb3/src/main/resources/subsystem-templates/ejb3.xml
+++ b/ejb3/src/main/resources/subsystem-templates/ejb3.xml
@@ -2,7 +2,7 @@
 <!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
 <config default-supplement="default">
    <extension-module>org.jboss.as.ejb3</extension-module>
-   <subsystem xmlns="urn:jboss:domain:ejb3:3.1">
+   <subsystem xmlns="urn:jboss:domain:ejb3:4.0">
        <session-bean>
            <?STATEFUL-BEAN?>
            <singleton default-access-timeout="5000"/>

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -77,7 +77,7 @@ public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
 
     @Override
     protected String getSubsystemXsdPath() throws Exception {
-        return "schema/wildfly-ejb3_3_1.xsd";
+        return "schema/wildfly-ejb4_0_0.xsd";
     }
 
     @Override

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/subsystem.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:ejb3:3.1">
+<subsystem xmlns="urn:jboss:domain:ejb3:4.0">
     <session-bean>
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>
@@ -41,7 +41,7 @@
             <database-data-store name="database-data-store" datasource-jndi-name="${prop.timer-service-database:java:global/DataSource}" database="hsql" partition="mypartition" allow-execution="true" refresh-interval="100"/>
         </data-stores>
     </timer-service>
-    <remote connector-ref="remoting-connector" thread-pool-name="default">
+    <remote connector-ref="remoting-connector" thread-pool-name="default" cluster="ejb">
         <channel-creation-options>
             <option name="READ_TIMEOUT" value="${prop.remoting-connector.read.timeout:20}" type="xnio"/>
             <option name="MAX_OUTBOUND_MESSAGES" value="1234" type="remoting"/>

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_2_1.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_2_1.xml
@@ -1,4 +1,4 @@
-<subsystem xmlns="urn:jboss:domain:ejb3:3.1">
+<subsystem xmlns="urn:jboss:domain:ejb3:4.0">
     <session-bean>
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>

--- a/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_3_0.xml
+++ b/ejb3/src/test/resources/org/jboss/as/ejb3/subsystem/transform_1_3_0.xml
@@ -20,7 +20,7 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<subsystem xmlns="urn:jboss:domain:ejb3:3.1">
+<subsystem xmlns="urn:jboss:domain:ejb3:4.0">
     <session-bean>
         <stateless>
             <bean-instance-pool-ref pool-name="slsb-strict-max-pool"/>


### PR DESCRIPTION
For details, see: https://issues.jboss.org/browse/WFLY-3290

This issue is required for Wildfly tests which involve two clusters and remote EJB invocations.
