### PR TITLE
[WFLY-5513] Fix messages that should have an id and be internationalized.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -836,6 +836,14 @@ public interface ConnectorLogger extends BasicLogger {
 
     @Message(id = 95, value = "At least one driver should be defined in a profile named 'default' activated on server where deploying *-ds.xml")
     IllegalStateException noDriverDefinedInDefaultProfile();
+
+    @LogMessage(level = ERROR)
+    @Message(id = 96, value = "Error during recovery shutdown")
+    void errorDuringRecoveryShutdown(@Cause Throwable cause);
+
+    @LogMessage(level = WARN)
+    @Message(id = 97, value = "Exception while stopping resource adapter")
+    void errorStoppingRA(@Cause Throwable cause);
 }
 
 

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/deployment/AbstractResourceAdapterDeploymentService.java
@@ -175,7 +175,7 @@ public abstract class AbstractResourceAdapterDeploymentService {
                             try {
                                 recovery.shutdown();
                             } catch (Exception e) {
-                                DEPLOYMENT_CONNECTOR_LOGGER.error("Error during recovery shutdown", e);
+                                DEPLOYMENT_CONNECTOR_LOGGER.errorDuringRecoveryShutdown(e);
                             } finally {
                                 rr.removeXAResourceRecovery(recovery);
                             }
@@ -196,7 +196,7 @@ public abstract class AbstractResourceAdapterDeploymentService {
                     WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(value.getDeployment().getResourceAdapter().getClass().getClassLoader());
                     value.getDeployment().getResourceAdapter().stop();
                 } catch (Throwable nfe) {
-                    DEPLOYMENT_CONNECTOR_LOGGER.warn("Exception during stopping resource adapter", nfe);
+                    DEPLOYMENT_CONNECTOR_LOGGER.errorStoppingRA(nfe);
                 } finally {
                     WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(old);
                 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceService.java
@@ -61,7 +61,7 @@ public class XaDataSourceService extends AbstractDataSourceService {
                     try {
                         recovery.shutdown();
                     } catch (Exception e) {
-                        ConnectorLogger.SUBSYSTEM_DATASOURCES_LOGGER.error("Error during recovery shutdown", e);
+                        ConnectorLogger.SUBSYSTEM_DATASOURCES_LOGGER.errorDuringRecoveryShutdown(e);
                     } finally {
                         rr.removeXAResourceRecovery(recovery);
                     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -114,6 +114,7 @@ import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
 import org.jboss.remoting3.Channel;
 import org.jboss.remoting3.MessageInputStream;
+import org.wildfly.clustering.group.Group;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 import static org.jboss.logging.Logger.Level.INFO;
@@ -3106,4 +3107,8 @@ public interface EjbLogger extends BasicLogger {
 
     @Message(id = 483, value = "Attributes are mutually exclusive: %s, %s")
     XMLStreamException mutuallyExclusiveAttributes(@Param Location location, String attribute1, String attribute2);
+
+    @LogMessage(level = WARN)
+    @Message(id = 484, value = "Could not send a cluster removal message for cluster: (%s) to the client on channel %s")
+    void couldNotSendClusterRemovalMessage(@Cause Throwable cause, Group group, Channel channel);
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -315,7 +315,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
                 this.sendClusterRemovedMessage(registry);
             }
         } catch (IOException ioe) {
-            EjbLogger.REMOTE_LOGGER.warn("Could not send a cluster removal message for cluster: " + registry.getGroup() + " to the client on channel " + channelAssociation.getChannel(), ioe);
+            EjbLogger.REMOTE_LOGGER.couldNotSendClusterRemovalMessage(ioe, registry.getGroup(), channelAssociation.getChannel());
         }
     }
 


### PR DESCRIPTION
The [JIRA](https://issues.jboss.org/browse/WFLY-5513) also had one [JPA message](https://github.com/jamezp/wildfly/blob/10.0.0.CR3/jpa/eclipselink/src/main/java/org/jipijapa/eclipselink/JBossLogger.java#L86) that may need to be converted, but would require some thoughts into how that logger works. I'm not sure it's needed for internationalization anyway.
