### PR TITLE
[WFLY-5371] Use ee channel for messaging cluster

### DIFF
--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -91,12 +91,12 @@
             <broadcast-group name="bg-group1"
                              connectors="http-connector"
                              jgroups-stack="udp"
-                             jgroups-channel="activemq-cluster"/>
+                             jgroups-channel="ee"/>
         </replacement>
         <replacement placeholder="DISCOVERY-GROUPS">
             <discovery-group name="dg-group1"
                              jgroups-stack="udp"
-                             jgroups-channel="activemq-cluster"/>
+                             jgroups-channel="ee"/>
         </replacement>
         <replacement placeholder="CLUSTER-CONNECTIONS">
                 <cluster-connection name="my-cluster"


### PR DESCRIPTION
Use the JGroups channel ee for messaging cluster communication.

JIRA: https://issues.jboss.org/browse/WFLY-5371
