### PR TITLE
[WFCORE-914] Adjust metrics to work when WFCORE-831 comes in  by sett…

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -126,9 +126,6 @@ public interface JGroupsLogger extends BasicLogger {
     @Message(id = 18, value = "Instantiation exception on converter for attribute/method %s")
     String instantiationExceptionOnConverterForAttribute(String attrName);
 
-    @Message(id = 19, value = "Protocol %s not found in current stack")
-    String protocolNotFoundInStack(String protocolName);
-
     @Message(id = 20, value = "Unable to load protocol class %s")
     String unableToLoadProtocol(String protocolName);
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolMetricsHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolMetricsHandler.java
@@ -263,8 +263,6 @@ public class ProtocolMetricsHandler extends AbstractRuntimeOnlyHandler {
                 } else {
                     context.getFailureDescription().set(JGroupsLogger.ROOT_LOGGER.unknownMetric(name));
                 }
-            } else {
-                context.getFailureDescription().set(JGroupsLogger.ROOT_LOGGER.protocolNotFoundInStack(protocolName));
             }
         } catch (ClassNotFoundException | ModuleLoadException e) {
             context.getFailureDescription().set(e.getLocalizedMessage());

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceRegistrationHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceRegistrationHandler.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.clustering.jgroups.subsystem.ProtocolResourceDefinition.Attribute.*;
+import static org.jboss.as.clustering.jgroups.subsystem.ProtocolResourceDefinition.Attribute.MODULE;
 
 import java.util.Collections;
 import java.util.Locale;
@@ -162,7 +162,7 @@ public class ProtocolResourceRegistrationHandler implements OperationStepHandler
             Attribute attribute = entry.getValue();
             FieldType type = FieldType.valueOf(attribute.getType());
             resolver.addDescription(name, attribute.getDescription());
-            builder.addMetric(new SimpleAttributeDefinitionBuilder(name, type.getModelType()).setStorageRuntime().build(), handler);
+            builder.addMetric(new SimpleAttributeDefinitionBuilder(name, type.getModelType(), true).setStorageRuntime().build(), handler);
         }
 
         return builder.build();

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -531,35 +531,35 @@ public class Constants {
     static final String START_WORK_REJECTED_NAME = "startwork-rejected";
 
 
-    static SimpleAttributeDefinition WORK_ACTIVE = new SimpleAttributeDefinitionBuilder(WORK_ACTIVE_NAME, ModelType.INT)
+    static SimpleAttributeDefinition WORK_ACTIVE = new SimpleAttributeDefinitionBuilder(WORK_ACTIVE_NAME, ModelType.INT, true)
             .setStorageRuntime()
             .build();
 
-    static SimpleAttributeDefinition WORK_SUCCESSFUL = new SimpleAttributeDefinitionBuilder(WORK_SUCEESSFUL_NAME, ModelType.INT)
+    static SimpleAttributeDefinition WORK_SUCCESSFUL = new SimpleAttributeDefinitionBuilder(WORK_SUCEESSFUL_NAME, ModelType.INT, true)
             .setStorageRuntime()
             .build();
-    static SimpleAttributeDefinition WORK_FAILED = new SimpleAttributeDefinitionBuilder(WORK_FAILED_NAME, ModelType.INT)
-            .setStorageRuntime()
-            .build();
-
-    static SimpleAttributeDefinition DO_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(DO_WORK_ACCEPTED_NAME, ModelType.INT)
-            .setStorageRuntime()
-            .build();
-    static SimpleAttributeDefinition DO_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(DO_WORK_REJECTED_NAME, ModelType.INT)
+    static SimpleAttributeDefinition WORK_FAILED = new SimpleAttributeDefinitionBuilder(WORK_FAILED_NAME, ModelType.INT, true)
             .setStorageRuntime()
             .build();
 
-    static SimpleAttributeDefinition SCHEDULED_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_ACCEPTED_NAME, ModelType.INT)
+    static SimpleAttributeDefinition DO_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(DO_WORK_ACCEPTED_NAME, ModelType.INT, true)
             .setStorageRuntime()
             .build();
