### PR TITLE
WFLY-5220 fix multiple maven-surefire-plugin execution when -Dtest is used

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -375,7 +375,6 @@
                 </property>
             </activation>
             <build>
-                <pluginManagement>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -400,7 +399,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-                </pluginManagement>
             </build>
         </profile>
 


### PR DESCRIPTION
Multiple `maven-surefire-plugin` executions were started when `-Dtest` maven switch was used in testsuite/integration/basic.

JIRA: https://issues.jboss.org/browse/WFLY-5220
