### PR TITLE
WFLY-5183 permissions.xml added for VaultSystemPropertyOnServerStartTestCase to work with security manager without AllPermission

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase-permissions.xml
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase-permissions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>vault.testing.property</name>
+        <actions>read</actions>
+    </permission>
+</permissions>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase.java
@@ -55,9 +55,9 @@ import org.junit.runner.RunWith;
 
 /**
  * Test whether server starts when system property contain vault value.
- * 
+ *
  * @author olukas
- * 
+ *
  */
 @RunWith(Arquillian.class)
 public class VaultSystemPropertyOnServerStartTestCase {
@@ -149,6 +149,8 @@ public class VaultSystemPropertyOnServerStartTestCase {
     public static Archive<?> getDeployment() {
         WebArchive war = ShrinkWrap.create(WebArchive.class, DEPLOYMENT + ".war");
         war.addClass(PrintSystemPropertyServlet.class);
+        war.addAsManifestResource(VaultSystemPropertyOnServerStartTestCase.class.getPackage(),
+                VaultSystemPropertyOnServerStartTestCase.class.getSimpleName() + "-permissions.xml", "permissions.xml");
         return war;
     }
 


### PR DESCRIPTION
WFLY-5183 permissions.xml added for VaultSystemPropertyOnServerStartTestCase to work with security manager without AllPermission
Fix for https://issues.jboss.org/browse/WFLY-5183
