### PR TITLE
[WFLY-5384] Validate Artemis Parameters

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -417,7 +417,11 @@ public class MigrateOperation implements OperationStepHandler {
                                 String name = address.getLastElement().getValue();
                                 ModelNode value = newAddOp.get(VALUE);
                                 ModelNode parentAddOp = newAddOperations.get(address.getParent());
-                                parentAddOp.get("params").add(new Property(name, value));
+                                if (name.equals("http-upgrade-endpoint") && address.getParent().getLastElement().getKey().equals("http-connector")) {
+                                    parentAddOp.get("endpoint").set(value);
+                                } else {
+                                    parentAddOp.get("params").add(new Property(name, value));
+                                }
                                 continue;
                             }
                             break;

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -73,6 +73,7 @@
         <connectors>
             <http-connector name="http" socket-binding="http">
                 <param key="batch-delay" value="${batch.delay:50}"/>
+                <param key="http-upgrade-endpoint" value="http"/>
             </http-connector>
             <netty-connector name="netty" socket-binding="messaging" />
             <netty-connector name="netty-throughput" socket-binding="messaging-throughput">

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPConnectorDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPConnectorDefinition.java
@@ -32,6 +32,7 @@ import org.jboss.as.controller.AttributeMarshaller;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.access.management.SensitiveTargetAccessConstraintDefinition;
 import org.jboss.dmr.ModelNode;
