### PR TITLE
[WFLY-914] Use undefinedMetricValue rather than undefined where it ma…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/resourceadapters/Constants.java
@@ -531,36 +531,49 @@ public class Constants {
     static final String START_WORK_REJECTED_NAME = "startwork-rejected";
 
 
-    static SimpleAttributeDefinition WORK_ACTIVE = new SimpleAttributeDefinitionBuilder(WORK_ACTIVE_NAME, ModelType.INT, true)
+    static SimpleAttributeDefinition WORK_ACTIVE = new SimpleAttributeDefinitionBuilder(WORK_ACTIVE_NAME, ModelType.INT)
             .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
-    static SimpleAttributeDefinition WORK_SUCCESSFUL = new SimpleAttributeDefinitionBuilder(WORK_SUCEESSFUL_NAME, ModelType.INT, true)
+    static SimpleAttributeDefinition WORK_SUCCESSFUL = new SimpleAttributeDefinitionBuilder(WORK_SUCEESSFUL_NAME, ModelType.INT)
             .setStorageRuntime()
-            .build();
-    static SimpleAttributeDefinition WORK_FAILED = new SimpleAttributeDefinitionBuilder(WORK_FAILED_NAME, ModelType.INT, true)
-            .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
-    static SimpleAttributeDefinition DO_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(DO_WORK_ACCEPTED_NAME, ModelType.INT, true)
+    static SimpleAttributeDefinition WORK_FAILED = new SimpleAttributeDefinitionBuilder(WORK_FAILED_NAME, ModelType.INT)
             .setStorageRuntime()
-            .build();
-    static SimpleAttributeDefinition DO_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(DO_WORK_REJECTED_NAME, ModelType.INT, true)
-            .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
-    static SimpleAttributeDefinition SCHEDULED_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_ACCEPTED_NAME, ModelType.INT, true)
+    static SimpleAttributeDefinition DO_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(DO_WORK_ACCEPTED_NAME, ModelType.INT)
             .setStorageRuntime()
-            .build();
-    static SimpleAttributeDefinition SCHEDULED_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_REJECTED_NAME, ModelType.INT, true)
-            .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
-    static SimpleAttributeDefinition START_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(START_WORK_ACCEPTED_NAME, ModelType.INT, true)
+    static SimpleAttributeDefinition DO_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(DO_WORK_REJECTED_NAME, ModelType.INT)
             .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
-    static SimpleAttributeDefinition START_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(START_WORK_REJECTED_NAME, ModelType.INT, true)
+
+    static SimpleAttributeDefinition SCHEDULED_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_ACCEPTED_NAME, ModelType.INT)
             .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
