### PR TITLE
Reduce unnecessary actions

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/datasource/DataSourceDefinitionInjectionSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/datasource/DataSourceDefinitionInjectionSource.java
@@ -317,8 +317,7 @@ public class DataSourceDefinitionInjectionSource extends ResourceDefinitionInjec
 
     private void setProperty(final DeploymentReflectionIndex deploymentReflectionIndex, final Class<?> dataSourceClass, final Map<String, String> properties, final String name, final Object value) {
         // Ignore defaulted values
-        if (value == null) return;
-        if (value instanceof String && "".equals(value)) return;
+        if (value == null || "".equals(value)) return;
         if (value instanceof Integer && ((Integer) value).intValue() == -1) return;
         StringBuilder builder = new StringBuilder("set").append(name);
         builder.setCharAt(3, Character.toUpperCase(name.charAt(0)));

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DriverProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DriverProcessor.java
@@ -76,8 +76,8 @@ public final class DriverProcessor implements DeploymentUnitProcessor {
                                 Integer.valueOf(minorVersion));
                     }
                     String driverName = deploymentUnit.getName();
-                    if ((deploymentUnit.getName().contains(".") && ! deploymentUnit.getName().endsWith(".jar")) || driverNames.size() != 1) {
-                        driverName = deploymentUnit.getName() + "_" + driverClassName + "_" + majorVersion +"_" + minorVersion;
+                    if ((driverName.contains(".") && ! driverName.endsWith(".jar")) || driverNames.size() != 1) {
+                        driverName += "_" + driverClassName + "_" + majorVersion + "_" + minorVersion;
                     }
                     InstalledDriver driverMetadata = new InstalledDriver(driverName, driverClass.getName(), null, null, majorVersion,
                             minorVersion, compliant);


### PR DESCRIPTION
We can avoid unnecessary instanceof check for String type. We will not have any exception or wrong results if checked value is not of String type. It will fall thru to further checks.
