### PR TITLE
upgrade surefire to 2.18

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
 
-        <version.surefire.plugin>2.17</version.surefire.plugin>
+        <version.surefire.plugin>2.18</version.surefire.plugin>
         <!--
             Dependency versions. Please keep alphabetical.
 


### PR DESCRIPTION
to avoid https://issues.apache.org/jira/browse/SUREFIRE-1091, which has intermittently been preventing SonarQube analysis on Nemo (http://nemo.sonarqube.org/dashboard/index?id=org.wildfly.core%3Awildfly-core-parent)
