### PR TITLE
[WFLY-5448] Allow byteman tests to run on IPv6 addresses.

### DIFF
--- a/clustering/infinispan/extension/pom.xml
+++ b/clustering/infinispan/extension/pom.xml
@@ -36,6 +36,12 @@
     <packaging>jar</packaging>
 
     <name>WildFly: Infinispan subsystem</name>
+
+    <properties>
+        <byteman.host>127.0.0.1</byteman.host>
+        <byteman.port>9091</byteman.port>
+    </properties>
+
     <build>
        <plugins>
            <!-- this is only needed on windows because of bug in byteman-->
@@ -57,8 +63,12 @@
                    <useManifestOnlyJar>false</useManifestOnlyJar>
                    <!-- the log manager needs to be setup before the agent this is only needed on windows!-->
                    <argLine>-Xbootclasspath/a:"${org.jboss.logmanager:jboss-logmanager:jar}"
-                       -javaagent:"${org.jboss.byteman:byteman:jar}"=port:9091,boot:"${org.jboss.byteman:byteman:jar}"
+                       -javaagent:"${org.jboss.byteman:byteman:jar}"=port:${byteman.port},address:${byteman.host},boot:"${org.jboss.byteman:byteman:jar}"
                    </argLine>
+                   <systemPropertyVariables>
+                       <org.jboss.byteman.contrib.bmunit.agent.host>${byteman.host}</org.jboss.byteman.contrib.bmunit.agent.host>
+                       <org.jboss.byteman.contrib.bmunit.agent.port>${byteman.port}</org.jboss.byteman.contrib.bmunit.agent.port>
+                   </systemPropertyVariables>
                </configuration>
            </plugin>
        </plugins>
@@ -166,4 +176,20 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- profile is the same name as the test IPv6 profile for consistency and in case the profile is enabled via
+        the profile name rather than the system property. -->
+        <profile>
+            <id>ts.ipv6</id>
+            <activation>
+                <property>
+                    <name>ipv6</name>
+                </property>
+            </activation>
+            <properties>
+                <byteman.host>::1</byteman.host>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/clustering/jgroups/extension/pom.xml
+++ b/clustering/jgroups/extension/pom.xml
@@ -37,6 +37,11 @@
 
     <name>WildFly: JGroups Subsystem</name>
 
+    <properties>
+        <byteman.host>127.0.0.1</byteman.host>
+        <byteman.port>9091</byteman.port>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -69,8 +74,12 @@
                     <useManifestOnlyJar>false</useManifestOnlyJar>
                     <!-- the log manager needs to be setup before the agent this is only needed on windows!-->
                     <argLine>-Xbootclasspath/a:"${org.jboss.logmanager:jboss-logmanager:jar}"
-                        -javaagent:"${org.jboss.byteman:byteman:jar}"=port:9091,boot:"${org.jboss.byteman:byteman:jar}"
+                        -javaagent:"${org.jboss.byteman:byteman:jar}"=port:${byteman.port},address:${byteman.host},boot:"${org.jboss.byteman:byteman:jar}"
                     </argLine>
+                    <systemPropertyVariables>
+                        <org.jboss.byteman.contrib.bmunit.agent.host>${byteman.host}</org.jboss.byteman.contrib.bmunit.agent.host>
+                        <org.jboss.byteman.contrib.bmunit.agent.port>${byteman.port}</org.jboss.byteman.contrib.bmunit.agent.port>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>
@@ -138,4 +147,20 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- profile is the same name as the test IPv6 profile for consistency and in case the profile is enabled via
+        the profile name rather than the system property. -->
+        <profile>
+            <id>ts.ipv6</id>
+            <activation>
+                <property>
+                    <name>ipv6</name>
+                </property>
+            </activation>
+            <properties>
+                <byteman.host>::1</byteman.host>
+            </properties>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Some issues came up in QE with core byteman tests running on IPv6. This does the same thing in full that was done in core to ensure the tests will run in IPv6 only environments. https://github.com/wildfly/wildfly-core/pull/1135
