### PR TITLE
[WFLY-5138] Don't use ARQ for ParseAndMarshalModelsTestCase, plus Mod…

### DIFF
--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -58,6 +58,14 @@
             <fileset dir="target/jbossas"/>
         </copy>
 
+        <echo message="Copying and configuring instance jbossas-parse-marshal"/>
+        <copy todir="target/jbossas-parse-marshal">
+            <fileset dir="target/jbossas"/>
+        </copy>
+        <copy todir="target/jbossas-parse-marshal/modules">
+            <fileset dir="${jboss.dist}/modules"/>
+        </copy>
+
         <!-- Connects back to original host (node0) -->
         <ts.config-as.add-remote-outbound-connection name="jbossas-with-remote-outbound-connection" node="${node0}"
                                                      remotePort="8080" protocol="http-remoting" securityRealm="PasswordRealm" userName="user1"/>


### PR DESCRIPTION
…elParserUtils now wants 'target' param to mean  location

This requires the fix to WFCORE-901 to be merged and the core release to be integrated.

http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=67269&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperiments is a custom run showing the combination of this and https://github.com/wildfly/wildfly-core/pull/991
