### PR TITLE
WFLY-5433 CommandDispatcher can throw InvalidClassException if command class is not available

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactory.java
@@ -108,10 +108,10 @@ public class ChannelCommandDispatcherFactory implements CommandDispatcherFactory
             try (Unmarshaller unmarshaller = this.marshallingContext.createUnmarshaller(version)) {
                 unmarshaller.start(Marshalling.createByteInput(input));
                 Object clientId = unmarshaller.readObject();
-                @SuppressWarnings("unchecked")
-                Command<Object, Object> command = (Command<Object, Object>) unmarshaller.readObject();
                 AtomicReference<Object> context = this.contexts.get(clientId);
                 if (context == null) return NoSuchService.INSTANCE;
+                @SuppressWarnings("unchecked")
+                Command<Object, Object> command = (Command<Object, Object>) unmarshaller.readObject();
                 return command.execute(context.get());
             }
         }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5433
