### PR TITLE
Don't fail :read-resource on jgroups metrics if the stack is not started

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/logging/JGroupsLogger.java
@@ -126,9 +126,6 @@ public interface JGroupsLogger extends BasicLogger {
     @Message(id = 18, value = "Instantiation exception on converter for attribute/method %s")
     String instantiationExceptionOnConverterForAttribute(String attrName);
 
-    @Message(id = 19, value = "Protocol %s not found in current stack")
-    String protocolNotFoundInStack(String protocolName);
-
     @Message(id = 20, value = "Unable to load protocol class %s")
     String unableToLoadProtocol(String protocolName);
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolMetricsHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolMetricsHandler.java
@@ -263,8 +263,6 @@ public class ProtocolMetricsHandler extends AbstractRuntimeOnlyHandler {
                 } else {
                     context.getFailureDescription().set(JGroupsLogger.ROOT_LOGGER.unknownMetric(name));
                 }
-            } else {
-                context.getFailureDescription().set(JGroupsLogger.ROOT_LOGGER.protocolNotFoundInStack(protocolName));
             }
         } catch (ClassNotFoundException | ModuleLoadException e) {
             context.getFailureDescription().set(e.getLocalizedMessage());


### PR DESCRIPTION
@kabir This would be it. Also, we don't register metrics in admin-only mode, so the problem does not happen there.
