### PR TITLE
Fix location of JASPIC secureResponse call

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentInfoService.java
@@ -150,7 +150,8 @@ import org.wildfly.extension.undertow.security.SecurityContextAssociationHandler
 import org.wildfly.extension.undertow.security.SecurityContextThreadSetupAction;
 import org.wildfly.extension.undertow.security.jacc.JACCAuthorizationManager;
 import org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler;
-import org.wildfly.extension.undertow.security.jaspi.JASPIAuthenticationMechanism;
+import org.wildfly.extension.undertow.security.jaspi.JASPICAuthenticationMechanism;
+import org.wildfly.extension.undertow.security.jaspi.JASPICSecureResponseHandler;
 import org.wildfly.extension.undertow.security.jaspi.JASPICSecurityContextFactory;
 import org.wildfly.extension.undertow.session.CodecSessionConfigWrapper;
 import org.wildfly.extension.undertow.session.SharedSessionManagerConfig;
@@ -452,7 +453,7 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
     }
 
     /**
-     * <p>Adds to the deployment the {@link JASPIAuthenticationMechanism}, if necessary. The handler will be added if the security domain
+     * <p>Adds to the deployment the {@link org.wildfly.extension.undertow.security.jaspi.JASPICAuthenticationMechanism}, if necessary. The handler will be added if the security domain
      * is configured with JASPI authentication.</p>
      *
      * @param deploymentInfo
@@ -469,8 +470,9 @@ public class UndertowDeploymentInfoService implements Service<DeploymentInfo> {
             if (loginConfig != null && loginConfig.getAuthMethods().size() > 0) {
                 authMethod = loginConfig.getAuthMethods().get(0).getName();
             }
-            deploymentInfo.setJaspiAuthenticationMechanism(new JASPIAuthenticationMechanism(securityDomain, authMethod));
+            deploymentInfo.setJaspiAuthenticationMechanism(new JASPICAuthenticationMechanism(securityDomain, authMethod));
             deploymentInfo.setSecurityContextFactory(new JASPICSecurityContextFactory(this.securityDomain));
+            deploymentInfo.addOuterHandlerChainWrapper(next -> new JASPICSecureResponseHandler(next));
         }
     }
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -331,4 +331,8 @@ public interface UndertowLogger extends BasicLogger {
     @LogMessage(level = ERROR)
     @Message(id = 78, value = "Failed to register management view for websocket %s at %s")
     void failedToRegisterWebsocket(Class endpoint, String path, @Cause Exception e);
+
+    @LogMessage(level = ERROR)
+    @Message(id = 77, value = "Error invoking secure response")
+    void errorInvokingSecureResponse(@Cause Exception e);
 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICContext.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICContext.java
@@ -1,0 +1,37 @@
+package org.wildfly.extension.undertow.security.jaspi;
+
+import io.undertow.util.AttachmentKey;
+import org.jboss.security.auth.callback.JASPICallbackHandler;
+import org.jboss.security.plugins.auth.JASPIServerAuthenticationManager;
+
+import javax.security.auth.message.MessageInfo;
+
+/**
+ * @author Stuart Douglas
+ */
+public class JASPICContext {
+
+    public static final AttachmentKey<JASPICContext> ATTACHMENT_KEY = AttachmentKey.create(JASPICContext.class);
+
+    private final MessageInfo messageInfo;
+    private final JASPIServerAuthenticationManager sam;
+    private final JASPICallbackHandler cbh;
+
+    public JASPICContext(MessageInfo messageInfo, JASPIServerAuthenticationManager sam, JASPICallbackHandler cbh) {
+        this.messageInfo = messageInfo;
+        this.sam = sam;
+        this.cbh = cbh;
+    }
+
+    public MessageInfo getMessageInfo() {
+        return messageInfo;
+    }
+
+    public JASPIServerAuthenticationManager getSam() {
+        return sam;
+    }
+
+    public JASPICallbackHandler getCbh() {
+        return cbh;
+    }
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICSecureResponseHandler.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/JASPICSecureResponseHandler.java
@@ -1,0 +1,48 @@
+package org.wildfly.extension.undertow.security.jaspi;
+
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.servlet.handlers.ServletRequestContext;
+import org.wildfly.extension.undertow.logging.UndertowLogger;
+
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Stuart Douglas
+ */
+public class JASPICSecureResponseHandler implements HttpHandler {
+
+    private final HttpHandler next;
+
+    public JASPICSecureResponseHandler(HttpHandler next) {
+        this.next = next;
+    }
+
+    @Override
+    public void handleRequest(HttpServerExchange exchange) throws Exception {
+        try {
+            next.handleRequest(exchange);
+        } finally {
+            try {
+                JASPICContext context = exchange.getAttachment(JASPICContext.ATTACHMENT_KEY);
+                ServletRequestContext requestContext = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
+                String applicationIdentifier = JASPICAuthenticationMechanism.buildApplicationIdentifier(requestContext);
+
+                if (!JASPICAuthenticationMechanism.wasAuthExceptionThrown(exchange)) {
+                    UndertowLogger.ROOT_LOGGER.debugf("secureResponse for layer [%s] and applicationContextIdentifier [%s].", JASPICAuthenticationMechanism.JASPI_HTTP_SERVLET_LAYER, applicationIdentifier);
+                    context.getSam().secureResponse(context.getMessageInfo(), new Subject(), JASPICAuthenticationMechanism.JASPI_HTTP_SERVLET_LAYER, applicationIdentifier, context.getCbh());
+
+                    // A SAM can unwrap the HTTP request/response objects - update the servlet request context with the values found in the message info.
+                    ServletRequestContext servletRequestContext = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
+                    servletRequestContext.setServletRequest((HttpServletRequest) context.getMessageInfo().getRequestMessage());
+                    servletRequestContext.setServletResponse((HttpServletResponse) context.getMessageInfo().getResponseMessage());
+                }
+            } catch (Exception e) {
+                UndertowLogger.ROOT_LOGGER.errorInvokingSecureResponse(e);
+            }
+        }
+    }
+
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/modules/HTTPSchemeServerAuthModule.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/security/jaspi/modules/HTTPSchemeServerAuthModule.java
@@ -27,7 +27,7 @@ import io.undertow.security.api.SecurityContext;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.servlet.handlers.ServletRequestContext;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
-import org.wildfly.extension.undertow.security.jaspi.JASPIAuthenticationMechanism;
+import org.wildfly.extension.undertow.security.jaspi.JASPICAuthenticationMechanism;
 
 import javax.security.auth.Subject;
 import javax.security.auth.callback.CallbackHandler;
@@ -77,8 +77,8 @@ public class HTTPSchemeServerAuthModule implements ServerAuthModule {
     @Override
     public AuthStatus validateRequest(MessageInfo messageInfo, Subject clientSubject, Subject serviceSubject)
             throws AuthException {
-        HttpServerExchange exchange = (HttpServerExchange) messageInfo.getMap().get(JASPIAuthenticationMechanism.HTTP_SERVER_EXCHANGE_ATTACHMENT_KEY);
-        SecurityContext securityContext = (SecurityContext) messageInfo.getMap().get(JASPIAuthenticationMechanism.SECURITY_CONTEXT_ATTACHMENT_KEY);
+        HttpServerExchange exchange = (HttpServerExchange) messageInfo.getMap().get(JASPICAuthenticationMechanism.HTTP_SERVER_EXCHANGE_ATTACHMENT_KEY);
+        SecurityContext securityContext = (SecurityContext) messageInfo.getMap().get(JASPICAuthenticationMechanism.SECURITY_CONTEXT_ATTACHMENT_KEY);
         ServletRequestContext src = exchange.getAttachment(ServletRequestContext.ATTACHMENT_KEY);
         List<AuthenticationMechanism> mechanisms = src.getDeployment().getAuthenticationMechanisms();
 


### PR DESCRIPTION
I have tested this against both the EE7 samples and the JASPIC TCK
