### PR TITLE
[WFLY-5552] - Upgrade PicketLink to 2.5.5.SP1.

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/picketlink/common/main/module.xml
@@ -35,6 +35,8 @@
     <dependencies>
         <module name="javax.api"/>
         <module name="javax.xml.stream.api"/>
+        <module name="javax.xml.bind.api" />
+        <module name="javax.xml.ws.api" />
         <module name="org.jboss.logging"/>
     </dependencies>
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/picketlink/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/picketlink/main/module.xml
@@ -33,6 +33,7 @@
 
     <dependencies>
         <module name="org.picketlink.federation" export="true" />
-        <module name="org.picketlink.federation.bindings" export="true" />
+        <module name="org.picketlink.federation.bindings" export="true" services="export" />
     </dependencies>
 </module>
+

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.opensaml.opensaml>3.1.1</version.org.opensaml.opensaml>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>
-        <version.org.picketlink>2.5.5.Final</version.org.picketlink>
+        <version.org.picketlink>2.5.5.SP1</version.org.picketlink>
         <version.org.scannotation>1.0.3</version.org.scannotation>
         <version.org.slf4j>1.7.7.jbossorg-1</version.org.slf4j>
         <version.org.syslog4j>0.9.30</version.org.syslog4j>

--- a/security/subsystem/src/main/resources/subsystem-templates/security.xml
+++ b/security/subsystem/src/main/resources/subsystem-templates/security.xml
@@ -45,7 +45,7 @@
            </security-domain>
            <security-domain name="sp" cache-type="default">
                <authentication>
-                   <login-module code="org.picketlink.identity.federation.bindings.wildfly.SAML2LoginModule" flag="required"/>
+                   <login-module code="org.picketlink.identity.federation.bindings.jboss.auth.SAML2LoginModule" flag="required"/>
                </authentication>
            </security-domain>
        </replacement>

--- a/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/federation/AbstractBasicFederationTestCase.java
+++ b/testsuite/integration/picketlink/src/test/java/org/wildfly/test/integration/security/picketlink/federation/AbstractBasicFederationTestCase.java
@@ -35,7 +35,7 @@ import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
 import org.jboss.logging.Logger;
 import org.junit.Test;
-import org.picketlink.identity.federation.bindings.wildfly.SAML2LoginModule;
+import org.picketlink.identity.federation.bindings.jboss.auth.SAML2LoginModule;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
### References
- https://issues.jboss.org/browse/WFLY-5552
### Overview

Updates PicketLink version to 2.5.5.SP1.

This PR also fixes #8288. Which should be closed before merging this PR.
