### PR TITLE
[WFLY-5177] VaultedInjectedJMSContextTestCase is unable create sessio…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/VaultedInjectedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/VaultedInjectedJMSContextTestCase.java
@@ -37,6 +37,8 @@ import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.net.SocketPermission;
+import java.util.PropertyPermission;
 import java.util.UUID;
 
 import javax.annotation.Resource;
@@ -150,7 +152,12 @@ public class VaultedInjectedJMSContextTestCase {
                 .addClass(TimeoutUtil.class)
                 .addPackage(VaultedMessageProducer.class.getPackage())
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsResource(createPermissionsXmlAsset(new RuntimePermission("getProtectionDomain")), "META-INF/jboss-permissions.xml");
+                .addAsResource(createPermissionsXmlAsset(new RuntimePermission("getProtectionDomain"),
+                        new PropertyPermission("ts.timeout.factor", "read"),
+                        // required because the VaultedMessageProducer uses the RemoteConnectionFactory
+                        // (that requires auth with vaulted credentials)
+                        new SocketPermission("*", "connect"),
+                        new RuntimePermission("setContextClassLoader")), "META-INF/jboss-permissions.xml");
     }
 
     @Test


### PR DESCRIPTION
…n factory with security manager

The test requires additional security permissions as it uses a remote
connection factory (to check vaulted credentials)

JIRA: https://issues.jboss.org/browse/WFLY-5177
