### PR TITLE
WFLY-4515 Fix reject/discard for implicitly added children

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/ImplicitlyAddedResourceDynamicDiscardPolicy.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/ImplicitlyAddedResourceDynamicDiscardPolicy.java
@@ -1,0 +1,58 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller.transform;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.transform.TransformationContext;
+import org.jboss.as.controller.transform.description.DiscardPolicy;
+import org.jboss.as.controller.transform.description.DynamicDiscardPolicy;
+import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.Property;
+
+/**
+ * Implementation of a generic {@link DynamicDiscardPolicy} that discards children resources which have all their
+ * attributes undefined; rejects otherwise. It is to be used for all implicitly added resources in
+ * {@link org.jboss.staxmapper.XMLElementReader} implementations.
+ *
+ * @author Radoslav Husar
+ * @version Sep 2015
+ */
+public class ImplicitlyAddedResourceDynamicDiscardPolicy implements DynamicDiscardPolicy {
+
+    /**
+     * @return {@link DiscardPolicy#REJECT_AND_WARN} if any of the attributes are defined; {@link DiscardPolicy#SILENT} otherwise
+     */
+    @Override
+    public DiscardPolicy checkResource(TransformationContext context, PathAddress address) {
+        ModelNode model = context.readResource(PathAddress.EMPTY_ADDRESS).getModel();
+
+        for (Property entry : model.asPropertyList()) {
+            if (entry.getValue().isDefined()) {
+                return DiscardPolicy.REJECT_AND_WARN;
+            }
+        }
+
+        return DiscardPolicy.SILENT;
+    }
+
+}

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
@@ -81,7 +81,7 @@ public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registra
     private final Attribute queueLength;
     private final Attribute keepAliveTime;
 
-    private ThreadPoolResourceDefinition(String name, String prefix, int defaultMinThreads, int defaultMaxThreads, int defaultQueueLength, long defaultKeepaliveTime) {
+    ThreadPoolResourceDefinition(String name, String prefix, int defaultMinThreads, int defaultMaxThreads, int defaultQueueLength, long defaultKeepaliveTime) {
         this.name = name;
         this.prefix = prefix;
         this.descriptionResolver = new JGroupsResourceDescriptionResolver(pathElement(PathElement.WILDCARD_VALUE));

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
@@ -99,6 +99,12 @@ public class TransformersTestCase extends OperationTestCaseBase {
         testTransformation(JGroupsModel.VERSION_1_2_0, version, formatLegacySubsystemArtifact(version));
     }
 
+    @Test
+    public void testTransformerEAP640() throws Exception {
+        ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_4_0;
+        testTransformation(JGroupsModel.VERSION_1_3_0, version, formatLegacySubsystemArtifact(version));
+    }
+
     /**
      * Tests transformation of model from current version into specified version.
      *
@@ -239,6 +245,12 @@ public class TransformersTestCase extends OperationTestCaseBase {
     public void testRejectionsEAP630() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_3_0;
         this.testRejections(JGroupsModel.VERSION_1_2_0, version, formatLegacySubsystemArtifact(version));
+    }
+
+    @Test
+    public void testRejectionsEAP640() throws Exception {
+        ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_4_0;
+        this.testRejections(JGroupsModel.VERSION_1_3_0, version, formatLegacySubsystemArtifact(version));
     }
 
     private void testRejections(JGroupsModel model, ModelTestControllerVersion controller, String... dependencies) throws Exception {

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
@@ -21,11 +21,7 @@
  */
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
 import static org.junit.Assert.assertEquals;
 
@@ -281,7 +277,8 @@ public class TransformersTestCase extends OperationTestCaseBase {
         PathAddress subsystemAddress = PathAddress.pathAddress(JGroupsSubsystemResourceDefinition.PATH);
 
         if (JGroupsModel.VERSION_3_0_0.requiresTransformation(version)) {
-            // This in real life would be not rejected, but since we don't have infinispan subsystem setup (this would also create a cyclic dependency) it has to be rejected in the test
+            // Channel resource in a typical configuration would be not rejected, but since we don't have infinispan subsystem setup (because
+            // that would create a cyclical dependency) it has to be rejected in this subsystem test
             config.addFailedAttribute(subsystemAddress.append(ChannelResourceDefinition.WILDCARD_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
             config.addFailedAttribute(subsystemAddress.append(StackResourceDefinition.WILDCARD_PATH).append(TransportResourceDefinition.WILDCARD_PATH).append(ThreadPoolResourceDefinition.WILDCARD_PATH), FailedOperationTransformationConfig.REJECTED_RESOURCE);
         }

--- a/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
+++ b/clustering/jgroups/extension/src/test/resources/org/jboss/as/clustering/jgroups/subsystem/subsystem-jgroups-transform-reject.xml
@@ -75,7 +75,12 @@
             </relay>
         </stack>
         <stack name="minimal">
-            <transport type="UDP"/>
+            <transport type="UDP">
+                <default-thread-pool min-threads="11"/>
+                <internal-thread-pool queue-length="22"/>
+                <oob-thread-pool keepalive-time="34"/>
+                <timer-thread-pool max-threads="43"/>
+            </transport>
         </stack>
     </stacks>
 </subsystem>


### PR DESCRIPTION
Removes warnings such as "WFLYCTL0303: Resource [...] is rejected on the target host, and will need to be ignored on the host" introduced by e769c366beb14f9e6d3bca73ae4280d4a43a45a4
