### PR TITLE
[WFLY-5452] Sometimes the calling javax.security.auth.login.Configuration.getConfiguration() fails with SecurityException in our tests

### DIFF
--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/Utils.java
@@ -1011,7 +1011,13 @@ public class Utils extends CoreUtils {
      * @return Configuration
      */
     public static Configuration getLoginConfiguration() {
-        return Configuration.getConfiguration();
+        Configuration configuration = null;
+        try {
+            configuration = Configuration.getConfiguration();
+        } catch (SecurityException e) {
+            LOGGER.debug("Unable to load default login configuration", e);
+        }
+        return configuration;
     }
 
     /**


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-5452

Some info about this issue: http://javlog.cacek.cz/2015/09/solution-to-failing-configurationgetcon.html
