### PR TITLE
[WFLY-5264] Upgrade JBeret to version 1.2.0.Final. 

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemParser_1_0.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemParser_1_0.java
@@ -42,6 +42,7 @@ import org.jboss.staxmapper.XMLElementReader;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.wildfly.extension.batch.jberet.job.repository.InMemoryJobRepositoryDefinition;
 import org.wildfly.extension.batch.jberet.job.repository.JdbcJobRepositoryDefinition;
+import org.wildfly.extension.batch.jberet.thread.pool.BatchThreadPoolResourceDefinition;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -78,7 +79,7 @@ public class BatchSubsystemParser_1_0 implements XMLStreamConstants, XMLElementR
             } else if (element == Element.THREAD_POOL) {
                 threadsParser.parseUnboundedQueueThreadPool(reader, namespace.getUriString(),
                         THREADS_1_1, subsystemAddress.toModelNode(), ops,
-                        BatchSubsystemDefinition.THREAD_POOL, null);
+                        BatchThreadPoolResourceDefinition.NAME, null);
                 requiredElements.remove(Element.THREAD_POOL);
             } else if (element == Element.THREAD_FACTORY) {
                 threadsParser.parseThreadFactory(reader, namespace.getUriString(),

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemWriter.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/BatchSubsystemWriter.java
@@ -33,6 +33,7 @@ import org.jboss.staxmapper.XMLElementWriter;
 import org.jboss.staxmapper.XMLExtendedStreamWriter;
 import org.wildfly.extension.batch.jberet.job.repository.InMemoryJobRepositoryDefinition;
 import org.wildfly.extension.batch.jberet.job.repository.JdbcJobRepositoryDefinition;
+import org.wildfly.extension.batch.jberet.thread.pool.BatchThreadPoolResourceDefinition;
 
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
@@ -72,8 +73,8 @@ public class BatchSubsystemWriter implements XMLElementWriter<SubsystemMarshalli
         }
 
         // Write the thread pool
-        if (model.hasDefined(BatchSubsystemDefinition.THREAD_POOL)) {
-            final List<Property> threadPools = model.get(BatchSubsystemDefinition.THREAD_POOL).asPropertyList();
+        if (model.hasDefined(BatchThreadPoolResourceDefinition.NAME)) {
+            final List<Property> threadPools = model.get(BatchThreadPoolResourceDefinition.NAME).asPropertyList();
             for (Property threadPool : threadPools) {
                 threadsParser.writeUnboundedQueueThreadPool(writer, threadPool, Element.THREAD_POOL.getLocalName(), true);
             }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/BatchLogger.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/BatchLogger.java
@@ -124,18 +124,6 @@ public interface BatchLogger extends BasicLogger {
     IllegalStateException indexedChildResourceRegistrationNotAvailable(PathElement address);
 
     /**
-     * Logs a warning message indicating the {@code type} defined in the {@code jboss-all.xml} deployment descriptor
-     * was not found.
-     *
-     * @param type           the type that is missing
-     * @param name           the name of the type that was not found
-     * @param deploymentName the name of the deployment
-     */
-    @LogMessage(level = Level.WARN)
-    @Message(id = 10, value = "Missing %1$s %2$s defined in the jboss-all.xml deployment descriptor was not found. Using the default %1$s for deployment %3$s")
-    void missingNamedService(String type, String name, String deploymentName);
-
-    /**
      * Creates an exception indicating the failure to create a job repository.
      *
      * @param cause the cause of the error
@@ -145,16 +133,6 @@ public interface BatchLogger extends BasicLogger {
      */
     @Message(id = 11, value = "Failed to create %s job repository.")
     StartException failedToCreateJobRepository(@Cause Throwable cause, String type);
-
-    /**
-     * Creates an exception indicating a failure to resolve job XML entries.
-     *
-     * @param cause the cause of the error
-     *
-     * @return a {@link StartException} for the error
-     */
-    @Message(id = 12, value = "Failed resolve job XMl entries.")
-    StartException failedToResolveJobXmlEntries(@Cause Throwable cause);
 
     /**
      * Logs an error message indicating only one job repository can be defined in the {@code jboss-all.xml} deployment

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/Capabilities.java
@@ -22,9 +22,8 @@
 
 package org.wildfly.extension.batch.jberet._private;
 
-import java.util.concurrent.ExecutorService;
-
 import org.jberet.repository.JobRepository;
+import org.jberet.spi.JobExecutor;
 import org.jboss.as.controller.capability.RuntimeCapability;
 
 /**
@@ -40,9 +39,15 @@ public class Capabilities {
     public static final String DATA_SOURCE_CAPABILITY = "org.wildfly.data-source";
 
     /**
+     * A capability for thread-pools.
+     */
+    public static final RuntimeCapability<Void> THREAD_POOL_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.batch.thread.pool", true, JobExecutor.class)
+            .build();
+
+    /**
      * A capability representing the default thread-pool to use in batch deployment environments.
      */
-    public static final RuntimeCapability<Void> DEFAULT_THREAD_POOL_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.batch.default.thread.pool", false, ExecutorService.class)
+    public static final RuntimeCapability<Void> DEFAULT_THREAD_POOL_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.batch.default.thread.pool", false, JobExecutor.class)
             .build();
 
     /**

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDeploymentDescriptorParser_1_0.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchDeploymentDescriptorParser_1_0.java
@@ -22,29 +22,22 @@
 
 package org.wildfly.extension.batch.jberet.deployment;
 
+import java.util.Properties;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
-import java.util.Properties;
-import java.util.concurrent.ExecutorService;
 
 import org.jberet.repository.InMemoryRepository;
 import org.jberet.repository.JdbcRepository;
 import org.jberet.repository.JobRepository;
-import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.controller.parsing.ParseUtils;
 import org.jboss.as.server.deployment.AttachmentKey;
-import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.jbossallxml.JBossAllXMLParser;
-import org.jboss.msc.service.ServiceController;
-import org.jboss.msc.service.ServiceName;
 import org.jboss.staxmapper.XMLExtendedStreamReader;
 import org.wildfly.extension.batch.jberet.Attribute;
-import org.wildfly.extension.batch.jberet.BatchServiceNames;
 import org.wildfly.extension.batch.jberet.Element;
 import org.wildfly.extension.batch.jberet._private.BatchLogger;
-import org.wildfly.extension.batch.jberet._private.Capabilities;
 
 /**
  * A parser for batch deployment descriptors in {@code jboss-all.xml}.
@@ -65,7 +58,8 @@ public class BatchDeploymentDescriptorParser_1_0 implements XMLStreamConstants, 
     @Override
     public BatchEnvironmentMetaData parse(final XMLExtendedStreamReader reader, final DeploymentUnit deploymentUnit) throws XMLStreamException {
         JobRepository jobRepository = null;
-        ExecutorService executorService = null;
+        String jobRepositoryName = null;
+        String jobExecutorName = null;
         boolean empty = true;
 
         while (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
@@ -75,22 +69,38 @@ public class BatchDeploymentDescriptorParser_1_0 implements XMLStreamConstants, 
             // Process the job repository
             if (element == Element.JOB_REPOSITORY) {
                 // Only one repository can be defined
-                if (jobRepository != null) {
+                if (jobRepository != null || jobRepositoryName != null) {
                     BatchLogger.LOGGER.multipleJobRepositoriesFound();
                 } else {
-                    jobRepository = parseJobRepository(reader, deploymentUnit);
+                    if (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
+                        final String name = reader.getLocalName();
+                        final Element jobRepositoryElement = Element.forName(name);
+                        if (jobRepositoryElement == Element.IN_MEMORY) {
+                            ParseUtils.requireNoContent(reader);
+                            jobRepository = new InMemoryRepository();
+                        } else if (jobRepositoryElement == Element.JDBC) {
+                            final String value = readRequiredAttribute(reader, Attribute.JNDI_NAME);
+                            final Properties configProperties = new Properties();
+                            configProperties.setProperty(JNDI_NAME, value);
+                            ParseUtils.requireNoContent(reader);
+                            jobRepository = JdbcRepository.create(configProperties);
+                        } else if (jobRepositoryElement == Element.NAMED) {
+                            jobRepositoryName = readRequiredAttribute(reader, Attribute.NAME);
+                            ParseUtils.requireNoContent(reader);
+                        } else {
+                            throw ParseUtils.unexpectedElement(reader);
+                        }
+                    }
+                    // Log an error indicating the job-repository is empty, but continue as normal
+                    if (jobRepository == null && jobRepositoryName == null) {
+                        BatchLogger.LOGGER.emptyJobRepositoryElement(deploymentUnit.getName());
+                    }
                 }
                 ParseUtils.requireNoContent(reader);
+
             } else if (element == Element.THREAD_POOL) {
                 // Only thread-pool's defined on the subsystem are allowed to be referenced
-                final String name = readRequiredAttribute(reader, Attribute.NAME);
-                final ServiceName serviceName = BatchServiceNames.BASE_BATCH_THREAD_POOL_NAME.append(name);
-                final ServiceController<?> controller = deploymentUnit.getServiceRegistry().getRequiredService(serviceName);
-                if (controller == null) {
-                    BatchLogger.LOGGER.missingNamedService("thread-pool", name, deploymentUnit.getName());
-                    return null;
-                }
-                executorService = (ExecutorService) controller.getValue();
+                jobExecutorName = readRequiredAttribute(reader, Attribute.NAME);
                 ParseUtils.requireNoContent(reader);
             } else {
                 throw ParseUtils.unexpectedElement(reader);
@@ -102,40 +112,7 @@ public class BatchDeploymentDescriptorParser_1_0 implements XMLStreamConstants, 
             BatchLogger.LOGGER.debugf("An empty batch element in the deployment descriptor was found for %s.", deploymentUnit.getName());
             return null;
         }
-        return new BatchEnvironmentMetaData(jobRepository, executorService);
-    }
-
-    private JobRepository parseJobRepository(final XMLExtendedStreamReader reader, final DeploymentUnit deploymentUnit) throws XMLStreamException {
-        if (reader.hasNext() && reader.nextTag() != END_ELEMENT) {
-            final String localName = reader.getLocalName();
-            final Element element = Element.forName(localName);
-            if (element == Element.IN_MEMORY) {
-                ParseUtils.requireNoContent(reader);
-                return new InMemoryRepository();
-            } else if (element == Element.JDBC) {
-                final String value = readRequiredAttribute(reader, Attribute.JNDI_NAME);
-                final Properties configProperties = new Properties();
-                configProperties.setProperty(JNDI_NAME, value);
-                ParseUtils.requireNoContent(reader);
-                return JdbcRepository.create(configProperties);
-            } else if (element == Element.NAMED) {
-                final String jobRepositoryName = readRequiredAttribute(reader, Attribute.NAME);
-                final CapabilityServiceSupport support = deploymentUnit.getAttachment(Attachments.CAPABILITY_SERVICE_SUPPORT);
-                final ServiceName serviceName = support.getCapabilityServiceName(Capabilities.JOB_REPOSITORY_CAPABILITY.getName(), jobRepositoryName);
-                final ServiceController<?> controller = deploymentUnit.getServiceRegistry().getRequiredService(serviceName);
-                if (controller == null) {
-                    BatchLogger.LOGGER.missingNamedService("job-repository", jobRepositoryName, deploymentUnit.getName());
-                    return null;
-                }
-                ParseUtils.requireNoContent(reader);
-                return (JobRepository) controller.getValue();
-            } else {
-                throw ParseUtils.unexpectedElement(reader);
-            }
-        }
-        // Log an error indicating the job-repository is empty, but return null to continue as normal
-        BatchLogger.LOGGER.emptyJobRepositoryElement(deploymentUnit.getName());
-        return null;
+        return new BatchEnvironmentMetaData(jobRepository, jobRepositoryName, jobExecutorName);
     }
 
     private static String readRequiredAttribute(final XMLExtendedStreamReader reader, final Attribute attribute) throws XMLStreamException {

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/impl/JobExecutorService.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/impl/JobExecutorService.java
@@ -20,35 +20,40 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.extension.batch.jberet.deployment;
+package org.wildfly.extension.batch.jberet.impl;
 
-import org.jberet.repository.JobRepository;
+import org.jberet.spi.JobExecutor;
+import org.jboss.as.threads.ManagedJBossThreadPoolExecutorService;
+import org.jboss.msc.service.Service;
+import org.jboss.msc.service.StartContext;
+import org.jboss.msc.service.StartException;
+import org.jboss.msc.service.StopContext;
+import org.jboss.msc.value.InjectedValue;
 
 /**
- * Represents environment objects created via a deployment descriptor.
- *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-class BatchEnvironmentMetaData {
-    private final JobRepository jobRepository;
-    private final String jobRepositoryName;
-    private final String executorName;
+public class JobExecutorService implements Service<JobExecutor> {
 
-    protected BatchEnvironmentMetaData(final JobRepository jobRepository, final String jobRepositoryName, final String executorName) {
-        this.jobRepository = jobRepository;
-        this.jobRepositoryName = jobRepositoryName;
-        this.executorName = executorName;
+    private final InjectedValue<ManagedJBossThreadPoolExecutorService> threadPoolInjector = new InjectedValue<>();
+    private WildFlyJobExecutor jobExecutor;
+
+    @Override
+    public synchronized void start(final StartContext context) throws StartException {
+        jobExecutor = new WildFlyJobExecutor(threadPoolInjector.getValue());
     }
 
-    public JobRepository getJobRepository() {
-        return jobRepository;
+    @Override
+    public synchronized void stop(final StopContext context) {
+        jobExecutor = null;
     }
 
-    public String getJobRepositoryName() {
-        return jobRepositoryName;
+    @Override
+    public JobExecutor getValue() throws IllegalStateException, IllegalArgumentException {
+        return jobExecutor;
     }
 
-    public String getExecutorName() {
-        return executorName;
+    public InjectedValue<ManagedJBossThreadPoolExecutorService> getThreadPoolInjector() {
+        return threadPoolInjector;
     }
 }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/impl/WildFlyJobExecutor.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/impl/WildFlyJobExecutor.java
@@ -20,35 +20,24 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.extension.batch.jberet.deployment;
+package org.wildfly.extension.batch.jberet.impl;
 
-import org.jberet.repository.JobRepository;
+import org.jberet.spi.JobExecutor;
+import org.jboss.as.threads.ManagedJBossThreadPoolExecutorService;
 
 /**
- * Represents environment objects created via a deployment descriptor.
- *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-class BatchEnvironmentMetaData {
-    private final JobRepository jobRepository;
-    private final String jobRepositoryName;
-    private final String executorName;
+class WildFlyJobExecutor extends JobExecutor {
+    private final ManagedJBossThreadPoolExecutorService delegate;
 
-    protected BatchEnvironmentMetaData(final JobRepository jobRepository, final String jobRepositoryName, final String executorName) {
-        this.jobRepository = jobRepository;
-        this.jobRepositoryName = jobRepositoryName;
-        this.executorName = executorName;
+    public WildFlyJobExecutor(final ManagedJBossThreadPoolExecutorService delegate) {
+        super(delegate);
+        this.delegate = delegate;
     }
 
-    public JobRepository getJobRepository() {
-        return jobRepository;
-    }
-
-    public String getJobRepositoryName() {
-        return jobRepositoryName;
-    }
-
-    public String getExecutorName() {
-        return executorName;
+    @Override
+    protected int getMaximumPoolSize() {
+        return delegate.getMaxThreads();
     }
 }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/thread/pool/BatchThreadPoolResourceDefinition.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/thread/pool/BatchThreadPoolResourceDefinition.java
@@ -1,0 +1,278 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.extension.batch.jberet.thread.pool;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.jberet.spi.JobExecutor;
+import org.jboss.as.controller.OperationContext;
+import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.ReadResourceNameOperationStepHandler;
+import org.jboss.as.controller.SimpleResourceDefinition;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
+import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
+import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.threads.CommonAttributes;
+import org.jboss.as.threads.ManagedJBossThreadPoolExecutorService;
+import org.jboss.as.threads.PoolAttributeDefinitions;
+import org.jboss.as.threads.ThreadFactoryResolver;
+import org.jboss.as.threads.ThreadsServices;
+import org.jboss.as.threads.UnboundedQueueThreadPoolAdd;
+import org.jboss.as.threads.UnboundedQueueThreadPoolMetricsHandler;
+import org.jboss.as.threads.UnboundedQueueThreadPoolRemove;
+import org.jboss.as.threads.UnboundedQueueThreadPoolWriteAttributeHandler;
+import org.jboss.dmr.ModelNode;
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceName;
+import org.jboss.msc.service.ServiceTarget;
+import org.wildfly.extension.batch.jberet.BatchResourceDescriptionResolver;
+import org.wildfly.extension.batch.jberet.BatchServiceNames;
+import org.wildfly.extension.batch.jberet._private.Capabilities;
+import org.wildfly.extension.batch.jberet.impl.JobExecutorService;
+
+/**
+ * A resource definition for the batch thread pool.
+ *
+ * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
+ */
+public class BatchThreadPoolResourceDefinition extends SimpleResourceDefinition {
+
+    public static final String NAME = "thread-pool";
+    static final PathElement PATH = PathElement.pathElement(NAME);
+
+    private final boolean registerRuntimeOnly;
+
+    public BatchThreadPoolResourceDefinition(final boolean registerRuntimeOnly) {
+        super(PATH, BatchThreadPoolDescriptionResolver.INSTANCE,
+                BatchThreadPoolAdd.INSTANCE, BatchThreadPoolRemove.INSTANCE);
+        this.registerRuntimeOnly = registerRuntimeOnly;
+    }
+
+    @Override
+    public void registerAttributes(final ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerReadOnlyAttribute(PoolAttributeDefinitions.NAME, ReadResourceNameOperationStepHandler.INSTANCE);
+        new UnboundedQueueThreadPoolWriteAttributeHandler(BatchServiceNames.BASE_BATCH_THREAD_POOL_NAME).registerAttributes(resourceRegistration);
+        if (registerRuntimeOnly) {
+            new UnboundedQueueThreadPoolMetricsHandler(BatchServiceNames.BASE_BATCH_THREAD_POOL_NAME).registerAttributes(resourceRegistration);
+        }
+    }
+
+    @Override
+    public void registerCapabilities(final ManagementResourceRegistration resourceRegistration) {
+        resourceRegistration.registerCapability(Capabilities.THREAD_POOL_CAPABILITY);
+    }
+
+    static class BatchThreadPoolAdd extends UnboundedQueueThreadPoolAdd {
+        static final BatchThreadPoolAdd INSTANCE = new BatchThreadPoolAdd(BatchThreadFactoryResolver.INSTANCE, BatchServiceNames.BASE_BATCH_THREAD_POOL_NAME);
+        private final ServiceName serviceNameBase;
+
+        public BatchThreadPoolAdd(final ThreadFactoryResolver threadFactoryResolver, final ServiceName serviceNameBase) {
+            super(threadFactoryResolver, serviceNameBase);
+            this.serviceNameBase = serviceNameBase;
+        }
+
+        @Override
+        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            super.performRuntime(context, operation, model);
+            final String name = context.getCurrentAddressValue();
+            final ServiceTarget target = context.getServiceTarget();
+            final JobExecutorService service = new JobExecutorService();
+            final ServiceBuilder<?> serviceBuilder = target.addService(context.getCapabilityServiceName(Capabilities.THREAD_POOL_CAPABILITY.getName(), name, JobExecutor.class),
+                    service);
+            serviceBuilder.addDependency(serviceNameBase.append(name), ManagedJBossThreadPoolExecutorService.class, service.getThreadPoolInjector());
+            serviceBuilder.install();
+        }
+    }
+
+    static class BatchThreadPoolRemove extends UnboundedQueueThreadPoolRemove {
+        static final BatchThreadPoolRemove INSTANCE = new BatchThreadPoolRemove();
+
+        public BatchThreadPoolRemove() {
+            super(BatchThreadPoolAdd.INSTANCE);
+        }
+
+        @Override
+        protected void performRuntime(final OperationContext context, final ModelNode operation, final ModelNode model) throws OperationFailedException {
+            // First remove the JobExecutor service, then delegate
+            context.removeService(context.getCapabilityServiceName(Capabilities.THREAD_POOL_CAPABILITY.getName(), context.getCurrentAddressValue(), null));
+            super.performRuntime(context, operation, model);
+        }
+    }
+
+    private static class BatchThreadFactoryResolver extends ThreadFactoryResolver.SimpleResolver {
+        static final BatchThreadFactoryResolver INSTANCE = new BatchThreadFactoryResolver();
+
+        private BatchThreadFactoryResolver() {
+            super(ThreadsServices.FACTORY);
+        }
+
+        @Override
+        protected String getThreadGroupName(String threadPoolName) {
+            return "Batch Thread";
+        }
+    }
+
+    private static class BatchThreadPoolDescriptionResolver implements ResourceDescriptionResolver {
+        static final BatchThreadPoolDescriptionResolver INSTANCE = new BatchThreadPoolDescriptionResolver();
+
+        private static final Set<String> COMMON_ATTRIBUTE_NAMES;
+
+        static {
+            // Common attributes as copied from the ThreadPoolResourceDescriptionResolver minus the attributes not used
+            // for an UnboundedThreadPoolResourceDefinition
+            COMMON_ATTRIBUTE_NAMES = Stream.of(
+                    PoolAttributeDefinitions.ACTIVE_COUNT.getName(),
+                    PoolAttributeDefinitions.COMPLETED_TASK_COUNT.getName(),
+                    PoolAttributeDefinitions.CURRENT_THREAD_COUNT.getName(),
+                    CommonAttributes.KEEPALIVE_TIME,
+                    PoolAttributeDefinitions.LARGEST_THREAD_COUNT.getName(),
+                    PoolAttributeDefinitions.MAX_THREADS.getName(),
+                    PoolAttributeDefinitions.NAME.getName(),
+                    PoolAttributeDefinitions.QUEUE_SIZE.getName(),
+                    PoolAttributeDefinitions.TASK_COUNT.getName(),
+                    PoolAttributeDefinitions.THREAD_FACTORY.getName()
+            )
+                    .collect(Collectors.toSet());
+        }
+
+        private static final String COMMON_PREFIX = "threadpool.common";
+        private final StandardResourceDescriptionResolver delegate;
+
+        private BatchThreadPoolDescriptionResolver() {
+            this.delegate = BatchResourceDescriptionResolver.getResourceDescriptionResolver(NAME);
+        }
+
+        @Override
+        public ResourceBundle getResourceBundle(final Locale locale) {
+            return delegate.getResourceBundle(locale);
+        }
+
+        @Override
+        public String getResourceDescription(final Locale locale, final ResourceBundle bundle) {
+            return delegate.getResourceDescription(locale, bundle);
+        }
+
+        @Override
+        public String getResourceAttributeDescription(final String attributeName, final Locale locale, final ResourceBundle bundle) {
+            if (COMMON_ATTRIBUTE_NAMES.contains(attributeName)) {
+                return bundle.getString(getKey(attributeName));
+            }
+            return delegate.getResourceAttributeDescription(attributeName, locale, bundle);
+        }
+
+        @Override
+        public String getResourceAttributeValueTypeDescription(final String attributeName, final Locale locale, final ResourceBundle bundle, final String... suffixes) {
+            if (COMMON_ATTRIBUTE_NAMES.contains(attributeName)) {
+                return bundle.getString(getVariableBundleKey(new String[]{attributeName}, suffixes));
+            }
+            return delegate.getResourceAttributeValueTypeDescription(attributeName, locale, bundle, suffixes);
+        }
+
+        @Override
+        public String getOperationDescription(final String operationName, final Locale locale, final ResourceBundle bundle) {
+            return delegate.getOperationDescription(operationName, locale, bundle);
+        }
+
+        @Override
+        public String getOperationParameterDescription(final String operationName, final String paramName, final Locale locale, final ResourceBundle bundle) {
+            if (ModelDescriptionConstants.ADD.equals(operationName) && COMMON_ATTRIBUTE_NAMES.contains(paramName)) {
+                return bundle.getString(getKey(paramName));
+            }
+            return delegate.getOperationParameterDescription(operationName, paramName, locale, bundle);
+        }
+
+        @Override
+        public String getOperationParameterValueTypeDescription(final String operationName, final String paramName, final Locale locale, final ResourceBundle bundle, final String... suffixes) {
+            if (ModelDescriptionConstants.ADD.equals(operationName) && COMMON_ATTRIBUTE_NAMES.contains(paramName)) {
+                return bundle.getString(getVariableBundleKey(new String[]{paramName}, suffixes));
+            }
+            return delegate.getOperationParameterValueTypeDescription(operationName, paramName, locale, bundle, suffixes);
+        }
+
+        @Override
+        public String getOperationReplyDescription(final String operationName, final Locale locale, final ResourceBundle bundle) {
+            return delegate.getOperationReplyDescription(operationName, locale, bundle);
+        }
+
+        @Override
+        public String getOperationReplyValueTypeDescription(final String operationName, final Locale locale, final ResourceBundle bundle, final String... suffixes) {
+            return delegate.getOperationReplyValueTypeDescription(operationName, locale, bundle, suffixes);
+        }
+
+        @Override
+        public String getNotificationDescription(final String notificationType, final Locale locale, final ResourceBundle bundle) {
+            return delegate.getNotificationDescription(notificationType, locale, bundle);
+        }
+
+        @Override
+        public String getChildTypeDescription(final String childType, final Locale locale, final ResourceBundle bundle) {
+            return delegate.getChildTypeDescription(childType, locale, bundle);
+        }
+
+        @Override
+        public String getResourceDeprecatedDescription(final Locale locale, final ResourceBundle bundle) {
+            return delegate.getResourceDeprecatedDescription(locale, bundle);
+        }
+
+        @Override
+        public String getResourceAttributeDeprecatedDescription(final String attributeName, final Locale locale, final ResourceBundle bundle) {
+            return delegate.getResourceAttributeDeprecatedDescription(attributeName, locale, bundle);
+        }
+
+        @Override
+        public String getOperationDeprecatedDescription(final String operationName, final Locale locale, final ResourceBundle bundle) {
+            return delegate.getOperationDeprecatedDescription(operationName, locale, bundle);
+        }
+
+        @Override
+        public String getOperationParameterDeprecatedDescription(final String operationName, final String paramName, final Locale locale, final ResourceBundle bundle) {
+            return delegate.getOperationParameterDeprecatedDescription(operationName, paramName, locale, bundle);
+        }
+
+
+        private String getKey(final String... args) {
+            return getVariableBundleKey(args);
+        }
+
+        private String getVariableBundleKey(final String[] fixed, final String... variable) {
+            StringBuilder sb = new StringBuilder(COMMON_PREFIX);
+            for (String arg : fixed) {
+                sb.append('.');
+                sb.append(arg);
+            }
+            if (variable != null) {
+                for (String arg : variable) {
+                    sb.append('.');
+                    sb.append(arg);
+                }
+            }
+            return sb.toString();
+        }
+    }
+}

--- a/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
+++ b/batch/extension-jberet/src/main/resources/org/wildfly/extension/batch/jberet/LocalDescriptions.properties
@@ -42,7 +42,26 @@ batch.jberet.jdbc-job-repository.remove=Removes a JDBC job repository.
 batch.jberet.jdbc-job-repository.data-source=The data source name used to connect to the database.
 
 # Thread pool
-batch.jberet.thread-pool=The thread pool used for batch jobs.
+batch.jberet.thread-pool=The thread pool used for batch jobs. Note that the max-thread attribute should always be greater\
+   than 3. Two threads are reserved to ensure partition jobs can execute.
+batch.jberet.thread-pool.add=Adds an unbounded thread pool.
+batch.jberet.thread-pool.remove=Removes an unbounded thread pool.
+batch.jberet.thread-pool.name=The name of the thread pool.
+batch.jberet.thread-pool.rejected-count=The number of tasks that have been rejected.
+# These must be prefixed with threadpool.common for the default thread-pool resources to resolve the description
+threadpool.common.active-count=The approximate number of threads that are actively executing tasks.
+threadpool.common.completed-task-count=The approximate total number of tasks that have completed execution.
+threadpool.common.current-thread-count=The current number of threads in the pool.
+threadpool.common.keepalive-time=Used to specify the amount of time that pool threads should be kept running when idle; if not specified, threads will run until the executor is shut down.
+threadpool.common.keepalive-time.time=The time
+threadpool.common.keepalive-time.unit=The time unit
+threadpool.common.largest-thread-count=The largest number of threads that have ever simultaneously been in the pool.
+threadpool.common.max-threads=The maximum thread pool size. Note this should always be greater than 3. Two threads are \
+  reserved to ensure partition jobs can execute as expected.
+threadpool.common.name=The name of the thread pool.
+threadpool.common.queue-size=The queue size.
+threadpool.common.task-count=The approximate total number of tasks that have ever been scheduled for execution.
+threadpool.common.thread-factory=Specifies the name of a specific thread factory to use to create worker threads. If not defined an appropriate default thread factory will be used.
 
 # Thread factory
 batch.jberet.thread-factory=The thread factory used for the thread-pool.

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/_private/Capabilities.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/_private/Capabilities.java
@@ -20,35 +20,21 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.wildfly.extension.batch.jberet.deployment;
+package org.wildfly.extension.batch._private;
 
-import org.jberet.repository.JobRepository;
+import org.jberet.spi.JobExecutor;
+import org.jboss.as.controller.capability.RuntimeCapability;
 
 /**
- * Represents environment objects created via a deployment descriptor.
+ * Capabilities for the batch extension. This is not to be used outside of this extension.
  *
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
-class BatchEnvironmentMetaData {
-    private final JobRepository jobRepository;
-    private final String jobRepositoryName;
-    private final String executorName;
+public class Capabilities {
 
-    protected BatchEnvironmentMetaData(final JobRepository jobRepository, final String jobRepositoryName, final String executorName) {
-        this.jobRepository = jobRepository;
-        this.jobRepositoryName = jobRepositoryName;
-        this.executorName = executorName;
-    }
-
-    public JobRepository getJobRepository() {
-        return jobRepository;
-    }
-
-    public String getJobRepositoryName() {
-        return jobRepositoryName;
-    }
-
-    public String getExecutorName() {
-        return executorName;
-    }
+    /**
+     * A capability representing the default thread-pool to use in batch deployment environments.
+     */
+    public static final RuntimeCapability<Void> DEFAULT_THREAD_POOL_CAPABILITY = RuntimeCapability.Builder.of("org.wildfly.batch.default.thread.pool", false, JobExecutor.class)
+            .build();
 }

--- a/batch/extension/src/test/java/org/wildfly/extension/batch/SubsystemOperationsTestCase.java
+++ b/batch/extension/src/test/java/org/wildfly/extension/batch/SubsystemOperationsTestCase.java
@@ -147,25 +147,4 @@ public class SubsystemOperationsTestCase extends AbstractBatchTestCase {
         final ModelNode removeSubsystemOp = SubsystemOperations.createRemoveOperation(createAddress(null));
         executeOperation(kernelServices, removeSubsystemOp);
     }
-
-    @Test
-    public void testAddRemoveSubsystem() throws Exception {
-        final KernelServices kernelServices = boot();
-        final ModelNode removeSubsystemOp = SubsystemOperations.createRemoveOperation(createAddress(null));
-        executeOperation(kernelServices, removeSubsystemOp);
-        // Create the base subsystem address
-        final ModelNode subsystemAddress = createAddress(null);
-        final ModelNode addSubsystemOp = SubsystemOperations.createAddOperation(subsystemAddress);
-
-        addSubsystemOp.get(BatchSubsystemDefinition.JOB_REPOSITORY_TYPE.getName()).set("in-memory");
-
-        final ModelNode threadPool = addSubsystemOp.get(BatchConstants.THREAD_POOL, BatchConstants.THREAD_POOL_NAME);
-        threadPool.get("max-threads").set(10);
-        final ModelNode keepAlive = threadPool.get("keepalive-time");
-        keepAlive.get("time").set(100L);
-        keepAlive.get("unit").set(TimeUnit.MILLISECONDS.toString());
-
-        // Execute the add operation
-        executeOperation(kernelServices, addSubsystemOp);
-    }
 }

--- a/batch/jberet/src/main/java/org/wildfly/jberet/BatchEnvironmentFactory.java
+++ b/batch/jberet/src/main/java/org/wildfly/jberet/BatchEnvironmentFactory.java
@@ -30,6 +30,7 @@ import javax.transaction.TransactionManager;
 import org.jberet.repository.JobRepository;
 import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.BatchEnvironment;
+import org.jberet.spi.JobTask;
 import org.jberet.spi.JobXmlResolver;
 import org.wildfly.jberet._private.WildFlyBatchLogger;
 import org.wildfly.security.manager.WildFlySecurityManager;
@@ -53,7 +54,7 @@ public class BatchEnvironmentFactory {
         }
 
         @Override
-        public void submitTask(final Runnable runnable) {
+        public void submitTask(final JobTask jobTask) {
             throw WildFlyBatchLogger.LOGGER.invalidBatchEnvironment();
         }
 
@@ -74,11 +75,6 @@ public class BatchEnvironmentFactory {
 
         @Override
         public Properties getBatchConfigurationProperties() {
-            throw WildFlyBatchLogger.LOGGER.invalidBatchEnvironment();
-        }
-
-        @Override
-        public void jobExecutionFinished() {
             throw WildFlyBatchLogger.LOGGER.invalidBatchEnvironment();
         }
     };

--- a/batch/jberet/src/main/java/org/wildfly/jberet/DelegatingBatchEnvironment.java
+++ b/batch/jberet/src/main/java/org/wildfly/jberet/DelegatingBatchEnvironment.java
@@ -28,6 +28,7 @@ import javax.transaction.TransactionManager;
 import org.jberet.repository.JobRepository;
 import org.jberet.spi.ArtifactFactory;
 import org.jberet.spi.BatchEnvironment;
+import org.jberet.spi.JobTask;
 import org.jberet.spi.JobXmlResolver;
 
 /**
@@ -52,8 +53,8 @@ public class DelegatingBatchEnvironment implements BatchEnvironment {
     }
 
     @Override
-    public void submitTask(final Runnable task) {
-        delegate.submitTask(task);
+    public void submitTask(final JobTask jobTask) {
+        delegate.submitTask(jobTask);
     }
 
     @Override
@@ -74,10 +75,5 @@ public class DelegatingBatchEnvironment implements BatchEnvironment {
     @Override
     public Properties getBatchConfigurationProperties() {
         return delegate.getBatchConfigurationProperties();
-    }
-
-    @Override
-    public void jobExecutionFinished() {
-        delegate.jobExecutionFinished();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
         <version.org.infinispan>8.0.0.Final</version.org.infinispan>
         <version.org.jasypt>1.9.1</version.org.jasypt>
         <version.org.javassist>3.18.1-GA</version.org.javassist>
-        <version.org.jberet>1.2.0.Beta1</version.org.jberet>
+        <version.org.jberet>1.2.0.Final</version.org.jberet>
         <version.org.jdom>1.1.3</version.org.jdom>
         <version.org.jboss.activemq.artemis.integration>1.0.1</version.org.jboss.activemq.artemis.integration>
         <version.org.jboss.common.jboss-common-beans>2.0.0.Final</version.org.jboss.common.jboss-common-beans>


### PR DESCRIPTION
 Implement new JobExecutor and update with SPI changes.

As a new requirement for JBeret a custom executor was added to ensure specific batch jobs don't deadlock, see [JBERET-180](https://issues.jboss.org/browse/JBERET-180) for details. As a result of this there was a need to override the way the thread pool was registered. This PR adds a new resource definition which mostly delegates to the `UnboundedQueueThreadPoolXxx`. The new resource description simply adds a capability and registers the new service for the `JobExecutor`.
