### PR TITLE
[WFLY-5328] validate journal-min-files min value '2'

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -191,6 +191,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setAllowNull(true)
             .setAllowExpression(true)
             .setRestartAllServices()
+            .setValidator(new IntRangeValidator(2, true, true))
             .build();
     public static final SimpleAttributeDefinition JOURNAL_SYNC_NON_TRANSACTIONAL = create("journal-sync-non-transactional", BOOLEAN)
             .setAttributeGroup("journal")


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5328
validate journal-min-files min value '2', otherwise it will lead to IllegalArgumentException in journal creation at https://github.com/apache/activemq-artemis/blob/1.1.0/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java#L241 
