### PR TITLE
[WFLY-5194]: Restore the original legacy configs for use in ParseAndMarshalModelsTestCase.

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -18,7 +18,7 @@
 * License along with this software; if not, write to the Free
 * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-*/
+ */
 package org.jboss.as.test.manualmode.parse;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
@@ -35,14 +35,17 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Tests the ability to parse the config files we ship or have shipped in the past, as well as the ability
- * to marshal them back to xml in a manner such that reparsing them produces a consistent in-memory configuration model.
+ * Tests the ability to parse the config files we ship or have shipped in the past, as well as the ability to marshal
+ * them back to xml in a manner such that reparsing them produces a consistent in-memory configuration model.
  *
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 public class ParseAndMarshalModelsTestCase {
+
+    private static final String[] EAP_VERSIONS = {"6-0-0", "6-1-0", "6-2-0", "6-3-0"};
+    private static final String[] AS_VERSIONS = {"7-1-3", "7-2-0"};
 
     private static final File JBOSS_HOME = new File(".." + File.separatorChar + "jbossas-parse-marshal");
 
@@ -92,233 +95,129 @@ public class ParseAndMarshalModelsTestCase {
     }
 
     @Test
-    public void test713StandaloneXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-3.xml"));
-        validateJsfSubsystem(model);
+    public void testJBossASStandaloneXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version + ".xml"));
+            validateJsfSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test713StandaloneFullHaXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-3-full-ha.xml"));
-        validateJsfSubsystem(model);
+    public void testJBossASStandaloneFullHaXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version + "-full-ha.xml"));
+            validateJsfSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test713StandaloneFullXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-3-full.xml"));
-        validateJsfSubsystem(model);
+    public void testJBossASStandaloneFullXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version + "-full.xml"));
+            validateJsfSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test713StandaloneHornetQCollocatedXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-3-hornetq-colocated.xml"));
+    public void testJBossASStandaloneHornetQCollocatedXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            standaloneXmlTest(getLegacyConfigFile("standalone", version + "-hornetq-colocated.xml"));
+        }
     }
 
     @Test
-    public void test713StandaloneJtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-3-jts.xml"));
+    public void testJBossASStandaloneJtsXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            standaloneXmlTest(getLegacyConfigFile("standalone", version + "-jts.xml"));
+        }
     }
 
     @Test
-    public void test713StandaloneMinimalisticXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-3-minimalistic.xml"));
+    public void testJBossASStandaloneMinimalisticXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            standaloneXmlTest(getLegacyConfigFile("standalone", version + "-minimalistic.xml"));
+        }
     }
 
     @Test
-    public void test713StandaloneXtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-1-3-xts.xml"));
+    public void testJBossASStandaloneXtsXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            standaloneXmlTest(getLegacyConfigFile("standalone", version + "-xts.xml"));
+        }
     }
 
     @Test
-    public void test720StandaloneFullHaXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "7-2-0-full-ha.xml"));
-        validateJsfSubsystem(model);
+    public void testEAPStandaloneFullHaXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-" + version + "-full-ha.xml"));
+            validateWebSubsystem(model, version);
+            validateJsfSubsystem(model, version);
+            validateCmpSubsystem(model, version);
+            validateMessagingSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test720StandaloneFullXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "7-2-0-full.xml"));
-        validateJsfSubsystem(model);
+    public void testEAPStandaloneFullXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-" + version + "-full.xml"));
+            validateWebSubsystem(model, version);
+            validateJsfSubsystem(model, version);
+            validateCmpSubsystem(model, version);
+            validateMessagingSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test720StandaloneHornetQCollocatedXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-2-0-hornetq-colocated.xml"));
+    public void testEAPStandaloneXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-" + version + ".xml"));
+            validateWebSubsystem(model, version);
+            validateJsfSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test720StandaloneJtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-2-0-jts.xml"));
+    public void testEAPStandaloneHornetQCollocatedXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-" + version + "-hornetq-colocated.xml"));
+            validateWebSubsystem(model, version);
+            validateJsfSubsystem(model, version);
+            validateMessagingSubsystem(model, version);
+            validateThreadsSubsystem(model, version);
+            validateJacordSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test720StandaloneMinimalisticXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-2-0-minimalistic.xml"));
+    public void testEAPStandaloneJtsXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-" + version + "-jts.xml"));
+            validateWebSubsystem(model, version);
+            validateJsfSubsystem(model, version);
+            validateThreadsSubsystem(model, version);
+            validateJacordSubsystem(model, version);
+        }
     }
 
     @Test
-    public void test720StandaloneXtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "7-2-0-xts.xml"));
+    public void testEAPStandaloneMinimalisticXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            standaloneXmlTest(getLegacyConfigFile("standalone", "eap-" + version + "-minimalistic.xml"));
+        }
     }
 
     @Test