-    static SimpleAttributeDefinition SCHEDULED_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_REJECTED_NAME, ModelType.INT)
+    static SimpleAttributeDefinition DO_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(DO_WORK_REJECTED_NAME, ModelType.INT, true)
             .setStorageRuntime()
             .build();
 
-    static SimpleAttributeDefinition START_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(START_WORK_ACCEPTED_NAME, ModelType.INT)
+    static SimpleAttributeDefinition SCHEDULED_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_ACCEPTED_NAME, ModelType.INT, true)
             .setStorageRuntime()
             .build();
-    static SimpleAttributeDefinition START_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(START_WORK_REJECTED_NAME, ModelType.INT)
+    static SimpleAttributeDefinition SCHEDULED_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_REJECTED_NAME, ModelType.INT, true)
+            .setStorageRuntime()
+            .build();
+
+    static SimpleAttributeDefinition START_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(START_WORK_ACCEPTED_NAME, ModelType.INT, true)
+            .setStorageRuntime()
+            .build();
+    static SimpleAttributeDefinition START_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(START_WORK_REJECTED_NAME, ModelType.INT, true)
             .setStorageRuntime()
             .build();
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentResourceDefinition.java
@@ -57,17 +57,17 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
             .build();
 
     private static final AttributeDefinition EXECUTION_TIME = new SimpleAttributeDefinitionBuilder("execution-time", ModelType.LONG)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition INVOCATIONS = new SimpleAttributeDefinitionBuilder("invocations", ModelType.LONG)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition PEAK_CONCURRENT_INVOCATIONS = new SimpleAttributeDefinitionBuilder("peak-concurrent-invocations", ModelType.LONG)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
@@ -76,12 +76,12 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
             .build();
 
     private static final AttributeDefinition WAIT_TIME = new SimpleAttributeDefinitionBuilder("wait-time", ModelType.LONG)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition METHODS = ObjectTypeAttributeDefinition.Builder.of("methods", EXECUTION_TIME, INVOCATIONS, WAIT_TIME)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
