### PR TITLE
WFLY-5319 ignore TxTimeoutTestCase which seems to fail due to EJB Sta…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/txtimeout/TxTimeoutTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jpa/mockprovider/txtimeout/TxTimeoutTestCase.java
@@ -51,6 +51,7 @@ import org.junit.runner.RunWith;
  *
  * @author Scott Marlow
  */
+@Ignore // WFLY-5319 is for fixing this test (see failure https://gist.github.com/scottmarlow/6409290362f35f2d1320)
 @RunWith(Arquillian.class)
 public class TxTimeoutTestCase {
 


### PR DESCRIPTION
…tefulSessionSynchronizationInterceptor.releaseLock not expecting to be called from TM Reaper thread
