### PR TITLE
WFLY-5171 permissions.xml files added for test deployments to work with security manager without AllPermission

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
@@ -43,10 +43,12 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
+import java.net.SocketPermission;
 import java.util.PropertyPermission;
 
 import static org.jboss.as.test.integration.ejb.mdb.dynamic.impl.TtyCodes.TTY_Bright;
 import static org.jboss.as.test.integration.ejb.mdb.dynamic.impl.TtyCodes.TTY_Reset;
+import org.jboss.as.test.integration.security.common.Utils;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.jboss.shrinkwrap.api.ShrinkWrap.create;
 import static org.junit.Assert.assertEquals;
@@ -77,8 +79,15 @@ public class DynamicMessageListenerTestCase {
                         .addPackages(true, TelnetResourceAdapter.class.getPackage(), TelnetListener.class.getPackage(), TelnetServer.class.getPackage()))
                 .addAsModule(create(JavaArchive.class, "mdb.jar")
                         .addClasses(MyMdb.class));
-        // the deployment uses PropertyEditorManager which needs this
-        ear.addAsResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "META-INF/permissions.xml");
+
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                new PropertyPermission("*", "read,write"),
+                new RuntimePermission("accessDeclaredMembers"),
+                new RuntimePermission("defineClassInPackage." + MyMdb.class.getPackage().getName()),
+                new RuntimePermission("getClassLoader"),
+                new SocketPermission(Utils.getDefaultHost(true), "accept,listen,resolve"),
+                new PropertyPermission("ts.timeout.factor", "read")),
+                "permissions.xml");
         return ear;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
@@ -81,12 +81,14 @@ public class DynamicMessageListenerTestCase {
                         .addClasses(MyMdb.class));
 
         ear.addAsManifestResource(createPermissionsXmlAsset(
+                // Cmd (TelnetServer package) uses PropertyEditorManager#registerEditor during static initialization
                 new PropertyPermission("*", "read,write"),
+                // TelnetResourceAdapter#endpointActivation instantiates new end point using reflection
                 new RuntimePermission("accessDeclaredMembers"),
                 new RuntimePermission("defineClassInPackage." + MyMdb.class.getPackage().getName()),
                 new RuntimePermission("getClassLoader"),
-                new SocketPermission(Utils.getDefaultHost(true), "accept,listen,resolve"),
-                new PropertyPermission("ts.timeout.factor", "read")),
+                // TelnetServer binds socket and accepts connections
+                new SocketPermission(Utils.getDefaultHost(true), "accept,listen,resolve")),
                 "permissions.xml");
         return ear;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/adapter/TelnetResourceAdapter.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/adapter/TelnetResourceAdapter.java
@@ -52,13 +52,16 @@ public class TelnetResourceAdapter implements javax.resource.spi.ResourceAdapter
         this.port = port;
     }
 
+    @Override
     public void start(BootstrapContext bootstrapContext) throws ResourceAdapterInternalException {
         this.workManager = bootstrapContext.getWorkManager();
     }
 
+    @Override
     public void stop() {
     }
 
+    @Override
     public void endpointActivation(MessageEndpointFactory messageEndpointFactory, ActivationSpec activationSpec) throws ResourceException {
         final TelnetActivationSpec telnetActivationSpec = (TelnetActivationSpec) activationSpec;
 
@@ -90,6 +93,7 @@ public class TelnetResourceAdapter implements javax.resource.spi.ResourceAdapter
         }
     }
 
+    @Override
     public void endpointDeactivation(MessageEndpointFactory messageEndpointFactory, ActivationSpec activationSpec) {
         final TelnetActivationSpec telnetActivationSpec = (TelnetActivationSpec) activationSpec;
 
@@ -106,6 +110,7 @@ public class TelnetResourceAdapter implements javax.resource.spi.ResourceAdapter
         endpoint.release();
     }
 
