### PR TITLE
upgrade build tools plugin to address WFLY-5383 & WFLY-5428

### DIFF
--- a/dist/server-provisioning.xml
+++ b/dist/server-provisioning.xml
@@ -19,7 +19,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" extract-schemas="true" copy-module-artifacts="true">
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" extract-schemas="true" copy-module-artifacts="true" extract-schemas-groups="org.jboss.as org.wildfly org.wildfly.core">
     <feature-packs>
         <feature-pack groupId="org.wildfly" artifactId="wildfly-feature-pack" version="${project.version}"/>
     </feature-packs>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.org.scannotation>1.0.3</version.org.scannotation>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>
-        <version.org.wildfly.build-tools>1.1.0.CR1</version.org.wildfly.build-tools>
+        <version.org.wildfly.build-tools>1.1.0.CR2</version.org.wildfly.build-tools>
         <version.org.wildfly.checkstyle-config>1.0.4.Final</version.org.wildfly.checkstyle-config>
         <version.org.wildfly.core>2.0.0.CR6</version.org.wildfly.core>
         <version.org.wildfly.arquillian>1.0.1.Final</version.org.wildfly.arquillian>

--- a/servlet-dist/server-provisioning.xml
+++ b/servlet-dist/server-provisioning.xml
@@ -19,7 +19,7 @@
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
-<server-provisioning xmlns="urn:wildfly:server-provisioning:1.0" extract-schemas="true" copy-module-artifacts="true">
+<server-provisioning xmlns="urn:wildfly:server-provisioning:1.1" extract-schemas="true" copy-module-artifacts="true" extract-schemas-groups="org.jboss.as org.wildfly org.wildfly.core">
     <feature-packs>
         <feature-pack groupId="org.wildfly" artifactId="wildfly-servlet-feature-pack" version="${project.version}"/>
     </feature-packs>

--- a/testsuite/mixed-domain/pom.xml
+++ b/testsuite/mixed-domain/pom.xml
@@ -27,8 +27,8 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <artifactId>wildfly-testsuite</artifactId>
         <groupId>org.wildfly</groupId>
+        <artifactId>wildfly-testsuite</artifactId>
         <version>10.0.0.CR3-SNAPSHOT</version>
     </parent>
 
@@ -67,6 +67,17 @@
         <dependency>
             <groupId>org.wildfly.core</groupId>
             <artifactId>wildfly-subsystem-test-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly</groupId>
+            <artifactId>wildfly-testsuite-shared</artifactId>
+            <exclusions>
+                <!-- exclude woodstox as it is doesn't work right with adding new lines after document end -->
+                <exclusion>
+                    <groupId>org.codehaus.woodstox</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <build>


### PR DESCRIPTION
-  WFLY-5383  xsd/dtd files in docs/schema not related to management, mainly from opensaml and othr cxf related artifacts
-  WFLY-5428 Xml files from wildfly don't end with "new line character"
