### PR TITLE
WFLY-4255 Allow Arquillian to specify a timeout value for the WildFly clean shutdown mechanism when shutting down a server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
         <version.org.wildfly.build-tools>1.1.0.Beta2</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>2.0.0.Beta5</version.org.wildfly.core>
-        <version.org.wildfly.arquillian>1.0.1.Final</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>1.0.2.Final-SNAPSHOT</version.org.wildfly.arquillian>
         <version.org.yaml.snakeyaml>1.15</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.clustering;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.logging.Logger;
 
 /**
@@ -78,6 +79,18 @@ public final class NodeUtil {
                 log.info("Stopping container=" + container);
                 controller.stop(container);
                 log.info("Stopped container=" + container);
+            } catch (Throwable e) {
+                log.error("Failed to stop containers", e);
+            }
+        }
+    }
+
+    public static void stop(int timeout, WildFlyContainerController controller, String... containers) {
+        for (String container : containers) {
+            try {
+                log.info("Stopping container=" + container + ", timeout=" + timeout);
+                controller.stop(container, timeout);
+                log.info("Stopped container=" + container + ", timeout=" + timeout);
             } catch (Throwable e) {
                 log.error("Failed to stop containers", e);
             }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -26,10 +26,10 @@ import java.util.TreeMap;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
-import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.as.test.clustering.ClusteringTestConstants;
 import org.jboss.as.test.clustering.NodeUtil;
 import org.jboss.as.web.session.RoutingSupport;
@@ -75,7 +75,7 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
     }
 
     @ArquillianResource
-    protected ContainerController controller;
+    protected WildFlyContainerController controller;
     @ArquillianResource
     protected Deployer deployer;
 
@@ -109,6 +109,10 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
 
     protected void stop(String... containers) {
         NodeUtil.stop(this.controller, containers);
+    }
+
+    protected void stop(int timeout, String... containers) {
+        NodeUtil.stop(timeout, this.controller, containers);
     }
 
     protected void deploy(String... deployments) {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -58,7 +58,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -68,7 +67,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("WFLY-3532")
 public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     private static final Logger log = Logger.getLogger(RemoteFailoverTestCase.class);
     private static final String MODULE_NAME = "remote-failover-test";

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -78,6 +78,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     private static final int COUNT = 20;
     private static final long CLIENT_TOPOLOGY_UPDATE_WAIT = TimeoutUtil.adjust(5000);
     private static final long INVOCATION_WAIT = TimeoutUtil.adjust(10);
+    public static final int SHUTDOWN_TIMEOUT = TimeoutUtil.adjust(15);
 
     @Deployment(name = DEPLOYMENT_1, managed = false, testable = false)
     @TargetsContainer(CONTAINER_1)
@@ -158,7 +159,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 Assert.assertTrue(String.valueOf(frequency) + " invocations were routed to " + node, frequency > 0);
             }
 
-            stop(CONTAINER_2);
+            stop(SHUTDOWN_TIMEOUT, CONTAINER_2);
 
             for (int i = 0; i < COUNT; ++i) {
                 Result<Integer> result = bean.increment();
@@ -243,7 +244,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 Assert.assertEquals(String.valueOf(i), target, result.getNode());
             }
 
-            stop(this.findContainer(target));
+            stop(SHUTDOWN_TIMEOUT, this.findContainer(target));
 
             result = bean.increment();
             // Bean should failover to other node
@@ -315,7 +316,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 future = executor.scheduleWithFixedDelay(new IncrementTask(bean, count, latch), 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
                 latch.await();
 
-                stop(this.findContainer(target));
+                stop(SHUTDOWN_TIMEOUT, this.findContainer(target));
 
                 future.cancel(false);
                 try {
@@ -345,7 +346,7 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
                 future = executor.scheduleWithFixedDelay(new LookupTask(directory, SlowToDestroyStatefulIncrementorBean.class, latch), 0, INVOCATION_WAIT, TimeUnit.MILLISECONDS);
                 latch.await();
 
-                stop(this.findContainer(target));
+                stop(SHUTDOWN_TIMEOUT, this.findContainer(target));
 
                 future.cancel(false);
                 try {


### PR DESCRIPTION
Jiras
https://issues.jboss.org/browse/WFLY-4255
https://issues.jboss.org/browse/WFLY-3532

https://issues.jboss.org/browse/ARQ-1976

This requires snapshot of wildfly-arquillian with https://github.com/wildfly/wildfly-arquillian/pull/37 for 1.0.x (master is https://github.com/wildfly/wildfly-arquillian/pull/13)
