### PR TITLE
[WFLY-5409] Fix skipping Kerberos tests when on IPv6 hosts without hostname

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/KerberosTestUtils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/negotiation/KerberosTestUtils.java
@@ -23,14 +23,13 @@
 package org.jboss.as.test.integration.security.common.negotiation;
 
 import static org.jboss.as.test.integration.security.common.Utils.IBM_JDK;
-import static org.jboss.as.test.integration.security.common.Utils.OPEN_JDK;
 import static org.jboss.as.test.integration.security.common.Utils.ORACLE_JDK;
 
 import org.apache.commons.lang.SystemUtils;
 import org.jboss.as.network.NetworkUtils;
 import org.jboss.as.test.integration.security.common.Utils;
 import org.jboss.logging.Logger;
-import org.junit.internal.AssumptionViolatedException;
+import org.junit.AssumptionViolatedException;
 
 /**
  * Helper methods for JGSSAPI &amp; SPNEGO &amp; Kerberos testcases. It mainly helps to skip tests on configurations which
@@ -67,18 +66,8 @@ public final class KerberosTestUtils {
                     "Kerberos tests are not supported on IBM Java with IPv6. Find more info in https://bugzilla.redhat.com/show_bug.cgi?id=1188632");
         }
         if (isIPv6Hostname(hostName)) {
-            if (IBM_JDK && SystemUtils.IS_JAVA_1_7) {
-                throw new AssumptionViolatedException(
-                        "Kerberos tests are not supported on IBM Java 7 with IPv6-based hostnames. Find more info in https://bugzilla.redhat.com/show_bug.cgi?id=1185917");
-            }
-            if (IBM_JDK && SystemUtils.IS_JAVA_1_6) {
-                throw new AssumptionViolatedException(
-                        "Kerberos tests are not supported on IBM Java 6 with IPv6-based hostnames. Find more info in https://bugzilla.redhat.com/show_bug.cgi?id=1186129");
-            }
-            if (OPEN_JDK && SystemUtils.IS_JAVA_1_6) {
-                throw new AssumptionViolatedException(
-                        "Kerberos tests are not supported on OpenJDK 6 with IPv6-based hostnames. Find more info in https://bugzilla.redhat.com/show_bug.cgi?id=1186132");
-            }
+            throw new AssumptionViolatedException(
+                    "Kerberos tests are not supported when hostname is not available for tested IPv6 address. Find more info in https://issues.jboss.org/browse/WFLY-5409");
         }
     }
 


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-5409
Downstream: https://issues.jboss.org/browse/JBEAP-1168

Condition used in `KerberosTestUtils.assumeKerberosAuthenticationSupported(String)` in `testsuite/shared` wasn't sufficient - Java 8 wasn't covered.
