### PR TITLE
WFLY-5015 Add dependency on jboss-ejb-policy

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/EJBComponentDescription.java
@@ -106,6 +106,7 @@ import org.jboss.metadata.javaee.spec.SecurityRolesMetaData;
 import org.jboss.msc.service.Service;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
+import org.jboss.security.SecurityConstants;
 
 /**
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
@@ -851,6 +852,7 @@ public abstract class EJBComponentDescription extends ComponentDescription {
                         final ServiceName securityDomainServiceName = SecurityDomainService.SERVICE_NAME.append(securityDomainName);
                         serviceBuilder.addDependency(securityDomainServiceName);
                     }
+                    serviceBuilder.addDependency(SecurityDomainService.SERVICE_NAME.append(SecurityConstants.DEFAULT_EJB_APPLICATION_POLICY));
                 }
             });
         }


### PR DESCRIPTION
The requirement for this domain is hard coded into picketbox, it needs a service dependency as well so EJB invocation can continue to work on server shutdown.
