### PR TITLE
WFLY-5176 permissions.xml files added to deployments for login in test cases to work with security manager without AllPermission

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnotationAuthorizationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AnnotationAuthorizationTestCase.java
@@ -65,15 +65,17 @@ public class AnnotationAuthorizationTestCase {
 
     @Deployment
     public static Archive<?> runAsDeployment() {
+        final Package currentPackage = AnnotationAuthorizationTestCase.class.getPackage();
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "ejb3security.war")
                 .addPackage(RolesAllowedOverrideBean.class.getPackage()).addClass(Util.class)
                 .addClasses(AnnotationAuthorizationTestCase.class)
                 .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
-                .addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "users.properties", "users.properties")
-                .addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "roles.properties", "roles.properties")
-                .addAsWebInfResource(AnnotationAuthorizationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
-                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage, "roles.properties", "roles.properties")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml")
+                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF")
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase-permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase-permissions.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>javax.security.auth.AuthPermission</class-name>
+        <name>modifyPrincipals</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>org.jboss.security.getSecurityContext</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>org.jboss.security.SecurityContextFactory.createSecurityContext</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>org.jboss.security.SecurityContextFactory.createUtil</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>org.jboss.security.plugins.JBossSecurityContext.setSubjectInfo</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>org.jboss.security.setSecurityContext</name>
+    </permission>
+</permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/AuthenticationTestCase.java
@@ -96,18 +96,20 @@ public class AuthenticationTestCase {
 
     @Deployment
     public static Archive<?> deployment() {
+        final Package currentPackage = AuthenticationTestCase.class.getPackage();
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "ejb3security.war")
                 .addPackage(WhoAmIBean.class.getPackage()).addPackage(EntryBean.class.getPackage())
                 .addClass(WhoAmI.class).addClass(Util.class).addClass(Entry.class)
                 .addClasses(WhoAmIServlet.class, AuthenticationTestCase.class)
                 .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
-                .addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "users.properties", "users.properties")
-                .addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "roles.properties", "roles.properties")
-                .addAsWebInfResource(AnnotationAuthorizationTestCase.class.getPackage(), "web.xml", "web.xml")
-                .addAsWebInfResource(AnnotationAuthorizationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
-                .addAsWebInfResource(AuthenticationTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage, "roles.properties", "roles.properties")
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF")
+                .addAsManifestResource(currentPackage, AuthenticationTestCase.class.getSimpleName() + "-permissions.xml", "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/EJBInWarDefaultSecurityDomainTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/EJBInWarDefaultSecurityDomainTestCase.java
@@ -65,13 +65,16 @@ public class EJBInWarDefaultSecurityDomainTestCase {
 
     @Deployment
     public static WebArchive createDeployment() {
-        final WebArchive war = ShrinkWrap.create(WebArchive.class, "ejb-security-test.war");
-        war.addClasses(BeanWithoutExplicitSecurityDomain.class, Restriction.class, FullAccess.class, EjbSecurityDomainSetup.class, Util.class);
-        war.addAsWebInfResource(EJBInWarDefaultSecurityDomainTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
-        war.addPackage(CommonCriteria.class.getPackage());
-        war.addPackage(AbstractSecurityDomainSetup.class.getPackage());
-        war.addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "users.properties", "users.properties");
-        war.addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "roles.properties", "roles.properties");
+        final Package currentPackage = EJBInWarDefaultSecurityDomainTestCase.class.getPackage();
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, "ejb-security-test.war")
+                .addClasses(BeanWithoutExplicitSecurityDomain.class, Restriction.class)
+                .addClasses(FullAccess.class, EjbSecurityDomainSetup.class, Util.class)
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml")
+                .addPackage(CommonCriteria.class.getPackage())
+                .addPackage(AbstractSecurityDomainSetup.class.getPackage())
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage, "roles.properties", "roles.properties")
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/LifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/LifecycleTestCase.java
@@ -71,16 +71,18 @@ public class LifecycleTestCase  {
 
     @Deployment
     public static Archive<?> runAsDeployment() {
+        final Package currentPackage = LifecycleTestCase.class.getPackage();
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "ejb3security.war")
                 .addPackage(EntryBean.class.getPackage())
                 .addClasses(Util.class) // TODO - Should not need to exclude the interfaces.
                 .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
-                .addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "users.properties", "users.properties")
-                .addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "roles.properties", "roles.properties")
-                .addAsWebInfResource(AnnotationAuthorizationTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
-                .addAsWebInfResource(LifecycleTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage, "roles.properties", "roles.properties")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF")
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/SecurityDDOverrideTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/SecurityDDOverrideTestCase.java
@@ -58,15 +58,17 @@ public class SecurityDDOverrideTestCase {
 
     @Deployment
     public static Archive<?> runAsDeployment() {
-        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb3-security-partial-dd-test.jar");
-        jar.addPackage(PartialDDBean.class.getPackage());
-        jar.addClass(Util.class);
-        jar.addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class);
-        jar.addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "users.properties", "users.properties");
-        jar.addAsResource(AnnotationAuthorizationTestCase.class.getPackage(), "roles.properties", "roles.properties");
-        jar.addAsManifestResource(AnnotationAuthorizationTestCase.class.getPackage(), "partial-ejb-jar.xml", "ejb-jar.xml");
-        jar.addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
-        jar.addPackage(CommonCriteria.class.getPackage());
+        final Package currentPackage = SecurityDDOverrideTestCase.class.getPackage();
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "ejb3-security-partial-dd-test.jar")
+                .addPackage(PartialDDBean.class.getPackage())
+                .addClass(Util.class)
+                .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage, "roles.properties", "roles.properties")
+                .addAsManifestResource(currentPackage, "partial-ejb-jar.xml", "ejb-jar.xml")
+                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF")
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml")
+                .addPackage(CommonCriteria.class.getPackage());
         logger.info(jar.toString(true));
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/asynchronous/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/asynchronous/permissions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>javax.security.auth.AuthPermission</class-name>
+        <name>modifyPrincipals</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>org.jboss.security.getSecurityContext</name>
+    </permission>
+</permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsDefaultAllowedTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsDefaultAllowedTestCase.java
@@ -22,7 +22,6 @@
 
 package org.jboss.as.test.integration.ejb.security.missingmethodpermission;
 