+    @Override
     public XAResource[] getXAResources(ActivationSpec[] activationSpecs) throws ResourceException {
         return new XAResource[0];
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/NoMethodMessageListenerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/NoMethodMessageListenerTestCase.java
@@ -61,22 +61,23 @@ public class NoMethodMessageListenerTestCase {
 
     @Deployment
     public static Archive createDeployment() {
-        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_NAME + ".ear");
+        final Package currentPackage = NoMethodMessageListenerTestCase.class.getPackage();
 
-        final JavaArchive rar = ShrinkWrap.create(JavaArchive.class, RAR_NAME + ".rar");
-        rar.addAsManifestResource(NoMethodMessageListenerTestCase.class.getPackage(), "ra.xml", "ra.xml");
+        final JavaArchive rar = ShrinkWrap.create(JavaArchive.class, RAR_NAME + ".rar")
+                .addAsManifestResource(currentPackage, "ra.xml", "ra.xml");
 
-        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, EJB_JAR_NAME + ".jar");
-        ejbJar.addClasses(SimpleMessageDrivenBean.class, NoMethodMessageListenerTestCase.class,
-                ReceivedMessageTracker.class);
+        final JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, EJB_JAR_NAME + ".jar")
+                .addClasses(SimpleMessageDrivenBean.class, NoMethodMessageListenerTestCase.class, ReceivedMessageTracker.class);
 
-        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, LIB_JAR_NAME + ".jar");
-        libJar.addClasses(SimpleActivationSpec.class, SimpleResourceAdapter.class,
-                NoMethodMessageListener.class, TimeoutUtil.class);
+        final JavaArchive libJar = ShrinkWrap.create(JavaArchive.class, LIB_JAR_NAME + ".jar")
+                .addClasses(SimpleActivationSpec.class, SimpleResourceAdapter.class)
+                .addClasses(NoMethodMessageListener.class, TimeoutUtil.class);
 
-        ear.addAsModule(rar);
-        ear.addAsModule(ejbJar);
-        ear.addAsLibrary(libJar);
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, EAR_NAME + ".ear")
+                .addAsModule(rar)
+                .addAsModule(ejbJar)
+                .addAsLibrary(libJar)
+                .addAsManifestResource(currentPackage, "permissions.xml", "permissions.xml");
 
         return ear;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/permissions.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>accessDeclaredMembers</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>defineClassInPackage.org.jboss.as.test.integration.ejb.mdb.messagelistener.nomethodinterface</name>
+    </permission>
+    <permission>
+        <class-name>java.lang.RuntimePermission</class-name>
+        <name>getClassLoader</name>
+    </permission>
+    <permission>
+        <class-name>java.util.PropertyPermission</class-name>
+        <name>ts.timeout.factor</name>
+        <actions>read</actions>
+    </permission>
+</permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/messagelistener/nomethodinterface/permissions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <permissions version="7">
+    <!--SimpleResourceAdapter#endpointActivation instantiates new end point using reflection -->
     <permission>
         <class-name>java.lang.RuntimePermission</class-name>
         <name>accessDeclaredMembers</name>
@@ -12,6 +13,8 @@
         <class-name>java.lang.RuntimePermission</class-name>
         <name>getClassLoader</name>
     </permission>
+
+    <!--org.jboss.as.test.shared.TimeoutUtil reads ts.timeout.factor system property during static initialization-->
     <permission>
         <class-name>java.util.PropertyPermission</class-name>
         <name>ts.timeout.factor</name>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/objectstore/TransactionObjectStoreTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/objectstore/TransactionObjectStoreTestCase.java
