### PR TITLE
[WFLY-5548] Migrate backup-group-name attribute

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -40,6 +40,7 @@ import static org.jboss.as.messaging.CommonAttributes.ACCEPTOR;
 import static org.jboss.as.messaging.CommonAttributes.ADDRESS;
 import static org.jboss.as.messaging.CommonAttributes.ALLOW_FAILBACK;
 import static org.jboss.as.messaging.CommonAttributes.BACKUP;
+import static org.jboss.as.messaging.CommonAttributes.BACKUP_GROUP_NAME;
 import static org.jboss.as.messaging.CommonAttributes.BRIDGE;
 import static org.jboss.as.messaging.CommonAttributes.BROADCAST_GROUP;
 import static org.jboss.as.messaging.CommonAttributes.CHECK_FOR_LIVE_SERVER;
@@ -627,10 +628,11 @@ public class MigrateOperation implements OperationStepHandler {
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, ALLOW_FAILBACK, "allow-failback");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, FAILBACK_DELAY, "failback-delay");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, MAX_SAVED_REPLICATED_JOURNAL_SIZE, "max-saved-replicated-journal-size");
-
+                setAndDiscard(haPolicyAddOperation, serverAddOperation, BACKUP_GROUP_NAME, "group-name");
             } else {
                 haPolicyAddress = serverAddress.append(HA_POLICY, "replication-master");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, CHECK_FOR_LIVE_SERVER, "check-for-live-server");
+                setAndDiscard(haPolicyAddOperation, serverAddOperation, BACKUP_GROUP_NAME, "group-name");
             }
         }
         haPolicyAddOperation.get(OP_ADDR).set(haPolicyAddress.toModelNode());

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -116,12 +116,14 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         ModelNode haPolicyForReplicationMasterServer = model.get(SUBSYSTEM, MESSAGING_ACTIVEMQ_SUBSYSTEM_NAME, "server", "replication-master", "ha-policy", "replication-master");
         assertTrue(haPolicyForReplicationMasterServer.isDefined());
         assertEquals("${check.for.live.server:true}", haPolicyForReplicationMasterServer.get("check-for-live-server").asString());
+        assertEquals("${replication.master.group.name:mygroup}", haPolicyForReplicationMasterServer.get("group-name").asString());
 
         ModelNode haPolicyForReplicationSlaveServer = model.get(SUBSYSTEM, MESSAGING_ACTIVEMQ_SUBSYSTEM_NAME, "server", "replication-slave", "ha-policy", "replication-slave");
         assertTrue(haPolicyForReplicationSlaveServer.isDefined());
         assertEquals("${allow.failback.2:false}", haPolicyForReplicationSlaveServer.get("allow-failback").asString());
         assertEquals("${failback.delay.2:1234}", haPolicyForReplicationSlaveServer.get("failback-delay").asString());
         assertEquals("${max.saved.replicated.journal.size:2}", haPolicyForReplicationSlaveServer.get("max-saved-replicated-journal-size").asString());
+        assertEquals("${replication.master.group.name:mygroup2}", haPolicyForReplicationSlaveServer.get("group-name").asString());
     }
 
     @Test

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration_ha.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration_ha.xml
@@ -31,6 +31,7 @@
         <backup>false</backup>
         <check-for-live-server>${check.for.live.server:true}</check-for-live-server>
         <shared-store>false</shared-store>
+        <backup-group-name>${replication.master.group.name:mygroup}</backup-group-name>
     </hornetq-server>
 
     <hornetq-server name="replication-slave">
@@ -39,5 +40,6 @@
         <failback-delay>${failback.delay.2:1234}</failback-delay>
         <max-saved-replicated-journal-size>${max.saved.replicated.journal.size:2}</max-saved-replicated-journal-size>
         <shared-store>false</shared-store>
+        <backup-group-name>${replication.master.group.name:mygroup2}</backup-group-name>
     </hornetq-server>
 </subsystem>


### PR DESCRIPTION
If the legacy hornetq-server has defined a backup-group-name, migrate it
to the new ha-policy resource for replication-master and
replication-slave types.

JIRA: https://issues.jboss.org/browse/WFLY-5548
