### PR TITLE
WFLY-5449 Custom socket factory for JGroups subsystem not set correctly

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
@@ -59,7 +59,6 @@ import org.jgroups.protocols.relay.config.RelayConfig;
 import org.jgroups.stack.Configurator;
 import org.jgroups.stack.Protocol;
 import org.jgroups.stack.ProtocolStack;
-import org.jgroups.util.SocketFactory;
 import org.wildfly.clustering.jgroups.spi.ChannelFactory;
 import org.wildfly.clustering.jgroups.spi.ProtocolConfiguration;
 import org.wildfly.clustering.jgroups.spi.ProtocolStackConfiguration;
@@ -100,15 +99,10 @@ public class JChannelFactory implements ChannelFactory, ProtocolStackConfigurato
         final JChannel channel = WildFlySecurityManager.doChecked(action);
         ProtocolStack stack = channel.getProtocolStack();
 
-        // We need to synchronize on shared transport,
-        // so we don't attempt to init a shared transport multiple times
-        TP transport = stack.getTransport();
-        if (transport.isSingleton()) {
-            synchronized (transport) {
-                this.init(transport);
-            }
-        } else {
-            this.init(transport);
+        TransportConfiguration transportConfig = this.configuration.getTransport();
+        SocketBinding binding = transportConfig.getSocketBinding();
+        if (binding != null) {
+            channel.setSocketFactory(new ManagedSocketFactory(binding.getSocketBindings()));
         }
 
         // Relay protocol is added to stack programmatically, not via ProtocolStackConfigurator
@@ -199,17 +193,6 @@ public class JChannelFactory implements ChannelFactory, ProtocolStackConfigurato
     @Override
     public boolean isUnknownForkResponse(ByteBuffer buffer) {
         return UNKNOWN_FORK_RESPONSE.equals(buffer);
-    }
-
-    private void init(TP transport) {
-        TransportConfiguration transportConfig = this.configuration.getTransport();
-        SocketBinding binding = transportConfig.getSocketBinding();
-        if (binding != null) {
-            SocketFactory factory = transport.getSocketFactory();
-            if (!(factory instanceof ManagedSocketFactory)) {
-                transport.setSocketFactory(new ManagedSocketFactory(factory, binding.getSocketBindings()));
-            }
-        }
     }
 
     /**

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
@@ -24,6 +24,7 @@ package org.jboss.as.clustering.jgroups;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -40,140 +41,115 @@ import org.jgroups.util.SocketFactory;
  */
 public class ManagedSocketFactory implements SocketFactory {
 
-    private final SocketFactory factory;
     private final SocketBindingManager manager;
 
-    public ManagedSocketFactory(SocketFactory factory, SocketBindingManager manager) {
-        this.factory = factory;
+    public ManagedSocketFactory(SocketBindingManager manager) {
         this.manager = manager;
     }
 
     @Override
     public Socket createSocket(String name) throws IOException {
-        return this.register(this.factory.createSocket(name));
+        return this.manager.getSocketFactory().createSocket(name);
     }
 
     @Override
     public Socket createSocket(String name, String host, int port) throws IOException {
-        return this.register(this.factory.createSocket(name, host, port));
+        return this.manager.getSocketFactory().createSocket(name, host, port);
     }
 
     @Override
     public Socket createSocket(String name, InetAddress address, int port) throws IOException {
-        return this.register(this.factory.createSocket(name, address, port));
+        return this.manager.getSocketFactory().createSocket(name, address, port);
     }
 
     @Override
-    public Socket createSocket(String name, String host, int port, InetAddress localAddress, int localPort) throws IOException {
-        return this.register(this.factory.createSocket(name, host, port, localAddress, localPort));
+    public Socket createSocket(String name, String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return this.manager.getSocketFactory().createSocket(name, host, port, localHost, localPort);
     }
 
     @Override
     public Socket createSocket(String name, InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
-        return this.register(this.factory.createSocket(name, address, port, localAddress, localPort));
-    }
-
-    private Socket register(final Socket socket) {
-        this.manager.getUnnamedRegistry().registerSocket(socket);
-        return socket;
+        return this.manager.getSocketFactory().createSocket(name, address, port, localAddress, localPort);
     }
 
     @Override
     public ServerSocket createServerSocket(String name) throws IOException {
-        return this.register(this.factory.createServerSocket(name));
+        return this.manager.getServerSocketFactory().createServerSocket(name);
     }
 
     @Override
     public ServerSocket createServerSocket(String name, int port) throws IOException {
-        return this.register(this.factory.createServerSocket(name, port));
+        return this.manager.getServerSocketFactory().createServerSocket(name, port);
     }
 
     @Override
     public ServerSocket createServerSocket(String name, int port, int backlog) throws IOException {
-        return this.register(this.factory.createServerSocket(name, port, backlog));
+        return this.manager.getServerSocketFactory().createServerSocket(name, port, backlog);
     }
 
     @Override
-    public ServerSocket createServerSocket(String name, int port, int backlog, InetAddress bindAddr) throws IOException {
-        return this.register(this.factory.createServerSocket(name, port, backlog, bindAddr));
-    }
-
-    private ServerSocket register(final ServerSocket socket) {
-        this.manager.getUnnamedRegistry().registerSocket(socket);
-        return socket;
+    public ServerSocket createServerSocket(String name, int port, int backlog, InetAddress ifAddress) throws IOException {
+        return this.manager.getServerSocketFactory().createServerSocket(name, port, backlog, ifAddress);
     }
 
     @Override
     public DatagramSocket createDatagramSocket(String name) throws SocketException {
-        return this.register(this.factory.createDatagramSocket(name));
+        return this.createDatagramSocket(name, 0);
     }
 
     @Override
-    public DatagramSocket createDatagramSocket(String name, SocketAddress bindAddress) throws SocketException {
-        return this.register(this.factory.createDatagramSocket(name, bindAddress));
+    public DatagramSocket createDatagramSocket(String name, SocketAddress address) throws SocketException {
+        return this.manager.createDatagramSocket(name, address);
     }
 
     @Override
     public DatagramSocket createDatagramSocket(String name, int port) throws SocketException {
-        return this.register(this.factory.createDatagramSocket(name, port));
+        return this.createDatagramSocket(name, new InetSocketAddress(port));
     }
 
     @Override
-    public DatagramSocket createDatagramSocket(String name, int port, InetAddress localAddress) throws SocketException {
-        return this.register(this.factory.createDatagramSocket(name, port, localAddress));
-    }
-
-    private DatagramSocket register(final DatagramSocket socket) {
-        this.manager.getUnnamedRegistry().registerSocket(socket);
-        return socket;
+    public DatagramSocket createDatagramSocket(String name, int port, InetAddress address) throws SocketException {
+        return this.createDatagramSocket(name, new InetSocketAddress(address, port));
     }
 
     @Override
     public MulticastSocket createMulticastSocket(String name) throws IOException {
-        return this.register(this.factory.createMulticastSocket(name));
+        return this.createMulticastSocket(name, 0);
     }
 
     @Override
     public MulticastSocket createMulticastSocket(String name, int port) throws IOException {
-        return this.register(this.factory.createMulticastSocket(name, port));
+        return this.createMulticastSocket(name, new InetSocketAddress(port));
     }
 
     @Override
-    public MulticastSocket createMulticastSocket(String name, SocketAddress bindAddress) throws IOException {
-        return this.register(this.factory.createMulticastSocket(name, bindAddress));
-    }
-
-    private MulticastSocket register(final MulticastSocket socket) {
-        this.manager.getUnnamedRegistry().registerSocket(socket);
-        return socket;
+    public MulticastSocket createMulticastSocket(String name, SocketAddress address) throws IOException {
+        return this.manager.createMulticastSocket(name, address);
     }
 
     @Override
     public void close(Socket socket) throws IOException {
         if (socket != null) {
-            this.manager.getUnnamedRegistry().unregisterSocket(socket);
-            this.factory.close(socket);
+            socket.close();
         }
     }
 
     @Override
     public void close(ServerSocket socket) throws IOException {
         if (socket != null) {
-            this.manager.getUnnamedRegistry().unregisterSocket(socket);
-            this.factory.close(socket);
+            socket.close();
         }
     }
 
     @Override
     public void close(DatagramSocket socket) {
         if (socket != null) {
-            this.manager.getUnnamedRegistry().unregisterSocket(socket);
-            this.factory.close(socket);
+            socket.close();
         }
     }
 
     @Override
     public Map<Object, String> getSockets() {
-        return this.factory.getSockets();
+        return null;
     }
 }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
@@ -99,7 +99,8 @@ public class ManagedSocketFactory implements SocketFactory {
 
     @Override
     public DatagramSocket createDatagramSocket(String name, SocketAddress address) throws SocketException {
-        return this.manager.createDatagramSocket(name, address);
+        // Creating the socket using the name throws an ISE, See WFCORE-1063
+        return this.manager.createDatagramSocket(address);
     }
 
     @Override

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
@@ -33,9 +33,11 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
 
+import org.jboss.as.network.ManagedServerSocketFactory;
+import org.jboss.as.network.ManagedSocketFactory;
 import org.jboss.as.network.SocketBindingManager;
 import org.jgroups.util.SocketFactory;
-import org.junit.Before;
+import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -43,44 +45,38 @@ import org.junit.Test;
  */
 public class ManagedSocketFactoryTest {
 
-    private SocketFactory factory = mock(SocketFactory.class);
     private SocketBindingManager manager = mock(SocketBindingManager.class);
-    private SocketBindingManager.UnnamedBindingRegistry registry = mock(SocketBindingManager.UnnamedBindingRegistry.class);
 
-    private ManagedSocketFactory subject = new ManagedSocketFactory(this.factory, this.manager);
+    private SocketFactory subject = new org.jboss.as.clustering.jgroups.ManagedSocketFactory(this.manager);
 
-    @Before
-    public void setUp() {
-        when(this.manager.getUnnamedRegistry()).thenReturn(registry);
+    @After
+    public void destroy() {
+        reset(this.manager);
     }
 
     @Test
     public void createSocket() throws IOException {
 
-        Socket socket1 = new Socket();
-        Socket socket2 = new Socket();
-        Socket socket3 = new Socket();
-        Socket socket4 = new Socket();
-        Socket socket5 = new Socket();
+        ManagedSocketFactory factory = mock(ManagedSocketFactory.class);
+        Socket socket1 = mock(Socket.class);
+        Socket socket2 = mock(Socket.class);
+        Socket socket3 = mock(Socket.class);
+        Socket socket4 = mock(Socket.class);
+        Socket socket5 = mock(Socket.class);
         InetAddress localhost = InetAddress.getLocalHost();
 
-        when(this.factory.createSocket("test")).thenReturn(socket1);
-        when(this.factory.createSocket("test", localhost, 1)).thenReturn(socket2);
-        when(this.factory.createSocket("test", "host", 1)).thenReturn(socket3);
-        when(this.factory.createSocket("test", localhost, 1, localhost, 2)).thenReturn(socket4);
-        when(this.factory.createSocket("test", "host", 1, localhost, 2)).thenReturn(socket5);
+        when(this.manager.getSocketFactory()).thenReturn(factory);
+        when(factory.createSocket("test")).thenReturn(socket1);
+        when(factory.createSocket("test", localhost, 1)).thenReturn(socket2);
+        when(factory.createSocket("test", "host", 1)).thenReturn(socket3);
+        when(factory.createSocket("test", localhost, 1, localhost, 2)).thenReturn(socket4);
+        when(factory.createSocket("test", "host", 1, localhost, 2)).thenReturn(socket5);
 
         Socket result1 = this.subject.createSocket("test");
         Socket result2 = this.subject.createSocket("test", localhost, 1);
         Socket result3 = this.subject.createSocket("test", "host", 1);
         Socket result4 = this.subject.createSocket("test", localhost, 1, localhost, 2);
         Socket result5 = this.subject.createSocket("test", "host", 1, localhost, 2);
-
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket1);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket2);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket3);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket4);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket5);
 
         assertSame(socket1, result1);
         assertSame(socket2, result2);
@@ -92,26 +88,23 @@ public class ManagedSocketFactoryTest {
     @Test
     public void createServerSocket() throws IOException {
 
-        ServerSocket socket1 = new ServerSocket();
-        ServerSocket socket2 = new ServerSocket();
-        ServerSocket socket3 = new ServerSocket();
-        ServerSocket socket4 = new ServerSocket();
+        ManagedServerSocketFactory factory = mock(ManagedServerSocketFactory.class);
+        ServerSocket socket1 = mock(ServerSocket.class);
+        ServerSocket socket2 = mock(ServerSocket.class);
+        ServerSocket socket3 = mock(ServerSocket.class);
+        ServerSocket socket4 = mock(ServerSocket.class);
         InetAddress localhost = InetAddress.getLocalHost();
 
-        when(this.factory.createServerSocket("test")).thenReturn(socket1);
-        when(this.factory.createServerSocket("test", 1)).thenReturn(socket2);
-        when(this.factory.createServerSocket("test", 1, 0)).thenReturn(socket3);
-        when(this.factory.createServerSocket("test", 1, 0, localhost)).thenReturn(socket4);
+        when(this.manager.getServerSocketFactory()).thenReturn(factory);
+        when(factory.createServerSocket("test")).thenReturn(socket1);
+        when(factory.createServerSocket("test", 1)).thenReturn(socket2);
+        when(factory.createServerSocket("test", 1, 0)).thenReturn(socket3);
+        when(factory.createServerSocket("test", 1, 0, localhost)).thenReturn(socket4);
 
         ServerSocket result1 = this.subject.createServerSocket("test");
         ServerSocket result2 = this.subject.createServerSocket("test", 1);
         ServerSocket result3 = this.subject.createServerSocket("test", 1, 0);
         ServerSocket result4 = this.subject.createServerSocket("test", 1, 0, localhost);
-
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket1);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket2);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket3);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket4);
 
         assertSame(socket1, result1);
         assertSame(socket2, result2);
@@ -122,27 +115,22 @@ public class ManagedSocketFactoryTest {
     @Test
     public void createDatagram() throws IOException {
 
-        DatagramSocket socket1 = new DatagramSocket();
-        DatagramSocket socket2 = new DatagramSocket();
-        DatagramSocket socket3 = new DatagramSocket();
-        DatagramSocket socket4 = new DatagramSocket();
+        DatagramSocket socket1 = mock(DatagramSocket.class);
+        DatagramSocket socket2 = mock(DatagramSocket.class);
+        DatagramSocket socket3 = mock(DatagramSocket.class);
+        DatagramSocket socket4 = mock(DatagramSocket.class);
         InetAddress localhost = InetAddress.getLocalHost();
-        SocketAddress socketAddress = new InetSocketAddress(localhost, 1);
+        SocketAddress socketAddress = new InetSocketAddress(localhost, 2);
 
-        when(this.factory.createDatagramSocket("test")).thenReturn(socket1);
-        when(this.factory.createDatagramSocket("test", 1)).thenReturn(socket2);
-        when(this.factory.createDatagramSocket("test", socketAddress)).thenReturn(socket3);
-        when(this.factory.createDatagramSocket("test", 1, localhost)).thenReturn(socket4);
+        when(this.manager.createDatagramSocket("test", new InetSocketAddress(0))).thenReturn(socket1);
+        when(this.manager.createDatagramSocket("test", new InetSocketAddress(1))).thenReturn(socket2);
+        when(this.manager.createDatagramSocket("test", socketAddress)).thenReturn(socket3);
+        when(this.manager.createDatagramSocket("test", new InetSocketAddress(localhost, 1))).thenReturn(socket4);
 
         DatagramSocket result1 = this.subject.createDatagramSocket("test");
         DatagramSocket result2 = this.subject.createDatagramSocket("test", 1);
         DatagramSocket result3 = this.subject.createDatagramSocket("test", socketAddress);
         DatagramSocket result4 = this.subject.createDatagramSocket("test", 1, localhost);
-
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket1);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket2);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket3);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket4);
 
         assertSame(socket1, result1);
         assertSame(socket2, result2);
@@ -153,22 +141,18 @@ public class ManagedSocketFactoryTest {
     @Test
     public void createMulticastSocket() throws IOException {
 
-        MulticastSocket socket1 = new MulticastSocket();
-        MulticastSocket socket2 = new MulticastSocket();
-        MulticastSocket socket3 = new MulticastSocket();
+        MulticastSocket socket1 = mock(MulticastSocket.class);
+        MulticastSocket socket2 = mock(MulticastSocket.class);
+        MulticastSocket socket3 = mock(MulticastSocket.class);
         SocketAddress address = new InetSocketAddress(InetAddress.getLocalHost(), 1);
 
-        when(this.factory.createMulticastSocket("test")).thenReturn(socket1);
-        when(this.factory.createMulticastSocket("test", 1)).thenReturn(socket2);
-        when(this.factory.createMulticastSocket("test", address)).thenReturn(socket3);
+        when(this.manager.createMulticastSocket("test", new InetSocketAddress(0))).thenReturn(socket1);
+        when(this.manager.createMulticastSocket("test", new InetSocketAddress(1))).thenReturn(socket2);
+        when(this.manager.createMulticastSocket("test", address)).thenReturn(socket3);
 
         MulticastSocket result1 = this.subject.createMulticastSocket("test");
         MulticastSocket result2 = this.subject.createMulticastSocket("test", 1);
         MulticastSocket result3 = this.subject.createMulticastSocket("test", address);
-
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket1);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket2);
-        verify(this.manager.getUnnamedRegistry()).registerSocket(socket3);
 
         assertSame(socket1, result1);
         assertSame(socket2, result2);
@@ -178,44 +162,40 @@ public class ManagedSocketFactoryTest {
     @Test
     public void closeSocket() throws IOException {
 
-        Socket socket = new Socket();
+        Socket socket = mock(Socket.class);
 
         this.subject.close(socket);
 
-        verify(this.factory).close(socket);
-        verify(this.manager.getUnnamedRegistry()).unregisterSocket(socket);
+        verify(socket).close();
     }
 
     @Test
     public void closeServerSocket() throws IOException {
 
-        ServerSocket socket = new ServerSocket();
+        ServerSocket socket = mock(ServerSocket.class);
 
         this.subject.close(socket);
 
-        verify(this.factory).close(socket);
-        verify(this.manager.getUnnamedRegistry()).unregisterSocket(socket);
+        verify(socket).close();
     }
 
     @Test
-    public void closeDatagramSocket() throws IOException {
+    public void closeDatagramSocket() {
 
-        DatagramSocket socket = new DatagramSocket();
+        DatagramSocket socket = mock(DatagramSocket.class);
 
         this.subject.close(socket);
 
-        verify(this.factory).close(socket);
-        verify(this.manager.getUnnamedRegistry()).unregisterSocket(socket);
+        verify(socket).close();
     }
 
     @Test
-    public void closeMulticastSocket() throws IOException {
+    public void closeMulticastSocket() {
 
-        MulticastSocket socket = new MulticastSocket();
+        MulticastSocket socket = mock(MulticastSocket.class);
 
         this.subject.close(socket);
 
-        verify(this.factory).close(socket);
-        verify(this.manager.getUnnamedRegistry()).unregisterSocket(socket);
+        verify(socket).close();
     }
 }

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
@@ -113,7 +113,7 @@ public class ManagedSocketFactoryTest {
     }
 
     @Test
-    public void createDatagram() throws IOException {
+    public void createDatagramSocket() throws IOException {
 
         DatagramSocket socket1 = mock(DatagramSocket.class);
         DatagramSocket socket2 = mock(DatagramSocket.class);
@@ -122,10 +122,10 @@ public class ManagedSocketFactoryTest {
         InetAddress localhost = InetAddress.getLocalHost();
         SocketAddress socketAddress = new InetSocketAddress(localhost, 2);
 
-        when(this.manager.createDatagramSocket("test", new InetSocketAddress(0))).thenReturn(socket1);
-        when(this.manager.createDatagramSocket("test", new InetSocketAddress(1))).thenReturn(socket2);
-        when(this.manager.createDatagramSocket("test", socketAddress)).thenReturn(socket3);
-        when(this.manager.createDatagramSocket("test", new InetSocketAddress(localhost, 1))).thenReturn(socket4);
+        when(this.manager.createDatagramSocket(new InetSocketAddress(0))).thenReturn(socket1);
+        when(this.manager.createDatagramSocket(new InetSocketAddress(1))).thenReturn(socket2);
+        when(this.manager.createDatagramSocket(socketAddress)).thenReturn(socket3);
+        when(this.manager.createDatagramSocket(new InetSocketAddress(localhost, 1))).thenReturn(socket4);
 
         DatagramSocket result1 = this.subject.createDatagramSocket("test");
         DatagramSocket result2 = this.subject.createDatagramSocket("test", 1);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5449

Requires workaround for https://issues.jboss.org/browse/WFCORE-1063.
