### PR TITLE
Exclude unnecessary finally and catch blocks

### DIFF
--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientParsingDeploymentProcessor.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientParsingDeploymentProcessor.java
@@ -127,7 +127,6 @@ public class ApplicationClientParsingDeploymentProcessor implements DeploymentUn
         final VirtualFile deploymentRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT).getRoot();
         final VirtualFile appXml = deploymentRoot.getChild(JBOSS_CLIENT_XML);
         if (appXml.exists()) {
-            InputStream is = null;
             try (InputStream is = appXml.openStream()) {
                 JBossClientMetaData data = new JBossClientMetaDataParser().parse(getXMLStreamReader(is), propertyReplacer);
                 return data;

--- a/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientParsingDeploymentProcessor.java
+++ b/appclient/src/main/java/org/jboss/as/appclient/deployment/ApplicationClientParsingDeploymentProcessor.java
@@ -110,24 +110,14 @@ public class ApplicationClientParsingDeploymentProcessor implements DeploymentUn
             descriptor = deploymentRoot.getRoot().getChild(APP_XML);
         }
         if (descriptor.exists()) {
-            InputStream is = null;
-            try {
-                is = descriptor.openStream();
+            try (InputStream is = descriptor.openStream()) {
                 ApplicationClientMetaData data = new ApplicationClientMetaDataParser().parse(getXMLStreamReader(is), propertyReplacer);
                 return data;
             } catch (XMLStreamException e) {
                 throw AppClientLogger.ROOT_LOGGER.failedToParseXml(e, descriptor, e.getLocation().getLineNumber(), e.getLocation().getColumnNumber());
             } catch (IOException e) {
                 throw new DeploymentUnitProcessingException("Failed to parse " + descriptor, e);
-            } finally {
-                try {
-                    if (is != null) {
-                        is.close();
-                    }
-                } catch (IOException e) {
-                    // Ignore
-                }
-            }
+            } 
         } else {
             return null;
         }
@@ -138,24 +128,14 @@ public class ApplicationClientParsingDeploymentProcessor implements DeploymentUn
         final VirtualFile appXml = deploymentRoot.getChild(JBOSS_CLIENT_XML);
         if (appXml.exists()) {
             InputStream is = null;
-            try {
-                is = appXml.openStream();
+            try (InputStream is = appXml.openStream()) {
                 JBossClientMetaData data = new JBossClientMetaDataParser().parse(getXMLStreamReader(is), propertyReplacer);
                 return data;
             } catch (XMLStreamException e) {
                 throw AppClientLogger.ROOT_LOGGER.failedToParseXml(e, appXml, e.getLocation().getLineNumber(), e.getLocation().getColumnNumber());
-
             } catch (IOException e) {
                 throw AppClientLogger.ROOT_LOGGER.failedToParseXml(e, appXml);
-            } finally {
-                try {
-                    if (is != null) {
-                        is.close();
-                    }
-                } catch (IOException e) {
-                    // Ignore
-                }
-            }
+            } 
         } else {
             //we may already have this info from jboss-all.xml
             return deploymentUnit.getAttachment(AppClientJBossAllParser.ATTACHMENT_KEY);


### PR DESCRIPTION
We can exclude finally blocks, because of try-with-resources construction.
It will execute `close()` methods automatically.
We don't need catching IOExceptions from `close()` methods of resources, because they will be suppressed (according to Oracle's [doccummentation](https://docs.oracle.com/javase/7/docs/technotes/guides/language/try-with-resources.html)).
