### PR TITLE
WFLY-4255 Allow Arquillian to specify a timeout value for the WildFly clean shutdown mechanism when shutting down a server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
         <version.org.wildfly.build-tools>1.1.3.Final</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.5.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>3.0.0.Alpha5</version.org.wildfly.core>
-        <version.org.wildfly.arquillian>1.0.2.Final</version.org.wildfly.arquillian>
+        <version.org.wildfly.arquillian>2.0.0.Final</version.org.wildfly.arquillian>
         <version.org.yaml.snakeyaml>1.15</version.org.yaml.snakeyaml>
         <version.sun.jaxb>2.2.11.jbossorg-1</version.sun.jaxb>
         <version.sun.saaj-impl>1.3.16-jbossorg-1</version.sun.saaj-impl>
@@ -6024,17 +6024,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
             <dependency>
                 <groupId>org.wildfly.arquillian</groupId>
                 <artifactId>wildfly-arquillian-common</artifactId>
                 <version>${version.org.wildfly.arquillian}</version>
-            </dependency>
-
-            <!-- only needed until wildfly-arquillian has properly synced this version with arquillian it uses -->
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.descriptors</groupId>
-                <artifactId>shrinkwrap-descriptors-impl-base</artifactId>
-                <version>${version.org.jboss.shrinkwrap.descriptors}</version>
             </dependency>
 
             <dependency>

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/ClusteringTestConstants.java
@@ -76,6 +76,7 @@ public interface ClusteringTestConstants {
      * Timeouts.
      */
     int GRACE_TIME_TO_REPLICATE = TimeoutUtil.adjust(3000);
+    int GRACEFUL_SHUTDOWN_TIMEOUT = TimeoutUtil.adjust(15);
 
     /**
      * TODO: This will be removed.

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/NodeUtil.java
@@ -23,6 +23,7 @@ package org.jboss.as.test.clustering;
 
 import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.logging.Logger;
 
 /**
@@ -78,6 +79,18 @@ public final class NodeUtil {
                 log.info("Stopping container=" + container);
                 controller.stop(container);
                 log.info("Stopped container=" + container);
+            } catch (Throwable e) {
+                log.error("Failed to stop containers", e);
+            }
+        }
+    }
+
+    public static void stop(int timeout, WildFlyContainerController controller, String... containers) {
+        for (String container : containers) {
+            try {
+                log.info("Stopping container=" + container + ", timeout=" + timeout);
+                controller.stop(container, timeout);
+                log.info("Stopped container=" + container + ", timeout=" + timeout);
             } catch (Throwable e) {
                 log.error("Failed to stop containers", e);
             }

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ClusterAbstractTestCase.java
@@ -26,10 +26,10 @@ import java.util.TreeMap;
 
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
-import org.jboss.arquillian.container.test.api.ContainerController;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.WildFlyContainerController;
 import org.jboss.as.test.clustering.ClusteringTestConstants;
 import org.jboss.as.test.clustering.NodeUtil;
 import org.jboss.as.web.session.RoutingSupport;
@@ -75,7 +75,7 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
     }
 
     @ArquillianResource
-    protected ContainerController controller;
+    protected WildFlyContainerController controller;
     @ArquillianResource
     protected Deployer deployer;
 
@@ -109,6 +109,10 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
 
     protected void stop(String... containers) {
         NodeUtil.stop(this.controller, containers);
+    }
+
+    protected void stop(int timeout, String... containers) {
+        NodeUtil.stop(timeout, this.controller, containers);
     }
 
     protected void deploy(String... deployments) {
@@ -153,7 +157,7 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
             ClusterAbstractTestCase.this.stop(this.getContainers(nodes));
         }
 
-        private String[] getContainers(String... nodes) {
+        String[] getContainers(String... nodes) {
             String[] containers = new String[nodes.length];
             for (int i = 0; i < nodes.length; ++i) {
                 String node = nodes[i];
@@ -164,6 +168,13 @@ public abstract class ClusterAbstractTestCase implements ClusteringTestConstants
                 containers[i] = container;
             }
             return containers;
+        }
+    }
+
+    public class GracefulRestartLifecycle extends RestartLifecycle {
+        @Override
+        public void stop(String... nodes) {
+            ClusterAbstractTestCase.this.stop(GRACEFUL_SHUTDOWN_TIMEOUT, this.getContainers(nodes));
         }
     }
 


### PR DESCRIPTION
Jiras
https://issues.jboss.org/browse/WFLY-6615
https://issues.jboss.org/browse/WFLY-4255
https://issues.jboss.org/browse/WFLY-3532

@jamezp is afraid this might jeopardy testsuite stability and prefers to have this in 11.x
@rachmatowicz believes we cannot support    RemoteFailoverTestCase without support for graceful shutdown
