### PR TITLE
Update to xalan 2.7.1.jbossorg-2

### DIFF
--- a/feature-pack/javadoc/extractPublicApiArtifactsList.sh
+++ b/feature-pack/javadoc/extractPublicApiArtifactsList.sh
@@ -100,7 +100,7 @@ echo '</root>'
 ###  Not used;  this uses Xalan instead of xsltproc which might not be available.
 function doXSLT(){
   AS_DIR=`ls -1d build/target/jboss-as-*`
-  CP=$AS_DIR/modules/org/apache/xalan/main/xalan-2.7.1.jbossorg-1.jar
+  CP=$AS_DIR/modules/org/apache/xalan/main/xalan-2.7.1.jbossorg-2.jar
   echo java -cp $CP org.apache.xalan.xslt.Process -IN $1 -XSL $2 -OUT $3
   java -cp $CP org.apache.xalan.xslt.Process -IN $1 -XSL $2 -OUT $3
 }

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <version.org.apache.velocity>1.7</version.org.apache.velocity>
         <version.org.apache.ws.security>2.1.2</version.org.apache.ws.security>
         <version.org.apache.ws.xmlschema>2.2.1</version.org.apache.ws.xmlschema>
-        <version.org.apache.xalan>2.7.1.jbossorg-1</version.org.apache.xalan>
+        <version.org.apache.xalan>2.7.1.jbossorg-2</version.org.apache.xalan>
         <version.org.bouncycastle>1.52</version.org.bouncycastle>
         <version.org.codehaus.jackson>1.9.13</version.org.codehaus.jackson>
         <version.org.codehaus.jettison>1.3.3</version.org.codehaus.jettison>


### PR DESCRIPTION
xalan:xalan 2.7.1.jbossorg-1 has a broken pom that refers to a non-existent
version of xalan:serializer. xalan:xalan 2.7.1.jbossorg-2 was released
to address that, and should be identical to jbossorg-1 other than that
change (see https://issues.jboss.org/browse/JBBUILD-708).

Updating to jbossorg-2 makes it easier for consumers of the xalan
module.xml to resolve the artifacts it refers to (wildfly-swarm is one
such consumer).
