### PR TITLE
Clustered EJB performance tweaks

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BasicSessionIDExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BasicSessionIDExternalizer.java
@@ -23,6 +23,7 @@
 package org.wildfly.clustering.ejb.infinispan;
 
 import org.jboss.ejb.client.BasicSessionID;
+import org.wildfly.clustering.marshalling.jboss.IndexExternalizer;
 
 /**
  * @author Paul Ferraro
@@ -30,6 +31,6 @@ import org.jboss.ejb.client.BasicSessionID;
 public class BasicSessionIDExternalizer extends SessionIDExternalizer {
 
     public BasicSessionIDExternalizer() {
-        super(BasicSessionID.class);
+        super(BasicSessionID.class, IndexExternalizer.UNSIGNED_BYTE);
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/ClientMappingExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/ClientMappingExternalizer.java
@@ -28,6 +28,7 @@ import java.net.InetAddress;
 
 import org.jboss.as.network.ClientMapping;
 import org.wildfly.clustering.marshalling.Externalizer;
+import org.wildfly.clustering.marshalling.jboss.IndexExternalizer;
 
 /**
  * @author Paul Ferraro
@@ -37,21 +38,21 @@ public class ClientMappingExternalizer implements Externalizer<ClientMapping> {
     @Override
     public void writeObject(ObjectOutput output, ClientMapping mapping) throws IOException {
         byte[] address = mapping.getSourceNetworkAddress().getAddress();
-        output.writeInt(address.length);
+        IndexExternalizer.UNSIGNED_BYTE.writeData(output, address.length);
         output.write(address);
-        output.writeInt(mapping.getSourceNetworkMaskBits());
+        IndexExternalizer.UNSIGNED_BYTE.writeData(output, mapping.getSourceNetworkMaskBits());
         output.writeUTF(mapping.getDestinationAddress());
-        output.writeInt(mapping.getDestinationPort());
+        IndexExternalizer.UNSIGNED_SHORT.writeData(output, mapping.getDestinationPort());
     }
 
     @Override
     public ClientMapping readObject(ObjectInput input) throws IOException {
-        byte[] sourceAddress = new byte[input.readInt()];
+        byte[] sourceAddress = new byte[IndexExternalizer.UNSIGNED_BYTE.readData(input)];
         input.readFully(sourceAddress);
-        int sourcePort = input.readInt();
+        int sourceNetworkMaskBits = IndexExternalizer.UNSIGNED_BYTE.readData(input);
         String destAddress = input.readUTF();
-        int destPort = input.readInt();
-        return new ClientMapping(InetAddress.getByAddress(sourceAddress), sourcePort, destAddress, destPort);
+        int destPort = IndexExternalizer.UNSIGNED_SHORT.readData(input);
+        return new ClientMapping(InetAddress.getByAddress(sourceAddress), sourceNetworkMaskBits, destAddress, destPort);
     }
 
     @Override

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SessionIDExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SessionIDExternalizer.java
@@ -34,21 +34,23 @@ import org.wildfly.clustering.marshalling.Externalizer;
 public class SessionIDExternalizer implements Externalizer<SessionID> {
 
     private final Class<? extends SessionID> targetClass;
+    private final Externalizer<Integer> externalizer;
 
-    SessionIDExternalizer(Class<? extends SessionID> targetClass) {
+    SessionIDExternalizer(Class<? extends SessionID> targetClass, Externalizer<Integer> externalizer) {
         this.targetClass = targetClass;
+        this.externalizer = externalizer;
     }
 
     @Override
     public void writeObject(ObjectOutput output, SessionID id) throws IOException {
         byte[] encoded = id.getEncodedForm();
-        output.writeInt(encoded.length);
+        this.externalizer.writeObject(output, encoded.length);
         output.write(encoded);
     }
 
     @Override
-    public SessionID readObject(ObjectInput input) throws IOException {
-        byte[] encoded = new byte[input.readInt()];
+    public SessionID readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        byte[] encoded = new byte[this.externalizer.readObject(input)];
         input.readFully(encoded);
         return SessionID.createSessionID(encoded);
     }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/UnknownSessionIDExternalizer.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/UnknownSessionIDExternalizer.java
@@ -23,6 +23,7 @@
 package org.wildfly.clustering.ejb.infinispan;
 
 import org.jboss.ejb.client.UnknownSessionID;
+import org.wildfly.clustering.marshalling.jboss.IndexExternalizer;
 
 /**
  * @author Paul Ferraro
@@ -30,6 +31,6 @@ import org.jboss.ejb.client.UnknownSessionID;
 public class UnknownSessionIDExternalizer extends SessionIDExternalizer {
 
     public UnknownSessionIDExternalizer() {
-        super(UnknownSessionID.class);
+        super(UnknownSessionID.class, IndexExternalizer.VARIABLE);
     }
 }


### PR DESCRIPTION
Optimize marshalled size of cache keys used for distributed EJBs.
Optimize marshalled size of client mappings.