-import java.lang.annotation.Annotation;
 
 import javax.ejb.EJBAccessException;
 import javax.naming.InitialContext;
@@ -111,24 +110,27 @@ public class MissingMethodPermissionsDefaultAllowedTestCase {
 
     @Deployment
     public static Archive createDeployment() {
-        final JavaArchive ejbJarOne = ShrinkWrap.create(JavaArchive.class, MODULE_ONE_NAME + ".jar");
-        ejbJarOne.addClasses(SecuredBeanOne.class);
-        ejbJarOne.addAsManifestResource(SecuredBeanOne.class.getPackage(), "one-jboss-ejb3.xml", "jboss-ejb3.xml");
+        final Package currentPackage = MissingMethodPermissionsDefaultAllowedTestCase.class.getPackage();
 
-        final JavaArchive ejbJarTwo = ShrinkWrap.create(JavaArchive.class, MODULE_TWO_NAME + ".jar");
-        ejbJarTwo.addClass(SecuredBeanTwo.class);
-        ejbJarTwo.addAsManifestResource(SecuredBeanTwo.class.getPackage(), "two-jboss-ejb3.xml", "jboss-ejb3.xml");
+        final JavaArchive ejbJarOne = ShrinkWrap.create(JavaArchive.class, MODULE_ONE_NAME + ".jar")
+                .addClasses(SecuredBeanOne.class)
+                .addAsManifestResource(currentPackage, "one-jboss-ejb3.xml", "jboss-ejb3.xml");
+
+        final JavaArchive ejbJarTwo = ShrinkWrap.create(JavaArchive.class, MODULE_TWO_NAME + ".jar")
+                .addClass(SecuredBeanTwo.class)
+                .addAsManifestResource(currentPackage, "two-jboss-ejb3.xml", "jboss-ejb3.xml");
 
 
-        final JavaArchive ejbJarThree = ShrinkWrap.create(JavaArchive.class, MODULE_THREE_NAME + ".jar");
-        ejbJarThree.addClass(SecuredBeanThree.class);
+        final JavaArchive ejbJarThree = ShrinkWrap.create(JavaArchive.class, MODULE_THREE_NAME + ".jar")
+                .addClass(SecuredBeanThree.class);
 
-        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, "bean-interfaces.jar");
-        libJar.addClasses(SecurityTestRemoteView.class, Util.class, MissingMethodPermissionsDefaultAllowedTestCase.class);
+        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, "bean-interfaces.jar")
+                .addClasses(SecurityTestRemoteView.class, Util.class, MissingMethodPermissionsDefaultAllowedTestCase.class);
 