@@ -58,9 +58,10 @@ public class TransactionObjectStoreTestCase extends AbstractCliTestBase {
 
     @Deployment
     public static Archive<?> getDeployment() {
-        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, TransactionObjectStoreTestCase.class.getSimpleName() + ".jar");
-        jar.addClass(ObjectStoreBrowserService.class);
-        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts\n"), "MANIFEST.MF");
+        JavaArchive jar = ShrinkWrap.create(JavaArchive.class, TransactionObjectStoreTestCase.class.getSimpleName() + ".jar")
+                .addClass(ObjectStoreBrowserService.class)
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.jts\n"), "MANIFEST.MF")
+                .addAsManifestResource(TransactionObjectStoreTestCase.class.getPackage(), "permissions.xml", "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/objectstore/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/objectstore/permissions.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <permissions version="7">
+    <!--ObjectStoreBrowserService instantiates and starts new com.arjuna.ats.arjuna.tools.osb.api.mbeans.RecoveryStoreBean MBean-->
     <permission>
         <class-name>javax.management.MBeanPermission</class-name>
         <name>com.arjuna.ats.arjuna.tools.osb.api.mbeans.RecoveryStoreBean#-[jboss.jta:name=store1,type=com.arjuna.ats.arjuna.tools.osb.api.mbeans.RecoveryStoreBean]</name>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/objectstore/permissions.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/management/cli/objectstore/permissions.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<permissions version="7">
+    <permission>
+        <class-name>javax.management.MBeanPermission</class-name>
+        <name>com.arjuna.ats.arjuna.tools.osb.api.mbeans.RecoveryStoreBean#-[jboss.jta:name=store1,type=com.arjuna.ats.arjuna.tools.osb.api.mbeans.RecoveryStoreBean]</name>
+        <actions>registerMBean</actions>
+    </permission>
+</permissions>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
@@ -1,6 +1,5 @@
 package org.jboss.as.test.integration.naming.remote.multiple;
 
-import java.lang.reflect.ReflectPermission;
 import java.net.SocketPermission;
 import java.net.URL;
 import java.util.PropertyPermission;
@@ -48,15 +47,12 @@ public class MultipleClientRemoteJndiTestCase {
                 .setWebXML(thisPackage, "web.xml")
                 .addAsManifestResource(thisPackage, "war-jboss-deployment-structure.xml", "jboss-deployment-structure.xml")
                 .addAsManifestResource(createPermissionsXmlAsset(
+                        // RunRmiServlet reads node0 system property
                         new PropertyPermission("node0", "read"),
-                        new RemotingPermission("createEndpoint"),
-                        new RuntimePermission("createXnioWorker"),
-                        new RemotingPermission("addConnectionProvider"),
+                        // RunRmiServlet looks up for MyObject using connection through http-remoting Endpoint
                         new RemotingPermission("connect"),
                         new SocketPermission(Utils.getDefaultHost(true), "accept,connect,listen,resolve"),
-                        new RuntimePermission("getClassLoader"),
-                        new RuntimePermission("accessDeclaredMembers"),
-                        new ReflectPermission("suppressAccessChecks")),
+                        new RuntimePermission("getClassLoader")),
                         "permissions.xml");
     }
 
@@ -67,7 +63,9 @@ public class MultipleClientRemoteJndiTestCase {
                 .setWebXML(thisPackage, "web.xml")
                 .addAsManifestResource(thisPackage, "war-jboss-deployment-structure.xml", "jboss-deployment-structure.xml")
                 .addAsManifestResource(createPermissionsXmlAsset(
+                        // RunRmiServlet reads node0 system property
                         new PropertyPermission("node0", "read"),
+                        // RunRmiServlet looks up for MyObject using connection through http-remoting Endpoint
                         new RemotingPermission("connect"),
                         new SocketPermission(Utils.getDefaultHost(true), "accept,connect,listen,resolve"),
                         new RuntimePermission("getClassLoader")),
@@ -79,7 +77,9 @@ public class MultipleClientRemoteJndiTestCase {
         return ShrinkWrap.create(WebArchive.class, "binder.war")
                 .addClasses(BindRmiServlet.class, MyObject.class)
                 .setWebXML(MultipleClientRemoteJndiTestCase.class.getPackage(), "web.xml")
+                // dependency to org.jboss.as.naming module is used to grant JndiPermission
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
+                // BindRmiServlet binds java:jboss/exported/loc/stub
                 .addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("java:jboss/exported/loc/stub", "bind")),
                         "permissions.xml");
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
@@ -52,15 +52,12 @@ public class NestedRemoteContextTestCase {
                 .addAsModule(war)
                 .addAsManifestResource(thisPackage, "ear-jboss-deployment-structure.xml", "jboss-deployment-structure.xml")
                 .addAsManifestResource(createPermissionsXmlAsset(
+                        // CallEjbServlet reads node0 system property
                         new PropertyPermission("node0", "read"),
-                        new RemotingPermission("createEndpoint"),
-                        new RuntimePermission("createXnioWorker"),
-                        new RemotingPermission("addConnectionProvider"),
+                        // CallEjbServlet looks up for MyObject using connection through http-remoting Endpoint
                         new RemotingPermission("connect"),
                         new SocketPermission(Utils.getDefaultHost(true), "accept,connect,listen,resolve"),
-                        new RuntimePermission("getClassLoader"),
-                        new RuntimePermission("accessDeclaredMembers"),
-                        new ReflectPermission("suppressAccessChecks")),
+                        new RuntimePermission("getClassLoader")),
                         "permissions.xml");
         return ear;
     }
@@ -70,7 +67,9 @@ public class NestedRemoteContextTestCase {
         return ShrinkWrap.create(WebArchive.class, "binder.war")
                 .addClasses(BindRmiServlet.class, MyObject.class)
                 .setWebXML(MultipleClientRemoteJndiTestCase.class.getPackage(), "web.xml")
+                // dependency to org.jboss.as.naming module is used to grant JndiPermission
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
+                // BindRmiServlet binds java:jboss/exported/loc/stub
                 .addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("java:jboss/exported/loc/stub", "bind")),
                         "permissions.xml");
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
@@ -1,6 +1,9 @@
 package org.jboss.as.test.integration.naming.remote.multiple;
 
