### PR TITLE
[WFLY-5138] Don't use ARQ for ParseAndMarshalModelsTestCase, plus Mod…

### DIFF
--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -58,6 +58,14 @@
             <fileset dir="target/jbossas"/>
         </copy>
 
+        <echo message="Copying and configuring instance jbossas-parse-marshal"/>
+        <copy todir="target/jbossas-parse-marshal">
+            <fileset dir="target/jbossas"/>
+        </copy>
+        <copy todir="target/jbossas-parse-marshal/modules">
+            <fileset dir="${jboss.dist}/modules"/>
+        </copy>
+
         <!-- Connects back to original host (node0) -->
         <ts.config-as.add-remote-outbound-connection name="jbossas-with-remote-outbound-connection" node="${node0}"
                                                      remotePort="8080" protocol="http-remoting" securityRealm="PasswordRealm" userName="user1"/>


### PR DESCRIPTION
…elParserUtils now wants 'target' param to mean  location

Replace #7985 with the same change, since it seems CI doesn't want to test the old one any more.
