### PR TITLE
WFLY-5220 When -Dtest= is used just run the standalone-full.xml profile

### DIFF
--- a/testsuite/integration/basic/pom.xml
+++ b/testsuite/integration/basic/pom.xml
@@ -378,32 +378,35 @@
                 </property>
             </activation>
             <build>
-                <pluginManagement>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>basic-integration-default-full.surefire</id>
-                                <phase>test</phase>
-                            </execution>
-                            <execution>
-                                <id>basic-integration-default-web.surefire</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>basic-integration-2nd.surefire</id>
-                                <phase>none</phase>
-                            </execution>
-                            <execution>
-                                <id>basic-integration-ldap.surefire</id>
-                                <phase>none</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-                </pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>basic-integration-default-full.surefire</id>
+                                    <phase>test</phase>
+                                    <configuration>
+                                        <includes>
+                                            <include>**</include>
+                                        </includes>
+                                    </configuration>
+                                </execution>
+                                <execution>
+                                    <id>basic-integration-default-web.surefire</id>
+                                    <phase>none</phase>
+                                </execution>
+                                <execution>
+                                    <id>basic-integration-2nd.surefire</id>
+                                    <phase>none</phase>
+                                </execution>
+                                <execution>
+                                    <id>basic-integration-ldap.surefire</id>
+                                    <phase>none</phase>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
             </build>
         </profile>
 


### PR DESCRIPTION
IMHO we should try and get rid of the whole multiple executions per module concept. It provides no advantages and has caused nothing but trouble.