@@ -97,17 +97,17 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
             .build();
 
     private static final AttributeDefinition CACHE_SIZE = new SimpleAttributeDefinitionBuilder("cache-size", ModelType.LONG)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition PASSIVATED_SIZE = new SimpleAttributeDefinitionBuilder("passivated-count",
-            ModelType.LONG).setAllowNull(false)
+            ModelType.LONG).setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition TOTAL_SIZE = new SimpleAttributeDefinitionBuilder("total-size", ModelType.LONG)
-            .setAllowNull(false)
+            .setAllowNull(true)
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -85,6 +85,7 @@ public interface CommonAttributes {
 
     AttributeDefinition CONSUMER_COUNT = create("consumer-count", INT)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     SimpleAttributeDefinition BRIDGE_CONFIRMATION_WINDOW_SIZE = create("confirmation-window-size", INT)
@@ -110,6 +111,7 @@ public interface CommonAttributes {
 
     AttributeDefinition DELIVERING_COUNT = create("delivering-count", INT)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     StringListAttributeDefinition DESTINATION_ENTRIES = new StringListAttributeDefinition.Builder(ENTRIES)
@@ -195,10 +197,12 @@ public interface CommonAttributes {
 
     AttributeDefinition MESSAGE_COUNT = create("message-count", LONG)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     AttributeDefinition MESSAGES_ADDED = create("messages-added", LONG)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     AttributeDefinition MIN_LARGE_MESSAGE_SIZE = create("min-large-message-size", INT)
@@ -255,6 +259,7 @@ public interface CommonAttributes {
 
     AttributeDefinition SCHEDULED_COUNT = create("scheduled-count", LONG)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     SimpleAttributeDefinition SELECTOR = create("selector", ModelType.STRING)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicDefinition.java
@@ -73,22 +73,27 @@ public class JMSTopicDefinition extends PersistentResourceDefinition {
 
     static final AttributeDefinition DURABLE_MESSAGE_COUNT = create(CommonAttributes.DURABLE_MESSAGE_COUNT, INT)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     static final AttributeDefinition NON_DURABLE_MESSAGE_COUNT = create(CommonAttributes.NON_DURABLE_MESSAGE_COUNT, INT)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     static final AttributeDefinition SUBSCRIPTION_COUNT = create(CommonAttributes.SUBSCRIPTION_COUNT, INT)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     static final AttributeDefinition DURABLE_SUBSCRIPTION_COUNT = create(CommonAttributes.DURABLE_SUBSCRIPTION_COUNT, INT)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     static final AttributeDefinition NON_DURABLE_SUBSCRIPTION_COUNT = create(CommonAttributes.NON_DURABLE_SUBSCRIPTION_COUNT, INT)
             .setStorageRuntime()
+            .setAllowNull(true)
             .build();
 
     static final AttributeDefinition[] METRICS = { CommonAttributes.DELIVERING_COUNT,

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/model/ReadFullModelTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/model/ReadFullModelTestCase.java
@@ -1,0 +1,89 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.manualmode.model;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_RUNTIME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+
+import org.jboss.arquillian.container.test.api.ContainerController;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Ensures that the full model including runtime resources/attributes can be read in both normal and admin-only mode
+ * for the fullest server config possible
+ *
+ * @author Kabir Khan
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class ReadFullModelTestCase {
+
+    //This is the full-ha setup which is the fullest config we have
+    //Reuse this rather than a setup
+    public static final String SERVER = "jbossas-messaging-ha-server1";
+
+    @ArquillianResource
+    protected static ContainerController controller;
+
+    protected static ModelControllerClient createClient1() {
+        return TestSuiteEnvironment.getModelControllerClient();
+    }
+
+
+    @Test
+    public void test() throws Exception {
+        controller.start(SERVER);
+        try {
+            ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
+            ModelNode rr = Util.createEmptyOperation(READ_RESOURCE_OPERATION, PathAddress.EMPTY_ADDRESS);
+            rr.get(INCLUDE_RUNTIME).set(true);
+            rr.get(RECURSIVE).set(true);
+            ModelNode result = ModelTestUtils.checkResultAndGetContents(client.execute(rr));
+
+            //Just a quick sanity test to check that we are full-ha by making sure some of the expected subsystems are there
+            Assert.assertTrue(result.hasDefined(SUBSYSTEM, "messaging-activemq"));
+            Assert.assertTrue(result.hasDefined(SUBSYSTEM, "jgroups"));
+
+            ServerReload.executeReloadAndWaitForCompletion(client, true);
+            result = ModelTestUtils.checkResultAndGetContents(client.execute(rr));
+        } finally {
+            if (controller.isStarted(SERVER)) {
+                controller.stop(SERVER);
+            }
+        }
+    }
+
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -28,9 +28,6 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.undertow.server.session.SessionManager;
-import io.undertow.server.session.SessionManagerStatistics;
-import io.undertow.servlet.api.Deployment;
 import org.jboss.as.controller.AbstractRuntimeOnlyHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -47,6 +44,10 @@ import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
 import org.wildfly.extension.undertow.deployment.UndertowDeploymentService;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
+
+import io.undertow.server.session.SessionManager;
+import io.undertow.server.session.SessionManagerStatistics;
+import io.undertow.servlet.api.Deployment;
 
 /**
  * @author Tomaz Cerar
@@ -168,14 +169,14 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
     }
 
     public enum SessionStat {
-        ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("active-sessions", ModelType.INT, false).setStorageRuntime().build()),
-        EXPIRED_SESSIONS(new SimpleAttributeDefinitionBuilder("expired-sessions", ModelType.INT, false).setStorageRuntime().build()),
-        SESSIONS_CREATED(new SimpleAttributeDefinitionBuilder("sessions-created", ModelType.INT, false).setStorageRuntime().build()),
+        ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("active-sessions", ModelType.INT, true).setStorageRuntime().build()),
+        EXPIRED_SESSIONS(new SimpleAttributeDefinitionBuilder("expired-sessions", ModelType.INT, true).setStorageRuntime().build()),
+        SESSIONS_CREATED(new SimpleAttributeDefinitionBuilder("sessions-created", ModelType.INT, true).setStorageRuntime().build()),
         //DUPLICATED_SESSION_IDS(new SimpleAttributeDefinition("duplicated-session-ids", ModelType.INT, false)),
-        SESSION_AVG_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-avg-alive-time", ModelType.INT, false).setStorageRuntime().build()),
-        SESSION_MAX_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-max-alive-time", ModelType.INT, false).setStorageRuntime().build()),
-        REJECTED_SESSIONS(new SimpleAttributeDefinitionBuilder("rejected-sessions", ModelType.INT, false).setStorageRuntime().build()),
-        MAX_ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("max-active-sessions", ModelType.INT, false).setStorageRuntime().build());
+        SESSION_AVG_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-avg-alive-time", ModelType.INT, true).setStorageRuntime().build()),
+        SESSION_MAX_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-max-alive-time", ModelType.INT, true).setStorageRuntime().build()),
+        REJECTED_SESSIONS(new SimpleAttributeDefinitionBuilder("rejected-sessions", ModelType.INT, true).setStorageRuntime().build()),
+        MAX_ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("max-active-sessions", ModelType.INT, true).setStorageRuntime().build());
 
         private static final Map<String, SessionStat> MAP = new HashMap<>();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentServletDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentServletDefinition.java
@@ -22,9 +22,6 @@
 
 package org.wildfly.extension.undertow;
 
-import io.undertow.server.handlers.MetricsHandler;
-import io.undertow.servlet.api.DeploymentInfo;
-import io.undertow.servlet.api.ServletInfo;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
@@ -43,6 +40,10 @@ import org.jboss.msc.service.ServiceController;
 import org.wildfly.extension.undertow.deployment.UndertowDeploymentService;
 import org.wildfly.extension.undertow.deployment.UndertowMetricsCollector;
 
+import io.undertow.server.handlers.MetricsHandler;
+import io.undertow.servlet.api.DeploymentInfo;
+import io.undertow.servlet.api.ServletInfo;
+
 /**
  * @author Tomaz Cerar
  * @created 23.2.12 18:35
@@ -56,7 +57,10 @@ public class DeploymentServletDefinition extends SimpleResourceDefinition {
     static final SimpleAttributeDefinition MIN_REQUEST_TIME = new SimpleAttributeDefinitionBuilder("min-request-time", ModelType.LONG, true).setStorageRuntime().build();
     static final SimpleAttributeDefinition TOTAL_REQUEST_TIME = new SimpleAttributeDefinitionBuilder("total-request-time", ModelType.LONG, true).setStorageRuntime().build();
     static final SimpleAttributeDefinition REQUEST_COUNT = new SimpleAttributeDefinitionBuilder("request-count", ModelType.LONG, true).setStorageRuntime().build();
-    static final SimpleListAttributeDefinition SERVLET_MAPPINGS = new SimpleListAttributeDefinition.Builder("mappings", new SimpleAttributeDefinitionBuilder("mapping", ModelType.STRING, false).build()).setStorageRuntime().build();
+    static final SimpleListAttributeDefinition SERVLET_MAPPINGS = new SimpleListAttributeDefinition.Builder("mappings", new SimpleAttributeDefinitionBuilder("mapping", ModelType.STRING).setAllowNull(true).build())
+            .setAllowNull(true)
+            .setStorageRuntime()
+            .build();
 
 
     private DeploymentServletDefinition() {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -32,8 +32,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
-import io.undertow.UndertowOptions;
-import io.undertow.server.ConnectorStatistics;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
@@ -56,6 +54,9 @@ import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
 import org.wildfly.extension.io.OptionAttributeDefinition;
 import org.xnio.Options;
+
+import io.undertow.UndertowOptions;
+import io.undertow.server.ConnectorStatistics;
 
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
@@ -146,12 +147,12 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
     public static final OptionAttributeDefinition REQUEST_PARSE_TIMEOUT = OptionAttributeDefinition.builder("request-parse-timeout", UndertowOptions.REQUEST_PARSE_TIMEOUT).setMeasurementUnit(MeasurementUnit.MILLISECONDS).setAllowNull(true).setAllowExpression(true).build();
 
     public enum ConnectorStat {
-        REQUEST_COUNT(new SimpleAttributeDefinitionBuilder("request-count", ModelType.LONG, false).setStorageRuntime().build()),
-        BYTES_SENT(new SimpleAttributeDefinitionBuilder("bytes-sent", ModelType.LONG, false).setStorageRuntime().build()),
-        BYTES_RECEIVED(new SimpleAttributeDefinitionBuilder("bytes-received", ModelType.LONG, false).setStorageRuntime().build()),
-        ERROR_COUNT(new SimpleAttributeDefinitionBuilder("error-count", ModelType.LONG, false).setStorageRuntime().build()),
-        PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("processing-time", ModelType.LONG, false).setStorageRuntime().build()),
-        MAX_PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("max-processing-time", ModelType.LONG, false).setStorageRuntime().build());
+        REQUEST_COUNT(new SimpleAttributeDefinitionBuilder("request-count", ModelType.LONG, true).setStorageRuntime().build()),
+        BYTES_SENT(new SimpleAttributeDefinitionBuilder("bytes-sent", ModelType.LONG, true).setStorageRuntime().build()),
+        BYTES_RECEIVED(new SimpleAttributeDefinitionBuilder("bytes-received", ModelType.LONG, true).setStorageRuntime().build()),
+        ERROR_COUNT(new SimpleAttributeDefinitionBuilder("error-count", ModelType.LONG, true).setStorageRuntime().build()),
+        PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("processing-time", ModelType.LONG, true).setStorageRuntime().build()),
+        MAX_PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("max-processing-time", ModelType.LONG, true).setStorageRuntime().build());
 
         private static final Map<String, ConnectorStat> MAP = new HashMap<>();
 


### PR DESCRIPTION
…ing them to nillable

A WFCORE upgrade is coming in with adjustments to the threads metrics
attributes. The current usage of this in the wildfly codebase are
-ejb3 (has been bumped to 4.0.0 from 3.0.0 in 9.0.1.Final)
-jca (has been bumped to 4.0.0 from 3.0.0 in 9.0.1.Final)
-batch (this passes in false for 'registerRuntimeOnly' so metrics do not
get registered)
-batch-jberet (this is new and so does not require a version bump)

Similarly in this PR we have made changes to
-ejb3 (see above, no bump needed)
-jgroups (has been bumped to 4.0.0 from 3.0.0 in 9.0.1.Final)
-messaging-activemq (this is new, and so does not require a version
bump)
-undertow (was 2.0.0 in 9.0.1, and has been bumped to 3.0.0 already)

With this fix, I am _mostly_ able to do a 

```
 :read-resource(recursive=true,include-runtime=true)
```

in both admin-only and normal modes, against the snapshot of WFCORE-831. 
Mostly, because I still need to comment out https://github.com/wildfly/wildfly/blob/master/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolMetricsHandler.java#L267 to get it to work. However, this is not just hit when running in admin-only mode, but also in normal mode when the server has no deployments involving clustering. The simple fix is to remove that line, but @rhusar is investigating whether that can be made more fine-grained.
