### PR TITLE
[WFLY-5213] Injecting external context to Artemis fails

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -46,6 +46,8 @@
         <module name="io.netty"/>
         <module name="org.jgroups"/>
         <module name="javax.resource.api"/>
+        <!-- WFLY-5213 Optional dependency to use the org.apache.activemq.artemis as a naming's external-context module -->
+        <module name="org.jboss.invocation" optional="true"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <!--this reverse dependency is here so integration classes in the AS code base can be instantiated by Artemis-->
         <module name="org.wildfly.extension.messaging-activemq"/>


### PR DESCRIPTION
Adding an optional dependency to the org.jboss.invocation so that the
org.apache.activemq.artemis module can be used in a naming's
external-context to lookup JMS resources on a remote Artemis broker

JIRA: https://issues.jboss.org/browse/WFLY-5213
