### PR TITLE
WFLY-4515 Fix JGroups transformers

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/Operations.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/Operations.java
@@ -55,7 +55,7 @@ public final class Operations {
     /**
      * Sets the address of the specified operation.
      * @param operation an operation
-     * @param a path address
+     * @param address a path address
      */
     public static void setPathAddress(ModelNode operation, PathAddress address) {
         operation.get(ModelDescriptionConstants.OP_ADDR).set(address.toModelNode());
@@ -90,7 +90,7 @@ public final class Operations {
 
     /**
      * Creates a composite operation using the specified operation steps.
-     * @param operation steps
+     * @param operations steps
      * @return a composite operation
      */
     public static ModelNode createCompositeOperation(List<ModelNode> operations) {
@@ -104,7 +104,7 @@ public final class Operations {
 
     /**
      * Creates a composite operation using the specified operation steps.
-     * @param operation steps
+     * @param operations steps
      * @return a composite operation
      */
     public static ModelNode createCompositeOperation(ModelNode... operations) {
@@ -126,9 +126,9 @@ public final class Operations {
     }
 
     /**
-     * Creates an indexed add operation using the specified address and parameters
+     * Creates an indexed add operation using the specified address and index
      * @param address a path address
-     * @param parameters a map of values per attribute
+     * @param index
      * @return an add operation
      */
     public static ModelNode createAddOperation(PathAddress address, int index) {
@@ -161,7 +161,7 @@ public final class Operations {
     }
 
     /**
-     * Creates a write-attribute operation using the specified address, namem and value.
+     * Creates a write-attribute operation using the specified address, name and value.
      * @param address a resource path
      * @param attribute an attribute
      * @param value an attribute value
@@ -238,6 +238,12 @@ public final class Operations {
 
     public static ModelNode createMapRemoveOperation(PathAddress address, Attribute attribute, String key) {
         return createMapEntryOperation(MapOperations.MAP_REMOVE_DEFINITION, address, attribute, key);
+    }
+
+    public static ModelNode createMapClearOperation(PathAddress address, Attribute attribute) {
+        ModelNode operation = Util.createOperation(MapOperations.MAP_CLEAR_DEFINITION, address);
+        operation.get(ModelDescriptionConstants.NAME).set(attribute.getDefinition().getName());
+        return operation;
     }
 
     private static ModelNode createMapEntryOperation(OperationDefinition definition, PathAddress address, Attribute attribute, String key) {

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredWriteAttributeHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredWriteAttributeHandler.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.jboss.as.clustering.controller.transform.PreviousAttributeValueOperationContextAttachment;
+import org.jboss.as.clustering.controller.transform.InitialAttributeValueOperationContextAttachment;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
@@ -54,7 +54,12 @@ public class ReloadRequiredWriteAttributeHandler extends org.jboss.as.controller
 
         if (!context.isBooting()) {
             TransformerOperationAttachment attachment = TransformerOperationAttachment.getOrCreate(context);
-            attachment.attachIfAbsent(PreviousAttributeValueOperationContextAttachment.KEY, new PreviousAttributeValueOperationContextAttachment(oldValue.clone()));
+            InitialAttributeValueOperationContextAttachment valuesAttachment = attachment.getAttachment(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT);
+            if (valuesAttachment == null) {
+                valuesAttachment = new InitialAttributeValueOperationContextAttachment();
+                attachment.attach(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT, valuesAttachment);
+            }
+            valuesAttachment.putIfAbsentInitialValue(Operations.getPathAddress(operation), attributeName, oldValue);
         }
     }
 

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredWriteAttributeHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ReloadRequiredWriteAttributeHandler.java
@@ -22,7 +22,13 @@
 
 package org.jboss.as.clustering.controller;
 
+import org.jboss.as.clustering.controller.transform.PreviousAttributeValueOperationContextAttachment;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.transform.TransformerOperationAttachment;
+import org.jboss.dmr.ModelNode;
 
 /**
  * Convenience extension of {@link org.jboss.as.controller.ReloadRequiredWriteAttributeHandler} that can be initialized with an {@link Attribute} set.
@@ -41,4 +47,15 @@ public class ReloadRequiredWriteAttributeHandler extends org.jboss.as.controller
     public void register(ManagementResourceRegistration registration) {
         this.descriptor.getAttributes().forEach(attribute -> registration.registerReadWriteAttribute(attribute, null, this));
     }
+
+    @Override
+    protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue, ModelNode oldValue, Resource model) throws OperationFailedException {
+        super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
+
+        if (!context.isBooting()) {
+            TransformerOperationAttachment attachment = TransformerOperationAttachment.getOrCreate(context);
+            attachment.attachIfAbsent(PreviousAttributeValueOperationContextAttachment.KEY, new PreviousAttributeValueOperationContextAttachment(oldValue.clone()));
+        }
+    }
+
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceWriteAttributeHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceWriteAttributeHandler.java
@@ -22,7 +22,7 @@
 
 package org.jboss.as.clustering.controller;
 
-import org.jboss.as.clustering.controller.transform.PreviousAttributeValueOperationContextAttachment;
+import org.jboss.as.clustering.controller.transform.InitialAttributeValueOperationContextAttachment;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -74,7 +74,12 @@ public class RestartParentResourceWriteAttributeHandler<T> extends RestartParent
 
         if (!context.isBooting()) {
             TransformerOperationAttachment attachment = TransformerOperationAttachment.getOrCreate(context);
-            attachment.attachIfAbsent(PreviousAttributeValueOperationContextAttachment.KEY, new PreviousAttributeValueOperationContextAttachment(oldValue.clone()));
+            InitialAttributeValueOperationContextAttachment valuesAttachment = attachment.getAttachment(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT);
+            if (valuesAttachment == null) {
+                valuesAttachment = new InitialAttributeValueOperationContextAttachment();
+                attachment.attach(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT, valuesAttachment);
+            }
+            valuesAttachment.putIfAbsentInitialValue(Operations.getPathAddress(operation), attributeName, oldValue);
         }
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceWriteAttributeHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RestartParentResourceWriteAttributeHandler.java
@@ -22,11 +22,14 @@
 
 package org.jboss.as.clustering.controller;
 
+import org.jboss.as.clustering.controller.transform.PreviousAttributeValueOperationContextAttachment;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RestartParentWriteAttributeHandler;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.transform.TransformerOperationAttachment;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
@@ -63,5 +66,15 @@ public class RestartParentResourceWriteAttributeHandler<T> extends RestartParent
     @Override
     public void register(ManagementResourceRegistration registration) {
         this.descriptor.getAttributes().forEach(attribute -> registration.registerReadWriteAttribute(attribute, null, this));
+    }
+
+    @Override
+    protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue, ModelNode oldValue, Resource model) throws OperationFailedException {
+        super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
+
+        if (!context.isBooting()) {
+            TransformerOperationAttachment attachment = TransformerOperationAttachment.getOrCreate(context);
+            attachment.attachIfAbsent(PreviousAttributeValueOperationContextAttachment.KEY, new PreviousAttributeValueOperationContextAttachment(oldValue.clone()));
+        }
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/ChainedOperationTransformer.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/ChainedOperationTransformer.java
@@ -44,9 +44,25 @@ import org.jboss.dmr.ModelNode;
 public class ChainedOperationTransformer implements OperationTransformer {
 
     private final List<OperationTransformer> transformers;
+    private final boolean collate;
 
     public ChainedOperationTransformer(List<OperationTransformer> transformers) {
         this.transformers = transformers;
+        this.collate = true;
+    }
+
+    /**
+     * Constructs ChainedOperationTransformer with control over collation. Disable collation in cases where operations
+     * cannot be collated (e.g. the original operation is no longer at the same path) and all
+     * {@link OperationTransformer}s can deal with the fact.
+     *
+     * @param transformers list of transformers to process
+     * @param collate      true if the results of the operation should be collated in a composite operation;
+     *                     false if no further processing should be done on the resulting operations
+     */
+    public ChainedOperationTransformer(List<OperationTransformer> transformers, boolean collate) {
+        this.transformers = transformers;
+        this.collate = collate;
     }
 
     /**
@@ -62,7 +78,7 @@ public class ChainedOperationTransformer implements OperationTransformer {
         for (OperationTransformer transformer: this.transformers) {
             operation = transformer.transformOperation(context, address, operation).getTransformedOperation();
             // If the transformed operation is a composite operation, locate the modified operation and record any pre/post operations
-            if (operation.get(ModelDescriptionConstants.OP).asString().equals(ModelDescriptionConstants.COMPOSITE)) {
+            if (collate && operation.get(ModelDescriptionConstants.OP).asString().equals(ModelDescriptionConstants.COMPOSITE)) {
                 List<ModelNode> stepList = operation.get(ModelDescriptionConstants.STEPS).asList();
                 ListIterator<ModelNode> steps = stepList.listIterator();
                 while (steps.hasNext()) {
@@ -87,14 +103,16 @@ public class ChainedOperationTransformer implements OperationTransformer {
                 }
             }
         }
-        int count = preSteps.size() + postSteps.size() + 1;
-        // If there are any pre or post steps, we need a composite operation
-        if (count > 1) {
-            List<ModelNode> steps = new ArrayList<>(count);
-            steps.addAll(preSteps);
-            steps.add(operation);
-            steps.addAll(postSteps);
-            operation = Operations.createCompositeOperation(steps);
+        if (collate) {
+            int count = preSteps.size() + postSteps.size() + 1;
+            // If there are any pre or post steps, we need a composite operation
+            if (count > 1) {
+                List<ModelNode> steps = new ArrayList<>(count);
+                steps.addAll(preSteps);
+                steps.add(operation);
+                steps.addAll(postSteps);
+                operation = Operations.createCompositeOperation(steps);
+            }
         }
         return new TransformedOperation(operation, OperationResultTransformer.ORIGINAL_RESULT);
     }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/InitialAttributeValueOperationContextAttachment.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/InitialAttributeValueOperationContextAttachment.java
@@ -22,27 +22,36 @@
 
 package org.jboss.as.clustering.controller.transform;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.PathAddress;
 import org.jboss.dmr.ModelNode;
 
 /**
- * A generic and reusable attachment that exposes a old value of an attribute.
+ * A generic and reusable operation context attachment that exposes an initial value of an attribute before a write.
+ * Values have to be looked up by the {@link PathAddress} address of the attribute and attribute's name.
  *
  * @author Radoslav Husar
  * @version August 2015
  */
-public class PreviousAttributeValueOperationContextAttachment {
+public class InitialAttributeValueOperationContextAttachment {
 
-    public static final OperationContext.AttachmentKey<PreviousAttributeValueOperationContextAttachment> KEY = OperationContext.AttachmentKey.create(PreviousAttributeValueOperationContextAttachment.class);
+    public static final OperationContext.AttachmentKey<InitialAttributeValueOperationContextAttachment> INITIAL_VALUES_ATTACHMENT = OperationContext.AttachmentKey.create(InitialAttributeValueOperationContextAttachment.class);
 
-    public volatile ModelNode previousValue;
+    private volatile Map<String, ModelNode> initialValues = new HashMap<>();
 
-    public PreviousAttributeValueOperationContextAttachment(ModelNode previousValue) {
-        this.previousValue = previousValue.clone();
-        previousValue.protect();
+    public ModelNode putIfAbsentInitialValue(PathAddress address, String attributeName, ModelNode initialValue) {
+        return initialValues.putIfAbsent(this.keyFor(address, attributeName), initialValue.clone());
     }
 
-    public ModelNode getPreviousValue() {
-        return previousValue;
+    public ModelNode getInitialValue(PathAddress address, String attributeName) {
+        return initialValues.get(this.keyFor(address, attributeName));
+    }
+
+
+    private String keyFor(PathAddress address, String attributeName) {
+        return address.toString() + attributeName;
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/PreviousAttributeValueOperationContextAttachment.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/PreviousAttributeValueOperationContextAttachment.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller.transform;
+
+import org.jboss.as.controller.OperationContext;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * A generic and reusable attachment that exposes a old value of an attribute.
+ *
+ * @author Radoslav Husar
+ * @version August 2015
+ */
+public class PreviousAttributeValueOperationContextAttachment {
+
+    public static final OperationContext.AttachmentKey<PreviousAttributeValueOperationContextAttachment> KEY = OperationContext.AttachmentKey.create(PreviousAttributeValueOperationContextAttachment.class);
+
+    public volatile ModelNode previousValue;
+
+    public PreviousAttributeValueOperationContextAttachment(ModelNode previousValue) {
+        this.previousValue = previousValue.clone();
+        previousValue.protect();
+    }
+
+    public ModelNode getPreviousValue() {
+        return previousValue;
+    }
+}

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/SimplePathOperationTransformer.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/SimplePathOperationTransformer.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.clustering.controller.transform;
 
+import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.transform.OperationResultTransformer;
@@ -45,6 +46,15 @@ public class SimplePathOperationTransformer implements OperationTransformer {
     public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) {
         ModelNode legacyOperation = operation.clone();
         legacyOperation.get(ModelDescriptionConstants.OP_ADDR).set(this.addressTransformer.transform(address).toModelNode());
+
+        InitialAttributeValueOperationContextAttachment attachment = context.getAttachment(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT);
+        if (attachment != null) {
+            ModelNode value = attachment.getInitialValue(address, Operations.getAttributeName(operation));
+            if (value != null) {
+                attachment.putIfAbsentInitialValue(addressTransformer.transform(address), Operations.getAttributeName(operation), value);
+            }
+        }
+
         return new TransformedOperation(legacyOperation, OperationResultTransformer.ORIGINAL_RESULT);
     }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/SimplePathOperationTransformer.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/SimplePathOperationTransformer.java
@@ -1,0 +1,50 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller.transform;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.transform.OperationResultTransformer;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * @author Radoslav Husar
+ * @version Jun 2015
+ */
+public class SimplePathOperationTransformer implements OperationTransformer {
+
+    private final PathAddressTransformer addressTransformer;
+
+    public SimplePathOperationTransformer(PathAddressTransformer addressTransformer) {
+        this.addressTransformer = addressTransformer;
+    }
+
+    @Override
+    public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) {
+        ModelNode legacyOperation = operation.clone();
+        legacyOperation.get(ModelDescriptionConstants.OP_ADDR).set(this.addressTransformer.transform(address).toModelNode());
+        return new TransformedOperation(legacyOperation, OperationResultTransformer.ORIGINAL_RESULT);
+    }
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -69,7 +69,7 @@ public abstract class ProtocolResourceDefinition extends ChildResourceDefinition
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
-    static PathElement pathElement(String name) {
+    public static PathElement pathElement(String name) {
         return PathElement.pathElement("protocol", name);
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RelayResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/RelayResourceDefinition.java
@@ -50,7 +50,7 @@ public class RelayResourceDefinition extends ProtocolResourceDefinition {
     static final PathElement LEGACY_PATH = pathElement("RELAY");
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
-    static PathElement pathElement(String name) {
+    public static PathElement pathElement(String name) {
         return PathElement.pathElement("relay", name);
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -85,7 +85,7 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
     static final PathElement LEGACY_PATH = pathElement("TRANSPORT");
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);
 
-    static PathElement pathElement(String name) {
+    public static PathElement pathElement(String name) {
         return PathElement.pathElement("transport", name);
     }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -23,9 +23,12 @@
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
+import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
@@ -35,14 +38,13 @@ import org.jboss.as.clustering.controller.RestartParentResourceAddStepHandler;
 import org.jboss.as.clustering.controller.RestartParentResourceRemoveStepHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
+import org.jboss.as.clustering.controller.transform.ChainedOperationTransformer;
 import org.jboss.as.clustering.controller.transform.PathAddressTransformer;
-import org.jboss.as.clustering.controller.transform.SimpleAddOperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleDescribeOperationTransformer;
+import org.jboss.as.clustering.controller.transform.SimpleOperationTransformer;
+import org.jboss.as.clustering.controller.transform.SimplePathOperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleReadAttributeOperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleRemoveOperationTransformer;
-import org.jboss.as.clustering.controller.transform.SimpleResourceTransformer;
-import org.jboss.as.clustering.controller.transform.SimpleUndefineAttributeOperationTransformer;
-import org.jboss.as.clustering.controller.transform.SimpleWriteAttributeOperationTransformer;
 import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.CapabilityReferenceRecorder;
@@ -57,9 +59,14 @@ import org.jboss.as.controller.access.management.AccessConstraintDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.operations.global.MapOperations;
 import org.jboss.as.controller.registry.AttributeAccess;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.controller.transform.ResourceTransformationContext;
+import org.jboss.as.controller.transform.ResourceTransformer;
 import org.jboss.as.controller.transform.description.AttributeConverter.DefaultValueAttributeConverter;
 import org.jboss.as.controller.transform.description.ResourceTransformationDescriptionBuilder;
 import org.jboss.as.network.SocketBinding;
@@ -171,13 +178,48 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
         if (JGroupsModel.VERSION_3_0_0.requiresTransformation(version)) {
             builder.getAttributeBuilder().setValueConverter(new DefaultValueAttributeConverter(Attribute.SHARED.getDefinition()), Attribute.SHARED.getDefinition());
 
-            builder.setCustomResourceTransformer(new SimpleResourceTransformer(LEGACY_ADDRESS_TRANSFORMER));
-            builder.addOperationTransformationOverride(ModelDescriptionConstants.ADD).setCustomOperationTransformer(new SimpleAddOperationTransformer(LEGACY_ADDRESS_TRANSFORMER).addAttributes(Attribute.class).addAttributes(ThreadingAttribute.class).addAttributes(ProtocolResourceDefinition.Attribute.class)).inheritResourceAttributeDefinitions();
+            builder.setCustomResourceTransformer(new ResourceTransformer() {
+                @Override
+                public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {
+                    PropertyResourceDefinition.PROPERTIES_RESOURCE_TRANSFORMER.transformResource(context, LEGACY_ADDRESS_TRANSFORMER.transform(address), resource);
+                }
+            });
+            builder.addOperationTransformationOverride(ModelDescriptionConstants.ADD).setCustomOperationTransformer(new SimpleOperationTransformer(new org.jboss.as.clustering.controller.transform.OperationTransformer() {
+                @Override
+                public ModelNode transformOperation(final ModelNode operation) {
+                    operation.get(ModelDescriptionConstants.OP_ADDR).set(LEGACY_ADDRESS_TRANSFORMER.transform(Operations.getPathAddress(operation)).toModelNode());
+                    return PropertyResourceDefinition.PROPERTIES_ADD_OP_TRANSFORMER.transformOperation(operation);
+                }
+            })).inheritResourceAttributeDefinitions();
             builder.addOperationTransformationOverride(ModelDescriptionConstants.REMOVE).setCustomOperationTransformer(new SimpleRemoveOperationTransformer(LEGACY_ADDRESS_TRANSFORMER));
             builder.addOperationTransformationOverride(ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION).setCustomOperationTransformer(new SimpleReadAttributeOperationTransformer(LEGACY_ADDRESS_TRANSFORMER));
-            builder.addOperationTransformationOverride(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION).setCustomOperationTransformer(new SimpleWriteAttributeOperationTransformer(LEGACY_ADDRESS_TRANSFORMER));
-            builder.addOperationTransformationOverride(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION).setCustomOperationTransformer(new SimpleUndefineAttributeOperationTransformer(LEGACY_ADDRESS_TRANSFORMER));
             builder.addOperationTransformationOverride(ModelDescriptionConstants.DESCRIBE).setCustomOperationTransformer(new SimpleDescribeOperationTransformer(LEGACY_ADDRESS_TRANSFORMER));
+
+            org.jboss.as.clustering.controller.transform.OperationTransformer getPropertyTransformer = new org.jboss.as.clustering.controller.transform.OperationTransformer() {
+                @Override
+                public ModelNode transformOperation(ModelNode operation) {
+                    if (operation.get(ModelDescriptionConstants.NAME).asString().equals(ProtocolResourceDefinition.Attribute.PROPERTIES.getDefinition().getName())) {
+                        String key = operation.get("key").asString();
+                        PathAddress address = TransportResourceDefinition.LEGACY_ADDRESS_TRANSFORMER.transform(Operations.getPathAddress(operation));
+                        ModelNode transformedOperation = Util.createOperation(ModelDescriptionConstants.READ_ATTRIBUTE_OPERATION, address.append(PropertyResourceDefinition.pathElement(key)));
+                        transformedOperation.get(ModelDescriptionConstants.NAME).set(PropertyResourceDefinition.VALUE.getName());
+                        return transformedOperation;
+                    }
+                    return operation;
+                }
+            };
+            builder.addRawOperationTransformationOverride(MapOperations.MAP_GET_DEFINITION.getName(), new SimpleOperationTransformer(getPropertyTransformer));
+
+            List<OperationTransformer> transformerChain = new LinkedList<>();
+            transformerChain.add(new SimplePathOperationTransformer(LEGACY_ADDRESS_TRANSFORMER));
+            transformerChain.add(PropertyResourceDefinition.PROPERTIES_OP_TRANSFORMER);
+            ChainedOperationTransformer chainedTransformer = new ChainedOperationTransformer(transformerChain, false);
+
+            builder.addRawOperationTransformationOverride(MapOperations.MAP_PUT_DEFINITION.getName(), chainedTransformer)
+                    .addRawOperationTransformationOverride(MapOperations.MAP_REMOVE_DEFINITION.getName(), chainedTransformer)
+                    .addRawOperationTransformationOverride(MapOperations.MAP_CLEAR_DEFINITION.getName(), chainedTransformer)
+                    .addRawOperationTransformationOverride(ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION, chainedTransformer)
+                    .addRawOperationTransformationOverride(ModelDescriptionConstants.UNDEFINE_ATTRIBUTE_OPERATION, chainedTransformer);
 
             // Reject thread pool configuration, support EAP 6.x slaves using deprecated attributes
             builder.rejectChildResource(ThreadPoolResourceDefinition.WILDCARD_PATH);

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationSequencesTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationSequencesTestCase.java
@@ -84,7 +84,7 @@ public class OperationSequencesTestCase extends OperationTestCaseBase {
         Assert.assertEquals(FAILED, result.get(OUTCOME).asString());
     }
 
-    /*
+    /**
      * Tests the ability of the /subsystem=jgroups/stack=X:add() operation
      * to correctly process the optional TRANSPORT and PROTOCOLS parameters.
      */

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
@@ -1,16 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 package org.jboss.as.clustering.jgroups.subsystem;
 
 import java.io.IOException;
-
-import javax.xml.stream.XMLStreamException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 import org.jboss.as.clustering.controller.Attribute;
 import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.SimpleAttribute;
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
+import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.transform.TransformerOperationAttachment;
+import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
@@ -107,6 +133,7 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return Operations.createWriteAttributeOperation(getTransportPropertyAddress(stackName, type, propertyName), new SimpleAttribute(PropertyResourceDefinition.VALUE), new ModelNode(propertyValue));
     }
 
+    // Transport property map operations
     protected static ModelNode getTransportGetPropertyOperation(String stackName, String type, String propertyName) {
         return Operations.createMapGetOperation(getTransportAddress(stackName, type), ProtocolResourceDefinition.Attribute.PROPERTIES, propertyName);
     }
@@ -119,6 +146,24 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return Operations.createMapRemoveOperation(getTransportAddress(stackName, type), ProtocolResourceDefinition.Attribute.PROPERTIES, propertyName);
     }
 
+    protected static ModelNode getTransportClearPropertiesOperation(String stackName, String type) {
+        return Operations.createMapClearOperation(getTransportAddress(stackName, type), ProtocolResourceDefinition.Attribute.PROPERTIES);
+    }
+
+    protected static ModelNode getTransportUndefinePropertiesOperation(String stackName, String protocolName) {
+        return Operations.createUndefineAttributeOperation(getProtocolAddress(stackName, protocolName), ProtocolResourceDefinition.Attribute.PROPERTIES);
+    }
+
+    /**
+     * Creates operations such as /subsystem=jgroups/stack=tcp/transport=TCP/:write-attribute(name=properties,value={a=b,c=d})".
+     *
+     * @return resulting :write-attribute operation
+     */
+    protected static ModelNode getTransportSetPropertiesOperation(String stackName, String type, ModelNode values) {
+        return Operations.createWriteAttributeOperation(getTransportAddress(stackName, type), ProtocolResourceDefinition.Attribute.PROPERTIES, values);
+    }
+
+    // Protocol operations
     protected static ModelNode getProtocolAddOperation(String stackName, String type) {
         return Util.createAddOperation(getProtocolAddress(stackName, type));
     }
@@ -170,6 +215,21 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return Operations.createMapRemoveOperation(getProtocolAddress(stackName, protocolName), ProtocolResourceDefinition.Attribute.PROPERTIES, propertyName);
     }
 
+    protected static ModelNode getProtocolClearPropertiesOperation(String stackName, String protocolName) {
+        return Operations.createMapClearOperation(getProtocolAddress(stackName, protocolName), ProtocolResourceDefinition.Attribute.PROPERTIES);
+    }
+
+    protected static ModelNode getProtocolUndefinePropertiesOperation(String stackName, String protocolName) {
+        return Operations.createUndefineAttributeOperation(getProtocolAddress(stackName, protocolName), ProtocolResourceDefinition.Attribute.PROPERTIES);
+    }
+
+    /**
+     * Creates operations such as /subsystem=jgroups/stack=tcp/protocol=MPING/:write-attribute(name=properties,value={a=b,c=d})".
+     */
+    protected static ModelNode getProtocolSetPropertiesOperation(String stackName, String protocolName, ModelNode values) {
+        return Operations.createWriteAttributeOperation(getProtocolAddress(stackName, protocolName), ProtocolResourceDefinition.Attribute.PROPERTIES, values);
+    }
+
     protected static ModelNode getProtocolRemoveOperation(String stackName, String type) {
         return Util.createRemoveOperation(getProtocolAddress(stackName, type));
     }
@@ -204,5 +264,23 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
 
     protected KernelServices buildKernelServices() throws Exception {
         return createKernelServicesBuilder(new AdditionalInitialization().require(RequiredCapability.SOCKET_BINDING, "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "new-socket-binding")).setSubsystemXml(this.getSubsystemXml()).build();
+    }
+
+    protected List<ModelNode> executeOpInBothControllers(KernelServices services, ModelVersion version, ModelNode operation) throws Exception {
+        List<ModelNode> results = new ArrayList<>(2);
+        results.add(ModelTestUtils.checkOutcome(services.executeOperation(operation.clone())));
+        results.add(ModelTestUtils.checkOutcome(services.executeOperation(version, services.transformOperation(version, operation.clone()))));
+        return results;
+    }
+
+    /**
+     * Executes a given operation asserting that an attachment has been created. Given {@link KernelServices} must have enabled attachment grabber.
+     *
+     * @return {@link ModelNode} result of the transformed operation
+     */
+    protected ModelNode executeOpInBothControllersWithAttachments(KernelServices services, ModelVersion version, ModelNode operation) throws Exception {
+        TransformerOperationAttachment attachments = services.executeAndGrabTransformerAttachment(operation.clone());
+        assert attachments != null;
+        return ModelTestUtils.checkOutcome(services.executeOperation(version, services.transformOperation(version, operation.clone(), attachments)));
     }
 }

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
@@ -150,8 +150,8 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return Operations.createMapClearOperation(getTransportAddress(stackName, type), ProtocolResourceDefinition.Attribute.PROPERTIES);
     }
 
-    protected static ModelNode getTransportUndefinePropertiesOperation(String stackName, String protocolName) {
-        return Operations.createUndefineAttributeOperation(getProtocolAddress(stackName, protocolName), ProtocolResourceDefinition.Attribute.PROPERTIES);
+    protected static ModelNode getTransportUndefinePropertiesOperation(String stackName, String type) {
+        return Operations.createUndefineAttributeOperation(getTransportAddress(stackName, type), ProtocolResourceDefinition.Attribute.PROPERTIES);
     }
 
     /**

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/SubsystemParsingTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/SubsystemParsingTestCase.java
@@ -95,11 +95,11 @@ public class SubsystemParsingTestCase extends ClusteringSubsystemTest {
     }
 
     @Override
-    protected org.jboss.as.subsystem.test.AdditionalInitialization createAdditionalInitialization() {
+    protected AdditionalInitialization createAdditionalInitialization() {
         return new AdditionalInitialization().require(RequiredCapability.SOCKET_BINDING, "jgroups-udp", "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "jgroups-state-xfr");
     }
 
-    /*
+    /**
      *  Create a collection of resources in the test which are not removed by a "remove" command
      *   (i.e. all resources of form /subsystem=jgroups/stack=maximal/protocol=*)
      *

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
@@ -21,7 +21,11 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.junit.Assert.assertEquals;
 
@@ -129,7 +133,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
         List<ModelNode> results;
 
         // Check operations on /transport=*
-        executeOpInBothControllersWithAttachments(services, version, getTransportUndefinePropertiesOperation("maximal", "MPING"));
+        executeOpInBothControllersWithAttachments(services, version, getTransportUndefinePropertiesOperation("maximal", "TCP"));
 
         executeOpInBothControllersWithAttachments(services, version, getTransportPutPropertyOperation("maximal", "TCP", "tcp_nodelay", "true"));
         results = executeOpInBothControllers(services, version, getTransportGetPropertyOperation("maximal", "TCP", "tcp_nodelay"));
@@ -155,6 +159,27 @@ public class TransformersTestCase extends OperationTestCaseBase {
         Assert.assertEquals(results.get(0).get(ModelDescriptionConstants.RESULT), results.get(1).get(ModelDescriptionConstants.RESULT));
 
         executeOpInBothControllersWithAttachments(services, version, getProtocolClearPropertiesOperation("maximal", "MPING"));
+
+// org.jboss.as.subsystem.test.MainKernelServicesImpl does not behave correctly:
+//
+//        In a real domain the operation and transformation will happen in one call to the controller,
+//        in the subsystem test, the attachment part was bolted on and we do two calls,
+//        which is why we need to test this currently in the mixed-domain part.
+//
+//        // Check composite operation
+//        final ModelNode composite = new ModelNode();
+//        composite.get(OP).set(COMPOSITE);
+//        composite.get(OP_ADDR).setEmptyList();
+//        composite.get(STEPS).add(getProtocolPutPropertyOperation("maximal", "MPING", "send_on_all_interfaces", "false"));
+//        composite.get(STEPS).add(getProtocolPutPropertyOperation("maximal", "MPING", "receive_on_all_interfaces", "false"));
+//        executeOpInBothControllersWithAttachments(services, version, composite);
+//
+//        // Reread values back
+//        results = executeOpInBothControllers(services, version, getProtocolGetPropertyOperation("maximal", "MPING", "send_on_all_interfaces"));
+//        Assert.assertEquals(results.get(0).get(ModelDescriptionConstants.RESULT), results.get(1).get(ModelDescriptionConstants.RESULT));
+//
+//        results = executeOpInBothControllers(services, version, getProtocolGetPropertyOperation("maximal", "MPING", "receive_on_all_interfaces"));
+//        Assert.assertEquals(results.get(0).get(ModelDescriptionConstants.RESULT), results.get(1).get(ModelDescriptionConstants.RESULT));
 
     }
 

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
@@ -27,13 +27,14 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.List;
 
+import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.subsystem.AdditionalInitialization;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
-import org.jboss.as.model.test.FailedOperationTransformationConfig.NewAttributesConfig;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
-import org.jboss.as.subsystem.test.AdditionalInitialization;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.byteman.contrib.bmunit.BMRule;
@@ -46,13 +47,6 @@ import org.junit.runner.RunWith;
 
 /**
  * Test cases for transformers used in the JGroups subsystem.
- *
- * AS version / model version / schema version overview
- * 7.1.1 / 1.1.0 / 1_1
- * 7.1.2 / 1.1.0 / 1_1
- * 7.1.3 / 1.1.0 / 1_1
- * 7.2.0 / 1.2.0 / 1_1
- * 8.0.0 / 2.0.0 / 2_0
  *
  * @author <a href="tomaz.cerar@redhat.com">Tomaz Cerar</a>
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
@@ -73,6 +67,10 @@ public class TransformersTestCase extends OperationTestCaseBase {
         return String.format(pattern, version.getMavenGavVersion());
     }
 
+    protected AdditionalInitialization createAdditionalInitialization() {
+        return new AdditionalInitialization().require(RequiredCapability.SOCKET_BINDING, "jgroups-tcp", "jgroups-udp", "jgroups-udp-fd", "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "jgroups-state-xfr");
+    }
+
     @Test
     public void testTransformerWF800() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.WILDFLY_8_0_0_FINAL;
@@ -86,14 +84,12 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    @Ignore(value = "WFLY-4515")
     public void testTransformerEAP620() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_2_0;
         testTransformation(JGroupsModel.VERSION_1_2_0, version, formatLegacySubsystemArtifact(version));
     }
 
     @Test
-    @Ignore(value = "WFLY-4515")
     public void testTransformerEAP630() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_3_0;
         testTransformation(JGroupsModel.VERSION_1_2_0, version, formatLegacySubsystemArtifact(version));
@@ -108,7 +104,9 @@ public class TransformersTestCase extends OperationTestCaseBase {
         ModelVersion version = model.getVersion();
 
         // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT).setSubsystemXmlResource("subsystem-jgroups-transform.xml");
+        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization())
+                .setSubsystemXmlResource("subsystem-jgroups-transform.xml")
+                .enableTransformerAttachmentGrabber();
 
         // initialize the legacy services and add required jars
         builder.createLegacyKernelServicesBuilder(null, controller, version).addMavenResourceURL(mavenResourceURLs).skipReverseControllerCheck();
@@ -120,6 +118,44 @@ public class TransformersTestCase extends OperationTestCaseBase {
 
         // check that both versions of the legacy model are the same and valid
         checkSubsystemModelTransformation(services, version);
+
+        // Test properties operations
+        propertiesMapOperationsTest(services, version);
+    }
+
+    private void propertiesMapOperationsTest(KernelServices services, ModelVersion version) throws Exception {
+
+        // n.b. only compare actual results since they differ in reload-required
+        List<ModelNode> results;
+
+        // Check operations on /transport=*
+        executeOpInBothControllersWithAttachments(services, version, getTransportUndefinePropertiesOperation("maximal", "MPING"));
+
+        executeOpInBothControllersWithAttachments(services, version, getTransportPutPropertyOperation("maximal", "TCP", "tcp_nodelay", "true"));
+        results = executeOpInBothControllers(services, version, getTransportGetPropertyOperation("maximal", "TCP", "tcp_nodelay"));
+        Assert.assertEquals("Failed to read property value back following a put", results.get(0).get(ModelDescriptionConstants.RESULT), results.get(1).get(ModelDescriptionConstants.RESULT));
+
+        executeOpInBothControllersWithAttachments(services, version, getTransportRemovePropertyOperation("maximal", "TCP", "tcp_nodelay"));
+        executeOpInBothControllersWithAttachments(services, version, getTransportPutPropertyOperation("maximal", "TCP", "tcp_nodelay", "true"));
+        results = executeOpInBothControllers(services, version, getTransportGetPropertyOperation("maximal", "TCP", "tcp_nodelay"));
+        Assert.assertEquals("Failed to read property value following a remove and a put", results.get(0).get(ModelDescriptionConstants.RESULT), results.get(1).get(ModelDescriptionConstants.RESULT));
+
+        executeOpInBothControllersWithAttachments(services, version, getTransportClearPropertiesOperation("maximal", "TCP"));
+
+        // Check operations on /protocol=*
+        executeOpInBothControllersWithAttachments(services, version, getProtocolUndefinePropertiesOperation("maximal", "MPING"));
+
+        executeOpInBothControllersWithAttachments(services, version, getProtocolPutPropertyOperation("maximal", "MPING", "send_on_all_interfaces", "true"));
+        results = executeOpInBothControllers(services, version, getProtocolGetPropertyOperation("maximal", "MPING", "send_on_all_interfaces"));
+        Assert.assertEquals(results.get(0).get(ModelDescriptionConstants.RESULT), results.get(1).get(ModelDescriptionConstants.RESULT));
+
+        executeOpInBothControllersWithAttachments(services, version, getProtocolRemovePropertyOperation("maximal", "MPING", "send_on_all_interfaces"));
+        executeOpInBothControllersWithAttachments(services, version, getProtocolPutPropertyOperation("maximal", "MPING", "send_on_all_interfaces", "true"));
+        results = executeOpInBothControllers(services, version, getProtocolGetPropertyOperation("maximal", "MPING", "send_on_all_interfaces"));
+        Assert.assertEquals(results.get(0).get(ModelDescriptionConstants.RESULT), results.get(1).get(ModelDescriptionConstants.RESULT));
+
+        executeOpInBothControllersWithAttachments(services, version, getProtocolClearPropertiesOperation("maximal", "MPING"));
+
     }
 
     /**
@@ -130,8 +166,6 @@ public class TransformersTestCase extends OperationTestCaseBase {
      *
      * The test is currently broken due to an outstanding class loading problem with Byteman, but it is included
      * here for re-enabling when the issue is resolved.
-     *
-     * @throws Exception
      */
     @Ignore
     @Test
@@ -171,14 +205,12 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    @Ignore(value = "WFLY-4515")
     public void testRejectionsEAP620() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_2_0;
         this.testRejections(JGroupsModel.VERSION_1_2_0, version, formatLegacySubsystemArtifact(version));
     }
 
     @Test
-    @Ignore(value = "WFLY-4515")
     public void testRejectionsEAP630() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_3_0;
         this.testRejections(JGroupsModel.VERSION_1_2_0, version, formatLegacySubsystemArtifact(version));
@@ -188,7 +220,8 @@ public class TransformersTestCase extends OperationTestCaseBase {
         ModelVersion version = model.getVersion();
 
         // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(AdditionalInitialization.MANAGEMENT);
+        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization())
+                .enableTransformerAttachmentGrabber();
 
         // initialize the legacy services and add required jars
         builder.createLegacyKernelServicesBuilder(null, controller, version)
@@ -211,7 +244,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
         PathAddress subsystemAddress = PathAddress.pathAddress(JGroupsSubsystemResourceDefinition.PATH);
 
         if (JGroupsModel.VERSION_3_0_0.requiresTransformation(version)) {
-            config.addFailedAttribute(subsystemAddress, new NewAttributesConfig(JGroupsSubsystemResourceDefinition.Attribute.DEFAULT_CHANNEL.getDefinition()));
+            // This in real life would be not rejected, but since we don't have infinispan subsystem setup (this would also create a cyclic dependency) it has to be rejected in the test
             config.addFailedAttribute(subsystemAddress.append(ChannelResourceDefinition.WILDCARD_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
             config.addFailedAttribute(subsystemAddress.append(StackResourceDefinition.WILDCARD_PATH).append(TransportResourceDefinition.WILDCARD_PATH).append(ThreadPoolResourceDefinition.WILDCARD_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
         }

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-1_1.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-1_1.xml
@@ -1,4 +1,26 @@
-<subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="${test.expr:maximal}">
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:jgroups:1.1" default-stack="maximal">
     <stack name="minimal">
         <transport type="UDP"/>
     </stack>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-2_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-2_0.xml
@@ -1,4 +1,26 @@
-<subsystem xmlns="urn:jboss:domain:jgroups:2.0" default-stack="${test.expr:maximal}">
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:jgroups:2.0" default-stack="maximal">
     <stack name="minimal">
         <transport type="UDP"/>
     </stack>
@@ -23,7 +45,7 @@
         <protocol type="MFC"/>
         <protocol type="FRAG2"/>
         <protocol type="RSVP"/>
-        <relay site="LONDON">
+        <relay site="LON">
             <remote-site name="SFO" stack="minimal" cluster="bridge"/>
             <remote-site name="NYC" stack="minimal" cluster="bridge"/>
         </relay>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-3_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-3_0.xml
@@ -1,5 +1,27 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
 <subsystem xmlns="urn:jboss:domain:jgroups:3.0">
-    <channels default="${test.expr:ee}">
+    <channels default="ee">
         <channel name="ee">
             <fork name="web">
                 <protocol type="CENTRAL_LOCK">
@@ -9,7 +31,7 @@
         </channel>
         <channel name="bridge" stack="minimal"/>
     </channels>
-    <stacks default="${test.expr:maximal}">
+    <stacks default="maximal">
         <stack name="minimal">
             <transport type="UDP"/>
         </stack>
@@ -55,7 +77,7 @@
             <protocol type="MFC"/>
             <protocol type="FRAG2"/>
             <protocol type="RSVP"/>
-            <relay site="LONDON">
+            <relay site="LON">
                 <remote-site name="SFO" channel="bridge"/>
                 <remote-site name="NYC" channel="bridge"/>
             </relay>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_0.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-4_0.xml
@@ -1,6 +1,28 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
 <subsystem xmlns="urn:jboss:domain:jgroups:4.0">
-    <channels default="${test.channel:ee}">
-        <channel name="ee" stack="${test.expr:maximal}" cluster="${test.expr:mycluster}">
+    <channels default="ee">
+        <channel name="ee" stack="maximal" cluster="${test.expr:mycluster}">
             <fork name="web">
                 <protocol type="CENTRAL_LOCK">
                     <property name="num_backups">1</property>
@@ -55,7 +77,7 @@
             <protocol type="MFC"/>
             <protocol type="FRAG2"/>
             <protocol type="RSVP"/>
-            <relay site="LONDON">
+            <relay site="LON">
                 <remote-site name="SFO" channel="bridge"/>
                 <remote-site name="NYC" channel="bridge"/>
             </relay>

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
@@ -1,4 +1,26 @@
-<subsystem xmlns="urn:jboss:domain:jgroups:3.0">
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:jgroups:4.0">
     <channels default="default">
         <channel name="default" stack="minimal"/>
     </channels>
@@ -47,9 +69,9 @@
             <protocol type="MFC"/>
             <protocol type="FRAG2"/>
             <protocol type="RSVP"/>
-            <relay site="LONDON">
-                <remote-site name="SFO" stack="minimal" cluster="global"/>
-                <remote-site name="NYC" stack="minimal" cluster="global"/>
+            <relay site="LON">
+                <remote-site name="SFO" channel="bridge"/>
+                <remote-site name="NYC" channel="bridge"/>
             </relay>
         </stack>
         <stack name="minimal">

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform.xml
@@ -1,10 +1,46 @@
-<subsystem xmlns="urn:jboss:domain:jgroups:3.0">
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<subsystem xmlns="urn:jboss:domain:jgroups:4.0">
     <stacks default="maximal">
         <stack name="maximal">
-            <transport type="TCP" module="org.jgroups" socket-binding="jgroups-tcp" diagnostics-socket-binding="jgroups-diagnostics" default-executor="jgroups" oob-executor="jgroups-oob" timer-executor="jgroups-timer" shared="false" thread-factory="jgroups-thread-factory" machine="machine1" rack="rack1" site="site1" >
+            <transport type="TCP"
+                       module="org.jgroups"
+                       socket-binding="jgroups-tcp"
+                       diagnostics-socket-binding="jgroups-diagnostics"
+                       default-executor="jgroups"
+                       oob-executor="jgroups-oob"
+                       timer-executor="jgroups-timer"
+                       shared="false"
+                       thread-factory="jgroups-thread-factory"
+                       machine="machine1"
+                       rack="rack1"
+                       site="site1">
                 <property name="enable_bundling">true</property>
             </transport>
-            <protocol type="MPING" module="org.jgroups"/>
+            <protocol type="MPING" module="org.jgroups">
+                <property name="ip_ttl">1</property>
+                <property name="receive_on_all_interfaces">true</property>
+            </protocol>
             <protocol type="MERGE2"/>
             <protocol type="FD_SOCK" socket-binding="jgroups-udp-fd"/>
             <protocol type="FD"/>

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSupport.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSupport.java
@@ -44,7 +44,6 @@ import org.junit.Assert;
 
 
 /**
- *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 public class MixedDomainTestSupport extends DomainTestSupport {
@@ -57,7 +56,7 @@ public class MixedDomainTestSupport extends DomainTestSupport {
     private MixedDomainTestSupport(Version.AsVersion version, String testClass, String domainConfig, String masterConfig, String slaveConfig,
                                    String jbossHome, boolean adjustDomain)
             throws Exception {
-        super(testClass, domainConfig, masterConfig, slaveConfig,  new WildFlyManagedConfiguration(), new WildFlyManagedConfiguration(jbossHome));
+        super(testClass, domainConfig, masterConfig, slaveConfig, new WildFlyManagedConfiguration(), new WildFlyManagedConfiguration(jbossHome));
         this.version = version;
         this.adjustDomain = adjustDomain;
     }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/OldVersionCopier.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/OldVersionCopier.java
@@ -21,9 +21,6 @@
 */
 package org.jboss.as.test.integration.domain.mixed;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/SimpleMixedDomainTest.java
@@ -72,7 +72,6 @@ import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.xnio.IoUtils;
@@ -189,7 +188,6 @@ public abstract class SimpleMixedDomainTest  {
     }
 
     @Test
-    @Ignore
     public void testJgroupsTransformers() throws Exception {
         final DomainClient masterClient = support.getDomainMasterLifecycleUtil().createDomainClient();
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/DomainAdjuster630.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/DomainAdjuster630.java
@@ -22,9 +22,6 @@
 
 package org.jboss.as.test.integration.domain.mixed.eap630;
 
-import static org.jboss.as.controller.operations.common.Util.createAddOperation;
-import static org.jboss.as.controller.operations.common.Util.createRemoveOperation;
-import static org.jboss.as.controller.operations.common.Util.getUndefineAttributeOperation;
 import static org.jboss.as.controller.operations.common.Util.getWriteAttributeOperation;
 
 import java.util.ArrayList;
@@ -46,8 +43,6 @@ public class DomainAdjuster630 extends DomainAdjuster640 {
         List<ModelNode> list = super.adjustForVersion(client, profileAddress);
 
 //        list.addAll(adjustInfinispan(profileAddress.append(SUBSYSTEM, InfinispanExtension.SUBSYSTEM_NAME)));
-//        list.addAll(adjustJGroups(profileAddress.append(SUBSYSTEM, JGroupsExtension.SUBSYSTEM_NAME)));
-
 
         return list;
     }
@@ -64,7 +59,7 @@ public class DomainAdjuster630 extends DomainAdjuster640 {
                 subsystem.append("cache-container", "server")));
         list.add(setStatisticsEnabledTrue(
                 subsystem.append("cache-container", "server").append("replicated-cache", "default")));
-        list.add(getWriteAttributeOperation(subsystem.append("cache-container", "server").append("transport", "TRANSPORT"), "stack", new ModelNode("udp ")));
+        list.add(getWriteAttributeOperation(subsystem.append("cache-container", "server").append("transport", "TRANSPORT"), "stack", new ModelNode("udp")));
         list.add(setStatisticsEnabledTrue(
                 subsystem.append("cache-container", "web")));
         list.add(setStatisticsEnabledTrue(
@@ -83,61 +78,6 @@ public class DomainAdjuster630 extends DomainAdjuster640 {
                 subsystem.append("cache-container", "hibernate").append("replicated-cache", "timestamps")));
         return list;
     }
-
-
-
-
-    private List<ModelNode> adjustJGroups(final PathAddress subsystem) throws Exception {
-        final List<ModelNode> list = new ArrayList<>();
-        //default-channel is not understood
-        list.add(
-                getUndefineAttributeOperation(
-                        subsystem, "default-channel"));
-        //In fact channels don't work
-        list.add(createRemoveOperation(subsystem.append("channel", "ee")));
-
-        // pbcast.NAKACK2 does not exist, use pbcast.NAKACK instead
-        // UNICAST3 does not exist, use UNICAST2 instead
-        //All this code is to remove and re-add the protocols including the rename to preserve the order
-        //TODO once we support indexed adds, use those instead
-        //udp
-        PathAddress udp = subsystem.append("stack", "udp");
-        list.add(createRemoveOperation(udp.append("protocol", "pbcast.NAKACK2")));
-        list.add(createRemoveOperation(udp.append("protocol", "UNICAST3")));
-        list.add(createRemoveOperation(udp.append("protocol", "pbcast.STABLE")));
-        list.add(createRemoveOperation(udp.append("protocol", "pbcast.GMS")));
-        list.add(createRemoveOperation(udp.append("protocol", "UFC")));
-        list.add(createRemoveOperation(udp.append("protocol", "MFC")));
-        list.add(createRemoveOperation(udp.append("protocol", "FRAG2")));
-        list.add(createAddOperation(udp.append("protocol", "pbcast.NAKACK")));
-        list.add(createAddOperation(udp.append("protocol", "UNICAST2")));
-        list.add(createAddOperation(udp.append("protocol", "pbcast.STABLE")));
-        list.add(createAddOperation(udp.append("protocol", "pbcast.GMS")));
-        list.add(createAddOperation(udp.append("protocol", "UFC")));
-        list.add(createAddOperation(udp.append("protocol", "MFC")));
-        list.add(createAddOperation(udp.append("protocol", "FRAG2")));
-        list.add(createAddOperation(udp.append("protocol", "RSVP")));
-
-        //udp
-        PathAddress tcp = subsystem.append("stack", "tcp");
-        list.add(createRemoveOperation(tcp.append("protocol", "pbcast.NAKACK2")));
-        list.add(createRemoveOperation(tcp.append("protocol", "UNICAST3")));
-        list.add(createRemoveOperation(tcp.append("protocol", "pbcast.STABLE")));
-        list.add(createRemoveOperation(tcp.append("protocol", "pbcast.GMS")));
-        list.add(createRemoveOperation(tcp.append("protocol", "MFC")));
-        list.add(createRemoveOperation(tcp.append("protocol", "FRAG2")));
-        list.add(createAddOperation(tcp.append("protocol", "pbcast.NAKACK")));
-        list.add(createAddOperation(tcp.append("protocol", "UNICAST2")));
-        list.add(createAddOperation(tcp.append("protocol", "pbcast.STABLE")));
-        list.add(createAddOperation(tcp.append("protocol", "pbcast.GMS")));
-        list.add(createAddOperation(tcp.append("protocol", "UFC")));
-        list.add(createAddOperation(tcp.append("protocol", "FRAG2")));
-        list.add(createAddOperation(tcp.append("protocol", "RSVP")));
-
-        return list;
-    }
-
-
 
     private ModelNode setStatisticsEnabledTrue(final PathAddress addr) {
         return getWriteAttributeOperation(addr, "statistics-enabled", true);


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-4515 (JGroups portion only)
- fix transformer contradictions
- discard used channels, reject otherwise
- reenable mixed domain tests for clustering (jgroups part)
- fix jgroups properties attribute transformations
- implement map operation transformations with new tranformers attachments API
- handle properties transformation for :add-protocol operation
- add missing tests
- code cleanup
