### PR TITLE
Add IntermittentFailure class to disable intermittent failures

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSTopicManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSTopicManagementTestCase.java
@@ -27,6 +27,7 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.NAME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.VALUE;
 import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.operations.common.Util.getEmptyOperation;
+import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -53,7 +54,6 @@ import org.jboss.dmr.ModelType;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -398,8 +398,10 @@ public class JMSTopicManagementTestCase {
     }
 
     @Test
-    @Ignore("WFLY-5019")
     public void removeJMSTopicRemovesAllMessages() throws Exception {
+
+        thisTestIsFailingIntermittently("WFLY-5019");
+
         // create a durable subscriber
         final String subscriptionName = "removeJMSTopicRemovesAllMessages";
         // stop the consumer connection to prevent eager consumption of messages

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
@@ -22,6 +22,7 @@
 
 package org.jboss.as.test.clustering.messaging;
 
+import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -50,7 +51,7 @@ import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.as.test.shared.TestSuiteEnvironment;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.wildfly.test.api.Authentication;
@@ -60,7 +61,6 @@ import org.wildfly.test.api.Authentication;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("fails intermittently")
 public class ClusteredMessagingTestCase {
 
     public static final String CONTAINER_0 = "messaging-container-0";
@@ -83,6 +83,11 @@ public class ClusteredMessagingTestCase {
         return ModelControllerClient.Factory.create(InetAddress.getByName(TestSuiteEnvironment.getServerAddress()),
                 TestSuiteEnvironment.getServerPort() + 100,
                 Authentication.getCallbackHandler());
+    }
+
+    @BeforeClass
+    public static void beforeClass() {
+        thisTestIsFailingIntermittently("WFLY-5390");
     }
 
     @Before

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/FailoverTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/FailoverTestCase.java
@@ -30,7 +30,6 @@ import javax.naming.InitialContext;
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
-import org.junit.Assert;
 import org.junit.Test;
 
 /**

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/ReplicatedFailoverTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/ReplicatedFailoverTestCase.java
@@ -26,24 +26,28 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
+import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.dmr.ModelNode;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 
 /**
  * IGNORE until  https://issues.apache.org/jira/browse/ARTEMIS-103 is fixed.
  *
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
  */
-@Ignore
 public class ReplicatedFailoverTestCase extends FailoverTestCase {
+
+    @BeforeClass
+    public static void beforeClass() {
+        thisTestIsFailingIntermittently("WFLY-5531");
+    }
 
     @Override
     protected void setUpServer1(ModelControllerClient client) throws Exception {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/SharedStoreFailoverTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/SharedStoreFailoverTestCase.java
@@ -28,6 +28,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 
 import java.io.File;
 
@@ -36,17 +37,21 @@ import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.dmr.ModelNode;
 import org.junit.Before;
-import org.junit.Ignore;
+import org.junit.BeforeClass;
 
 /**
  * IGNORE until https://issues.apache.org/jira/browse/ARTEMIS-138 is fixed.
  *
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
  */
-@Ignore
 public class SharedStoreFailoverTestCase extends FailoverTestCase {
 
     private static final File SHARED_STORE_DIR = new File(System.getProperty("java.io.tmpdir"), "activemq");
+
+    @BeforeClass
+    public static void beforeClass() {
+        thisTestIsFailingIntermittently("WFLY-5531");
+    }
 
     @Before
     @Override

--- a/testsuite/shared/src/main/java/org/jboss/as/test/shared/IntermittentFailure.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/shared/IntermittentFailure.java
@@ -1,0 +1,57 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.shared;
+
+import org.junit.Assume;
+
+/**
+ * Utility class to disable intermittently failing tests.
+ *
+ * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
+ */
+public final class IntermittentFailure {
+
+    /**
+     * This method can be used to disable tests that are failing intermittently.
+     *
+     * The purpose to calling this method (as opposed to annotating tests with {@code @Ignore} is to
+     * be able to enable or disable the test based on the presence of the {@code jboss.test.enableIntermittentFailingTests}
+     * System property.
+     *
+     * To run tests disabled by this method, you must add {@code -Djboss.test.enableIntermittentFailingTests} argument
+     * to the JVM running the tests.
+     *
+     * @param message a optional description about disabling this test (e.g. it can contain a WFLY issue).
+     */
+    public static void thisTestIsFailingIntermittently(String message) {
+        boolean enableTest = System.getProperty("jboss.test.enableIntermittentFailingTests") != null;
+        Assume.assumeTrue(message, enableTest);
+    }
+
+    /**
+     * @see #thisTestIsFailingIntermittently(String)
+     */
+    public static void thisTestIsFailingIntermittently() {
+        thisTestIsFailingIntermittently("");
+    }
+}


### PR DESCRIPTION
This class allows to disable/enable running intermittently failing
tests based on the presence of a system property

By default, the tests calling that method  are skipped to keep the same
behaviour than @Ignore-ing them. But it is possible to run them by
passing the `jboss.test.enableIntermittentFailingTests` System property.

Use that new class to flag the messaging tests that are failing intermittently