+import org.jboss.dmr.ModelType;
 
 /**
  * HTTP connector resource definition
@@ -54,9 +55,15 @@ public class HTTPConnectorDefinition extends AbstractTransportDefinition {
             .addAccessConstraint(SensitiveTargetAccessConstraintDefinition.SOCKET_BINDING_REF)
             .build();
 
+    // for remote acceptor, the socket-binding is required
+    public static final SimpleAttributeDefinition ENDPOINT = create("endpoint", ModelType.STRING)
+            .setAllowNull(false)
+            .setAllowExpression(false) // references another resource
+            .build();
+
     static final HTTPConnectorDefinition INSTANCE = new HTTPConnectorDefinition();
 
     public HTTPConnectorDefinition() {
-        super(false, CommonAttributes.HTTP_CONNECTOR, SOCKET_BINDING, PARAMS);
+        super(false, CommonAttributes.HTTP_CONNECTOR, SOCKET_BINDING, ENDPOINT, PARAMS);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
@@ -117,7 +117,7 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
                     public boolean handleUpgrade(HttpServerExchange exchange) throws IOException {
 
                         if (super.handleUpgrade(exchange)) {
-                            final String endpoint = exchange.getRequestHeaders().getFirst(HTTP_UPGRADE_ENDPOINT_PROP_NAME);
+                            final String endpoint = exchange.getRequestHeaders().getFirst(getHttpUpgradeEndpointKey());
                             if (endpoint == null) {
                                 return true;
                             } else {
@@ -169,6 +169,11 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
         return SEC_ACTIVEMQ_REMOTING_ACCEPT;
     }
 
+    protected String getHttpUpgradeEndpointKey() {
+        return HTTP_UPGRADE_ENDPOINT_PROP_NAME;
+    }
+
+
     /**
      * Service to handle HTTP upgrade for legacy (HornetQ) clients.
      *
@@ -195,6 +200,11 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
         @Override
         protected String getProtocol() {
             return HORNETQ_REMOTING;
+        }
+
+        @Override
+        protected String getHttpUpgradeEndpointKey() {
+            return "http-upgrade-endpoint";
         }
 
         @Override

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -294,6 +294,7 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                         builder(HTTPConnectorDefinition.INSTANCE)
                                                 .addAttributes(
                                                         HTTPConnectorDefinition.SOCKET_BINDING,
+                                                        HTTPConnectorDefinition.ENDPOINT,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
                                         builder(RemoteTransportDefinition.CONNECTOR_INSTANCE)

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -22,6 +22,7 @@
 
 package org.wildfly.extension.messaging.activemq;
 
+import static org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.ACCEPTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.CONNECTOR;
 import static org.wildfly.extension.messaging.activemq.CommonAttributes.FACTORY_CLASS;
@@ -48,12 +49,164 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.Property;
+
 /**
  * Basic {@link TransportConfiguration} (Acceptor/Connector) related operations.
+ *
+ * Artemis changed the naming convention for naming its parameters and uses CamelCase names.
+ * WildFly convention is to use hyphen-separated names. The mapping is done when creating Artemis connector/acceptor
+ * configuration based on the WildFly management model.
  *
  * @author Emanuel Muckenhuber
  */
 public class TransportConfigOperationHandlers {
+
+    private static final Map<String, String> CONNECTORS_KEYS_MAP = new HashMap<>();
+    private static final Map<String, String> ACCEPTOR_KEYS_MAP = new HashMap<>();
+
+    private static final String BATCH_DELAY = "batch-delay";
+    private static final String HTTP_UPGRADE_ENABLED = "http-upgrade-enabled";
+    private static final String KEY_STORE_PASSWORD = "key-store-password";
+    private static final String KEY_STORE_PATH = "key-store-path";
+    private static final String KEY_STORE_PROVIDER = "key-store-provider";
+    private static final String TCP_RECEIVE_BUFFER_SIZE = "tcp-receive-buffer-size";
+    private static final String TCP_SEND_BUFFER_SIZE = "tcp-send-buffer-size";
+    private static final String TRUST_STORE_PASSWORD = "trust-store-password";
+    private static final String TRUST_STORE_PATH = "trust-store-path";
+    private static final String TRUST_STORE_PROVIDER = "trust-store-provider";
+    private static final String ENABLED_PROTOCOLS = "enabled-protocols";
+    private static final String ENABLED_CIPHER_SUITES = "enabled-cipher-suites";
+    private static final String HOST = "host";
+    private static final String PORT = "port";
+    public static final String SSL_ENABLED = "ssl-enabled";
+    public static final String USE_NIO = "use-nio";
+    public static final String TCP_NO_DELAY = "tcp-no-delay";
+
+    static {
+        CONNECTORS_KEYS_MAP.put(InVMTransportDefinition.SERVER_ID.getName(),
+                org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(SSL_ENABLED,
+                TransportConstants.SSL_ENABLED_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("http-enabled",
+                TransportConstants.HTTP_ENABLED_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("http-client-idle-time",
+                TransportConstants.HTTP_CLIENT_IDLE_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("http-client-idle-scan-period",
+                TransportConstants.HTTP_CLIENT_IDLE_SCAN_PERIOD);
+        CONNECTORS_KEYS_MAP.put("http-requires-session-id",
+                TransportConstants.HTTP_REQUIRES_SESSION_ID);
+        CONNECTORS_KEYS_MAP.put(HTTP_UPGRADE_ENABLED,
+                TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("http-upgrade-endpoint",
+                TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("use-servlet",
+                TransportConstants.USE_SERVLET_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("servlet-path",
+                TransportConstants.SERVLET_PATH);
+        CONNECTORS_KEYS_MAP.put(USE_NIO,
+                TransportConstants.USE_NIO_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("use-nio-global-worker-pool",
+                TransportConstants.USE_NIO_GLOBAL_WORKER_POOL_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(HOST,
+                TransportConstants.HOST_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(PORT,
+                TransportConstants.PORT_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("local-address",
+                TransportConstants.LOCAL_ADDRESS_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put("local-port",
+                TransportConstants.LOCAL_PORT_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(KEY_STORE_PROVIDER,
+                TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(KEY_STORE_PATH,
+                TransportConstants.KEYSTORE_PATH_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(KEY_STORE_PASSWORD,
+                TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(TRUST_STORE_PROVIDER,
+                TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(TRUST_STORE_PATH,
+                TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(TRUST_STORE_PASSWORD,
+                TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(ENABLED_CIPHER_SUITES,
+                TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(ENABLED_PROTOCOLS,
+                TransportConstants.ENABLED_PROTOCOLS_PROP_NAME);
+        CONNECTORS_KEYS_MAP.put(TCP_NO_DELAY,
+                TransportConstants.TCP_NODELAY_PROPNAME);
+        CONNECTORS_KEYS_MAP.put(TCP_SEND_BUFFER_SIZE,
+                TransportConstants.TCP_SENDBUFFER_SIZE_PROPNAME);
+        CONNECTORS_KEYS_MAP.put(TCP_RECEIVE_BUFFER_SIZE,
+                TransportConstants.TCP_RECEIVEBUFFER_SIZE_PROPNAME);
+        CONNECTORS_KEYS_MAP.put("nio-remoting-threads",
+                TransportConstants.NIO_REMOTING_THREADS_PROPNAME);
+        CONNECTORS_KEYS_MAP.put(BATCH_DELAY,
+                TransportConstants.BATCH_DELAY);
+        CONNECTORS_KEYS_MAP.put("connect-timeout-millis",
+                TransportConstants.NETTY_CONNECT_TIMEOUT);
+
+        ACCEPTOR_KEYS_MAP.put(InVMTransportDefinition.SERVER_ID.getName(),
+                org.apache.activemq.artemis.core.remoting.impl.invm.TransportConstants.SERVER_ID_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(BATCH_DELAY,
+                TransportConstants.BATCH_DELAY);
+        ACCEPTOR_KEYS_MAP.put("cluster-connection",
+                TransportConstants.CLUSTER_CONNECTION);
+        ACCEPTOR_KEYS_MAP.put("connection-ttl",
+                TransportConstants.CONNECTION_TTL);
+        ACCEPTOR_KEYS_MAP.put("connections-allowed",
+                TransportConstants.CONNECTIONS_ALLOWED);
+        ACCEPTOR_KEYS_MAP.put("direct-deliver",
+                TransportConstants.DIRECT_DELIVER);
+        ACCEPTOR_KEYS_MAP.put(ENABLED_CIPHER_SUITES,
+                TransportConstants.ENABLED_CIPHER_SUITES_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(ENABLED_PROTOCOLS,
+                TransportConstants.ENABLED_PROTOCOLS_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(HOST,
+                TransportConstants.HOST_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put("http-response-time",
+                TransportConstants.HTTP_RESPONSE_TIME_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put("http-server-scan-period",
+                TransportConstants.HTTP_SERVER_SCAN_PERIOD_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(HTTP_UPGRADE_ENABLED,
+                TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(KEY_STORE_PASSWORD,
+                TransportConstants.KEYSTORE_PASSWORD_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(KEY_STORE_PATH,
+                TransportConstants.KEYSTORE_PATH_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(KEY_STORE_PROVIDER,
+                TransportConstants.KEYSTORE_PROVIDER_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put("needs-client-auth",
+                TransportConstants.NEED_CLIENT_AUTH_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put("nio-remoting-threads",
+                TransportConstants.NIO_REMOTING_THREADS_PROPNAME);
+        ACCEPTOR_KEYS_MAP.put(PORT,
+                TransportConstants.PORT_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put("protocols",
+                TransportConstants.PROTOCOLS_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(SSL_ENABLED,
+                TransportConstants.SSL_ENABLED_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put("stomp-enable-message-id",
+                TransportConstants.STOMP_ENABLE_MESSAGE_ID);
+        ACCEPTOR_KEYS_MAP.put("stomp-min-large-message-size",
+                TransportConstants.STOMP_MIN_LARGE_MESSAGE_SIZE);
+        ACCEPTOR_KEYS_MAP.put("stomp-consumer-credits",
+                TransportConstants.STOMP_CONSUMERS_CREDIT);
+        ACCEPTOR_KEYS_MAP.put(TCP_NO_DELAY,
+                TransportConstants.TCP_NODELAY_PROPNAME);
+        ACCEPTOR_KEYS_MAP.put(TCP_RECEIVE_BUFFER_SIZE,
+                TransportConstants.TCP_RECEIVEBUFFER_SIZE_PROPNAME);
+        ACCEPTOR_KEYS_MAP.put(TCP_SEND_BUFFER_SIZE,
+                TransportConstants.TCP_SENDBUFFER_SIZE_PROPNAME);
+        ACCEPTOR_KEYS_MAP.put(TRUST_STORE_PASSWORD,
+                TransportConstants.TRUSTSTORE_PASSWORD_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(TRUST_STORE_PATH,
+                TransportConstants.TRUSTSTORE_PATH_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(TRUST_STORE_PROVIDER,
+                TransportConstants.TRUSTSTORE_PROVIDER_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put("use-invm",
+                TransportConstants.USE_INVM_PROP_NAME);
+        ACCEPTOR_KEYS_MAP.put(USE_NIO,
+                TransportConstants.USE_NIO_PROP_NAME);
+    }
 
     /**
      * Process the acceptor information.
@@ -70,7 +223,7 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(ACCEPTOR).asPropertyList()) {
                 final String acceptorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
+                final Map<String, Object> parameters = getParameters(context, config, ACCEPTOR_KEYS_MAP);
                 final String clazz = config.get(FACTORY_CLASS.getName()).asString();
                 acceptors.put(acceptorName, new TransportConfiguration(clazz, parameters, acceptorName));
             }
@@ -79,10 +232,11 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(REMOTE_ACCEPTOR).asPropertyList()) {
                 final String acceptorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
+                final Map<String, Object> parameters = getParameters(context, config, ACCEPTOR_KEYS_MAP);
                 final String binding = config.get(RemoteTransportDefinition.SOCKET_BINDING.getName()).asString();
-                parameters.put(RemoteTransportDefinition.SOCKET_BINDING.getName(), binding);
                 bindings.add(binding);
+                // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
+                parameters.put(RemoteTransportDefinition.SOCKET_BINDING.getName(), binding);
                 acceptors.put(acceptorName, new TransportConfiguration(NettyAcceptorFactory.class.getName(), parameters, acceptorName));
             }
         }
@@ -90,8 +244,8 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(IN_VM_ACCEPTOR).asPropertyList()) {
                 final String acceptorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
-                parameters.put(InVMTransportDefinition.SERVER_ID.getName(), InVMTransportDefinition.SERVER_ID.resolveModelAttribute(context, config).asInt());
+                final Map<String, Object> parameters = getParameters(context, config, ACCEPTOR_KEYS_MAP);
+                parameters.put(SERVER_ID_PROP_NAME, InVMTransportDefinition.SERVER_ID.resolveModelAttribute(context, config).asInt());
                 acceptors.put(acceptorName, new TransportConfiguration(InVMAcceptorFactory.class.getName(), parameters, acceptorName));
             }
         }
@@ -99,7 +253,7 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(HTTP_ACCEPTOR).asPropertyList()) {
                 final String acceptorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
+                final Map<String, Object> parameters = getParameters(context, config, ACCEPTOR_KEYS_MAP);
                 parameters.put(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME, true);
                 acceptors.put(acceptorName, new TransportConfiguration(NettyAcceptorFactory.class.getName(), parameters, acceptorName));
             }
@@ -112,12 +266,19 @@ public class TransportConfigOperationHandlers {
      *
      * @param context the operation context
      * @param config the transport configuration
+     * @param mapping Mapping betwen WildFly parameters (keys) and Artemis constants (values)
      * @return the extracted parameters
      * @throws OperationFailedException if an expression can not be resolved
      */
-    public static Map<String, Object> getParameters(final OperationContext context, final ModelNode config) throws OperationFailedException {
+    public static Map<String, Object> getParameters(final OperationContext context, final ModelNode config, final Map<String, String> mapping) throws OperationFailedException {
         Map<String, String> fromModel = CommonAttributes.PARAMS.unwrap(context, config);
-        return new HashMap<String, Object>(fromModel);
+        Map<String, Object> parameters = new HashMap<>();
+        for (Map.Entry<String, String> entry : fromModel.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            parameters.put(mapping.getOrDefault(key, key), value);
+        }
+        return parameters;
     }
 
     /**
@@ -135,7 +296,7 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(CONNECTOR).asPropertyList()) {
                 final String connectorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
+                final Map<String, Object> parameters = getParameters(context, config, CONNECTORS_KEYS_MAP);
                 final String clazz = FACTORY_CLASS.resolveModelAttribute(context, config).asString();
                 connectors.put(connectorName, new TransportConfiguration(clazz, parameters, connectorName));
             }
@@ -144,10 +305,11 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(REMOTE_CONNECTOR).asPropertyList()) {
                 final String connectorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
+                final Map<String, Object> parameters = getParameters(context, config, CONNECTORS_KEYS_MAP);
                 final String binding = config.get(RemoteTransportDefinition.SOCKET_BINDING.getName()).asString();
-                parameters.put(RemoteTransportDefinition.SOCKET_BINDING.getName(), binding);
                 bindings.add(binding);
+                // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
+                parameters.put(RemoteTransportDefinition.SOCKET_BINDING.getName(), binding);
                 connectors.put(connectorName, new TransportConfiguration(NettyConnectorFactory.class.getName(), parameters, connectorName));
             }
         }
@@ -155,8 +317,8 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(IN_VM_CONNECTOR).asPropertyList()) {
                 final String connectorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
-                parameters.put(InVMTransportDefinition.SERVER_ID.getName(), InVMTransportDefinition.SERVER_ID.resolveModelAttribute(context, config).asInt());
+                final Map<String, Object> parameters = getParameters(context, config, CONNECTORS_KEYS_MAP);
+                parameters.put(CONNECTORS_KEYS_MAP.get(InVMTransportDefinition.SERVER_ID.getName()), InVMTransportDefinition.SERVER_ID.resolveModelAttribute(context, config).asInt());
                 connectors.put(connectorName, new TransportConfiguration(InVMConnectorFactory.class.getName(), parameters, connectorName));
             }
         }
@@ -164,12 +326,14 @@ public class TransportConfigOperationHandlers {
             for (final Property property : params.get(HTTP_CONNECTOR).asPropertyList()) {
                 final String connectorName = property.getName();
                 final ModelNode config = property.getValue();
-                final Map<String, Object> parameters = getParameters(context, config);
+                final Map<String, Object> parameters = getParameters(context, config, CONNECTORS_KEYS_MAP);
 
                 final String binding = HTTPConnectorDefinition.SOCKET_BINDING.resolveModelAttribute(context, config).asString();
                 bindings.add(binding);
-                parameters.put(HTTPConnectorDefinition.SOCKET_BINDING.getName(), binding);
                 parameters.put(TransportConstants.HTTP_UPGRADE_ENABLED_PROP_NAME, true);
+                parameters.put(TransportConstants.HTTP_UPGRADE_ENDPOINT_PROP_NAME, HTTPConnectorDefinition.ENDPOINT.resolveModelAttribute(context, config).asString());
+                // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
+                parameters.put(HTTPConnectorDefinition.SOCKET_BINDING.getName(), binding);
                 connectors.put(connectorName, new TransportConfiguration(NettyConnectorFactory.class.getName(), parameters, connectorName));
             }
         }

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -174,6 +174,7 @@ connector-service.remove=Operation removing a connector service
 connector-service=TODO
 connector.add.params=A set of key-value pairs understood by the connector factory-class and used to configure it.
 connector.add=Operation adding a connector
+connector.endpoint=The http-acceptor that serves as the endpoint of this http-connector.
 connector.factory-class=Class name of the factory class that can instantiate the connector.
 connector.params=A key-value pair understood by the connector factory-class and used to configure it.
 connector.remove=Operation removing a connector

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
@@ -260,6 +260,7 @@
                     </xs:sequence>
                     <xs:attribute name="name" type="xs:string" use="required" />
                     <xs:attribute name="socket-binding" type="xs:string" use="required" />
+                    <xs:attribute name="endpoint" type="xs:string" use="required" />
                 </xs:complexType>
             </xs:element>
 

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -17,14 +17,11 @@
             <?ADDRESS-SETTINGS?>
 
             <http-connector name="http-connector"
-                            socket-binding="http">
-                <param name="http-upgrade-endpoint"
-                       value="http-acceptor"/>
-            </http-connector>
+                            socket-binding="http"
+                            endpoint="http-acceptor" />
             <http-connector name="http-connector-throughput"
-                            socket-binding="http">
-                <param name="http-upgrade-endpoint"
-                       value="http-acceptor-throughput"/>
+                            socket-binding="http"
+                            endpoint="http-acceptor-throughput">
                 <param name="batch-delay"
                        value="50"/>
             </http-connector>

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
@@ -122,7 +122,8 @@
                          slow-consumer-threshold="${slow.consumer.threshold:456}"/>
 
         <http-connector name="http"
-                        socket-binding="http">
+                        socket-binding="http"
+                        endpoint="http">
             <param name="batch-delay" value="${batch.delay:50}"/>
         </http-connector>
         <remote-connector name="netty"
@@ -157,7 +158,7 @@
                         server-id="${my.server-id:0}"/>
         <acceptor name="myacceptor"
                   factory-class="org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnectorFactory">
-            <param name="batch-delay" value="${batch.delay:50}"/>
+            <param name="batchDelay" value="${batch.delay:50}"/>
         </acceptor>
 
         <broadcast-group name="groupT"

--- a/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
+++ b/testsuite/domain/src/test/resources/domain-configs/domain-standard.xml
@@ -334,11 +334,8 @@
                         <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
                     </security-setting>
                     <address-setting name="#" dead-letter-address="jms.queue.DLQ" expiry-address="jms.queue.ExpiryQueue" max-size-bytes="10485760" page-size-bytes="2097152" message-counter-history-day-limit="10"/>
-                    <http-connector name="http-connector" socket-binding="http">
-                        <param name="http-upgrade-endpoint" value="http-acceptor"/>
-                    </http-connector>
-                    <http-connector name="http-connector-throughput" socket-binding="http">
-                        <param name="http-upgrade-endpoint" value="http-acceptor-throughput"/>
+                    <http-connector name="http-connector" socket-binding="http" endpoint="http-acceptor" />
+                    <http-connector name="http-connector-throughput" socket-binding="http" endpoint="http-acceptor-throughput">
                         <param name="batch-delay" value="50"/>
                     </http-connector>
                     <in-vm-connector name="in-vm" server-id="0"/>
@@ -598,11 +595,8 @@
                         <role name="guest" send="true" consume="true" create-non-durable-queue="true" delete-non-durable-queue="true"/>
                     </security-setting>
                     <address-setting name="#" dead-letter-address="jms.queue.DLQ" expiry-address="jms.queue.ExpiryQueue" max-size-bytes="10485760" page-size-bytes="2097152" message-counter-history-day-limit="10"/>
-                    <http-connector name="http-connector" socket-binding="http">
-                        <param name="http-upgrade-endpoint" value="http-acceptor"/>
-                    </http-connector>
-                    <http-connector name="http-connector-throughput" socket-binding="http">
-                        <param name="http-upgrade-endpoint" value="http-acceptor-throughput"/>
+                    <http-connector name="http-connector" socket-binding="http" endpoint="http-acceptor" />
+                    <http-connector name="http-connector-throughput" socket-binding="http" endpoint="http-acceptor-throughput">
                         <param name="batch-delay" value="50"/>
                     </http-connector>
                     <in-vm-connector name="in-vm" server-id="0"/>


### PR DESCRIPTION
- check that the configuration parameters keys are accepted by Artemis.
- update the messaging-activemq templates to use the keys accepted by
  Artemis (now using CamelCase convention).

JIRA: https://issues.jboss.org/browse/WFLY-5384
