### PR TITLE
[WFLY-5397] WeldDeployment is returning the wrong BDA for the specified beanClass

### DIFF
--- a/weld/src/main/java/org/jboss/as/weld/deployment/WeldDeployment.java
+++ b/weld/src/main/java/org/jboss/as/weld/deployment/WeldDeployment.java
@@ -224,9 +224,11 @@ public class WeldDeployment implements CDI11Deployment {
     @Override
     public synchronized BeanDeploymentArchive getBeanDeploymentArchive(final Class<?> beanClass) {
         ClassLoader moduleClassLoader = WildFlySecurityManager.getClassLoaderPrivileged(beanClass);
-        for (BeanDeploymentArchiveImpl bda : beanDeploymentArchives) {
-            if (bda.getBeanClasses().contains(beanClass.getName()) && moduleClassLoader != null && moduleClassLoader.equals(beanClass.getClassLoader())) {
-                return bda;
+        if (moduleClassLoader != null) {
+            for (BeanDeploymentArchiveImpl bda : beanDeploymentArchives) {
+                if (bda.getBeanClasses().contains(beanClass.getName()) && moduleClassLoader.equals(bda.getClassLoader())) {
+                    return bda;
+                }
             }
         }
         /*

--- a/weld/src/main/java/org/jboss/as/weld/util/Reflections.java
+++ b/weld/src/main/java/org/jboss/as/weld/util/Reflections.java
@@ -57,7 +57,7 @@ public class Reflections {
     public static <T> Class<T> loadClass(String className, ClassLoader classLoader) {
         try {
             return cast(classLoader.loadClass(className));
-        } catch (Exception e) {
+        } catch (Throwable e) {
             return null;
         }
     }


### PR DESCRIPTION
From @Dawuid:

> When you are deploying an EAR with libraries and multiple WARs that includes same libraries (for example jsf libraries), the method is returning the first BeanDeploymentArchive that includes the bean name, but not the one that has the bean name AND shares the same classloader.
> 
> With this fix you can use BeanManager and CDI.current() again without mixing classloaders.
