### PR TITLE
Remove deprecated KernelServicesBuilder#enableTransformerAttachmentGr…

### DIFF
--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/TransformersTestCase.java
@@ -122,8 +122,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
 
         // create builder for current subsystem version
         KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization())
-                .setSubsystemXmlResource("subsystem-jgroups-transform.xml")
-                .enableTransformerAttachmentGrabber();
+                .setSubsystemXmlResource("subsystem-jgroups-transform.xml");
 
         // initialize the legacy services and add required jars
         builder.createLegacyKernelServicesBuilder(null, controller, version).addMavenResourceURL(mavenResourceURLs).skipReverseControllerCheck();
@@ -412,8 +411,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
         ModelVersion version = model.getVersion();
 
         // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization())
-                .enableTransformerAttachmentGrabber();
+        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization());
 
         // initialize the legacy services and add required jars
         builder.createLegacyKernelServicesBuilder(null, controller, version)

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/TransformersTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/TransformersTestCase.java
@@ -148,8 +148,7 @@ public class TransformersTestCase extends AbstractSubsystemBaseTest {
 
     private void testRejections(ModelVersion model, ModelTestControllerVersion controller, String ... mavenResourceURLs) throws Exception {
         // create builder for current subsystem version
-        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization())
-                .enableTransformerAttachmentGrabber();
+        KernelServicesBuilder builder = createKernelServicesBuilder(this.createAdditionalInitialization());
 
         // initialize the legacy services and add required jars
         builder.createLegacyKernelServicesBuilder(null, controller, model)


### PR DESCRIPTION
…abber

No longer needed -- it's enabled by defalt now with latest changes.
