### PR TITLE
WFLY-5436 Lack of EmbeddedCacheManager.undefineConfiguration(...) can cause memory/classloader leaks

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
@@ -84,6 +84,11 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
     }
 
     @Override
+    public void undefineConfiguration(String cacheName) {
+        this.cm.undefineConfiguration(this.getCacheName(cacheName));
+    }
+
+    @Override
     public Configuration getDefaultCacheConfiguration() {
         return this.cm.getCacheConfiguration(this.defaultCacheName);
     }
@@ -102,23 +107,26 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
         return this.getCache(this.defaultCacheName);
     }
 
-    /**
-     * {@inheritDoc}
-     * @see org.infinispan.manager.CacheContainer#getCache(java.lang.String)
-     */
     @Override
     public <K, V> Cache<K, V> getCache(String cacheName) {
-        return this.getCache(cacheName, true);
+        return this.getCache(cacheName, cacheName);
     }
 
-    /**
-     * {@inheritDoc}
-     * @see org.infinispan.manager.EmbeddedCacheManager#getCache(java.lang.String, boolean)
-     */
+    @Override
+    public <K, V> Cache<K, V> getCache(String cacheName, String configurationName) {
+        Cache<K, V> cache = this.cm.<K, V>getCache(this.getCacheName(cacheName), this.getCacheName(configurationName));
+        return (cache != null) ? new DefaultCache<>(this, this.batcherFactory, cache.getAdvancedCache()) : null;
+    }
+
     @Override
     public <K, V> Cache<K, V> getCache(String cacheName, boolean createIfAbsent) {
-        Cache<K, V> cache = this.cm.<K, V>getCache(this.getCacheName(cacheName), createIfAbsent);
-        return (cache != null) ? new DefaultCache<>(this, this.batcherFactory, cache.getAdvancedCache()) : null;
+        return this.getCache(cacheName, cacheName, createIfAbsent);
+    }
+
+    @Override
+    public <K, V> Cache<K, V> getCache(String cacheName, String configurationTemplate, boolean createIfAbsent) {
+        boolean cacheExists = this.cacheExists(cacheName);
+        return (cacheExists || createIfAbsent) ? this.getCache(cacheName, configurationTemplate) : null;
     }
 
     /**

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/DefaultCacheTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/DefaultCacheTestCase.java
@@ -1,0 +1,117 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.infinispan;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.infinispan.AdvancedCache;
+import org.infinispan.manager.EmbeddedCacheManager;
+import org.junit.After;
+import org.junit.Test;
+import org.wildfly.clustering.ee.Batcher;
+import org.wildfly.clustering.ee.infinispan.TransactionBatch;
+
+/**
+ * Unit test for {@link DefaultCache}.
+ * @author Paul Ferraro
+ */
+public class DefaultCacheTestCase {
+
+    private final EmbeddedCacheManager manager = mock(EmbeddedCacheManager.class);
+    private final BatcherFactory batcherFactory = mock(BatcherFactory.class);
+    private final AdvancedCache<Object, Object> cache = mock(AdvancedCache.class);
+
+    @After
+    public void init() {
+        reset(this.manager, this.batcherFactory, this.cache);
+    }
+
+    @Test
+    public void noBatcher() {
+        when(this.batcherFactory.createBatcher(this.cache)).thenReturn(null);
+
+        AdvancedCache<Object, Object> subject = new DefaultCache<>(this.manager, this.batcherFactory, this.cache);
+
+        // Validate no-op batching logic
+        boolean started = subject.startBatch();
+
+        assertFalse(started);
+
+        verify(this.cache, never()).startBatch();
+
+        subject.endBatch(false);
+
+        verify(this.cache, never()).endBatch(false);
+    }
+
+    @Test
+    public void batcher() {
+        Batcher<TransactionBatch> batcher = mock(Batcher.class);
+        TransactionBatch batch = mock(TransactionBatch.class);
+
+        when(this.batcherFactory.createBatcher(this.cache)).thenReturn(batcher);
+
+        AdvancedCache<Object, Object> subject = new DefaultCache<>(this.manager, this.batcherFactory, this.cache);
+
+        // Validate batching logic
+        when(batcher.createBatch()).thenReturn(batch);
+
+        boolean started = subject.startBatch();
+
+        assertTrue(started);
+
+        started = subject.startBatch();
+
+        assertFalse(started);
+
+        // Verify commit
+        subject.endBatch(true);
+
+        verify(batch).close();
+        reset(batch);
+
+        // Verify re-commit is a no-op
+        subject.endBatch(true);
+
+        verify(batch, never()).close();
+        verify(batch, never()).discard();
+
+        // Verify rollback
+        started = subject.startBatch();
+
+        assertTrue(started);
+
+        subject.endBatch(false);
+
+        verify(batch).discard();
+
+        reset(batch);
+
+        // Verify re-rollback is a no-op
+        subject.endBatch(true);
+
+        verify(batch, never()).close();
+        verify(batch, never()).discard();
+    }
+}

--- a/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/service/ConfigurationBuilder.java
+++ b/clustering/infinispan/spi/src/main/java/org/wildfly/clustering/infinispan/spi/service/ConfigurationBuilder.java
@@ -77,6 +77,6 @@ public class ConfigurationBuilder implements Builder<Configuration>, Service<Con
 
     @Override
     public void stop(StopContext context) {
-        // Infinispan has no undefineConfiguration(...)
+        this.container.getValue().undefineConfiguration(this.cacheName);
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5436

Now that https://issues.jboss.org/browse/ISPN-5033 is fixed, we can now patch this leak.
