### PR TITLE
WFLY-5478 allow custom scoped persistence unit name hint (jboss.as.jpa.scopedname) in persistence unit definition.

### DIFF
--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/config/Configuration.java
@@ -156,6 +156,12 @@ public class Configuration {
     private static final String JPA_DEFER_DETACH = "jboss.as.jpa.deferdetach";
 
     /**
+     * unique name for the persistence unit that is unique across all deployments (
+     * defaults to include the application name prepended to the persistence unit name)
+     */
+    private static final String JPA_SCOPED_PERSISTENCE_UNIT_NAME = "jboss.as.jpa.scopedname";
+
+    /**
      * name of the persistence provider adapter class
      */
     public static final String ADAPTER_CLASS = "jboss.as.jpa.adapterClass";
@@ -287,4 +293,12 @@ public class Configuration {
         return result;
     }
 
+    public static String getScopedPersistenceUnitName(PersistenceUnitMetadata pu) {
+
+        Object name = pu.getProperties().get(JPA_SCOPED_PERSISTENCE_UNIT_NAME);
+        if (name instanceof String) {
+            return (String)name;
+        }
+        return null;
+    }
 }

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/messages/JpaLogger.java
@@ -506,14 +506,12 @@ public interface JpaLogger extends BasicLogger {
     IllegalArgumentException invalidPersistenceUnitName(String persistenceUnitName, char c);
 
     /**
-     * Creates an exception indicating the scoped persistence name is invalid.
+     * Creates an exception indicating the (custom) scoped persistence unit name is invalid.
      *
-     * @param validName the valid scope name.
-     * @param name      the scope name that was supplied.
      * @return a {@link RuntimeException} for the error.
      */
-    //@Message(id = 44, value = "Scoped persistence name should be \"%s\" but was %s")
-    //RuntimeException invalidScopeName(String validName, String name);
+    @Message(id = 44, value = "jboss.as.jpa.scopedname hint (%s) contains illegal '%s' character")
+    IllegalArgumentException invalidScopedName(String persistenceUnitName, char c);
 
     /**
      * Creates an exception indicating the inability to integrate the module, represented by the {@code integrationName}


### PR DESCRIPTION
if there is time to merge WFLY-5478 into WildFly 10, let me know so I can update the jira to be fixed in WildFly 10.  We would like to address a Jon issue with EAP 6, by backporting this change (could also go into WildFly 11).