+import java.lang.reflect.ReflectPermission;
+import java.net.SocketPermission;
 import java.net.URL;
+import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -15,6 +18,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import org.jboss.as.naming.JndiPermission;
+import org.jboss.as.test.integration.security.common.Utils;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import org.jboss.remoting3.security.RemotingPermission;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -24,38 +32,52 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Arquillian.class)
 @RunAsClient
 public class NestedRemoteContextTestCase {
-	@ArquillianResource(CallEjbServlet.class)
-	private URL callEjbUrl;
+    @ArquillianResource(CallEjbServlet.class)
+    private URL callEjbUrl;
 
-	private static final Package thisPackage = NestedRemoteContextTestCase.class.getPackage();
+    private static final Package thisPackage = NestedRemoteContextTestCase.class.getPackage();
 
 
-	@Deployment
-	public static EnterpriseArchive deploymentTwo() {
-		JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "ejb.jar")
-				.addClasses(MyEjbBean.class, MyEjb.class, MyObject.class);
+    @Deployment
+    public static EnterpriseArchive deploymentTwo() {
+        JavaArchive ejbJar = ShrinkWrap.create(JavaArchive.class, "ejb.jar")
+                .addClasses(MyEjbBean.class, MyEjb.class, MyObject.class);
 
-		WebArchive war = ShrinkWrap.create(WebArchive.class, "web.war")
-				.addClasses(CallEjbServlet.class,  MyObject.class)
-				.setWebXML(thisPackage, "web.xml");
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "web.war")
+                .addClasses(CallEjbServlet.class,  MyObject.class)
+                .setWebXML(thisPackage, "web.xml");
 
-		EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ejb.ear")
-				.addAsModule(ejbJar)
-				.addAsModule(war)
-				.addAsManifestResource(thisPackage, "ear-jboss-deployment-structure.xml", "jboss-deployment-structure.xml");
-		return ear;
-	}
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ejb.ear")
+                .addAsModule(ejbJar)
+                .addAsModule(war)
+                .addAsManifestResource(thisPackage, "ear-jboss-deployment-structure.xml", "jboss-deployment-structure.xml")
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new PropertyPermission("node0", "read"),
+                        new RemotingPermission("createEndpoint"),
+                        new RuntimePermission("createXnioWorker"),
+                        new RemotingPermission("addConnectionProvider"),
+                        new RemotingPermission("connect"),
+                        new SocketPermission(Utils.getDefaultHost(true), "accept,connect,listen,resolve"),
+                        new RuntimePermission("getClassLoader"),
+                        new RuntimePermission("accessDeclaredMembers"),
+                        new ReflectPermission("suppressAccessChecks")),
+                        "permissions.xml");
+        return ear;
+    }
 
-	@Deployment(name="binder")
-	public static WebArchive deploymentThree() {
-		return ShrinkWrap.create(WebArchive.class, "binder.war")
-				.addClasses(BindRmiServlet.class, MyObject.class)
-				.setWebXML(MultipleClientRemoteJndiTestCase.class.getPackage(), "web.xml");
-	}
+    @Deployment(name="binder")
+    public static WebArchive deploymentThree() {
+        return ShrinkWrap.create(WebArchive.class, "binder.war")
+                .addClasses(BindRmiServlet.class, MyObject.class)
+                .setWebXML(MultipleClientRemoteJndiTestCase.class.getPackage(), "web.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("java:jboss/exported/loc/stub", "bind")),
+                        "permissions.xml");
+    }
 
