### PR TITLE
[WFLY-5526] Migrate forward-when-no-consumers attribute

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -820,4 +820,7 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 85, value = "Could not create a legacy-connection-factory based on connection-factory %s. It used a HornetQ in-vm connector that is not compatible with Artemis in-vm connector ")
     String couldNotCreateLegacyConnectionFactoryUsingInVMConnector(PathAddress address);
+
+    @Message(id = 86, value = "Could not migrate attribute %s from resource %s. The attribute uses an expression that can be resolved differently depending on system properties. To be able to migrate this property, replace the expression by an actual value.")
+    String couldNotMigrateResourceAttributeWithExpression(String attribute, PathAddress address);
 }

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -159,7 +159,8 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         // 5 warnings about discovery-group attributes that can not be migrated.
         // 2 warnings about interceptors that can not be migrated.
         // 1 warning about HA migration (attributes have expressions)
-        int expectedNumberOfWarnings = 6 + 5 + 2 + 1;
+        // 1 warning about cluster-connection forward-when-no-consumers attribute having an expresion.
+        int expectedNumberOfWarnings = 6 + 5 + 2 + 1 + 1;
         // 1 warning if add-legacy-entries is true because an in-vm connector can not be used in a legacy-connection-factory
         if (addLegacyEntries) {
             expectedNumberOfWarnings += 1;
@@ -176,6 +177,9 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         ModelNode newServer = newSubsystem.get("server", "default");
         assertNotNull(newServer);
         assertTrue(newServer.isDefined());
+
+        assertEquals("STRICT", newServer.get("cluster-connection", "cc2", "message-load-balancing-type").asString());
+        assertEquals("ON_DEMAND", newServer.get("cluster-connection", "cc3", "message-load-balancing-type").asString());
 
         if (addLegacyEntries) {
             // check that legacy entries were added to JMS resources

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -232,6 +232,7 @@
             <cluster-connection name="cc2">
                 <address>cc2-address</address>
                 <connector-ref>netty</connector-ref>
+                <forward-when-no-consumers>true</forward-when-no-consumers>
                 <static-connectors allow-direct-connections-only="true">
                     <connector-ref>in-vm</connector-ref>
                     <connector-ref>netty</connector-ref>
@@ -240,6 +241,7 @@
             <cluster-connection name="cc3">
                 <address>cc3-address</address>
                 <connector-ref>netty</connector-ref>
+                <forward-when-no-consumers>false</forward-when-no-consumers>
                 <discovery-group-ref discovery-group-name="groupC"/>
             </cluster-connection>
             <cluster-connection name="cc4">


### PR DESCRIPTION
Warn if the attribute is using an expression (and discard it).
Otherwise change it to the message-load-balancing-type according to
Artemis documentation at
http://activemq.apache.org/artemis/docs/1.1.0/clusters.html#configuring-cluster-connections

JIRA: https://issues.jboss.org/browse/WFLY-5526
