### PR TITLE
WFLY-5242 ipv6 format in undertow message

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/AjpListenerService.java
@@ -28,6 +28,8 @@ import java.net.InetSocketAddress;
 import io.undertow.UndertowOptions;
 import io.undertow.server.OpenListener;
 import io.undertow.server.protocol.ajp.AjpOpenListener;
+
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.msc.service.StartContext;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 import org.xnio.ChannelListener;
@@ -61,7 +63,7 @@ public class AjpListenerService extends ListenerService<AjpListenerService> {
     void startListening(XnioWorker worker, InetSocketAddress socketAddress, ChannelListener<AcceptingChannel<StreamConnection>> acceptListener) throws IOException {
         server = worker.createStreamConnectionServer(socketAddress, acceptListener, OptionMap.builder().addAll(commonOptions).addAll(socketOptions).getMap());
         server.resumeAccepts();
-        UndertowLogger.ROOT_LOGGER.listenerStarted("AJP", getName(), binding.getValue().getSocketAddress());
+        UndertowLogger.ROOT_LOGGER.listenerStarted("AJP", getName(), NetworkUtils.formatIPAddressForURI(binding.getValue().getSocketAddress().getAddress()), binding.getValue().getPort());
     }
 
     @Override
@@ -74,7 +76,7 @@ public class AjpListenerService extends ListenerService<AjpListenerService> {
         server.suspendAccepts();
         UndertowLogger.ROOT_LOGGER.listenerSuspend("AJP", getName());
         IoUtils.safeClose(server);
-        UndertowLogger.ROOT_LOGGER.listenerStopped("AJP", getName(), getBinding().getValue().getSocketAddress());
+        UndertowLogger.ROOT_LOGGER.listenerStopped("AJP", getName(), NetworkUtils.formatIPAddressForURI(getBinding().getValue().getSocketAddress().getAddress()), getBinding().getValue().getPort());
     }
 
     @Override

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpListenerService.java
@@ -35,6 +35,8 @@ import io.undertow.server.handlers.ProxyPeerAddressHandler;
 import io.undertow.server.handlers.SSLHeaderHandler;
 import io.undertow.server.protocol.http.HttpOpenListener;
 import io.undertow.server.protocol.http2.Http2UpgradeHandler;
+
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.ValueService;
@@ -123,7 +125,7 @@ public class HttpListenerService extends ListenerService<HttpListenerService> {
             throws IOException {
         server = worker.createStreamConnectionServer(socketAddress, acceptListener, OptionMap.builder().addAll(commonOptions).addAll(socketOptions).getMap());
         server.resumeAccepts();
-        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTP", getName(), socketAddress);
+        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTP", getName(), NetworkUtils.formatIPAddressForURI(socketAddress.getAddress()), socketAddress.getPort());
     }
 
     @Override
@@ -137,7 +139,7 @@ public class HttpListenerService extends ListenerService<HttpListenerService> {
         UndertowLogger.ROOT_LOGGER.listenerSuspend("HTTP", getName());
         IoUtils.safeClose(server);
         server = null;
-        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTP", getName(), getBinding().getValue().getSocketAddress());
+        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTP", getName(), NetworkUtils.formatIPAddressForURI(getBinding().getValue().getSocketAddress().getAddress()), getBinding().getValue().getPort());
         httpListenerRegistry.getValue().removeListener(getName());
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HttpsListenerService.java
@@ -35,6 +35,7 @@ import io.undertow.server.protocol.http.HttpOpenListener;
 import io.undertow.server.protocol.http2.Http2OpenListener;
 import io.undertow.server.protocol.spdy.SpdyOpenListener;
 import org.jboss.as.domain.management.SecurityRealm;
+import org.jboss.as.network.NetworkUtils;
 import org.jboss.msc.value.InjectedValue;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 import org.xnio.ChannelListener;
@@ -113,7 +114,7 @@ public class HttpsListenerService extends HttpListenerService {
         sslServer = xnioSsl.createSslConnectionServer(worker, socketAddress, (ChannelListener) acceptListener, combined);
         sslServer.resumeAccepts();
 
-        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTPS", getName(), socketAddress);
+        UndertowLogger.ROOT_LOGGER.listenerStarted("HTTPS", getName(), NetworkUtils.formatIPAddressForURI(socketAddress.getAddress()), socketAddress.getPort());
     }
 
     @Override
@@ -127,7 +128,7 @@ public class HttpsListenerService extends HttpListenerService {
         UndertowLogger.ROOT_LOGGER.listenerSuspend("HTTPS", getName());
         IoUtils.safeClose(sslServer);
         sslServer = null;
-        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTPS", getName(), getBinding().getValue().getSocketAddress());
+        UndertowLogger.ROOT_LOGGER.listenerStopped("HTTPS", getName(), NetworkUtils.formatIPAddressForURI(getBinding().getValue().getSocketAddress().getAddress()), getBinding().getValue().getPort());
         httpListenerRegistry.getValue().removeListener(getName());
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -28,7 +28,6 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.nio.file.Path;
 import java.util.List;
 
@@ -91,12 +90,12 @@ public interface UndertowLogger extends BasicLogger {
      * @param address socket address
      */
     @LogMessage(level = INFO)
-    @Message(id = 6, value = "Undertow %s listener %s listening on %s")
-    void listenerStarted(String type, String name, InetSocketAddress address);
+    @Message(id = 6, value = "Undertow %s listener %s listening on %s:%d")
+    void listenerStarted(String type, String name, String address, int port);
 
     @LogMessage(level = INFO)
-    @Message(id = 7, value = "Undertow %s listener %s stopped, was bound to %s")
-    void listenerStopped(String type, String name, InetSocketAddress address);
+    @Message(id = 7, value = "Undertow %s listener %s stopped, was bound to %s:%d")
+    void listenerStopped(String type, String name, String address, int port);
 
     @LogMessage(level = INFO)
     @Message(id = 8, value = "Undertow %s listener %s suspending")


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5242
format IPV6 address in undertow messages from /0:0:0:0:0:0:0:1:PORT change to [::1]:PORT