-	@Test
-	public void testLifeCycle() throws Exception {
-		String result = HttpRequest.get(callEjbUrl.toExternalForm() + "CallEjbServlet", 1000, SECONDS);
-		assertEquals("TestHello", result);
-	}
+    @Test
+    public void testLifeCycle() throws Exception {
+        String result = HttpRequest.get(callEjbUrl.toExternalForm() + "CallEjbServlet", 1000, SECONDS);
+        assertEquals("TestHello", result);
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/ear-jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/ear-jboss-deployment-structure.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0"?>
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
-	<sub-deployment name="web.war">
-		<dependencies>
-			<module name="org.jboss.remote-naming" />
-			<module name="org.jboss.as.network" />
-		</dependencies>
-	</sub-deployment>
-	<sub-deployment name="ejb.jar">
-		<dependencies>
-			<module name="org.jboss.remote-naming" />
-			<module name="org.jboss.as.network" />
-		</dependencies>
-	</sub-deployment>
+    <deployment>
+        <dependencies>
+            <module name="org.jboss.remoting" />
+        </dependencies>
+    </deployment>
+    <sub-deployment name="web.war">
+        <dependencies>
+            <module name="org.jboss.remote-naming" />
+            <module name="org.jboss.as.network" />
+        </dependencies>
+    </sub-deployment>
+    <sub-deployment name="ejb.jar">
+        <dependencies>
+            <module name="org.jboss.remote-naming" />
+            <module name="org.jboss.as.network" />
+        </dependencies>
+    </sub-deployment>
 </jboss-deployment-structure>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/ear-jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/ear-jboss-deployment-structure.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
     <deployment>
+        <!--used to grant RemotingPermission-->
         <dependencies>
             <module name="org.jboss.remoting" />
         </dependencies>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/war-jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/war-jboss-deployment-structure.xml
@@ -4,6 +4,7 @@
         <dependencies>
             <module name="org.jboss.remote-naming" />
             <module name="org.jboss.as.network" />
+            <!--used to grant RemotingPermission-->
             <module name="org.jboss.remoting" />
         </dependencies>
     </deployment>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/war-jboss-deployment-structure.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/war-jboss-deployment-structure.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0"?>
 <jboss-deployment-structure xmlns="urn:jboss:deployment-structure:1.2">
-	<deployment>
-		<dependencies>
-			<module name="org.jboss.remote-naming" />
-			<module name="org.jboss.as.network" />
-		</dependencies>
-	</deployment>
+    <deployment>
+        <dependencies>
+            <module name="org.jboss.remote-naming" />
+            <module name="org.jboss.as.network" />
+            <module name="org.jboss.remoting" />
+        </dependencies>
+    </deployment>
 </jboss-deployment-structure>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -56,10 +57,13 @@ public class RemoteNamingTestCase {
 
     @Deployment
     public static Archive<?> deploy() {
-        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test.jar");
-        jar.addClasses(BindingEjb.class);
-                // grant necessary permissions
-        jar.addAsResource(createPermissionsXmlAsset(new JndiPermission("java:jboss/exported/-", "all"), new JndiPermission("java:jboss/exported", "all")), "META-INF/jboss-permissions.xml");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test.jar")
+                .addClasses(BindingEjb.class)
+                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
+                .addAsManifestResource(createPermissionsXmlAsset(
+                        new JndiPermission("java:jboss/exported/test", "bind"),
+                        new JndiPermission("java:jboss/exported/context/test", "bind")),
+                        "permissions.xml");
 
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
@@ -59,7 +59,9 @@ public class RemoteNamingTestCase {
     public static Archive<?> deploy() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test.jar")
                 .addClasses(BindingEjb.class)
+                // dependency to org.jboss.as.naming module is used to grant JndiPermission
                 .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
+                // BindingEjb binds java:jboss/exported/test and java:jboss/exported/context/test
                 .addAsManifestResource(createPermissionsXmlAsset(
                         new JndiPermission("java:jboss/exported/test", "bind"),
                         new JndiPermission("java:jboss/exported/context/test", "bind")),


### PR DESCRIPTION
WFLY-5171 permissions.xml files added for test deployments to work with security manager without AllPermission
Fix for https://issues.jboss.org/browse/WFLY-5171

`org.jboss.as.test.integration.naming.remote.multiple.*TestCase`s need to be fixed under https://issues.jboss.org/browse/WFLY-5169
