### PR TITLE
[WFLY-5380]  Do not create legacy connection factory using in-vm connector

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -817,4 +817,7 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 84, value = "Could not migrate attribute %s from resource %s. Use instead the socket-attribute to configure this discovery-group.")
     String couldNotMigrateDiscoveryGroupAttribute(String attribute, PathAddress address);
+
+    @Message(id = 85, value = "Could not create a legacy-connection-factory based on connection-factory %s. It used a HornetQ in-vm connector that is not compatible with Artemis in-vm connector ")
+    String couldNotCreateLegacyConnectionFactoryUsingInVMConnector(PathAddress address);
 }

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -159,7 +159,12 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         // 5 warnings about discovery-group attributes that can not be migrated.
         // 2 warnings about interceptors that can not be migrated.
         // 1 warning about HA migration (attributes have expressions)
-        assertEquals(warnings.toString(), 6 + 5 + 2 + 1, warnings.asList().size());
+        int expectedNumberOfWarnings = 6 + 5 + 2 + 1;
+        // 1 warning if add-legacy-entries is true because an in-vm connector can not be used in a legacy-connection-factory
+        if (addLegacyEntries) {
+            expectedNumberOfWarnings += 1;
+        }
+        assertEquals(warnings.toString(), expectedNumberOfWarnings, warnings.asList().size());
 
         model = services.readWholeModel();
 


### PR DESCRIPTION
Artemis in-vm connectors are not compatible with HornetQ ones.
Instead of creating legacy-connection-factory that would generate errors
during reload, discard it and add a warning.

JIRA: https://issues.jboss.org/browse/WFLY-5380
