### PR TITLE
Name relaxedCookieHttpClient more accurately as promiscuous; avoid co…

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/cdi/CdiFailoverTestCase.java
@@ -128,7 +128,7 @@ public class CdiFailoverTestCase extends ClusterAbstractTestCase {
         URI uri1 = CdiServlet.createURI(baseURL1);
         URI uri2 = CdiServlet.createURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()){
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()){
             assertEquals(1, queryCount(client, uri1));
             assertEquals(2, queryCount(client, uri1));
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulFailoverTestCase.java
@@ -109,7 +109,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         URI uri1 = StatefulServlet.createURI(baseURL1, MODULE_NAME, PassivationIncapableIncrementorBean.class.getSimpleName());
         URI uri2 = StatefulServlet.createURI(baseURL2, MODULE_NAME, PassivationIncapableIncrementorBean.class.getSimpleName());
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             assertEquals(1, queryCount(client, uri1));
             assertEquals(2, queryCount(client, uri1));
 
@@ -185,7 +185,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         URI uri1 = StatefulServlet.createURI(baseURL1, MODULE_NAME, beanClass.getSimpleName());
         URI uri2 = StatefulServlet.createURI(baseURL2, MODULE_NAME, beanClass.getSimpleName());
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             assertEquals(1, queryCount(client, uri1));
             assertEquals(2, queryCount(client, uri1));
 
@@ -231,7 +231,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         URI uri1 = StatefulServlet.createURI(baseURL1, MODULE_NAME, SimpleIncrementorBean.class.getSimpleName());
         URI uri2 = StatefulServlet.createURI(baseURL2, MODULE_NAME, SimpleIncrementorBean.class.getSimpleName());
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             assertEquals(1, queryCount(client, uri1));
             assertEquals(2, queryCount(client, uri1));
 
@@ -278,7 +278,7 @@ public class StatefulFailoverTestCase extends ClusterAbstractTestCase {
         URI uri1 = StatefulServlet.createURI(baseURL1, MODULE_NAME, NestedIncrementorBean.class.getSimpleName());
         URI uri2 = StatefulServlet.createURI(baseURL2, MODULE_NAME, NestedIncrementorBean.class.getSimpleName());
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             assertEquals(20010101, queryCount(client, uri1));
             assertEquals(20020202, queryCount(client, uri1));
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/stateful/StatefulTimeoutTestCase.java
@@ -96,7 +96,7 @@ public class StatefulTimeoutTestCase extends ClusterAbstractTestCase {
         URI uri1 = StatefulServlet.createURI(baseURL1, MODULE_NAME, TimeoutIncrementorBean.class.getSimpleName());
         URI uri2 = StatefulServlet.createURI(baseURL2, MODULE_NAME, TimeoutIncrementorBean.class.getSimpleName());
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             assertEquals(1, queryCount(client, uri1));
             assertEquals(2, queryCount(client, uri1));
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/xpc/StatefulWithXPCFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/xpc/StatefulWithXPCFailoverTestCase.java
@@ -138,7 +138,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         URI xpc1_secondLevelCacheEntries_url = StatefulServlet.getEmployeesIn2LCURI(baseURL1);
         URI xpc2_secondLevelCacheEntries_url = StatefulServlet.getEmployeesIn2LCURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             assertExecuteUrl(client, StatefulServlet.echoURI(baseURL1, "StartingTestSecondLevelCache"));  // echo message to server.log
             assertExecuteUrl(client, StatefulServlet.echoURI(baseURL2, "StartingTestSecondLevelCache")); // echo message to server.log
 
@@ -201,7 +201,7 @@ public class StatefulWithXPCFailoverTestCase extends ClusterAbstractTestCase {
         URI xpc2_getempsecond_url = StatefulServlet.get2ndBeanEmployeeURI(baseURL2);
         URI xpc2_getdestroy_url = StatefulServlet.destroyURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             stop(CONTAINER_2);
 
             // extended persistence context is available on node1

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/jsf/JSFFailoverTestCase.java
@@ -208,7 +208,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
 
         log.info("URLs are: " + url1 + ", " + url2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response;
             NumberGuessState state;
 
@@ -332,7 +332,7 @@ public class JSFFailoverTestCase extends ClusterAbstractTestCase {
         String url1 = baseURL1.toString() + "home.jsf";
         String url2 = baseURL2.toString() + "home.jsf";
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response;
             NumberGuessState state;
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonDeploymentTestCase.java
@@ -71,7 +71,7 @@ public abstract class SingletonDeploymentTestCase extends ClusterAbstractTestCas
         // baseURL2 will not have been resolved, since the deployment would not have started
         URI uri2 = TraceServlet.createURI(new URL(baseURL2.getProtocol(), baseURL2.getHost(), baseURL2.getPort(), baseURL1.getFile()));
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpTrace(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/singleton/SingletonServiceTestCase.java
@@ -93,7 +93,7 @@ public class SingletonServiceTestCase extends ClusterAbstractTestCase {
         URI quorumURI1 = MyServiceServlet.createURI(baseURL1, MyService.QUORUM_SERVICE_NAME);
         URI quorumURI2 = MyServiceServlet.createURI(baseURL2, MyService.QUORUM_SERVICE_NAME);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(defaultURI1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebFailoverAbstractCase.java
@@ -104,7 +104,7 @@ public abstract class ClusteredWebFailoverAbstractCase extends ClusterAbstractTe
     }
 
     private void testFailover(Lifecycle lifecycle, URL baseURL1, URL baseURL2) throws IOException, URISyntaxException {
-        HttpClient client = TestHttpClientUtils.relaxedCookieHttpClient();
+        HttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient();
 
         URI uri1 = SimpleServlet.createURI(baseURL1);
         URI uri2 = SimpleServlet.createURI(baseURL2);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ClusteredWebSimpleTestCase.java
@@ -95,7 +95,7 @@ public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
         // returns the URL of the deployment (http://127.0.0.1:8180/distributable)
         URI uri = SimpleServlet.createURI(baseURL);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -127,7 +127,7 @@ public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
         URI url1 = SimpleServlet.createURI(baseURL1);
         URI url2 = SimpleServlet.createURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(url1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
@@ -193,7 +193,7 @@ public class ClusteredWebSimpleTestCase extends ClusterAbstractTestCase {
 
     private void abstractGracefulServe(URL baseURL, boolean undeployOnly) throws URISyntaxException, IOException, InterruptedException {
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             URI uri = SimpleServlet.createURI(baseURL);
 
             // Make sure a normal request will succeed

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ExternalizerTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ExternalizerTestCase.java
@@ -90,7 +90,7 @@ public class ExternalizerTestCase extends ClusterAbstractTestCase {
         URI uri1 = CounterServlet.createURI(baseURL1);
         URI uri2 = CounterServlet.createURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             assertValue(client, uri1, 1);
             assertValue(client, uri1, 2);
 

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonDistributableTestCase.java
@@ -83,7 +83,7 @@ public class NonDistributableTestCase extends ClusterAbstractTestCase {
         URI uri1 = SimpleServlet.createURI(baseURL1);
         URI uri2 = SimpleServlet.createURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri1));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/NonHaWebSessionPersistenceTestCase.java
@@ -89,7 +89,7 @@ public class NonHaWebSessionPersistenceTestCase extends ClusterAbstractTestCase 
 
         URI url = SimpleServlet.createURI(baseURL);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(url));
             Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
             Assert.assertEquals(1, Integer.parseInt(response.getFirstHeader("value").getValue()));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/ReplicationForNegotiationAuthenticatorTestCase.java
@@ -86,7 +86,7 @@ public class ReplicationForNegotiationAuthenticatorTestCase extends ClusteredWeb
         URI uri1 = SimpleServlet.createURI(baseURL1);
         URI uri2 = SimpleServlet.createURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
 
             HttpResponse response = client.execute(new HttpGet(uri1));
             try {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/async/AsyncServletTestCase.java
@@ -89,7 +89,7 @@ public class AsyncServletTestCase extends ClusterAbstractTestCase {
         URI uri1 = AsyncServlet.createURI(baseURL1);
         URI uri2 = AsyncServlet.createURI(baseURL2);
 
-        HttpClient client = TestHttpClientUtils.relaxedCookieHttpClient();
+        HttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient();
 
         try {
             assertValue(client, uri1, 1);

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/FormAuthenticationWebFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/authentication/FormAuthenticationWebFailoverTestCase.java
@@ -96,7 +96,7 @@ public class FormAuthenticationWebFailoverTestCase extends ClusterAbstractTestCa
         URI uri1 = SecureServlet.createURI(baseURL1);
         URI uri2 = SecureServlet.createURI(baseURL2);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             System.out.println(uri1);
             HttpResponse response = client.execute(new HttpGet(uri1));
             try {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/context/InvalidateConversationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/context/InvalidateConversationTestCase.java
@@ -92,7 +92,7 @@ public class InvalidateConversationTestCase extends ClusterAbstractTestCase {
 
         establishTopology(baseURL1, NODES);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(ConversationServlet.createURI(baseURL1)));
             try {
                 assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/expiration/SessionExpirationTestCase.java
@@ -60,7 +60,7 @@ public abstract class SessionExpirationTestCase extends ClusterAbstractTestCase 
     public void test(@ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_1) URL baseURL1,
                      @ArquillianResource(SessionOperationServlet.class) @OperateOnDeployment(DEPLOYMENT_2) URL baseURL2)
                              throws IOException, URISyntaxException, InterruptedException {
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             // This should trigger session creation event, but not added attribute event
             HttpResponse response = client.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a")));
             try {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/passivation/SessionPassivationTestCase.java
@@ -64,8 +64,8 @@ public abstract class SessionPassivationTestCase extends ClusterAbstractTestCase
         String session1 = null;
         String session2 = null;
 
-        try (CloseableHttpClient client1 = TestHttpClientUtils.relaxedCookieHttpClient();
-             CloseableHttpClient client2 = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client1 = TestHttpClientUtils.promiscuousCookieHttpClient();
+             CloseableHttpClient client2 = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             // This should not trigger any passivation/activation events
             HttpResponse response = client1.execute(new HttpGet(SessionOperationServlet.createSetURI(baseURL1, "a", "1")));
             try {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/web/shared/SharedSessionFailoverTestCase.java
@@ -101,7 +101,7 @@ public class SharedSessionFailoverTestCase extends ClusterAbstractTestCase {
         URI uri21 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_1).toURL());
         URI uri22 = SimpleServlet.createURI(baseURL2.toURI().resolve(MODULE_2).toURL());
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri11));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/singleton/SingletonServiceTestCase.java
@@ -75,7 +75,7 @@ public class SingletonServiceTestCase {
         URI defaultURI = MyServiceServlet.createURI(baseURL, MyService.DEFAULT_SERVICE_NAME);
         URI quorumURI = MyServiceServlet.createURI(baseURL, MyService.QUORUM_SERVICE_NAME);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(defaultURI));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/single/web/SimpleWebTestCase.java
@@ -71,7 +71,7 @@ public class SimpleWebTestCase {
 
         URI uri = SimpleServlet.createURI(baseURL);
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             HttpResponse response = client.execute(new HttpGet(uri));
             try {
                 Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteBackupForTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteBackupForTestCase.java
@@ -139,7 +139,7 @@ public class XSiteBackupForTestCase extends ExtendedClusterAbstractTestCase {
         URI url3 = CacheAccessServlet.createGetURI(baseURL3, "a");
         URI url4 = CacheAccessServlet.createGetURI(baseURL4, "a");
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             // put a value to LON-0
             System.out.println("Executing HTTP request: " + url1);
             HttpResponse response = client.execute(new HttpGet(url1));

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/xsite/XSiteSimpleTestCase.java
@@ -128,7 +128,7 @@ public class XSiteSimpleTestCase extends ExtendedClusterAbstractTestCase {
         URI url3 = CacheAccessServlet.createGetURI(baseURL3, "a");
         URI url4 = CacheAccessServlet.createGetURI(baseURL4, "a");
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             // put a value to LON-0
             System.out.println("Executing HTTP request: " + url1);
             HttpResponse response = client.execute(new HttpGet(url1));
@@ -183,7 +183,7 @@ public class XSiteSimpleTestCase extends ExtendedClusterAbstractTestCase {
         URI url1 = CacheAccessServlet.createGetURI(baseURL1, "b");
         URI url3 = CacheAccessServlet.createPutURI(baseURL3, "b", "200");
 
-        try (CloseableHttpClient client = TestHttpClientUtils.relaxedCookieHttpClient()) {
+        try (CloseableHttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient()) {
             // put a value to NYC-0
             System.out.println("Executing HTTP request: " + url3);
             HttpResponse response = client.execute(new HttpGet(url3));

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/sharedsession/SharedSessionTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/sharedsession/SharedSessionTestCase.java
@@ -82,7 +82,7 @@ public class SharedSessionTestCase {
     @OperateOnDeployment(EAR_DEPLOYMENT_SHARED_SESSIONS)
     public void testSharedSessionsOneEar() throws IOException {
         // Note that this test should not need to use a relaxed domain handling, however the http client does not treat ipv6 domains (e.g. ::1) properly
-        HttpClient client = TestHttpClientUtils.relaxedCookieHttpClient();
+        HttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient();
 
         HttpGet get1 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war1/SharedSessionServlet");
         HttpGet get2 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war2/SharedSessionServlet");
@@ -113,7 +113,7 @@ public class SharedSessionTestCase {
     @OperateOnDeployment(EAR_DEPLOYMENT_NOT_SHARED_SESSIONS)
     public void testNotSharedSessions() throws IOException {
         // Note that this test should not need to use a relaxed domain handling, however the http client does not treat ipv6 domains (e.g. ::1) properly
-        HttpClient client = TestHttpClientUtils.relaxedCookieHttpClient();
+        HttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient();
 
         HttpGet getX = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/warX/SharedSessionServlet");
         HttpGet getY = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/warY/SharedSessionServlet");
@@ -139,7 +139,7 @@ public class SharedSessionTestCase {
     @Test
     public void testSharedSessionsDoNotInterleave() throws IOException {
         // Note that this test should not need to use a relaxed domain handling, however the http client does not treat ipv6 domains (e.g. ::1) properly
-        HttpClient client = TestHttpClientUtils.relaxedCookieHttpClient();
+        HttpClient client = TestHttpClientUtils.promiscuousCookieHttpClient();
 
         HttpGet get1 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war1/SharedSessionServlet");
         HttpGet get2 = new HttpGet("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/war2/SharedSessionServlet");

--- a/testsuite/shared/src/main/java/org/jboss/as/test/http/util/TestHttpClientUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/http/util/TestHttpClientUtils.java
@@ -107,46 +107,46 @@ public class TestHttpClientUtils {
      * As we don't actually have a load balancer for the clustering tests, we use this instead.
      *
      * @return {@link CloseableHttpClient} that gives free cookies to everybody
-     * @see TestHttpClientUtils#relaxedCookieHttpClientBuilder()
+     * @see TestHttpClientUtils#promiscuousCookieHttpClientBuilder()
      * @see <a href="http://tools.ietf.org/html/rfc6265">RFC6265 -  HTTP State Management Mechanism</a>
      */
-    public static CloseableHttpClient relaxedCookieHttpClient() {
+    public static CloseableHttpClient promiscuousCookieHttpClient() {
 
-        return relaxedCookieHttpClientBuilder().build();
+        return promiscuousCookieHttpClientBuilder().build();
     }
 
     /**
-     * Same as {@link TestHttpClientUtils#relaxedCookieHttpClient()} but instead returns a builder that can be further configured.
+     * Same as {@link TestHttpClientUtils#promiscuousCookieHttpClient()} but instead returns a builder that can be further configured.
      *
      * @return {@link HttpClientBuilder} of the http client that gives free cookies to everybody
-     * @see TestHttpClientUtils#relaxedCookieHttpClient()
+     * @see TestHttpClientUtils#promiscuousCookieHttpClient()
      */
-    public static HttpClientBuilder relaxedCookieHttpClientBuilder() {
+    public static HttpClientBuilder promiscuousCookieHttpClientBuilder() {
 
         HttpClientBuilder builder = HttpClients.custom();
 
         RegistryBuilder<CookieSpecProvider> registryBuilder = CookieSpecRegistries.createDefaultBuilder();
-        Registry<CookieSpecProvider> relaxedCookieSpecRegistry = registryBuilder.register("relaxed", new RelaxedCookieSpecProvider()).build();
-        builder.setDefaultCookieSpecRegistry(relaxedCookieSpecRegistry);
+        Registry<CookieSpecProvider> promiscuousCookieSpecRegistry = registryBuilder.register("promiscuous", new PromiscuousCookieSpecProvider()).build();
+        builder.setDefaultCookieSpecRegistry(promiscuousCookieSpecRegistry);
 
-        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec("relaxed").build();
+        RequestConfig requestConfig = RequestConfig.custom().setCookieSpec("promiscuous").build();
         builder.setDefaultRequestConfig(requestConfig);
 
         return builder;
     }
 
 
-    private static class RelaxedCookieSpecProvider implements CookieSpecProvider {
+    private static class PromiscuousCookieSpecProvider implements CookieSpecProvider {
 
         @Override
         public CookieSpec create(HttpContext context) {
-            return new RelaxedCookieSpec();
+            return new PromiscuousCookieSpec();
         }
     }
 
-    private static class RelaxedCookieSpec extends RFC6265CookieSpec {
+    private static class PromiscuousCookieSpec extends RFC6265CookieSpec {
 
-        RelaxedCookieSpec(CommonCookieAttributeHandler... handlers) {
+        PromiscuousCookieSpec(CommonCookieAttributeHandler... handlers) {
             super(
                     new BasicPathHandler(),
                     new BasicDomainHandler() {

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/SSOTestBase.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/web/sso/SSOTestBase.java
@@ -84,7 +84,7 @@ public abstract class SSOTestBase {
 
         // Start by accessing the secured index.html of war1
         CookieStore store = new BasicCookieStore();
-        HttpClient httpclient = TestHttpClientUtils.relaxedCookieHttpClientBuilder()
+        HttpClient httpclient = TestHttpClientUtils.promiscuousCookieHttpClientBuilder()
                 .setDefaultCookieStore(store)
                 .disableRedirectHandling()
                 .build();
@@ -134,7 +134,7 @@ public abstract class SSOTestBase {
 
         // Start by accessing the secured index.html of war1
         CookieStore store = new BasicCookieStore();
-        HttpClient httpclient = TestHttpClientUtils.relaxedCookieHttpClientBuilder().setDefaultCookieStore(store).build();
+        HttpClient httpclient = TestHttpClientUtils.promiscuousCookieHttpClientBuilder().setDefaultCookieStore(store).build();
         try {
             checkAccessDenied(httpclient, warA1 + "index.html");
 


### PR DESCRIPTION
…nfusion with http client's "Standard" / "RFC6265LaxSpec" state
management policy compliant with a relaxed profile defined by RFC 6265