-        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
-        ear.addAsModules(ejbJarOne, ejbJarTwo, ejbJarThree);
-        ear.addAsLibrary(libJar);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear")
+                .addAsModules(ejbJarOne, ejbJarTwo, ejbJarThree)
+                .addAsLibrary(libJar)
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml");
 
         return ear;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/MissingMethodPermissionsTestCase.java
@@ -63,24 +63,26 @@ public class MissingMethodPermissionsTestCase {
 
     @Deployment
     public static Archive createDeployment() {
-        final JavaArchive ejbJarOne = ShrinkWrap.create(JavaArchive.class, MODULE_ONE_NAME + ".jar");
-        ejbJarOne.addClasses(SecuredBeanOne.class);
-        ejbJarOne.addAsManifestResource(SecuredBeanOne.class.getPackage(), "one-jboss-ejb3.xml", "jboss-ejb3.xml");
+        final Package currentPackage = MissingMethodPermissionsTestCase.class.getPackage();
 
-        final JavaArchive ejbJarTwo = ShrinkWrap.create(JavaArchive.class, MODULE_TWO_NAME + ".jar");
-        ejbJarTwo.addClass(SecuredBeanTwo.class);
-        ejbJarTwo.addAsManifestResource(SecuredBeanTwo.class.getPackage(), "two-jboss-ejb3.xml", "jboss-ejb3.xml");
+        final JavaArchive ejbJarOne = ShrinkWrap.create(JavaArchive.class, MODULE_ONE_NAME + ".jar")
+                .addClasses(SecuredBeanOne.class)
+                .addAsManifestResource(currentPackage, "one-jboss-ejb3.xml", "jboss-ejb3.xml");
 
+        final JavaArchive ejbJarTwo = ShrinkWrap.create(JavaArchive.class, MODULE_TWO_NAME + ".jar")
+                .addClass(SecuredBeanTwo.class)
+                .addAsManifestResource(currentPackage, "two-jboss-ejb3.xml", "jboss-ejb3.xml");
 
-        final JavaArchive ejbJarThree = ShrinkWrap.create(JavaArchive.class, MODULE_THREE_NAME + ".jar");
-        ejbJarThree.addClass(SecuredBeanThree.class);
+        final JavaArchive ejbJarThree = ShrinkWrap.create(JavaArchive.class, MODULE_THREE_NAME + ".jar")
+                .addClass(SecuredBeanThree.class);
 
-        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, "bean-interfaces.jar");
-        libJar.addClasses(SecurityTestRemoteView.class, Util.class, MissingMethodPermissionsTestCase.class);
+        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, "bean-interfaces.jar")
+                .addClasses(SecurityTestRemoteView.class, Util.class, MissingMethodPermissionsTestCase.class);
 
-        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
-        ear.addAsModules(ejbJarOne, ejbJarTwo, ejbJarThree);
-        ear.addAsLibrary(libJar);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear")
+                .addAsModules(ejbJarOne, ejbJarTwo, ejbJarThree)
+                .addAsLibrary(libJar)
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml");
 
         return ear;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/missingmethodpermission/permissions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>javax.security.auth.AuthPermission</class-name>
