### PR TITLE
WFLY-5189 Eliminate "discarding discovery request for cluster=X from Y; our cluster name is Z" WARN messages

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ChannelTransport.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/ChannelTransport.java
@@ -43,6 +43,9 @@ public class ChannelTransport extends JGroupsTransport {
     public ChannelTransport(Channel channel, ChannelFactory factory) {
         this.channel = channel;
         this.factory = factory;
+        this.connectChannel = true;
+        this.disconnectChannel = true;
+        this.closeChannel = false;
     }
 
     @Override
@@ -64,12 +67,9 @@ public class ChannelTransport extends JGroupsTransport {
     }
 
     @Override
-    protected synchronized void initChannel() {
-        this.channel.setDiscardOwnMessages(false);
+    protected void initChannel() {
         // This is necessary because JGroupsTransport nulls its channel reference in stop()
         super.channel = this.channel;
-        super.connectChannel = true;
-        super.disconnectChannel = true;
-        super.closeChannel = false;
+        super.channel.setDiscardOwnMessages(false);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheComponentBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheComponentBuilder.java
@@ -26,7 +26,7 @@ package org.jboss.as.clustering.infinispan.subsystem;
  * Abstract builder for the configuration of a cache component.
  * @author Paul Ferraro
  */
-public abstract class CacheComponentBuilder<C> extends ComponentConfigurationBuilder<C> {
+public abstract class CacheComponentBuilder<C> extends ComponentBuilder<C> {
 
     CacheComponentBuilder(CacheComponent component, String containerName, String cacheName) {
         super(new CacheComponentServiceNameProvider(component, containerName, cacheName));

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerBuilder.java
@@ -88,10 +88,8 @@ public class CacheContainerBuilder implements ResourceServiceBuilder<CacheContai
         ServiceBuilder<CacheContainer> builder = target.addService(this.getServiceName(), this)
                 .addDependency(CacheContainerServiceName.CONFIGURATION.getServiceName(this.name), GlobalConfiguration.class, this.configuration)
         ;
-        for (String alias : this.aliases) {
-            builder.addAliases(CacheContainerServiceName.CACHE_CONTAINER.getServiceName(alias));
-        }
-        return builder.setInitialMode(ServiceController.Mode.ON_DEMAND);
+        this.aliases.forEach(alias -> builder.addAliases(CacheContainerServiceName.CACHE_CONTAINER.getServiceName(alias)));
+        return builder.setInitialMode(ServiceController.Mode.PASSIVE);
     }
 
     CacheContainerBuilder setDefaultCache(String defaultCache) {
@@ -112,6 +110,8 @@ public class CacheContainerBuilder implements ResourceServiceBuilder<CacheContai
         this.manager.start();
         this.container = new DefaultCacheContainer(this.name, this.manager, this.defaultCache);
         InfinispanLogger.ROOT_LOGGER.debugf("%s cache container started", this.name);
+        // Ensure global components of this cache container start eagerly
+        this.container.getGlobalComponentRegistry().start();
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerComponentBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheContainerComponentBuilder.java
@@ -22,14 +22,22 @@
 
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import org.jboss.msc.service.ServiceBuilder;
+import org.jboss.msc.service.ServiceController;
+import org.jboss.msc.service.ServiceTarget;
 import org.wildfly.clustering.service.GroupServiceNameFactory;
 
 /**
  * @author Paul Ferraro
  */
-public abstract class CacheContainerComponentBuilder<C> extends ComponentConfigurationBuilder<C> {
+public abstract class CacheContainerComponentBuilder<C> extends ComponentBuilder<C> {
 
     CacheContainerComponentBuilder(GroupServiceNameFactory factory, String containerName) {
         super(new CacheContainerComponentServiceNameProvider(factory, containerName));
+    }
+
+    @Override
+    public ServiceBuilder<C> build(ServiceTarget target) {
+        return super.build(target).setInitialMode(ServiceController.Mode.PASSIVE);
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ComponentBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ComponentBuilder.java
@@ -35,11 +35,11 @@ import org.wildfly.clustering.service.ServiceNameProvider;
  * Builds a service that provides the configuration of a component.
  * @author Paul Ferraro
  */
-public abstract class ComponentConfigurationBuilder<C> implements Builder<C>, Value<C> {
+public abstract class ComponentBuilder<C> implements Builder<C>, Value<C> {
 
     private final ServiceNameProvider provider;
 
-    ComponentConfigurationBuilder(ServiceNameProvider provider) {
+    ComponentBuilder(ServiceNameProvider provider) {
         this.provider = provider;
     }
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/GlobalConfigurationBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/GlobalConfigurationBuilder.java
@@ -157,7 +157,7 @@ public class GlobalConfigurationBuilder implements ResourceServiceBuilder<Global
                 .addDependency(ThreadPoolResourceDefinition.PERSISTENCE.getServiceName(this.name), ThreadPoolConfiguration.class, this.persistenceThreadPool)
                 .addDependency(ThreadPoolResourceDefinition.REMOTE_COMMAND.getServiceName(this.name), ThreadPoolConfiguration.class, this.remoteCommandThreadPool)
                 .addDependency(ThreadPoolResourceDefinition.TRANSPORT.getServiceName(this.name), ThreadPoolConfiguration.class, this.transportThreadPool)
-                .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                .setInitialMode(ServiceController.Mode.PASSIVE)
         ;
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScheduledThreadPoolBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ScheduledThreadPoolBuilder.java
@@ -77,7 +77,7 @@ public class ScheduledThreadPoolBuilder extends CacheContainerComponentBuilder<T
     }
 
     @Override
-    public ThreadPoolConfiguration getValue() throws IllegalStateException, IllegalArgumentException {
+    public ThreadPoolConfiguration getValue() {
         return this.builder.create();
     }
 }

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SiteBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/SiteBuilder.java
@@ -38,8 +38,8 @@ import org.jboss.msc.value.InjectedValue;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 import org.wildfly.clustering.jgroups.spi.RelayConfiguration;
 import org.wildfly.clustering.jgroups.spi.service.ChannelServiceName;
-import org.wildfly.clustering.jgroups.spi.service.ChannelServiceNameFactory;
 import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.GroupServiceNameFactory;
 
 /**
  * @author Paul Ferraro
@@ -65,7 +65,7 @@ public class SiteBuilder extends CacheContainerComponentBuilder<SiteConfiguratio
 
     @Override
     public Builder<SiteConfiguration> configure(OperationContext context, ModelNode model) throws OperationFailedException {
-        this.channelName = ModelNodes.asString(CHANNEL.getDefinition().resolveModelAttribute(context, model), ChannelServiceNameFactory.DEFAULT_CHANNEL);
+        this.channelName = ModelNodes.asString(CHANNEL.getDefinition().resolveModelAttribute(context, model), GroupServiceNameFactory.DEFAULT_GROUP);
         return this;
     }
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolBuilder.java
@@ -36,13 +36,13 @@ import org.wildfly.clustering.service.Builder;
  * @author Radoslav Husar
  * @version August 2015
  */
-public class ThreadPoolBuilder extends ComponentConfigurationBuilder<ThreadPoolConfiguration> implements ResourceServiceBuilder<ThreadPoolConfiguration> {
+public class ThreadPoolBuilder extends CacheContainerComponentBuilder<ThreadPoolConfiguration> implements ResourceServiceBuilder<ThreadPoolConfiguration> {
 
     private final ThreadPoolConfigurationBuilder builder = new ThreadPoolConfigurationBuilder(null);
     private final ThreadPoolDefinition definition;
 
     ThreadPoolBuilder(ThreadPoolDefinition definition, String containerName) {
-        super(new CacheContainerComponentServiceNameProvider(definition, containerName));
+        super(definition, containerName);
         this.definition = definition;
     }
 
@@ -60,9 +60,8 @@ public class ThreadPoolBuilder extends ComponentConfigurationBuilder<ThreadPoolC
     }
 
     @Override
-    public ThreadPoolConfiguration getValue() throws IllegalStateException, IllegalArgumentException {
+    public ThreadPoolConfiguration getValue() {
         return this.builder.create();
     }
-
 }
 

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
@@ -36,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
 import org.jboss.as.clustering.jgroups.logging.JGroupsLogger;
 import org.jboss.as.network.SocketBinding;
 import org.jboss.modules.ModuleIdentifier;

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkChannelFactoryBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ForkChannelFactoryBuilder.java
@@ -73,7 +73,7 @@ public class ForkChannelFactoryBuilder implements ResourceServiceBuilder<Channel
         ServiceBuilder<ChannelFactory> builder = target.addService(this.getServiceName(), new ValueService<>(this))
                 .addDependency(ChannelServiceName.CONNECTOR.getServiceName(this.channelName), Channel.class, this.parentChannel)
                 .addDependency(ChannelServiceName.FACTORY.getServiceName(this.channelName), ChannelFactory.class, this.parentFactory)
-                .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                .setInitialMode(ServiceController.Mode.PASSIVE)
         ;
         for (Dependency dependency : this.protocols) {
             dependency.register(builder);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemServiceHandler.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/JGroupsSubsystemServiceHandler.java
@@ -42,6 +42,7 @@ import org.wildfly.clustering.jgroups.spi.service.ChannelServiceNameFactory;
 import org.wildfly.clustering.jgroups.spi.service.ProtocolStackServiceName;
 import org.wildfly.clustering.service.AliasServiceBuilder;
 import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.GroupServiceNameFactory;
 import org.wildfly.clustering.spi.DistributedGroupBuilderProvider;
 import org.wildfly.clustering.spi.GroupBuilderProvider;
 
@@ -58,20 +59,20 @@ public class JGroupsSubsystemServiceHandler implements ResourceServiceHandler {
 
         new ProtocolDefaultsBuilder().build(target).install();
 
-        String defaultChannel = ModelNodes.asString(DEFAULT_CHANNEL.getDefinition().resolveModelAttribute(context, model), ChannelServiceNameFactory.DEFAULT_CHANNEL);
+        String defaultChannel = ModelNodes.asString(DEFAULT_CHANNEL.getDefinition().resolveModelAttribute(context, model), GroupServiceNameFactory.DEFAULT_GROUP);
 
-        if (!defaultChannel.equals(ChannelServiceNameFactory.DEFAULT_CHANNEL)) {
+        if (!defaultChannel.equals(GroupServiceNameFactory.DEFAULT_GROUP)) {
             for (ChannelServiceNameFactory factory : ChannelServiceName.values()) {
                 new AliasServiceBuilder<>(factory.getServiceName(), factory.getServiceName(defaultChannel), Object.class).build(target).install();
             }
-            new BinderServiceBuilder<>(JGroupsBindingFactory.createChannelBinding(ChannelServiceNameFactory.DEFAULT_CHANNEL), ChannelServiceName.CHANNEL.getServiceName(defaultChannel), Channel.class).build(target).install();
+            new BinderServiceBuilder<>(JGroupsBindingFactory.createChannelBinding(GroupServiceNameFactory.DEFAULT_GROUP), ChannelServiceName.CHANNEL.getServiceName(defaultChannel), Channel.class).build(target).install();
 
-            new AliasServiceBuilder<>(ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(ChannelServiceNameFactory.DEFAULT_CHANNEL), ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(defaultChannel), ChannelFactory.class).build(target).install();
-            new BinderServiceBuilder<>(JGroupsBindingFactory.createChannelFactoryBinding(ChannelServiceNameFactory.DEFAULT_CHANNEL), ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(defaultChannel), ChannelFactory.class).build(target).install();
+            new AliasServiceBuilder<>(ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(GroupServiceNameFactory.DEFAULT_GROUP), ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(defaultChannel), ChannelFactory.class).build(target).install();
+            new BinderServiceBuilder<>(JGroupsBindingFactory.createChannelFactoryBinding(GroupServiceNameFactory.DEFAULT_GROUP), ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(defaultChannel), ChannelFactory.class).build(target).install();
 
             for (GroupBuilderProvider provider : ServiceLoader.load(DistributedGroupBuilderProvider.class, DistributedGroupBuilderProvider.class.getClassLoader())) {
                 Iterator<Builder<?>> groupBuilders = provider.getBuilders(defaultChannel, null).iterator();
-                for (Builder<?> groupBuilder : provider.getBuilders(ChannelServiceNameFactory.DEFAULT_CHANNEL, null)) {
+                for (Builder<?> groupBuilder : provider.getBuilders(GroupServiceNameFactory.DEFAULT_GROUP, null)) {
                     new AliasServiceBuilder<>(groupBuilder.getServiceName(), groupBuilders.next().getServiceName(), Object.class).build(target).install();
                 }
             }
@@ -83,20 +84,20 @@ public class JGroupsSubsystemServiceHandler implements ResourceServiceHandler {
         // remove the ProtocolDefaultsService
         context.removeService(new ProtocolDefaultsBuilder().getServiceName());
 
-        String defaultChannel = ModelNodes.asString(DEFAULT_CHANNEL.getDefinition().resolveModelAttribute(context, model), ChannelServiceNameFactory.DEFAULT_CHANNEL);
+        String defaultChannel = ModelNodes.asString(DEFAULT_CHANNEL.getDefinition().resolveModelAttribute(context, model), GroupServiceNameFactory.DEFAULT_GROUP);
 
-        if ((defaultChannel != null) && !defaultChannel.equals(ChannelServiceNameFactory.DEFAULT_CHANNEL)) {
+        if ((defaultChannel != null) && !defaultChannel.equals(GroupServiceNameFactory.DEFAULT_GROUP)) {
 
             for (GroupBuilderProvider provider : ServiceLoader.load(DistributedGroupBuilderProvider.class, DistributedGroupBuilderProvider.class.getClassLoader())) {
-                for (Builder<?> builder : provider.getBuilders(ChannelServiceNameFactory.DEFAULT_CHANNEL, null)) {
+                for (Builder<?> builder : provider.getBuilders(GroupServiceNameFactory.DEFAULT_GROUP, null)) {
                     context.removeService(builder.getServiceName());
                 }
             }
 
-            context.removeService(JGroupsBindingFactory.createChannelFactoryBinding(ChannelServiceNameFactory.DEFAULT_CHANNEL).getBinderServiceName());
-            context.removeService(ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(ChannelServiceNameFactory.DEFAULT_CHANNEL));
+            context.removeService(JGroupsBindingFactory.createChannelFactoryBinding(GroupServiceNameFactory.DEFAULT_GROUP).getBinderServiceName());
+            context.removeService(ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(GroupServiceNameFactory.DEFAULT_GROUP));
 
-            context.removeService(JGroupsBindingFactory.createChannelBinding(ChannelServiceNameFactory.DEFAULT_CHANNEL).getBinderServiceName());
+            context.removeService(JGroupsBindingFactory.createChannelBinding(GroupServiceNameFactory.DEFAULT_GROUP).getBinderServiceName());
 
             for (ChannelServiceNameFactory factory : ChannelServiceName.values()) {
                 context.removeService(factory.getServiceName());

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ProtocolResourceDefinition.java
@@ -202,7 +202,6 @@ public abstract class ProtocolResourceDefinition extends ChildResourceDefinition
     /**
      * Builds transformations common to both protocols and transport.
      */
-    @SuppressWarnings("deprecation")
     static void addTransformations(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
 
         if (JGroupsModel.VERSION_3_0_0.requiresTransformation(version)) {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportConfigurationBuilder.java
@@ -110,6 +110,7 @@ public class TransportConfigurationBuilder extends AbstractProtocolConfiguration
 
             // keepalive_time in milliseconds
             this.getProperties().put(prefix + ".keep_alive_time", pool.getKeepAliveTime().getDefinition().resolveModelAttribute(context, model).asString());
+            this.getProperties().put(prefix + ".rejection_policy", "abort");
         }
 
         return super.configure(context, transport);

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelServiceName.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelServiceName.java
@@ -47,6 +47,6 @@ public enum ChannelServiceName implements ChannelServiceNameFactory {
 
     @Override
     public ServiceName getServiceName() {
-        return this.getServiceName(DEFAULT_CHANNEL);
+        return this.getServiceName(DEFAULT_GROUP);
     }
 }

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelServiceNameFactory.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ChannelServiceNameFactory.java
@@ -31,11 +31,6 @@ import org.wildfly.clustering.service.GroupServiceNameFactory;
 public interface ChannelServiceNameFactory extends GroupServiceNameFactory {
 
     /**
-     * The alias for the default channel.
-     */
-    String DEFAULT_CHANNEL = "default";
-
-    /**
      * Returns an appropriate service name for the default channel
      * @return
      */

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ProtocolStackServiceName.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ProtocolStackServiceName.java
@@ -35,4 +35,8 @@ public enum ProtocolStackServiceName implements ProtocolStackServiceNameFactory 
 
     static final ServiceName BASE_NAME = ServiceName.JBOSS.append("jgroups");
 
+    @Override
+    public ServiceName getServiceName() {
+        return this.getServiceName(DEFAULT_GROUP);
+    }
 }

--- a/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ProtocolStackServiceNameFactory.java
+++ b/clustering/jgroups/spi/src/main/java/org/wildfly/clustering/jgroups/spi/service/ProtocolStackServiceNameFactory.java
@@ -22,17 +22,17 @@
 package org.wildfly.clustering.jgroups.spi.service;
 
 import org.jboss.msc.service.ServiceName;
+import org.wildfly.clustering.service.GroupServiceNameFactory;
 
 /**
  * Factory for creating service names for stack-based services
  * @author Paul Ferraro
  */
-public interface ProtocolStackServiceNameFactory {
+public interface ProtocolStackServiceNameFactory extends GroupServiceNameFactory {
 
     /**
-     * Returns an appropriate service name for the specified stack
-     * @param name the stack name
-     * @return {@link ServiceName} of the stack
+     * Returns an appropriate service name for the stack of the default channel
+     * @return {@link ServiceName} for the stack of the default channel
      */
-    ServiceName getServiceName(String name);
+    ServiceName getServiceName();
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/dispatcher/ChannelCommandDispatcherFactoryBuilder.java
@@ -107,7 +107,7 @@ public class ChannelCommandDispatcherFactoryBuilder extends CommandDispatcherFac
                 .addDependency(ChannelServiceName.CONNECTOR.getServiceName(this.group), Channel.class, this.channel)
                 .addDependency(ChannelServiceName.FACTORY.getServiceName(this.group), ChannelFactory.class, this.channelFactory)
                 .addDependency(Services.JBOSS_SERVICE_MODULE_LOADER, ModuleLoader.class, this.loader)
-                .setInitialMode(ServiceController.Mode.ON_DEMAND)
+                .setInitialMode(ServiceController.Mode.PASSIVE)
         ;
     }
 

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/group/ChannelNodeFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/group/ChannelNodeFactoryBuilder.java
@@ -53,7 +53,7 @@ public class ChannelNodeFactoryBuilder extends GroupNodeFactoryServiceNameProvid
     public ServiceBuilder<JGroupsNodeFactory> build(ServiceTarget target) {
         return target.addService(this.getServiceName(), this)
                 .addDependency(ChannelServiceName.CONNECTOR.getServiceName(this.group), Channel.class, this.channel)
-                .setInitialMode(ServiceController.Mode.ON_DEMAND);
+                .setInitialMode(ServiceController.Mode.PASSIVE);
     }
 
     @Override

--- a/clustering/server/src/test/java/org/wildfly/clustering/server/ServiceLoaderTestCase.java
+++ b/clustering/server/src/test/java/org/wildfly/clustering/server/ServiceLoaderTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.server;
+
+import java.util.ServiceLoader;
+
+import org.junit.Test;
+import org.wildfly.clustering.marshalling.Externalizer;
+import org.wildfly.clustering.marshalling.jboss.ClassTableContributor;
+import org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider;
+import org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider;
+import org.wildfly.clustering.spi.DistributedGroupBuilderProvider;
+import org.wildfly.clustering.spi.GroupAliasBuilderProvider;
+import org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider;
+import org.wildfly.clustering.spi.LocalGroupBuilderProvider;
+
+/**
+ * Validates loading of services.
+ * @author Paul Ferraro
+ */
+public class ServiceLoaderTestCase {
+
+    @Test
+    public void load() {
+        load(Externalizer.class);
+        load(ClassTableContributor.class);
+        load(GroupAliasBuilderProvider.class);
+        load(CacheGroupAliasBuilderProvider.class);
+        load(DistributedGroupBuilderProvider.class);
+        load(DistributedCacheGroupBuilderProvider.class);
+        load(LocalGroupBuilderProvider.class);
+        load(LocalCacheGroupBuilderProvider.class);
+    }
+
+    private static <T> void load(Class<T> targetClass) {
+        System.out.println(targetClass.getName() + ":");
+        ServiceLoader.load(targetClass, ServiceLoaderTestCase.class.getClassLoader()).forEach(object -> System.out.println("\t" + object.getClass().getName()));
+    }
+}

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/BroadcastGroupAdd.java
@@ -26,7 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.wildfly.extension.messaging.activemq.BroadcastGroupDefinition.CONNECTOR_REFS;
 import static org.wildfly.extension.messaging.activemq.BroadcastGroupDefinition.validateConnectors;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_STACK;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CHANNEL;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -60,8 +60,6 @@ import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
  * @author Brian Stansberry (c) 2011 Red Hat Inc.
  */
 public class BroadcastGroupAdd extends AbstractAddStepHandler {
-
-    private static final OperationValidator VALIDATOR = new OperationValidator.AttributeDefinitionOperationValidator(BroadcastGroupDefinition.ATTRIBUTES);
 
     public static final BroadcastGroupAdd INSTANCE = new BroadcastGroupAdd();
 
@@ -97,7 +95,7 @@ public class BroadcastGroupAdd extends AbstractAddStepHandler {
             final String name = address.getLastElement().getValue();
 
             final ServiceTarget target = context.getServiceTarget();
-            if(model.hasDefined(JGROUPS_STACK.getName())) {
+            if (model.hasDefined(JGROUPS_CHANNEL.getName())) {
                 // nothing to do, in that case, the clustering.jgroups subsystem will have setup the stack
             } else if(model.hasDefined(RemoteTransportDefinition.SOCKET_BINDING.getName())) {
                 final GroupBindingService bindingService = new GroupBindingService();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/DiscoveryGroupAdd.java
@@ -24,7 +24,7 @@ package org.wildfly.extension.messaging.activemq;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
-import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_STACK;
+import static org.wildfly.extension.messaging.activemq.CommonAttributes.JGROUPS_CHANNEL;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -73,7 +73,7 @@ public class DiscoveryGroupAdd extends AbstractAddStepHandler {
             context.reloadRequired();
         } else {
             final ServiceTarget target = context.getServiceTarget();
-            if(model.hasDefined(JGROUPS_STACK.getName())) {
+            if (model.hasDefined(JGROUPS_CHANNEL.getName())) {
                 // nothing to do, in that case, the clustering.jgroups subsystem will have setup the stack
             } else if(model.hasDefined(RemoteTransportDefinition.SOCKET_BINDING.getName())) {
                 final GroupBindingService bindingService = new GroupBindingService();

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -277,10 +277,11 @@ class ServerAdd extends AbstractAddStepHandler {
                         final String key = "broadcast" + name;
                         ModelNode broadcastGroupModel = model.get(BROADCAST_GROUP, name);
 
-                        if (broadcastGroupModel.hasDefined(JGROUPS_STACK.getName())) {
-                            String jgroupsStack = JGROUPS_STACK.resolveModelAttribute(context, broadcastGroupModel).asString();
+                        if (broadcastGroupModel.hasDefined(JGROUPS_CHANNEL.getName())) {
+                            ModelNode channelFactory = JGROUPS_STACK.resolveModelAttribute(context, broadcastGroupModel);
+                            ServiceName channelFactoryServiceName = channelFactory.isDefined() ? ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(channelFactory.asString()) : ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName();
                             String channelName = JGROUPS_CHANNEL.resolveModelAttribute(context, broadcastGroupModel).asString();
-                            serviceBuilder.addDependency(ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(jgroupsStack), ChannelFactory.class, serverService.getJGroupsInjector(key));
+                            serviceBuilder.addDependency(channelFactoryServiceName, ChannelFactory.class, serverService.getJGroupsInjector(key));
                             serverService.getJGroupsChannels().put(key, channelName);
                         } else {
                             final ServiceName groupBinding = GroupBindingService.getBroadcastBaseServiceName(activeMQServiceName).append(name);
@@ -293,10 +294,11 @@ class ServerAdd extends AbstractAddStepHandler {
                         final String name = config.getName();
                         final String key = "discovery" + name;
                         ModelNode discoveryGroupModel = model.get(DISCOVERY_GROUP, name);
-                        if (discoveryGroupModel.hasDefined(JGROUPS_STACK.getName())) {
-                            String jgroupsStack = JGROUPS_STACK.resolveModelAttribute(context, discoveryGroupModel).asString();
+                        if (discoveryGroupModel.hasDefined(JGROUPS_CHANNEL.getName())) {
+                            ModelNode channelFactory = JGROUPS_STACK.resolveModelAttribute(context, discoveryGroupModel);
+                            ServiceName channelFactoryServiceName = channelFactory.isDefined() ? ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(channelFactory.asString()) : ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName();
                             String channelName = JGROUPS_CHANNEL.resolveModelAttribute(context, discoveryGroupModel).asString();
-                            serviceBuilder.addDependency(ProtocolStackServiceName.CHANNEL_FACTORY.getServiceName(jgroupsStack), ChannelFactory.class, serverService.getJGroupsInjector(key));
+                            serviceBuilder.addDependency(channelFactoryServiceName, ChannelFactory.class, serverService.getJGroupsInjector(key));
                             serverService.getJGroupsChannels().put(key, channelName);
                         } else {
                             final ServiceName groupBinding = GroupBindingService.getDiscoveryBaseServiceName(activeMQServiceName).append(name);

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -90,12 +90,10 @@
         <replacement placeholder="BROADCAST-GROUPS">
             <broadcast-group name="bg-group1"
                              connectors="http-connector"
-                             jgroups-stack="udp"
                              jgroups-channel="activemq-cluster"/>
         </replacement>
         <replacement placeholder="DISCOVERY-GROUPS">
             <discovery-group name="dg-group1"
-                             jgroups-stack="udp"
                              jgroups-channel="activemq-cluster"/>
         </replacement>
         <replacement placeholder="CLUSTER-CONNECTIONS">


### PR DESCRIPTION
This happens because the messaging subsystem creates its own JChannel using the same bind address/port as the default server channel.  This causes the messaging and ee channels to receive each other messages.

This PR modifies the default messaging-activemq configuration to share the default channel of the server.  messaging now uses a ForkChannel created from the default channel of the server.

Since messaging connects its JGroups channel on startup (whereas other clustering services start on_demand), this change requires all channel-based services (Infinispan cache managers in particular) to be installed using PASSIVE mode.

This change has the unintended side-effect of speeding up the clustering testsuite significantly - since we no longer connect/disconnect the default JGroups channel as frequently, since messaging forces the channel to stay open between tests.

This PR needs reviewing by @jmesnil 
