### PR TITLE
[WFLY-4465] - Update PicketLink Capabilities.

### DIFF
--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/AbstractIDMResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/AbstractIDMResourceDefinition.java
@@ -46,11 +46,11 @@ public abstract class AbstractIDMResourceDefinition extends AbstractResourceDefi
     }
 
     protected AbstractIDMResourceDefinition(ModelElement modelElement, String name, OperationStepHandler addHandler, SimpleAttributeDefinition... attributes) {
-        super(modelElement, name, addHandler, IDMConfigRemoveStepHandler.INSTANCE, IDMExtension.getResourceDescriptionResolver(modelElement.getName()), attributes);
+        super(modelElement, name, addHandler, DefaultRemoveStepHandler.INSTANCE, IDMExtension.getResourceDescriptionResolver(modelElement.getName()), attributes);
     }
 
     protected AbstractIDMResourceDefinition(ModelElement modelElement, OperationStepHandler addHandler, SimpleAttributeDefinition... attributes) {
-        super(modelElement, addHandler, IDMConfigRemoveStepHandler.INSTANCE, IDMExtension.getResourceDescriptionResolver(modelElement.getName()), attributes);
+        super(modelElement, addHandler, DefaultRemoveStepHandler.INSTANCE, IDMExtension.getResourceDescriptionResolver(modelElement.getName()), attributes);
     }
 
     @Override

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/AbstractIdentityStoreResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/AbstractIdentityStoreResourceDefinition.java
@@ -42,6 +42,6 @@ public abstract class AbstractIdentityStoreResourceDefinition extends AbstractID
         .build();
 
     protected AbstractIdentityStoreResourceDefinition(ModelElement modelElement, OperationStepHandler addHandler, SimpleAttributeDefinition... attributes) {
-        super(modelElement, addHandler, attributes);
+        super(modelElement, addHandler, IdentityStoreRemoveStepHandler.INSTANCE, attributes);
     }
 }

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/IDMConfigAddStepHandler.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/IDMConfigAddStepHandler.java
@@ -27,7 +27,6 @@ import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.RestartParentResourceAddHandler;
-import org.jboss.as.controller.ServiceVerificationHandler;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
@@ -108,11 +107,11 @@ public class IDMConfigAddStepHandler extends RestartParentResourceAddHandler {
     }
 
     @Override
-    protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel, ServiceVerificationHandler verificationHandler) throws OperationFailedException {
+    protected void recreateParentService(OperationContext context, PathAddress parentAddress, ModelNode parentModel) throws OperationFailedException {
         final String federationName = parentAddress.getLastElement().getValue();
         PartitionManagerRemoveHandler.INSTANCE.removeIdentityStoreServices(context, parentModel, federationName);
         PartitionManagerAddHandler.INSTANCE.createPartitionManagerService(context, parentAddress.getLastElement()
-            .getValue(), parentModel, verificationHandler, null, false);
+            .getValue(), parentModel, false);
     }
 
     @Override

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/IdentityConfigurationResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/IdentityConfigurationResourceDefinition.java
@@ -36,7 +36,7 @@ public class IdentityConfigurationResourceDefinition extends AbstractIDMResource
     public static final IdentityConfigurationResourceDefinition INSTANCE = new IdentityConfigurationResourceDefinition();
 
     private IdentityConfigurationResourceDefinition() {
-        super(ModelElement.IDENTITY_CONFIGURATION, new IDMConfigAddStepHandler(getModelValidators()));
+        super(ModelElement.IDENTITY_CONFIGURATION, new IDMConfigAddStepHandler(getModelValidators()), IdentityConfigurationRemoveStepHandler.INSTANCE);
     }
 
     @Override

--- a/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/SupportedTypesResourceDefinition.java
+++ b/picketlink/src/main/java/org/wildfly/extension/picketlink/idm/model/SupportedTypesResourceDefinition.java
@@ -42,7 +42,7 @@ public class SupportedTypesResourceDefinition extends AbstractIDMResourceDefinit
     public static final SupportedTypesResourceDefinition INSTANCE = new SupportedTypesResourceDefinition(SUPPORTS_ALL);
 
     private SupportedTypesResourceDefinition(SimpleAttributeDefinition... attributes) {
-        super(ModelElement.SUPPORTED_TYPES, ModelElement.SUPPORTED_TYPES.getName(), new IDMConfigAddStepHandler(attributes), attributes);
+        super(ModelElement.SUPPORTED_TYPES, new IDMConfigAddStepHandler(attributes), attributes);
     }
 
     @Override


### PR DESCRIPTION
### References
- https://issues.jboss.org/browse/WFLY-4465
### Overview

Provides some minor changes to PicketLink modules and subsystem in order to provide the same capabilities currently supported in EAP 6 and JBossWeb. Specially WS-Trust and XACML.

This PR is also related with #8305. If possible, it should be merged first.
