### PR TITLE
[WFLY-5196] Downgrading PicketLink to 2.5.5.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.opensaml.opensaml>3.1.1</version.org.opensaml.opensaml>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
-        <version.org.picketlink>2.7.0.Final</version.org.picketlink>
+        <version.org.picketlink>2.5.5.CR1</version.org.picketlink>
         <version.org.scannotation>1.0.3</version.org.scannotation>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>


### PR DESCRIPTION
We have to downgrade PicketLink to 2.5.x to be in sync with EAP 7 and deprecation of PicketLink in WildFly.

https://issues.jboss.org/browse/WFLY-5196