-    public void testEAP600StandaloneFullHaXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-0-0-full-ha.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP600StandaloneFullXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-0-0-full.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP600StandaloneHornetQCollocatedXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-0-0-hornetq-colocated.xml"));
-    }
-
-    @Test
-    public void testEAP600StandaloneJtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-0-0-jts.xml"));
-    }
-
-    @Test
-    public void testEAP600StandaloneMinimalisticXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-0-0-minimalistic.xml"));
-    }
-
-    @Test
-    public void testEAP600StandaloneXtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-0-0-xts.xml"));
-    }
-
-    @Test
-    public void testEAP610StandaloneFullHaXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-1-0-full-ha.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP610StandaloneFullXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-1-0-full.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP610StandaloneHornetQCollocatedXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-1-0-hornetq-colocated.xml"));
-    }
-
-    @Test
-    public void testEAP610StandaloneJtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-1-0-jts.xml"));
-    }
-
-    @Test
-    public void testEAP610StandaloneMinimalisticXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-1-0-minimalistic.xml"));
-    }
-
-    @Test
-    public void testEAP610StandaloneXtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-1-0-xts.xml"));
-    }
-
-    @Test
-    public void testEAP620StandaloneFullHaXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-2-0-full-ha.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP620StandaloneFullXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-2-0-full.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP620StandaloneHornetQCollocatedXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-2-0-hornetq-colocated.xml"));
-    }
-
-    @Test
-    public void testEAP620StandaloneJtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-2-0-jts.xml"));
-    }
-
-    @Test
-    public void testEAP620StandaloneMinimalisticXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-2-0-minimalistic.xml"));
-    }
-
-    @Test
-    public void testEAP620StandaloneXtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-2-0-xts.xml"));
-    }
-
-    @Test
-    public void testEAP630StandaloneFullHaXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-3-0-full-ha.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP630StandaloneFullXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-3-0-full.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP630StandaloneHornetQCollocatedXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-3-0-hornetq-colocated.xml"));
-    }
-
-    @Test
-    public void testEAP630StandaloneJtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-3-0-jts.xml"));
-    }
-
-    @Test
-    public void testEAP630StandaloneMinimalisticXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-3-0-minimalistic.xml"));
-    }
-
-    @Test
-    public void testEAP630StandaloneXtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-3-0-xts.xml"));
-    }
-
-    @Test
-    public void testEAP640StandaloneFullHaXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-4-0-full-ha.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP640StandaloneFullXml() throws Exception {
-        ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-4-0-full.xml"));
-        validateJsfSubsystem(model);
-    }
-
-    @Test
-    public void testEAP640StandaloneHornetQCollocatedXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-4-0-hornetq-colocated.xml"));
-    }
-
-    @Test
-    public void testEAP640StandaloneJtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-4-0-jts.xml"));
-    }
-
-    @Test
-    public void testEAP640StandaloneMinimalisticXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-4-0-minimalistic.xml"));
-    }
-
-    @Test
-    public void testEAP640StandaloneXtsXml() throws Exception {
-        standaloneXmlTest(getLegacyConfigFile("standalone", "eap-6-4-0-xts.xml"));
+    public void testEAPStandaloneXtsXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", "eap-" + version + "-xts.xml"));
+            validateCmpSubsystem(model, version);
+            validateWebSubsystem(model, version);
+            validateJsfSubsystem(model, version);
+            validateThreadsSubsystem(model, version);
+            validateJacordSubsystem(model, version);
+            validateXtsSubsystem(model, version);
+        }
     }
 
     private ModelNode standaloneXmlTest(File original) throws Exception {
@@ -331,38 +230,17 @@ public class ParseAndMarshalModelsTestCase {
     }
 
     @Test
-    public void test713HostXml() throws Exception {
-        hostXmlTest(getLegacyConfigFile("host", "7-1-3.xml"));
+    public void testJBossASHostXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            hostXmlTest(getLegacyConfigFile("host", version + ".xml"));
+        }
     }
 
     @Test
-    public void test720HostXml() throws Exception {
-        hostXmlTest(getLegacyConfigFile("host", "7-2-0.xml"));
-    }
-
-    @Test
-    public void testEAP600HostXml() throws Exception {
-        hostXmlTest(getLegacyConfigFile("host", "eap-6-0-0.xml"));
-    }
-
-    @Test
-    public void testEAP610HostXml() throws Exception {
-        hostXmlTest(getLegacyConfigFile("host", "eap-6-1-0.xml"));
-    }
-
-    @Test
-    public void testEAP620HostXml() throws Exception {
-        hostXmlTest(getLegacyConfigFile("host", "eap-6-2-0.xml"));
-    }
-
-    @Test
-    public void testEAP630HostXml() throws Exception {
-        hostXmlTest(getLegacyConfigFile("host", "eap-6-3-0.xml"));
-    }
-
-    @Test
-    public void testEAP640HostXml() throws Exception {
-        hostXmlTest(getLegacyConfigFile("host", "eap-6-4-0.xml"));
+    public void testEAPHostXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            hostXmlTest(getLegacyConfigFile("host", "eap-" + version + ".xml"));
+        }
     }
 
     private void hostXmlTest(final File original) throws Exception {
@@ -375,61 +253,68 @@ public class ParseAndMarshalModelsTestCase {
     }
 
     @Test
-    public void test713DomainXml() throws Exception {
-        ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "7-1-3.xml"));
-        validateJsfProfiles(model);
+    public void testJBossASDomainXml() throws Exception {
+        for (String version : AS_VERSIONS) {
+            ModelNode model = domainXmlTest(getLegacyConfigFile("domain", version + ".xml"));
+            validateProfiles(model, version);
+        }
     }
 
     @Test
