### PR TITLE
[WFLY-5416] Unhandled exceptions from custom JASPI modules should cause the HTTP status code to be set as an error (500, 400, etc)

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/FailingAuthModule.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/FailingAuthModule.java
@@ -1,0 +1,75 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.security.jaspi;
+
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.message.AuthException;
+import javax.security.auth.message.AuthStatus;
+import javax.security.auth.message.MessageInfo;
+import javax.security.auth.message.MessagePolicy;
+import javax.security.auth.message.module.ServerAuthModule;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+/**
+ * A test AuthModule.
+ *
+ * Always throws an AuthException on {@link FailingAuthModule#validateRequest} call
+ *
+ * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+ */
+public class FailingAuthModule implements ServerAuthModule {
+
+    public FailingAuthModule(String securityDomain) {
+
+    }
+
+    @Override
+    public Class[] getSupportedMessageTypes() {
+        return new Class[]{ServletRequest.class, ServletResponse.class,
+                HttpServletRequest.class, HttpServletResponse.class};
+    }
+
+    @Override
+    public void initialize(MessagePolicy messagePolicy, MessagePolicy messagePolicy1, CallbackHandler callbackHandler, Map map) throws AuthException {
+
+    }
+
+    @Override
+    public void cleanSubject(MessageInfo messageInfo, Subject subject) throws AuthException {
+
+    }
+
+    @Override
+    public AuthStatus secureResponse(MessageInfo messageInfo, Subject subject) throws AuthException {
+        return null;
+    }
+
+    @Override
+    public AuthStatus validateRequest(MessageInfo messageInfo, Subject subject, Subject subject1) throws AuthException {
+        throw new AuthException("I always fail!!");
+    }
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/WebJaspiTestsSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/WebJaspiTestsSecurityDomainSetup.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.security.jaspi;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.security.Constants;
+import org.jboss.as.test.integration.security.common.AbstractSecurityDomainSetup;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.wildfly.extension.undertow.security.jaspi.modules.HTTPSchemeServerAuthModule;
+
+import java.util.Arrays;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import static org.jboss.as.security.Constants.*;
+import static org.jboss.as.security.Constants.CODE;
+import static org.jboss.as.security.Constants.MODULE;
+
+/**
+ * Creates SecurityDomain for JASPI auth tests. Concrete classes use different AuthModules.
+ *
+ * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+ */
+public abstract class WebJaspiTestsSecurityDomainSetup extends AbstractSecurityDomainSetup {
+
+    private static final Logger log = Logger.getLogger(WebJaspiTestsSecurityDomainSetup.class);
+
+    protected static final String WEB_SECURITY_DOMAIN = "web-tests";
+    protected final String authModuleClassName;
+
+    public WebJaspiTestsSecurityDomainSetup(String authModuleClassName) {
+        this.authModuleClassName = authModuleClassName;
+    }
+
+    @Override
+    public void setup(final ManagementClient managementClient, final String containerId) {
+        log.debug("start of the domain creation");
+
+        final ModelNode compositeOp = new ModelNode();
+        compositeOp.get(OP).set(COMPOSITE);
+        compositeOp.get(OP_ADDR).setEmptyList();
+
+        ModelNode steps = compositeOp.get(STEPS);
+        PathAddress address = PathAddress.pathAddress()
+                .append(SUBSYSTEM, "security")
+                .append(SECURITY_DOMAIN, getSecurityDomainName());
+
+        steps.add(Util.createAddOperation(address));
+        address = address.append(Constants.AUTHENTICATION, "jaspi");
+        steps.add(Util.createAddOperation(address));
+        ModelNode loginModuleStack = Util.createAddOperation(address.append(LOGIN_MODULE_STACK, "lm-stack"));
+        loginModuleStack.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        steps.add(loginModuleStack);
+
+        ModelNode loginModule = Util.createAddOperation(address.append(LOGIN_MODULE_STACK, "lm-stack").append(LOGIN_MODULE, "UsersRoles"));
+        loginModule.get(CODE).set("UsersRoles");
+        loginModule.get(FLAG).set("required");
+        loginModule.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        steps.add(loginModule);
+
+        final ModelNode authModule = Util.createAddOperation(address.append(AUTH_MODULE, authModuleClassName));
+        authModule.get(CODE).set(authModuleClassName);
+        authModule.get(MODULE).set("org.wildfly.extension.undertow");
+        authModule.get(LOGIN_MODULE_STACK_REF).set("lm-stack");
+        authModule.get(FLAG).set("required");
+        authModule.get(OPERATION_HEADERS).get(ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+        steps.add(authModule);
+
+        applyUpdates(managementClient.getControllerClient(), Arrays.asList(compositeOp));
+        log.debug("end of the domain creation");
+    }
+
+    @Override
+    protected String getSecurityDomainName() {
+        return WEB_SECURITY_DOMAIN;
+    }
+
+
+    /**
+     * Creates SecurityDomain for JASPI auth using a default AuthModule.
+     *
+     * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+     */
+    public static class WithDefaultAuthModule extends WebJaspiTestsSecurityDomainSetup {
+        public WithDefaultAuthModule() {
+            super(HTTPSchemeServerAuthModule.class.getName());
+        }
+    }
+
+    /**
+     * Creates SecurityDomain for JASPI auth using an always-failing AuthModule
+     *
+     * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+     */
+    public static class WithFailingAuthModule extends WebJaspiTestsSecurityDomainSetup {
+        public WithFailingAuthModule() {
+            super(FailingAuthModule.class.getName());
+        }
+    }
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/WebSecurityJaspiTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/WebSecurityJaspiTestCase.java
@@ -1,0 +1,106 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.security.jaspi;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.integration.web.security.SecuredServlet;
+import org.jboss.as.test.integration.web.security.WebSecurityPasswordBasedBase;
+import org.jboss.as.test.integration.web.security.basic.WebSecurityBASICTestCase;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that JASPI works correctly with BASIC authentication.
+ *
+ * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(WebJaspiTestsSecurityDomainSetup.WithDefaultAuthModule.class)
+@Category(CommonCriteria.class)
+public class WebSecurityJaspiTestCase extends WebSecurityPasswordBasedBase {
+
+    @Deployment
+    public static WebArchive deployment() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "web-secure-jaspi.war");
+        war.addClass(SecuredServlet.class);
+
+        war.addAsWebInfResource(WebSecurityBASICTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        war.addAsWebInfResource(WebSecurityBASICTestCase.class.getPackage(), "web.xml", "web.xml");
+
+        war.addAsResource(WebSecurityBASICTestCase.class.getPackage(), "users.properties", "users.properties");
+        war.addAsResource(WebSecurityBASICTestCase.class.getPackage(), "roles.properties", "roles.properties");
+
+        WebSecurityPasswordBasedBase.printWar(war);
+        return war;
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    protected void makeCall(String user, String pass, int expectedStatusCode) throws Exception {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        try {
+            httpclient.getCredentialsProvider().setCredentials(new AuthScope(url.getHost(), url.getPort()),
+                    new UsernamePasswordCredentials(user, pass));
+
+            HttpGet httpget = new HttpGet(url.toExternalForm() + "secured/");
+
+            System.out.println("executing request" + httpget.getRequestLine());
+            HttpResponse response = httpclient.execute(httpget);
+            HttpEntity entity = response.getEntity();
+
+            System.out.println("----------------------------------------");
+            StatusLine statusLine = response.getStatusLine();
+            System.out.println(statusLine);
+            if (entity != null) {
+                System.out.println("Response content length: " + entity.getContentLength());
+            }
+            assertEquals(expectedStatusCode, statusLine.getStatusCode());
+            EntityUtils.consume(entity);
+        } finally {
+            // When HttpClient instance is no longer needed,
+            // shut down the connection manager to ensure
+            // immediate deallocation of all system resources
+            httpclient.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/WebSecurityJaspiWithFailingAuthModuleTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/jaspi/WebSecurityJaspiWithFailingAuthModuleTestCase.java
@@ -1,0 +1,115 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.as.test.integration.web.security.jaspi;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.test.categories.CommonCriteria;
+import org.jboss.as.test.integration.web.security.SecuredServlet;
+import org.jboss.as.test.integration.web.security.WebSecurityPasswordBasedBase;
+import org.jboss.as.test.integration.web.security.basic.WebSecurityBASICTestCase;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests that JASPI authentication reports error if the authentication process fails.
+ *
+ * The AuthModule always throws Exception, but doesn't set the http error code.
+ *
+ * @author <a href="mailto:bspyrkos@redhat.com">Bartosz Spyrko-Smietanko</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(WebJaspiTestsSecurityDomainSetup.WithFailingAuthModule.class)
+@Category(CommonCriteria.class)
+public class WebSecurityJaspiWithFailingAuthModuleTestCase {
+
+    @Deployment
+    public static WebArchive deployment() throws Exception {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, "web-secure-jaspi.war");
+        war.addClass(SecuredServlet.class);
+        war.addClass(FailingAuthModule.class);
+
+        war.addAsWebInfResource(WebSecurityBASICTestCase.class.getPackage(), "jboss-web.xml", "jboss-web.xml");
+        war.addAsWebInfResource(WebSecurityBASICTestCase.class.getPackage(), "web.xml", "web.xml");
+
+        war.addAsResource(WebSecurityBASICTestCase.class.getPackage(), "users.properties", "users.properties");
+        war.addAsResource(WebSecurityBASICTestCase.class.getPackage(), "roles.properties", "roles.properties");
+
+        WebSecurityPasswordBasedBase.printWar(war);
+        return war;
+    }
+
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void testShouldReturnErrorCodeIfTheAuthModuleThrowsException() throws Exception {
+        makeCall("anil", "anil", 401);
+    }
+
+    protected void makeCall(String user, String pass, int expectedStatusCode) throws Exception {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        try {
+            httpclient.getCredentialsProvider().setCredentials(new AuthScope(url.getHost(), url.getPort()),
+                    new UsernamePasswordCredentials(user, pass));
+
+            HttpGet httpget = new HttpGet(url.toExternalForm() + "secured/");
+
+            System.out.println("executing request" + httpget.getRequestLine());
+            HttpResponse response = httpclient.execute(httpget);
+            HttpEntity entity = response.getEntity();
+
+            System.out.println("----------------------------------------");
+            StatusLine statusLine = response.getStatusLine();
+            System.out.println(statusLine);
+            if (entity != null) {
+                System.out.println("Response content length: " + entity.getContentLength());
+            }
+            assertEquals(expectedStatusCode, statusLine.getStatusCode());
+            EntityUtils.consume(entity);
+        } finally {
+            // When HttpClient instance is no longer needed,
+            // shut down the connection manager to ensure
+            // immediate deallocation of all system resources
+            httpclient.getConnectionManager().shutdown();
+        }
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPIAuthenticationMechanism.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPIAuthenticationMechanism.java
@@ -28,7 +28,9 @@ import io.undertow.server.HttpServerExchange;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import io.undertow.util.AttachmentKey;
 
+import io.undertow.util.StatusCodes;
 import org.jboss.security.SecurityConstants;
+import org.jboss.security.SecurityContextAssociation;
 import org.jboss.security.auth.message.GenericMessageInfo;
 import org.jboss.security.identity.plugins.SimpleRole;
 import org.jboss.security.identity.plugins.SimpleRoleGroup;
@@ -43,6 +45,8 @@ import java.util.Set;
 import org.jboss.security.auth.callback.JASPICallbackHandler;
 import org.jboss.security.identity.Role;
 import org.jboss.security.identity.RoleGroup;
+
+import javax.security.auth.message.AuthException;
 
 /**
  * <p>
@@ -106,6 +110,11 @@ public class JASPIAuthenticationMechanism implements AuthenticationMechanism {
         } else {
             outcome = AuthenticationMechanismOutcome.NOT_AUTHENTICATED;
             sc.authenticationFailed("JASPIC authentication failed.", authType);
+
+            final Object ex = SecurityContextAssociation.getSecurityContext().getData().get(AuthException.class.getName());
+            if (exchange.getResponseCode() == StatusCodes.OK && ex != null) {
+                exchange.setResponseCode(StatusCodes.INTERNAL_SERVER_ERROR);
+            }
         }
 
         return outcome;


### PR DESCRIPTION
Setting the returned status to 401 if the status is OK and an exception has been thrown inside JASPI AuthModule
