### PR TITLE
Anticipate release of WF core 2.0.0.CR7 containing Undertow api change.

### DIFF
--- a/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOnManager.java
+++ b/clustering/web/undertow/src/main/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOnManager.java
@@ -82,7 +82,10 @@ public class DistributableSingleSignOnManager implements SingleSignOnManager {
         return new DistributableSingleSignOn(sso, this.registry, batch);
     }
 
-    @Override
+    public void removeSingleSignOn(SingleSignOn sso) {
+        this.removeSingleSignOn(sso.getId());
+    }
+
     public void removeSingleSignOn(String id) {
         Batch batch = this.manager.getBatcher().createBatch();
         SSO<AuthenticatedSession, String, Void> sso = this.manager.findSSO(id);

--- a/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOnManagerTestCase.java
+++ b/clustering/web/undertow/src/test/java/org/wildfly/clustering/web/undertow/sso/DistributableSingleSignOnManagerTestCase.java
@@ -30,7 +30,6 @@ import javax.servlet.http.HttpServletRequest;
 import io.undertow.security.api.AuthenticatedSessionManager.AuthenticatedSession;
 import io.undertow.security.idm.Account;
 import io.undertow.security.impl.SingleSignOn;
-import io.undertow.security.impl.SingleSignOnManager;
 
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -48,7 +47,7 @@ public class DistributableSingleSignOnManagerTestCase {
     private final SSOManager<AuthenticatedSession, String, Void, Batch> manager = mock(SSOManager.class);
     private final SessionManagerRegistry registry = mock(SessionManagerRegistry.class);
 
-    private final SingleSignOnManager subject = new DistributableSingleSignOnManager(this.manager, this.registry);
+    private final DistributableSingleSignOnManager subject = new DistributableSingleSignOnManager(this.manager, this.registry);
 
     @Test
     public void createSingleSignOn() {


### PR DESCRIPTION
This will allow WF core to be upgraded without compilation errors.

The API change is all part of the eventual fix for:
https://issues.jboss.org/browse/WFLY-5473
https://issues.jboss.org/browse/WFLY-5422