-    public void test720DomainXml() throws Exception {
-        ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "7-2-0.xml"));
-        validateJsfProfiles(model);
-    }
-
-    @Test
-    public void testEAP600DomainXml() throws Exception {
-        ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "eap-6-0-0.xml"));
-        validateJsfProfiles(model);
-    }
-
-    @Test
-    public void testEAP610DomainXml() throws Exception {
-        ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "eap-6-1-0.xml"));
-        validateJsfProfiles(model);
-    }
-
-    @Test
-    public void testEAP620DomainXml() throws Exception {
-        ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "eap-6-2-0.xml"));
-        validateJsfProfiles(model);
-    }
-
-    @Test
-    public void testEAP630DomainXml() throws Exception {
-        ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "eap-6-3-0.xml"));
-        validateJsfProfiles(model);
-    }
-
-    @Test
-    public void testEAP640DomainXml() throws Exception {
-        ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "eap-6-4-0.xml"));
-        validateJsfProfiles(model);
+    public void testEAPDomainXml() throws Exception {
+        for (String version : EAP_VERSIONS) {
+            ModelNode model = domainXmlTest(getLegacyConfigFile("domain", "eap-" + version + ".xml"));
+            validateProfiles(model, version);
+        }
     }
 
     private ModelNode domainXmlTest(final File original) throws Exception {
         return ModelParserUtils.domainXmlTest(original, JBOSS_HOME);
     }
 
