### PR TITLE
[WFLY-5342] Upgrade to Artemis 1.1.0-wildfly-6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.1.0-wildfly-5</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.1.0-wildfly-6</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.1.2-jbossorg-2</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.3</version.org.apache.cxf.xjcplugins>


### PR DESCRIPTION
Artemis 1.1.0-wildfly-6 removes ARTEMIS-220 which was introducing leaky
connections to Artemis RA's endpoints.

JIRA: https://issues.jboss.org/browse/WFLY-5342
