### PR TITLE
Ignore intermittently failing tests

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
@@ -50,6 +50,7 @@ import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.api.Authentication;
@@ -59,6 +60,7 @@ import org.wildfly.test.api.Authentication;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
+@Ignore("fails intermittently")
 public class ClusteredMessagingTestCase {
 
     public static final String CONTAINER_0 = "messaging-container-0";


### PR DESCRIPTION
@jmesnil FYI. I see frequent failures of these tests in the CI runs, e.g.

http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WildFlyCore_PullRequest&buildTypeId=&tab=testDetails&testNameId=-7659393372285345673&order=START_DATE_DESC&branch_WildFlyCore_PullRequest=__all_branches__&itemsCount=50
