### PR TITLE
[WFLY-5084] Warning for unmigrated discovery-group attributes

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -814,4 +814,7 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 83, value = "Could not migrate the HA configuration of %s. Its shared-store and backup attributes holds expressions and it is not possible to determine unambiguously how to create the corresponding ha-policy for the messaging-activemq's server.")
     String couldNotMigrateHA(PathAddress address);
+
+    @Message(id = 84, value = "Could not migrate attribute %s from resource %s. Use instead the socket-attribute to configure this discovery-group.")
+    String couldNotMigrateDiscoveryGroupAttribute(String attribute, PathAddress address);
 }

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -156,9 +156,10 @@ public class MigrateTestCase extends AbstractSubsystemTest {
 
         ModelNode warnings = response.get(RESULT, "migration-warnings");
         // 6 warnings about broadcast-group attributes that can not be migrated.
+        // 5 warnings about discovery-group attributes that can not be migrated.
         // 2 warnings about interceptors that can not be migrated.
         // 1 warning about HA migration (attributes have expressions)
-        assertEquals(warnings.toString(), 6 + 2 + 1, warnings.asList().size());
+        assertEquals(warnings.toString(), 6 + 5 + 2 + 1, warnings.asList().size());
 
         model = services.readWholeModel();
 


### PR DESCRIPTION
Add migration-warnings when discovery-group attributes can not be be
migrated.

JIRA: https://issues.jboss.org/browse/WFLY-5084