+            .build();
+
+    static SimpleAttributeDefinition SCHEDULED_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(SCHEDULED_WORK_REJECTED_NAME, ModelType.INT)
+            .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
+            .build();
+
+    static SimpleAttributeDefinition START_WORK_ACCEPTED = new SimpleAttributeDefinitionBuilder(START_WORK_ACCEPTED_NAME, ModelType.INT)
+            .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
+            .build();
+
+    static SimpleAttributeDefinition START_WORK_REJECTED = new SimpleAttributeDefinitionBuilder(START_WORK_REJECTED_NAME, ModelType.INT)
+            .setStorageRuntime()
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentResourceDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/AbstractEJBComponentResourceDefinition.java
@@ -57,17 +57,17 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
             .build();
 
     private static final AttributeDefinition EXECUTION_TIME = new SimpleAttributeDefinitionBuilder("execution-time", ModelType.LONG)
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition INVOCATIONS = new SimpleAttributeDefinitionBuilder("invocations", ModelType.LONG)
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition PEAK_CONCURRENT_INVOCATIONS = new SimpleAttributeDefinitionBuilder("peak-concurrent-invocations", ModelType.LONG)
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
@@ -76,7 +76,7 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
             .build();
 
     private static final AttributeDefinition WAIT_TIME = new SimpleAttributeDefinitionBuilder("wait-time", ModelType.LONG)
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
@@ -97,17 +97,18 @@ public abstract class AbstractEJBComponentResourceDefinition extends SimpleResou
             .build();
 
     private static final AttributeDefinition CACHE_SIZE = new SimpleAttributeDefinitionBuilder("cache-size", ModelType.LONG)
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition PASSIVATED_SIZE = new SimpleAttributeDefinitionBuilder("passivated-count",
-            ModelType.LONG).setAllowNull(true)
+            ModelType.LONG)
+            .setUndefinedMetricValue(new ModelNode(0))
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 
     private static final AttributeDefinition TOTAL_SIZE = new SimpleAttributeDefinitionBuilder("total-size", ModelType.LONG)
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .setFlags(AttributeAccess.Flag.STORAGE_RUNTIME)
             .build();
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -111,7 +111,7 @@ public interface CommonAttributes {
 
     AttributeDefinition DELIVERING_COUNT = create("delivering-count", INT)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     StringListAttributeDefinition DESTINATION_ENTRIES = new StringListAttributeDefinition.Builder(ENTRIES)
@@ -197,12 +197,12 @@ public interface CommonAttributes {
 
     AttributeDefinition MESSAGE_COUNT = create("message-count", LONG)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     AttributeDefinition MESSAGES_ADDED = create("messages-added", LONG)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     AttributeDefinition MIN_LARGE_MESSAGE_SIZE = create("min-large-message-size", INT)
@@ -259,7 +259,7 @@ public interface CommonAttributes {
 
     AttributeDefinition SCHEDULED_COUNT = create("scheduled-count", LONG)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     SimpleAttributeDefinition SELECTOR = create("selector", ModelType.STRING)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSTopicDefinition.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.controller.StringListAttributeDefinition;
 import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.dmr.ModelNode;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingExtension;
 
@@ -73,27 +74,27 @@ public class JMSTopicDefinition extends PersistentResourceDefinition {
 
     static final AttributeDefinition DURABLE_MESSAGE_COUNT = create(CommonAttributes.DURABLE_MESSAGE_COUNT, INT)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     static final AttributeDefinition NON_DURABLE_MESSAGE_COUNT = create(CommonAttributes.NON_DURABLE_MESSAGE_COUNT, INT)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     static final AttributeDefinition SUBSCRIPTION_COUNT = create(CommonAttributes.SUBSCRIPTION_COUNT, INT)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     static final AttributeDefinition DURABLE_SUBSCRIPTION_COUNT = create(CommonAttributes.DURABLE_SUBSCRIPTION_COUNT, INT)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     static final AttributeDefinition NON_DURABLE_SUBSCRIPTION_COUNT = create(CommonAttributes.NON_DURABLE_SUBSCRIPTION_COUNT, INT)
             .setStorageRuntime()
-            .setAllowNull(true)
+            .setUndefinedMetricValue(new ModelNode(0))
             .build();
 
     static final AttributeDefinition[] METRICS = { CommonAttributes.DELIVERING_COUNT,

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentDefinition.java
@@ -169,14 +169,21 @@ public class DeploymentDefinition extends SimpleResourceDefinition {
     }
 
     public enum SessionStat {
-        ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("active-sessions", ModelType.INT, true).setStorageRuntime().build()),
-        EXPIRED_SESSIONS(new SimpleAttributeDefinitionBuilder("expired-sessions", ModelType.INT, true).setStorageRuntime().build()),
-        SESSIONS_CREATED(new SimpleAttributeDefinitionBuilder("sessions-created", ModelType.INT, true).setStorageRuntime().build()),
+        ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("active-sessions", ModelType.INT)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        EXPIRED_SESSIONS(new SimpleAttributeDefinitionBuilder("expired-sessions", ModelType.INT)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        SESSIONS_CREATED(new SimpleAttributeDefinitionBuilder("sessions-created", ModelType.INT)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
         //DUPLICATED_SESSION_IDS(new SimpleAttributeDefinition("duplicated-session-ids", ModelType.INT, false)),
-        SESSION_AVG_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-avg-alive-time", ModelType.INT, true).setStorageRuntime().build()),
-        SESSION_MAX_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-max-alive-time", ModelType.INT, true).setStorageRuntime().build()),
-        REJECTED_SESSIONS(new SimpleAttributeDefinitionBuilder("rejected-sessions", ModelType.INT, true).setStorageRuntime().build()),
-        MAX_ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("max-active-sessions", ModelType.INT, true).setStorageRuntime().build());
+        SESSION_AVG_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-avg-alive-time", ModelType.INT)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        SESSION_MAX_ALIVE_TIME(new SimpleAttributeDefinitionBuilder("session-max-alive-time", ModelType.INT)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        REJECTED_SESSIONS(new SimpleAttributeDefinitionBuilder("rejected-sessions", ModelType.INT)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        MAX_ACTIVE_SESSIONS(new SimpleAttributeDefinitionBuilder("max-active-sessions", ModelType.INT)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build());
 
         private static final Map<String, SessionStat> MAP = new HashMap<>();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ListenerResourceDefinition.java
@@ -147,12 +147,18 @@ abstract class ListenerResourceDefinition extends PersistentResourceDefinition {
     public static final OptionAttributeDefinition REQUEST_PARSE_TIMEOUT = OptionAttributeDefinition.builder("request-parse-timeout", UndertowOptions.REQUEST_PARSE_TIMEOUT).setMeasurementUnit(MeasurementUnit.MILLISECONDS).setAllowNull(true).setAllowExpression(true).build();
 
     public enum ConnectorStat {
-        REQUEST_COUNT(new SimpleAttributeDefinitionBuilder("request-count", ModelType.LONG, true).setStorageRuntime().build()),
-        BYTES_SENT(new SimpleAttributeDefinitionBuilder("bytes-sent", ModelType.LONG, true).setStorageRuntime().build()),
-        BYTES_RECEIVED(new SimpleAttributeDefinitionBuilder("bytes-received", ModelType.LONG, true).setStorageRuntime().build()),
-        ERROR_COUNT(new SimpleAttributeDefinitionBuilder("error-count", ModelType.LONG, true).setStorageRuntime().build()),
-        PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("processing-time", ModelType.LONG, true).setStorageRuntime().build()),
-        MAX_PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("max-processing-time", ModelType.LONG, true).setStorageRuntime().build());
+        REQUEST_COUNT(new SimpleAttributeDefinitionBuilder("request-count", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        BYTES_SENT(new SimpleAttributeDefinitionBuilder("bytes-sent", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        BYTES_RECEIVED(new SimpleAttributeDefinitionBuilder("bytes-received", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        ERROR_COUNT(new SimpleAttributeDefinitionBuilder("error-count", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("processing-time", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build()),
+        MAX_PROCESSING_TIME(new SimpleAttributeDefinitionBuilder("max-processing-time", ModelType.LONG)
+                .setUndefinedMetricValue(new ModelNode(0)).setStorageRuntime().build());
 
         private static final Map<String, ConnectorStat> MAP = new HashMap<>();
 


### PR DESCRIPTION
…kes sense

This is a follow up commit to https://github.com/wildfly/wildfly/pull/7991/files after speaking to Brian. 

Note that for the jgroups metrics I am still using undefined, since they are pulled out of jgroups so there is no clear idea of what is what. 
