### PR TITLE
Test case for WFLY-5221

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -169,6 +169,7 @@
                                         <include>org/jboss/as/test/integration/ejb/management/deployments/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/singleton/dependson/mdb/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist</include>
+                                        <include>org/jboss/as/test/integration/ejb/timerservice/gettimers/*TestCase.java</include>
                                         <include>org/jboss/as/test/integration/jaxr/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/jca/bootstrap/**/*TestCase*.java</include>
                                         <include>org/jboss/as/test/integration/messaging/**/*TestCase*.java</include>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/AbstractTimerBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/AbstractTimerBean.java
@@ -1,0 +1,76 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.integration.ejb.timerservice.gettimers;
+
+import java.util.Collection;
+
+import javax.annotation.Resource;
+import javax.ejb.Timeout;
+import javax.ejb.Timer;
+import javax.ejb.TimerService;
+
+import org.jboss.logging.Logger;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+public abstract class AbstractTimerBean {
+
+    public static final int NUMBER_OF_TIMERS = 5;
+
+    private Logger logger = Logger.getLogger(getClass());
+
+    @Resource
+    private TimerService timerService;
+
+    public void startTimers() {
+        logger.info("Initially had these timers:");
+        for (Timer timer: timerService.getTimers()) {
+            logger.info("   " + timer.getInfo());
+        }
+        for (int i = 0; i < NUMBER_OF_TIMERS; i++) {
+            String name = getClass().getSimpleName() + "#" + i;
+            logger.infof("Starting timer %s", name);
+            timerService.createTimer(100000, 100000, name); // doesn't really need any timeouts to happen
+        }
+    }
+
+    public Collection<Timer> getTimers() {
+        return timerService.getTimers();
+    }
+
+    public void stopTimers() {
+        logger.infof("Stopping all timers.");
+        for (Timer timer: timerService.getTimers()) {
+            logger.infof("Stopping timer %s.", timer.getInfo().toString());
+            timer.cancel();
+        }
+    }
+
+    @Timeout
+    public void timeout(Timer timer) {
+        logger.infof("Timeout %s", timer.getInfo());
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/GetTimersTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/GetTimersTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.integration.ejb.timerservice.gettimers;
+
+import java.util.Collection;
+import java.util.Map;
+
+import javax.ejb.Timer;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test case for https://issues.jboss.org/browse/WFLY-5221
+ *
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+@RunWith(Arquillian.class)
+public class GetTimersTestCase {
+
+    @Deployment
+    public static Archive<?> deploy() {
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "gettimers.jar");
+        jar.addPackage(GetTimersTestCase.class.getPackage());
+        return jar;
+    }
+
+    @Test
+    public void testGetTimers() throws NamingException {
+        InitialContext ctx = new InitialContext();
+        StartupBean starterBean = (StartupBean) ctx.lookup("java:module/" + StartupBean.class.getSimpleName());
+        AbstractTimerBean bean1 = (AbstractTimerBean) ctx.lookup("java:module/" + TimerBeanOne.class.getSimpleName());
+        AbstractTimerBean bean2 = (AbstractTimerBean) ctx.lookup("java:module/" + TimerBeanTwo.class.getSimpleName());
+
+        try {
+            Map<String, Collection<Timer>> beanTimersMap = starterBean.startTimers();
+            assertTimersPrefix(beanTimersMap.get(TimerBeanOne.class.getSimpleName()), TimerBeanOne.class.getSimpleName());
+            assertTimersPrefix(beanTimersMap.get(TimerBeanTwo.class.getSimpleName()), TimerBeanTwo.class.getSimpleName());
+        } finally {
+            bean1.stopTimers();
+            bean2.stopTimers();
+
+            Assert.assertEquals(0, bean1.getTimers().size());
+            Assert.assertEquals(0, bean2.getTimers().size());
+        }
+    }
+
+    public void assertTimersPrefix(Collection<Timer> timers, String bean) {
+        for (Timer timer : timers) {
+            Assert.assertTrue(String.format("Bean %s returned timer %s which doesn't belong to this bean.",
+                            bean, timer.getInfo()),
+                    timer.getInfo().toString().startsWith(bean));
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/StartupBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/StartupBean.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.integration.ejb.timerservice.gettimers;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.ejb.EJB;
+import javax.ejb.Singleton;
+import javax.ejb.Timer;
+import javax.ejb.TransactionAttribute;
+import javax.ejb.TransactionAttributeType;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+@Singleton
+public class StartupBean {
+
+    @EJB
+    TimerBeanOne timerBeanOne;
+
+    @EJB
+    TimerBeanTwo timerBeanTwo;
+
+    @TransactionAttribute(value = TransactionAttributeType.REQUIRED)
+    public Map<String, Collection<Timer>> startTimers() {
+        Map<String, Collection<Timer>> beanTimersMap = new HashMap<String, Collection<Timer>>();
+        timerBeanOne.startTimers();
+        beanTimersMap.put(TimerBeanOne.class.getSimpleName(), timerBeanOne.getTimers());
+        timerBeanTwo.startTimers();
+        beanTimersMap.put(TimerBeanTwo.class.getSimpleName(), timerBeanTwo.getTimers());
+        return beanTimersMap;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/TimerBeanOne.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/TimerBeanOne.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.integration.ejb.timerservice.gettimers;
+
+import javax.ejb.Stateless;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+@Stateless
+public class TimerBeanOne extends AbstractTimerBean {
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/TimerBeanTwo.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/gettimers/TimerBeanTwo.java
@@ -1,0 +1,33 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat Middleware LLC, and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ *
+ */
+
+package org.jboss.as.test.integration.ejb.timerservice.gettimers;
+
+import javax.ejb.Stateless;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+@Stateless
+public class TimerBeanTwo extends AbstractTimerBean {
+}


### PR DESCRIPTION
test case for WFLY-5221 - TimerServiceTimerService.getTimers() returns not only
the associated timer entries for the current Bean
