### PR TITLE
[WFLY-5458] Do not allow expressions for jgroup-stack and groups-channel attributes

### DIFF
--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -121,8 +121,8 @@
                 <socket-binding>group-s-binding</socket-binding>
             </broadcast-group>
             <broadcast-group name="groupT">
-                <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
-                <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
+                <jgroups-stack>udp</jgroups-stack>
+                <jgroups-channel>hq-cluster</jgroups-channel>
             </broadcast-group>
         </broadcast-groups>
         <discovery-groups>
@@ -141,8 +141,8 @@
                 <socket-binding>group-t-binding</socket-binding>
             </discovery-group>
             <discovery-group name="groupU">
-                <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
-                <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
+                <jgroups-stack>udp</jgroups-stack>
+                <jgroups-channel>hq-cluster</jgroups-channel>
             </discovery-group>
         </discovery-groups>
         <diverts>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/CommonAttributes.java
@@ -175,7 +175,8 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition JGROUPS_STACK = create("jgroups-stack", ModelType.STRING)
             .setAllowNull(true)
-            .setAllowExpression(true)
+            // do not allow expression as this may reference another resource
+            .setAllowExpression(false)
             .setAlternatives("socket-binding",
                     "group-address", "group-port",
                     "local-bind-address", "local-bind-port")
@@ -184,7 +185,8 @@ public interface CommonAttributes {
 
     SimpleAttributeDefinition JGROUPS_CHANNEL = create("jgroups-channel", ModelType.STRING)
             .setAllowNull(true)
-            .setAllowExpression(true)
+            // do not allow expression as this may reference another resource
+            .setAllowExpression(false)
             .setAlternatives("socket-binding",
                     "group-address", "group-port",
                     "local-bind-address", "local-bind-port")

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
@@ -162,8 +162,8 @@
         </acceptor>
 
         <broadcast-group name="groupT"
-                         jgroups-stack="${jgroups.stack:udp}"
-                         jgroups-channel="${jgroups.channel:activemq-cluster}"
+                         jgroups-stack="udp"
+                         jgroups-channel="activemq-cluster"
                          broadcast-period="${broadcast.group.period:1234}"
                          connectors="http netty"/>
         <broadcast-group name="groupS"
@@ -172,8 +172,8 @@
         <discovery-group name="groupT"
                          socket-binding="group-t-binding"/>
         <discovery-group name="groupU"
-                         jgroups-stack="${jgroups.stack:udp}"
-                         jgroups-channel="${jgroups.channel:activemq-cluster}"
+                         jgroups-stack="udp"
+                         jgroups-channel="activemq-cluster"
                          refresh-timeout="${discovery.group.refresh.timeout:2345}"
                          initial-wait-timeout="${discovery.group.initial.wait.timeout:2345}"/>
 


### PR DESCRIPTION
These attributes may referenceother management resources (cf. WFLY-5189) and must not
allow expressions.

JIRA: https://issues.jboss.org/browse/WFLY-5458
