### PR TITLE
[WFLY-5394] Generic acceptor/connector is ignoring its socket-binding

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GenericTransportDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/GenericTransportDefinition.java
@@ -44,18 +44,10 @@ public class GenericTransportDefinition extends AbstractTransportDefinition {
 
     static AttributeDefinition[] ATTRIBUTES = { CommonAttributes.FACTORY_CLASS, SOCKET_BINDING, CommonAttributes.PARAMS };
 
-    static final GenericTransportDefinition CONNECTOR_INSTANCE = createConnectorDefinition(false);
-    static final GenericTransportDefinition ACCEPTOR_INSTANCE = createAcceptorDefinition(false);
+    static final GenericTransportDefinition CONNECTOR_INSTANCE = new GenericTransportDefinition(false, CommonAttributes.CONNECTOR);
+    static final GenericTransportDefinition ACCEPTOR_INSTANCE = new GenericTransportDefinition(true, CommonAttributes.ACCEPTOR);
 
-    public static GenericTransportDefinition createAcceptorDefinition(final boolean registerRuntimeOnly) {
-        return new GenericTransportDefinition(registerRuntimeOnly, true, CommonAttributes.ACCEPTOR);
-    }
-
-    public static GenericTransportDefinition createConnectorDefinition(final boolean registerRuntimeOnly) {
-        return new GenericTransportDefinition(registerRuntimeOnly, false, CommonAttributes.CONNECTOR);
-    }
-
-    private GenericTransportDefinition(final boolean registerRuntimeOnly, boolean isAcceptor, String specificType) {
+    private GenericTransportDefinition(boolean isAcceptor, String specificType) {
         super(isAcceptor, specificType, ATTRIBUTES);
     }
 }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/TransportConfigOperationHandlers.java
@@ -225,6 +225,12 @@ public class TransportConfigOperationHandlers {
                 final ModelNode config = property.getValue();
                 final Map<String, Object> parameters = getParameters(context, config, ACCEPTOR_KEYS_MAP);
                 final String clazz = config.get(FACTORY_CLASS.getName()).asString();
+                ModelNode socketBinding = GenericTransportDefinition.SOCKET_BINDING.resolveModelAttribute(context, config);
+                if (socketBinding.isDefined()) {
+                    bindings.add(socketBinding.asString());
+                    // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
+                    parameters.put(GenericTransportDefinition.SOCKET_BINDING.getName(), socketBinding.asString());
+                }
                 acceptors.put(acceptorName, new TransportConfiguration(clazz, parameters, acceptorName));
             }
         }
@@ -297,6 +303,12 @@ public class TransportConfigOperationHandlers {
                 final String connectorName = property.getName();
                 final ModelNode config = property.getValue();
                 final Map<String, Object> parameters = getParameters(context, config, CONNECTORS_KEYS_MAP);
+                ModelNode socketBinding = GenericTransportDefinition.SOCKET_BINDING.resolveModelAttribute(context, config);
+                if (socketBinding.isDefined()) {
+                    bindings.add(socketBinding.asString());
+                    // uses the parameters to pass the socket binding name that will be read in ActiveMQServerService.start()
+                    parameters.put(GenericTransportDefinition.SOCKET_BINDING.getName(), socketBinding.asString());
+                }
                 final String clazz = FACTORY_CLASS.resolveModelAttribute(context, config).asString();
                 connectors.put(connectorName, new TransportConfiguration(clazz, parameters, connectorName));
             }


### PR DESCRIPTION
The socket-binding attribute of generic acceptor and connector must be
processed if it is defined in the model

JIRA: https://issues.jboss.org/browse/WFLY-5394
