### PR TITLE
Do not advertise at startup if advertiseFrequency <=0 - Related to ch…

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/filters/ModClusterService.java
@@ -136,10 +136,12 @@ public class ModClusterService extends FilterService {
         config = builder.build();
 
 
-        try {
-            modCluster.advertise(config);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        if(advertiseFrequency > 0) {
+            try {
+                modCluster.advertise(config);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
         modCluster.start();
     }


### PR DESCRIPTION
…anges in WFLY-5204

Following changes made for WFLY-5204, undertow was still trying to advertise initially even when advertise-frequency was set to 0, which caused the exception noted here: https://gist.github.com/brunolitman/a4f1d83f2ba96ba7082b

I simply added an extra test around the initial call to 'advertise()'
