### PR TITLE
WFLY-5221 TimerService.getTimers() returns all active timers instead …

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -397,14 +397,15 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
     @Override
     public Collection<Timer> getTimers() throws IllegalStateException, EJBException {
         assertTimerServiceState();
-        Object pk = currentPrimaryKey();
+        final Object pk = currentPrimaryKey();
+        final String timedObjectId = this.getInvoker().getTimedObjectId();
         final Set<Timer> activeTimers = new HashSet<Timer>();
         // get all active timers for this timerservice
         synchronized (this.timers) {
             for (final TimerImpl timer : this.timers.values()) {
-                if (timer.isActive()) {
+                if (timer.getTimedObjectId().equals(timedObjectId) && timer.isActive()) {
                     if (timer.getPrimaryKey() == null || timer.getPrimaryKey().equals(pk)) {
-                        activeTimers.add(timer);
+                       activeTimers.add(timer);
                     }
                 }
             }
@@ -412,7 +413,7 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
         // get all active timers which are persistent, but haven't yet been
         // persisted (waiting for tx to complete) that are in the current transaction
         for (final TimerImpl timer : getWaitingOnTxCompletionTimers().values()) {
-            if (timer.isActive()) {
+            if (timer.getTimedObjectId().equals(timedObjectId) && timer.isActive()) {
                 if (timer.getPrimaryKey() == null || timer.getPrimaryKey().equals(pk)) {
                     activeTimers.add(timer);
                 }


### PR DESCRIPTION
…of the timers associated to the current Bean

https://issues.jboss.org/browse/WFLY-5221