-    private static void validateJsfProfiles(ModelNode model) {
+    private static void validateProfiles(ModelNode model, String version) {
         Assert.assertTrue(model.hasDefined(PROFILE));
         for (Property prop : model.get(PROFILE).asPropertyList()) {
-            validateJsfSubsystem(prop.getValue());
+            validateWebSubsystem(prop.getValue(), version);
+            validateJsfSubsystem(prop.getValue(), version); 
+            validateThreadsSubsystem(prop.getValue(), version);
         }
     }
 
-    private static void validateJsfSubsystem(ModelNode model) {
+    private static void validateWebSubsystem(ModelNode model, String version) {
+        validateSubsystem(model, "web", version);
+        Assert.assertTrue(model.hasDefined(SUBSYSTEM, "web", "connector", "http"));
+    }
+
+    private static void validateJsfSubsystem(ModelNode model, String version) {
+        validateSubsystem(model, "jsf", version); //we cannot check for it as web subsystem is not present to add jsf one
+    }
+
+    private static void validateCmpSubsystem(ModelNode model, String version) {
+        validateSubsystem(model, "cmp", version);
+    }
+
+    private static void validateMessagingSubsystem(ModelNode model, String version) {
+        validateSubsystem(model, "messaging", version);
+        Assert.assertTrue(model.hasDefined(SUBSYSTEM, "messaging", "hornetq-server", "default"));
+    }
+
+    private static void validateThreadsSubsystem(ModelNode model, String version) {
+        validateSubsystem(model, "threads", version);
+    }
+
+    private static void validateJacordSubsystem(ModelNode model, String version) {
+        validateSubsystem(model, "jacorb", version);
+    }
+
+    private static void validateXtsSubsystem(ModelNode model, String version) {
+        validateSubsystem(model, "xts", version);
+        Assert.assertTrue(model.hasDefined(SUBSYSTEM, "xts", "host"));
+    }
+
+    private static void validateSubsystem(ModelNode model, String subsystem, String version) {
         Assert.assertTrue(model.hasDefined(SUBSYSTEM));
-        //Assert.assertTrue(model.get(SUBSYSTEM).hasDefined("jsf")); //we cannot check for it as web subsystem is not present to add jsf one
+        Assert.assertTrue("Missing " + subsystem + " subsystem for " + version, model.get(SUBSYSTEM).hasDefined(subsystem));
     }
     //  Get-config methods
 

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/7-1-3.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/7-1-3.xml
@@ -5,6 +5,7 @@
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
         <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
@@ -24,6 +25,7 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
         <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
@@ -73,6 +75,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -211,6 +214,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>
@@ -278,6 +282,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -494,6 +499,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>
@@ -563,6 +569,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -783,6 +790,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>
@@ -851,6 +859,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -1172,6 +1181,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/7-2-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/7-2-0.xml
@@ -5,6 +5,7 @@
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
         <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
@@ -25,6 +26,7 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
         <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
@@ -77,6 +79,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -224,6 +227,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>
@@ -295,6 +299,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -513,6 +518,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>
@@ -586,6 +592,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -815,6 +822,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>
@@ -887,6 +895,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -1209,6 +1218,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.2">
                 <core-environment>
                     <process-id>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-0-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-0-0.xml
@@ -5,6 +5,7 @@
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
         <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
@@ -67,6 +68,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -270,6 +272,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -556,6 +559,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -845,6 +849,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -1216,7 +1221,6 @@
             <socket-binding name="ajp" port="8009"/>
             <socket-binding name="http" port="8080"/>
             <socket-binding name="https" port="8443"/>
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
@@ -1235,7 +1239,6 @@
             <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
             <socket-binding name="jgroups-udp-fd" port="54200"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
@@ -1253,7 +1256,6 @@
             <socket-binding name="messaging" port="5445"/>
             <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
             <socket-binding name="messaging-throughput" port="5455"/>
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>
@@ -1277,7 +1279,6 @@
             <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
             <socket-binding name="messaging-throughput" port="5455"/>
             <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
-            <socket-binding name="osgi-http" interface="management" port="8090"/>
             <socket-binding name="remoting" port="4447"/>
             <socket-binding name="txn-recovery-environment" port="4712"/>
             <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-1-0.xml
@@ -5,6 +5,7 @@
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
         <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
@@ -71,6 +72,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -290,6 +292,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -582,6 +585,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -884,6 +888,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-2-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-2-0.xml
@@ -5,6 +5,7 @@
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
         <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
@@ -25,6 +26,7 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
         <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
@@ -81,6 +83,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -228,6 +231,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.4">
                 <core-environment>
                     <process-id>
@@ -299,6 +303,7 @@
                     </handlers>
                 </root-logger>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -517,6 +522,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.4">
                 <core-environment>
                     <process-id>
@@ -590,6 +596,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -820,6 +827,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.4">
                 <core-environment>
                     <process-id>
@@ -892,6 +900,7 @@
                 </root-logger>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.1">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -1220,6 +1229,7 @@
                     </security-domain>
                 </security-domains>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
             <subsystem xmlns="urn:jboss:domain:transactions:1.4">
                 <core-environment>
                     <process-id>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-3-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-3-0.xml
@@ -5,6 +5,7 @@
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
         <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
@@ -85,6 +86,7 @@
                     <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -311,6 +313,7 @@
                     <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -610,6 +613,7 @@
                 </formatter>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -928,6 +932,7 @@
                 </formatter>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-4-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/domain/eap-6-4-0.xml
@@ -5,6 +5,7 @@
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
         <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
@@ -85,6 +86,7 @@
                     <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -313,6 +315,7 @@
                     <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
                 </formatter>
             </subsystem>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -614,6 +617,7 @@
                 </formatter>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -934,6 +938,7 @@
                 </formatter>
             </subsystem>
             <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+            <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
             <subsystem xmlns="urn:jboss:domain:datasources:1.2">
                 <datasources>
                     <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-0-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/host/eap-6-0-0.xml
@@ -50,25 +50,25 @@
         </interface>
     </interfaces>
 
- 	<jvms>
- 	   <jvm name="default">
-          <heap size="64m" max-size="256m"/>
-          <permgen size="256m" max-size="256m"/>
+    <jvms>
+        <jvm name="default">
+            <heap size="64m" max-size="256m"/>
+            <permgen size="256m" max-size="256m"/>
             <jvm-options>
                 <option value="-server"/>
             </jvm-options>
-       </jvm>
- 	</jvms>
+        </jvm>
+    </jvms>
 
     <servers>
         <server name="server-one" group="main-server-group">
             <!-- Remote JPDA debugging for a specific server
-            <jvm name="default">
-              <jvm-options>
-                <option value="-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"/>
-              </jvm-options>
-           </jvm>
-           -->
+             <jvm name="default">
+               <jvm-options>
+                 <option value="-Xrunjdwp:transport=dt_socket,address=8787,server=y,suspend=n"/>
+               </jvm-options>
+            </jvm>
+            -->
         </server>
         <server name="server-two" group="main-server-group" auto-start="true">
             <!-- server-two avoids port conflicts by incrementing the ports in

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full-ha.xml
@@ -4,11 +4,14 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -23,7 +26,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -93,6 +98,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -182,7 +189,7 @@
                 </replicated-cache>
                 <!--
                   ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
-                  ~                 the socketbinding referenced by the EJB remoting connector
+                  ~                 the socketbinding referenced by the EJB remoting connector 
                   -->
                 <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true"/>
                 <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
@@ -208,11 +215,14 @@
                 </replicated-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="on"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+            <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -414,6 +424,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -422,6 +433,14 @@
             </core-environment>
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -446,7 +465,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>
@@ -454,7 +473,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-full.xml
@@ -3,11 +3,14 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -21,7 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -91,6 +96,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -171,11 +178,14 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="on"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+            <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -311,6 +321,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -319,6 +330,13 @@
             </core-environment>
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -343,7 +361,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>
@@ -351,7 +369,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-ha.xml
@@ -4,6 +4,7 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -20,7 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -90,6 +93,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -309,6 +313,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -317,6 +322,14 @@
             </core-environment>
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -349,7 +362,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-hornetq-colocated.xml
@@ -3,11 +3,12 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.jboss.as.jpa"/>
@@ -18,7 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -88,6 +91,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -163,11 +167,11 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="on"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -378,6 +382,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -386,6 +391,13 @@
             </core-environment>
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -418,7 +430,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-jts.xml
@@ -3,11 +3,12 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -19,7 +20,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -89,6 +92,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -164,11 +168,11 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="on"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -235,6 +239,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -244,6 +249,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
             <jts/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -276,7 +288,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3-xts.xml
@@ -3,11 +3,14 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -21,7 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
         <extension module="org.jboss.as.xts"/>
@@ -92,6 +97,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -172,11 +179,14 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.2">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.2">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="on"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+            <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -312,6 +322,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -320,6 +331,13 @@
             </core-environment>
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -347,7 +365,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>
@@ -355,7 +373,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-1-3.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -18,7 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -88,6 +91,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -229,6 +233,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -237,6 +242,13 @@
             </core-environment>
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:web:1.2" default-virtual-server="default-host" native="false">
+            <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
+            <virtual-server name="default-host" enable-welcome-root="true">
+                <alias name="localhost"/>
+                <alias name="example.com"/>
+            </virtual-server>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
@@ -269,7 +281,7 @@
     <socket-binding-group name="standard-sockets" default-interface="public" port-offset="${jboss.socket.binding.port-offset:0}">
         <socket-binding name="management-native" interface="management" port="${jboss.management.native.port:9999}"/>
         <socket-binding name="management-http" interface="management" port="${jboss.management.http.port:9990}"/>
-        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9993}"/>
+        <socket-binding name="management-https" interface="management" port="${jboss.management.https.port:9443}"/>
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-full-ha.xml
@@ -4,13 +4,13 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -26,8 +26,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -100,7 +101,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -192,7 +193,7 @@
                 </replicated-cache>
                 <!--
                   ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
-                  ~                 the socketbinding referenced by the EJB remoting connector
+                  ~                 the socketbinding referenced by the EJB remoting connector 
                   -->
                 <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true"/>
                 <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
@@ -218,14 +219,14 @@
                 </replicated-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -426,6 +427,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -435,14 +437,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -467,7 +469,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-full.xml
@@ -3,13 +3,13 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,8 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -98,7 +99,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -186,14 +187,14 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -331,6 +332,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -340,13 +342,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -371,7 +373,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-ha.xml
@@ -21,8 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -181,7 +182,7 @@
                 </replicated-cache>
                 <!--
                   ~  Clustered cache used internally by EJB subsytem for managing the client-mapping(s) of
-                  ~                 the socketbinding referenced by the EJB remoting connector
+                  ~                 the socketbinding referenced by the EJB remoting connector 
                   -->
                 <replicated-cache name="remote-connector-client-mappings" mode="SYNC" batching="true"/>
                 <distributed-cache name="dist" mode="ASYNC" batching="true" l1-lifespan="0">
@@ -316,6 +317,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -325,14 +327,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -357,7 +359,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-hornetq-colocated.xml
@@ -3,11 +3,12 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.jboss.as.jpa"/>
@@ -19,8 +20,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -93,6 +95,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -175,11 +178,11 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -390,6 +393,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -399,13 +403,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -430,7 +434,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-jts.xml
@@ -3,12 +3,12 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.configadmin"/>-->
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -17,13 +17,13 @@
         <extension module="org.jboss.as.logging"/>
         <extension module="org.jboss.as.mail"/>
         <extension module="org.jboss.as.naming"/>
-        <!--<extension module="org.jboss.as.osgi"/>-->
         <extension module="org.jboss.as.pojo"/>
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -96,7 +96,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -179,11 +179,11 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -222,27 +222,6 @@
         <subsystem xmlns="urn:jboss:domain:naming:1.2">
             <remote-naming/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
-            <properties>
-                <property name="org.osgi.framework.startlevel.beginning">1</property>
-            </properties>
-            <capabilities>
-                <capability name="javax.jws.api"/>
-                <capability name="javax.persistence.api"/>
-                <capability name="javax.servlet.api"/>
-                <capability name="javax.transaction.api"/>
-                <capability name="javax.ws.rs.api"/>
-                <capability name="javax.xml.bind.api"/>
-                <capability name="javax.xml.ws.api"/>
-                <capability name="org.slf4j"/>
-                <capability name="org.apache.felix.log" startlevel="1"/>
-                <capability name="org.jboss.osgi.logging" startlevel="1"/>
-                <capability name="org.apache.felix.configadmin" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.http" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.jpa" startlevel="1"/>
-            </capabilities>
-        </subsystem>-->
         <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
         <subsystem xmlns="urn:jboss:domain:remoting:1.1">
             <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
@@ -273,6 +252,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -283,13 +263,13 @@
             <coordinator-environment default-timeout="300"/>
             <jts/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -314,7 +294,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0-xts.xml
@@ -3,14 +3,14 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
-        <!--<extension module="org.jboss.as.configadmin"/>-->
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -21,13 +21,13 @@
         <extension module="org.jboss.as.mail"/>
         <extension module="org.jboss.as.messaging"/>
         <extension module="org.jboss.as.naming"/>
-        <!--<extension module="org.jboss.as.osgi"/>-->
         <extension module="org.jboss.as.pojo"/>
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
         <extension module="org.jboss.as.xts"/>
@@ -101,8 +101,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.0"/>-->
-        <!--<subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -190,14 +190,14 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -305,27 +305,6 @@
         <subsystem xmlns="urn:jboss:domain:naming:1.2">
             <remote-naming/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
-            <properties>
-                <property name="org.osgi.framework.startlevel.beginning">1</property>
-            </properties>
-            <capabilities>
-                <capability name="javax.jws.api"/>
-                <capability name="javax.persistence.api"/>
-                <capability name="javax.servlet.api"/>
-                <capability name="javax.transaction.api"/>
-                <capability name="javax.ws.rs.api"/>
-                <capability name="javax.xml.bind.api"/>
-                <capability name="javax.xml.ws.api"/>
-                <capability name="org.slf4j"/>
-                <capability name="org.apache.felix.log" startlevel="1"/>
-                <capability name="org.jboss.osgi.logging" startlevel="1"/>
-                <capability name="org.apache.felix.configadmin" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.http" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.jpa" startlevel="1"/>
-            </capabilities>
-        </subsystem>-->
         <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
         <subsystem xmlns="urn:jboss:domain:remoting:1.1">
             <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
@@ -356,6 +335,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -365,13 +345,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -399,7 +379,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/7-2-0.xml
@@ -19,8 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -243,6 +244,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -252,7 +254,6 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--
         <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
@@ -260,7 +261,6 @@
                 <alias name="example.com"/>
             </virtual-server>
         </subsystem>
-        -->
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -285,7 +285,7 @@
         <interface name="unsecure">
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL
+              ~                  To secure JacORB you need to setup SSL 
               -->
             <inet-address value="${jboss.bind.address.unsecure:127.0.0.1}"/>
         </interface>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-full-ha.xml
@@ -4,13 +4,14 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -25,9 +26,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -90,7 +91,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -211,9 +213,9 @@
                 <initializers transactions="spec" security="on"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -414,7 +416,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -424,14 +426,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -478,7 +480,6 @@
         <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
         <socket-binding name="messaging-throughput" port="5455"/>
         <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
-        <socket-binding name="osgi-http" interface="management" port="8090"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-full.xml
@@ -3,13 +3,14 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -23,9 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -95,7 +96,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -181,9 +183,9 @@
                 <initializers transactions="spec" security="on"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -319,7 +321,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -329,13 +331,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -376,7 +378,6 @@
         <socket-binding name="messaging" port="5445"/>
         <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
         <socket-binding name="messaging-throughput" port="5455"/>
-        <socket-binding name="osgi-http" interface="management" port="8090"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-ha.xml
@@ -4,6 +4,7 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -20,9 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -92,6 +93,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -311,7 +313,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -321,14 +323,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -370,7 +372,6 @@
         <socket-binding name="jgroups-udp" port="55200" multicast-address="${jboss.default.multicast.address:230.0.0.4}" multicast-port="45688"/>
         <socket-binding name="jgroups-udp-fd" port="54200"/>
         <socket-binding name="modcluster" port="0" multicast-address="224.0.1.105" multicast-port="23364"/>
-        <socket-binding name="osgi-http" interface="management" port="8090"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-hornetq-colocated.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -18,9 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -90,6 +91,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -380,7 +382,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -390,13 +392,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-jts.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -19,9 +20,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -91,6 +92,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -237,7 +239,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -248,13 +250,13 @@
             <coordinator-environment default-timeout="300"/>
             <jts/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -292,7 +294,6 @@
         <socket-binding name="https" port="8443"/>
         <socket-binding name="jacorb" interface="unsecure" port="3528"/>
         <socket-binding name="jacorb-ssl" interface="unsecure" port="3529"/>
-        <socket-binding name="osgi-http" interface="management" port="8090"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0-xts.xml
@@ -3,13 +3,14 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -23,9 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
         <extension module="org.jboss.as.xts"/>
@@ -96,7 +97,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.0"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -182,9 +184,9 @@
                 <initializers transactions="spec" security="on"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -320,7 +322,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -330,13 +332,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -380,7 +382,6 @@
         <socket-binding name="messaging" port="5445"/>
         <socket-binding name="messaging-group" port="0" multicast-address="${jboss.messaging.group.address:231.7.7.7}" multicast-port="${jboss.messaging.group.port:9876}"/>
         <socket-binding name="messaging-throughput" port="5455"/>
-        <socket-binding name="osgi-http" interface="management" port="8090"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-0-0.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.3">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -18,9 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -90,6 +91,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -231,7 +233,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.2">
             <core-environment>
                 <process-id>
@@ -241,13 +243,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.1">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>
@@ -283,7 +285,6 @@
         <socket-binding name="ajp" port="8009"/>
         <socket-binding name="http" port="8080"/>
         <socket-binding name="https" port="8443"/>
-        <socket-binding name="osgi-http" interface="management" port="8090"/>
         <socket-binding name="remoting" port="4447"/>
         <socket-binding name="txn-recovery-environment" port="4712"/>
         <socket-binding name="txn-status-manager" port="4713"/>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-full-ha.xml
@@ -4,13 +4,13 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -26,9 +26,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -94,7 +94,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -217,9 +217,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -425,7 +425,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.3">
             <core-environment>
                 <process-id>
@@ -435,14 +435,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-full.xml
@@ -3,13 +3,13 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,9 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -99,7 +99,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -192,9 +192,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -332,7 +332,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.3">
             <core-environment>
                 <process-id>
@@ -342,13 +342,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-ha.xml
@@ -21,9 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -317,7 +317,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.3">
             <core-environment>
                 <process-id>
@@ -327,14 +327,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-hornetq-colocated.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -19,9 +20,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -94,6 +95,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -391,7 +393,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.3">
             <core-environment>
                 <process-id>
@@ -401,13 +403,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-jts.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -20,9 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -95,6 +96,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -250,7 +252,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.3">
             <core-environment>
                 <process-id>
@@ -261,13 +263,13 @@
             <coordinator-environment default-timeout="300"/>
             <jts/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0-xts.xml
@@ -3,13 +3,14 @@
 <server xmlns="urn:jboss:domain:1.4">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/> -->
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,9 +25,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
         <extension module="org.jboss.as.xts"/>
@@ -100,7 +101,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -193,9 +195,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -333,7 +335,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.3">
             <core-environment>
                 <process-id>
@@ -343,13 +345,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-1-0.xml
@@ -19,9 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -244,7 +244,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.3">
             <core-environment>
                 <process-id>
@@ -254,13 +254,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.4" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-full-ha.xml
@@ -4,13 +4,13 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -26,8 +26,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -118,7 +119,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -236,14 +237,14 @@
                 </replicated-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -450,6 +451,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.4">
             <core-environment>
                 <process-id>
@@ -459,14 +461,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-full.xml
@@ -3,13 +3,13 @@
 <server xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,8 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -123,7 +124,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -211,14 +212,14 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -357,6 +358,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.4">
             <core-environment>
                 <process-id>
@@ -366,13 +368,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-ha.xml
@@ -21,8 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -341,6 +342,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.4">
             <core-environment>
                 <process-id>
@@ -350,14 +352,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-hornetq-colocated.xml
@@ -3,11 +3,12 @@
 <server xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jmx"/>
         <extension module="org.jboss.as.jpa"/>
@@ -19,8 +20,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -118,6 +120,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -200,11 +203,11 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -415,6 +418,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.4">
             <core-environment>
                 <process-id>
@@ -424,13 +428,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-jts.xml
@@ -3,12 +3,12 @@
 <server xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.configadmin"/>-->
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
+        <extension module="org.jboss.as.jacorb"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -17,13 +17,13 @@
         <extension module="org.jboss.as.logging"/>
         <extension module="org.jboss.as.mail"/>
         <extension module="org.jboss.as.naming"/>
-        <!--<extension module="org.jboss.as.osgi"/>-->
         <extension module="org.jboss.as.pojo"/>
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -121,7 +121,7 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>-->
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -204,11 +204,11 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -247,27 +247,6 @@
         <subsystem xmlns="urn:jboss:domain:naming:1.4">
             <remote-naming/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:osgi:1.2" activation="lazy">
-            <properties>
-                <property name="org.osgi.framework.startlevel.beginning">1</property>
-            </properties>
-            <capabilities>
-                <capability name="javax.jws.api"/>
-                <capability name="javax.persistence.api"/>
-                <capability name="javax.servlet.api"/>
-                <capability name="javax.transaction.api"/>
-                <capability name="javax.ws.rs.api"/>
-                <capability name="javax.xml.bind.api"/>
-                <capability name="javax.xml.ws.api"/>
-                <capability name="org.slf4j"/>
-                <capability name="org.apache.felix.log" startlevel="1"/>
-                <capability name="org.jboss.osgi.logging" startlevel="1"/>
-                <capability name="org.apache.felix.configadmin" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.configadmin" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.http" startlevel="1"/>
-                <capability name="org.jboss.as.osgi.jpa" startlevel="1"/>
-            </capabilities>
-        </subsystem>-->
         <subsystem xmlns="urn:jboss:domain:pojo:1.0"/>
         <subsystem xmlns="urn:jboss:domain:remoting:1.1">
             <connector name="remoting-connector" socket-binding="remoting" security-realm="ApplicationRealm"/>
@@ -298,6 +277,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.4">
             <core-environment>
                 <process-id>
@@ -308,13 +288,13 @@
             <coordinator-environment default-timeout="300"/>
             <jts/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0-xts.xml
@@ -3,13 +3,14 @@
 <server xmlns="urn:jboss:domain:1.5">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
-        <!--<extension module="org.jboss.as.jacorb"/>-->
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jacorb"/>
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -20,13 +21,13 @@
         <extension module="org.jboss.as.mail"/>
         <extension module="org.jboss.as.messaging"/>
         <extension module="org.jboss.as.naming"/>
-        <!--<extension module="org.jboss.as.osgi"/>-->
         <extension module="org.jboss.as.pojo"/>
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
         <extension module="org.jboss.as.xts"/>
@@ -125,7 +126,8 @@
                 </handlers>
             </root-logger>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.1">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -213,14 +215,14 @@
                 </local-cache>
             </cache-container>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jacorb:1.3">
+        <subsystem xmlns="urn:jboss:domain:jacorb:1.3">
             <orb socket-binding="jacorb" ssl-socket-binding="jacorb-ssl">
                 <initializers transactions="spec" security="identity"/>
             </orb>
-        </subsystem>-->
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        </subsystem>
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -359,6 +361,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.4">
             <core-environment>
                 <process-id>
@@ -368,13 +371,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-2-0.xml
@@ -19,8 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -268,6 +269,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.4">
             <core-environment>
                 <process-id>
@@ -277,13 +279,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:1.5" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-full-ha.xml
@@ -4,13 +4,13 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -26,9 +26,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -122,7 +122,7 @@
                 <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -246,9 +246,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -463,7 +463,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -473,14 +473,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-full.xml
@@ -3,13 +3,13 @@
 <server xmlns="urn:jboss:domain:1.6">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,9 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -130,7 +130,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -224,9 +224,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -373,7 +373,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -383,13 +383,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-ha.xml
@@ -21,9 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -349,7 +349,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -359,14 +359,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-hornetq-colocated.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.6">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -19,9 +20,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -125,6 +126,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -423,7 +425,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -433,13 +435,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-jts.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.6">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -20,9 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -126,6 +127,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -282,7 +284,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -293,13 +295,13 @@
             <coordinator-environment default-timeout="300"/>
             <jts/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0-xts.xml
@@ -3,13 +3,13 @@
 <server xmlns="urn:jboss:domain:1.6">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,9 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
         <extension module="org.jboss.as.xts"/>
@@ -131,7 +131,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -225,9 +225,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -374,7 +374,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -384,13 +384,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-3-0.xml
@@ -19,9 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -276,7 +276,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -286,13 +286,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.1" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-full-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-full-ha.xml
@@ -4,13 +4,13 @@
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
         <extension module="org.jboss.as.clustering.jgroups"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -26,9 +26,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -122,7 +122,7 @@
                 <pattern-formatter pattern="%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -248,9 +248,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -465,7 +465,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -475,14 +475,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-full.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-full.xml
@@ -3,13 +3,13 @@
 <server xmlns="urn:jboss:domain:1.7">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,9 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -130,7 +130,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -226,9 +226,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -375,7 +375,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -385,13 +385,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-ha.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-ha.xml
@@ -21,9 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -351,7 +351,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -361,14 +361,14 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <connector name="ajp" protocol="AJP/1.3" scheme="http" socket-binding="ajp"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-hornetq-colocated.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-hornetq-colocated.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.7">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -19,9 +20,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -125,6 +126,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -425,7 +427,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -435,13 +437,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-jts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-jts.xml
@@ -3,6 +3,7 @@
 <server xmlns="urn:jboss:domain:1.7">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
+        <extension module="org.jboss.as.configadmin"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
@@ -20,9 +21,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -126,6 +127,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
+        <subsystem xmlns="urn:jboss:domain:configadmin:1.0"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -284,7 +286,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -295,13 +297,13 @@
             <coordinator-environment default-timeout="300"/>
             <jts/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-xts.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0-xts.xml
@@ -3,13 +3,13 @@
 <server xmlns="urn:jboss:domain:1.7">
     <extensions>
         <extension module="org.jboss.as.clustering.infinispan"/>
-        <!--<extension module="org.jboss.as.cmp"/>-->
+        <extension module="org.jboss.as.cmp"/>
         <extension module="org.jboss.as.connector"/>
         <extension module="org.jboss.as.deployment-scanner"/>
         <extension module="org.jboss.as.ee"/>
         <extension module="org.jboss.as.ejb3"/>
         <extension module="org.jboss.as.jacorb"/>
-        <!--<extension module="org.jboss.as.jaxr"/>-->
+        <extension module="org.jboss.as.jaxr"/>
         <extension module="org.jboss.as.jaxrs"/>
         <extension module="org.jboss.as.jdr"/>
         <extension module="org.jboss.as.jmx"/>
@@ -24,9 +24,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
         <extension module="org.jboss.as.xts"/>
@@ -131,7 +131,7 @@
                 <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:cmp:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>
         <subsystem xmlns="urn:jboss:domain:datasources:1.2">
             <datasources>
                 <datasource jndi-name="java:jboss/datasources/ExampleDS" pool-name="ExampleDS" enabled="true" use-java-context="true">
@@ -227,9 +227,9 @@
                 <initializers transactions="spec" security="identity"/>
             </orb>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:jaxr:1.1">
+        <subsystem xmlns="urn:jboss:domain:jaxr:1.1">
             <connection-factory jndi-name="java:jboss/jaxr/ConnectionFactory"/>
-        </subsystem> -->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:jaxrs:1.0"/>
         <subsystem xmlns="urn:jboss:domain:jca:1.1">
             <archive-validation enabled="true" fail-on-error="true" fail-on-warn="false"/>
@@ -376,7 +376,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -386,13 +386,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>

--- a/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0.xml
+++ b/testsuite/integration/manualmode/src/test/resources/legacy-configs/standalone/eap-6-4-0.xml
@@ -19,9 +19,9 @@
         <extension module="org.jboss.as.remoting"/>
         <extension module="org.jboss.as.sar"/>
         <extension module="org.jboss.as.security"/>
-        <!--<extension module="org.jboss.as.threads"/>-->
+        <extension module="org.jboss.as.threads"/>
         <extension module="org.jboss.as.transactions"/>
-        <!--<extension module="org.jboss.as.web"/>-->
+        <extension module="org.jboss.as.web"/>
         <extension module="org.jboss.as.webservices"/>
         <extension module="org.jboss.as.weld"/>
     </extensions>
@@ -278,7 +278,7 @@
                 </security-domain>
             </security-domains>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:threads:1.1"/>-->
+        <subsystem xmlns="urn:jboss:domain:threads:1.1"/>
         <subsystem xmlns="urn:jboss:domain:transactions:1.5">
             <core-environment>
                 <process-id>
@@ -288,13 +288,13 @@
             <recovery-environment socket-binding="txn-recovery-environment" status-socket-binding="txn-status-manager"/>
             <coordinator-environment default-timeout="300"/>
         </subsystem>
-        <!--<subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
+        <subsystem xmlns="urn:jboss:domain:web:2.2" default-virtual-server="default-host" native="false">
             <connector name="http" protocol="HTTP/1.1" scheme="http" socket-binding="http"/>
             <virtual-server name="default-host" enable-welcome-root="true">
                 <alias name="localhost"/>
                 <alias name="example.com"/>
             </virtual-server>
-        </subsystem>-->
+        </subsystem>
         <subsystem xmlns="urn:jboss:domain:webservices:1.2">
             <modify-wsdl-address>true</modify-wsdl-address>
             <wsdl-host>${jboss.bind.address:127.0.0.1}</wsdl-host>


### PR DESCRIPTION
Using the default configuration files except for OSGI that is no longer supported.
Adding more check on the presence of legacy subsystems.

Jira: https://issues.jboss.org/browse/WFLY-5194