+        <name>modifyPrincipals</name>
+    </permission>
+</permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/permissions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>javax.security.auth.AuthPermission</class-name>
+        <name>modifyPrincipals</name>
+    </permission>
+</permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/SecurityRoleLinkTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/SecurityRoleLinkTestCase.java
@@ -61,16 +61,18 @@ public class SecurityRoleLinkTestCase {
 
     @Deployment
     public static Archive createDeployment() throws Exception {
+        final Package currentPackage = SecurityRoleLinkTestCase.class.getPackage();
 
-        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
-        jar.addPackage(CallerRoleCheckerBean.class.getPackage());
-        jar.addClasses(Util.class, SecurityRoleLinkTestCaseSetup.class);
-        jar.addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class);
-        jar.addAsResource(SecurityRoleLinkTestCase.class.getPackage(), "users.properties", "users.properties");
-        jar.addAsResource(SecurityRoleLinkTestCase.class.getPackage(),"roles.properties", "roles.properties");
-        jar.addAsManifestResource(SecurityRoleLinkTestCase.class.getPackage(),"ejb-jar.xml", "ejb-jar.xml");
-        jar.addAsManifestResource(SecurityRoleLinkTestCase.class.getPackage(),"jboss-ejb3.xml", "jboss-ejb3.xml");
-        jar.addPackage(CommonCriteria.class.getPackage());
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar")
+                .addPackage(CallerRoleCheckerBean.class.getPackage())
+                .addClasses(Util.class, SecurityRoleLinkTestCaseSetup.class)
+                .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage,"roles.properties", "roles.properties")
+                .addAsManifestResource(currentPackage,"ejb-jar.xml", "ejb-jar.xml")
+                .addAsManifestResource(currentPackage,"jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml")
+                .addPackage(CommonCriteria.class.getPackage());
 
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/rolelink/permissions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>javax.security.auth.AuthPermission</class-name>
+        <name>modifyPrincipals</name>
+    </permission>
+</permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/RunAsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/RunAsTestCase.java
@@ -85,17 +85,19 @@ public class RunAsTestCase {
      */
     @Deployment
     public static Archive<?> runAsDeployment() {
+        final Package currentPackage = RunAsTestCase.class.getPackage();
         // using JavaArchive doesn't work, because of a bug in Arquillian, it only deploys wars properly
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "ejb3security.war")
                 .addPackage(WhoAmIBean.class.getPackage()).addPackage(EntryBean.class.getPackage())
                 .addPackage(HttpRequest.class.getPackage()).addClass(WhoAmI.class).addClass(Util.class).addClass(Entry.class)
                 .addClasses(AbstractSecurityDomainSetup.class, EjbSecurityDomainSetup.class)
-                .addAsResource(RunAsTestCase.class.getPackage(), "users.properties", "users.properties")
-                .addAsResource(RunAsTestCase.class.getPackage(), "roles.properties", "roles.properties")
-                .addAsWebInfResource(RunAsTestCase.class.getPackage(), "web.xml", "web.xml")
-                .addAsWebInfResource(RunAsTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml")
-                .addAsWebInfResource(RunAsTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml")
-                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF");
+                .addAsResource(currentPackage, "users.properties", "users.properties")
+                .addAsResource(currentPackage, "roles.properties", "roles.properties")
+                .addAsWebInfResource(currentPackage, "web.xml", "web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-web.xml", "jboss-web.xml")
+                .addAsWebInfResource(currentPackage, "jboss-ejb3.xml", "jboss-ejb3.xml")
+                .addAsManifestResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.as.controller-client,org.jboss.dmr\n"), "MANIFEST.MF")
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml");
         war.addPackage(CommonCriteria.class.getPackage());
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/security/runas/permissions.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>javax.security.auth.AuthPermission</class-name>
+        <name>modifyPrincipals</name>
+    </permission>
+</permissions>


### PR DESCRIPTION
WFLY-5176 permissions.xml files added to deployments for login in test cases to work with security manager without AllPermission
Fix for https://issues.jboss.org/browse/WFLY-5176
