### PR TITLE
WFLY-5308 Handle race condition on redeploy where duplicate CacheRegistry entries exist

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFilter.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFilter.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.server.registry;
+
+import java.util.function.Predicate;
+
+import org.infinispan.filter.KeyFilter;
+import org.wildfly.clustering.group.Node;
+
+/**
+ * @author Paul Ferraro
+ */
+public class CacheRegistryFilter implements KeyFilter<Object>, Predicate<Object> {
+
+    @Override
+    public boolean accept(Object key) {
+        return key instanceof Node;
+    }
+
+    @Override
+    public boolean test(Object key) {
+        return this.accept(key);
+    }
+}

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFilterExternalizer.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFilterExternalizer.java
@@ -1,0 +1,49 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.server.registry;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.wildfly.clustering.marshalling.Externalizer;
+
+/**
+ * @author Paul Ferraro
+ */
+public class CacheRegistryFilterExternalizer implements Externalizer<CacheRegistryFilter> {
+
+    @Override
+    public void writeObject(ObjectOutput output, CacheRegistryFilter object) throws IOException {
+    }
+
+    @Override
+    public CacheRegistryFilter readObject(ObjectInput input) throws IOException, ClassNotFoundException {
+        return new CacheRegistryFilter();
+    }
+
+    @Override
+    public Class<? extends CacheRegistryFilter> getTargetClass() {
+        return CacheRegistryFilter.class;
+    }
+}

--- a/clustering/server/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
+++ b/clustering/server/src/main/resources/META-INF/services/org.wildfly.clustering.marshalling.Externalizer
@@ -1,2 +1,3 @@
 org.wildfly.clustering.server.group.AddressableNodeExternalizer
+org.wildfly.clustering.server.registry.CacheRegistryFilterExternalizer
 org.wildfly.clustering.server.singleton.ServiceNameExternalizer


### PR DESCRIPTION
… due to reincarnated addresses.

https://issues.jboss.org/browse/WFLY-5308
