### PR TITLE
Remove excessive INFO logging when creating distributed HttpSession

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/Capability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/Capability.java
@@ -35,5 +35,7 @@ public interface Capability extends Definable<RuntimeCapability<Void>> {
      * @param address a path address
      * @return a resolved runtime capability
      */
-    RuntimeCapability<Void> getRuntimeCapability(PathAddress address);
+    default RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
+        return this.getDefinition().fromBaseCapability(address.getLastElement().getValue());
+    }
 }

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceServiceBuilder.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/ResourceServiceBuilder.java
@@ -40,5 +40,7 @@ public interface ResourceServiceBuilder<T> extends Builder<T> {
      * @return the reference to this builder
      * @throws OperationFailedException if there was a failure reading the model
      */
-    Builder<T> configure(OperationContext context, ModelNode model) throws OperationFailedException;
+    default Builder<T> configure(OperationContext context, ModelNode model) throws OperationFailedException {
+        return this;
+    }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoStoreBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoStoreBuilder.java
@@ -25,9 +25,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.PersistenceConfiguration;
 import org.jboss.as.clustering.controller.ResourceServiceBuilder;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.dmr.ModelNode;
-import org.wildfly.clustering.service.Builder;
 
 /**
  * @author Paul Ferraro
@@ -41,10 +38,5 @@ public class NoStoreBuilder extends CacheComponentBuilder<PersistenceConfigurati
     @Override
     public PersistenceConfiguration getValue() {
         return new ConfigurationBuilder().persistence().passivation(false).create();
-    }
-
-    @Override
-    public Builder<PersistenceConfiguration> configure(OperationContext context, ModelNode model) {
-        return this;
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/NoStoreResourceDefinition.java
@@ -44,10 +44,6 @@ public class NoStoreResourceDefinition extends ChildResourceDefinition {
         // Nothing to do yet
     }
 
-    /**
-     * @param type
-     * @param allowRuntimeOnlyRegistration
-     */
     public NoStoreResourceDefinition() {
         super(PATH, new InfinispanResourceDescriptionResolver(PATH));
     }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/RemoteStoreResourceDefinition.java
@@ -57,7 +57,7 @@ public class RemoteStoreResourceDefinition extends StoreResourceDefinition {
     static final PathElement LEGACY_PATH = PathElement.pathElement("remote-store", "REMOTE_STORE");
     static final PathElement PATH = pathElement("remote");
 
-    private enum Capability implements org.jboss.as.clustering.controller.Capability {
+    enum Capability implements org.jboss.as.clustering.controller.Capability {
         OUTBOUND_SOCKET_BINDING("org.wildfly.clustering.infinispan.cache-container.cache.store.remote.outbound-socket-binding", OutboundSocketBinding.class),
         ;
         private final RuntimeCapability<Void> definition;

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteThroughBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreWriteThroughBuilder.java
@@ -25,9 +25,6 @@ package org.jboss.as.clustering.infinispan.subsystem;
 import org.infinispan.configuration.cache.AsyncStoreConfiguration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.jboss.as.clustering.controller.ResourceServiceBuilder;
-import org.jboss.as.controller.OperationContext;
-import org.jboss.dmr.ModelNode;
-import org.wildfly.clustering.service.Builder;
 
 /**
  * @author Paul Ferraro
@@ -41,10 +38,5 @@ public class StoreWriteThroughBuilder extends CacheComponentBuilder<AsyncStoreCo
     @Override
     public AsyncStoreConfiguration getValue() throws IllegalStateException, IllegalArgumentException {
         return new ConfigurationBuilder().persistence().addSingleFileStore().async().disable().create();
-    }
-
-    @Override
-    public Builder<AsyncStoreConfiguration> configure(OperationContext context, ModelNode model) {
-        return this;
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PropertyResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/PropertyResourceDefinition.java
@@ -174,7 +174,6 @@ public class PropertyResourceDefinition extends ChildResourceDefinition {
 
     static ResourceTransformer PROPERTIES_RESOURCE_TRANSFORMER = new ResourceTransformer() {
         @Override
-        @SuppressWarnings("deprecation")
         public void transformResource(ResourceTransformationContext context, PathAddress address, Resource resource) throws OperationFailedException {
             final ModelNode model = resource.getModel();
             final ModelNode properties = model.remove(ProtocolResourceDefinition.Attribute.PROPERTIES.getDefinition().getName());
@@ -197,7 +196,6 @@ public class PropertyResourceDefinition extends ChildResourceDefinition {
 
     static OperationTransformer PROPERTIES_ADD_OP_TRANSFORMER = new OperationTransformer()  {
         @Override
-        @SuppressWarnings("deprecation")
         public ModelNode transformOperation(ModelNode operation) {
             if (operation.hasDefined(ProtocolResourceDefinition.Attribute.PROPERTIES.getDefinition().getName())) {
                 final ModelNode addOp = operation.clone();
@@ -227,7 +225,6 @@ public class PropertyResourceDefinition extends ChildResourceDefinition {
     static org.jboss.as.controller.transform.OperationTransformer PROPERTIES_OP_TRANSFORMER = new org.jboss.as.controller.transform.OperationTransformer() {
 
         @Override
-        @SuppressWarnings("deprecation")
         public TransformedOperation transformOperation(TransformationContext context, PathAddress address, ModelNode operation) throws OperationFailedException {
             if (operation.get(ModelDescriptionConstants.NAME).asString().equals(ProtocolResourceDefinition.Attribute.PROPERTIES.getDefinition().getName())) {
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -91,7 +91,7 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
         return PathElement.pathElement("transport", name);
     }
 
-    private enum Capability implements org.jboss.as.clustering.controller.Capability {
+    enum Capability implements org.jboss.as.clustering.controller.Capability {
         DIAGNOSTICS_SOCKET_BINDING("org.wildfly.clustering.transport.diagnostics-socket-binding", SocketBinding.class),
         ;
         private final RuntimeCapability<Void> definition;

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyResourceDefinition.java
@@ -28,7 +28,6 @@ import org.jboss.as.clustering.controller.RemoveStepHandler;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
@@ -63,11 +62,6 @@ public class SingletonPolicyResourceDefinition extends ChildResourceDefinition {
         @Override
         public RuntimeCapability<Void> getDefinition() {
             return this.definition;
-        }
-
-        @Override
-        public RuntimeCapability<Void> getRuntimeCapability(PathAddress address) {
-            return this.definition.fromBaseCapability(address.getLastElement().getValue());
         }
     }
 

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/coarse/CoarseSessionFactory.java
@@ -110,7 +110,6 @@ public class CoarseSessionFactory<L> implements SessionFactory<CoarseSessionEntr
 
     @Override
     public CoarseSessionEntry<L> createValue(String id, Void context) {
-        InfinispanWebLogger.ROOT_LOGGER.infof("CoarseSessionFactory.createValue(%s)", id);
         SessionCreationMetaDataKey creationMetaDataKey = new SessionCreationMetaDataKey(id);
         SessionCreationMetaDataEntry<L> creationMetaDataEntry = new SessionCreationMetaDataEntry<>(new SimpleSessionCreationMetaData());
         SessionCreationMetaDataEntry<L> existingCreationMetaDataEntry = this.creationMetaDataCache.getAdvancedCache().withFlags(Flag.FORCE_SYNCHRONOUS).putIfAbsent(creationMetaDataKey, creationMetaDataEntry);


### PR DESCRIPTION
That log message was created for debugging, and was not intended to be committed.

Also, remove some redundant code.
