### PR TITLE
Add missing module dependancy to cxf

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/cxf/main/module.xml
@@ -38,6 +38,7 @@
         <module name="asm.asm" />
         <module name="javax.api" />
         <module name="javax.annotation.api" />
+        <module name="javax.validation.api" optional="true"/>
         <module name="javax.jws.api" />
         <module name="javax.mail.api" />
         <module name="javax.resource.api" />


### PR DESCRIPTION
Was reported out by user in hipchat room.

@asoldano please confirm
