### PR TITLE
[WFLY-5584] Remove the profile concept from installed sources that wa…

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/datasource/DataSourceDefinitionInjectionSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/datasource/DataSourceDefinitionInjectionSource.java
@@ -156,7 +156,7 @@ public class DataSourceDefinitionInjectionSource extends ResourceDefinitionInjec
                         null, null, null, poolName, true,
                         jndiName, false, false, Defaults.CONNECTABLE, Defaults.TRACKING, Defaults.MCP, Defaults.ENLISTMENT_TRACE, properties,
                         className, null, null,
-                        xaPool, null, null);
+                        xaPool, null);
                 final XaDataSourceService xds = new XaDataSourceService(bindInfo.getBinderServiceName().getCanonicalName(), bindInfo, module.getClassLoader());
                 xds.getDataSourceConfigInjector().inject(dataSource);
                 startDataSource(xds, bindInfo, eeModuleDescription, context, phaseContext.getServiceTarget(), serviceBuilder, injector, securityEnabled);
@@ -167,7 +167,7 @@ public class DataSourceDefinitionInjectionSource extends ResourceDefinitionInjec
                                                              Defaults.PREFILL, Defaults.USE_STRICT_MIN, Defaults.FLUSH_STRATEGY, Boolean.FALSE, null, null);
                 final ModifiableDataSource dataSource = new ModifiableDataSource(url, null, className, null, transactionIsolation(), properties,
                         null, dsSecurity, null, null, null, null, null, false, poolName, true, jndiName, Defaults.SPY, Defaults.USE_CCM,
-                        transactional, Defaults.CONNECTABLE, Defaults.TRACKING, Defaults.MCP, Defaults.ENLISTMENT_TRACE, commonPool, null);
+                        transactional, Defaults.CONNECTABLE, Defaults.TRACKING, Defaults.MCP, Defaults.ENLISTMENT_TRACE, commonPool);
                 final LocalDataSourceService ds = new LocalDataSourceService(bindInfo.getBinderServiceName().getCanonicalName(), bindInfo, module.getClassLoader());
                 ds.getDataSourceConfigInjector().inject(dataSource);
                 startDataSource(ds, bindInfo, eeModuleDescription, context, phaseContext.getServiceTarget(), serviceBuilder, injector, securityEnabled);

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DriverProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DriverProcessor.java
@@ -52,8 +52,6 @@ public final class DriverProcessor implements DeploymentUnitProcessor {
     /** {@inheritDoc} */
     @Override
     public void deploy(final DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
-        //TODO check profile
-
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final Module module = deploymentUnit.getAttachment(Attachments.MODULE);
         final ServicesAttachment servicesAttachment = deploymentUnit.getAttachment(Attachments.SERVICES);

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ds/processors/DsXmlDeploymentInstallProcessor.java
@@ -117,7 +117,6 @@ public class DsXmlDeploymentInstallProcessor implements DeploymentUnitProcessor 
      */
     @Override
     public void deploy(DeploymentPhaseContext phaseContext) throws DeploymentUnitProcessingException {
-        //TODO check profile
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
 
         final List<DataSources> dataSourcesList = deploymentUnit.getAttachmentList(DsXmlDeploymentParsingProcessor.DATA_SOURCES_ATTACHMENT_KEY);
@@ -241,7 +240,7 @@ public class DsXmlDeploymentInstallProcessor implements DeploymentUnitProcessor 
                 ds.getSecurity(), ds.getStatement(), ds.getValidation(),
                 ds.getUrlDelimiter(), ds.getUrlSelectorStrategyClassName(), ds.getNewConnectionSql(),
                 ds.isUseJavaContext(), ds.getPoolName(), ds.isEnabled(), ds.getJndiName(),
-                ds.isSpy(), ds.isUseCcm(), ds.isJTA(), ds.isConnectable(), ds.isTracking(), ds.getMcp(), ds.isEnlistmentTrace(), ds.getPool(), null);
+                ds.isSpy(), ds.isUseCcm(), ds.isJTA(), ds.isConnectable(), ds.isTracking(), ds.getMcp(), ds.isEnlistmentTrace(), ds.getPool());
     }
 
     private ModifiableXaDataSource buildXaDataSource(XaDataSource xads) throws org.jboss.jca.common.api.validator.ValidateException {
@@ -267,7 +266,7 @@ public class DsXmlDeploymentInstallProcessor implements DeploymentUnitProcessor 
                 xads.isSpy(), xads.isUseCcm(), xads.isConnectable(), xads.isTracking(),
                 xads.getMcp(), xads.isEnlistmentTrace(),
                 xads.getXaDataSourceProperty(), xads.getXaDataSourceClass(), xads.getDriver(),
-                xads.getNewConnectionSql(), xaPool, xads.getRecovery(), null);
+                xads.getNewConnectionSql(), xaPool, xads.getRecovery());
     }
 
     private <T> T getDef(T value, T def) {

--- a/connector/src/main/java/org/jboss/as/connector/services/driver/InstalledDriver.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/driver/InstalledDriver.java
@@ -39,7 +39,6 @@ public final class InstalledDriver {
     private final int majorVersion;
     private final int minorVersion;
     private final boolean jdbcCompliant;
-    private final String profile;
 
     /**
      * Creates a new InstalledDriver for a driver that was loaded from the
@@ -58,7 +57,7 @@ public final class InstalledDriver {
      */
     public InstalledDriver(final String driverName, final ModuleIdentifier moduleName, final String driverClassName,
                            final String dataSourceClassName, final String xaDataSourceClassName,
-                           final int majorVersion, final int minorVersion, final boolean jdbcCompliant, final String profile) {
+                           final int majorVersion, final int minorVersion, final boolean jdbcCompliant) {
         this.deploymentUnitName = null;
         this.moduleName = moduleName;
         this.driverName = driverName;
@@ -68,7 +67,6 @@ public final class InstalledDriver {
         this.majorVersion = majorVersion;
         this.minorVersion = minorVersion;
         this.jdbcCompliant = jdbcCompliant;
-        this.profile = profile;
     }
 
     /**
@@ -98,7 +96,6 @@ public final class InstalledDriver {
         this.majorVersion = majorVersion;
         this.minorVersion = minorVersion;
         this.jdbcCompliant = jdbcCompliant;
-        this.profile = null;
 
     }
 
@@ -185,8 +182,6 @@ public final class InstalledDriver {
         if (moduleName != null ? !moduleName.equals(that.moduleName) : that.moduleName != null) return false;
         if (xaDataSourceClassName != null ? !xaDataSourceClassName.equals(that.xaDataSourceClassName) : that.xaDataSourceClassName != null)
             return false;
-        if (profile != null ? !profile.equals(that.profile) : that.profile != null)
-            return false;
 
         return true;
     }
@@ -202,16 +197,12 @@ public final class InstalledDriver {
         result = 31 * result + majorVersion;
         result = 31 * result + minorVersion;
         result = 31 * result + (jdbcCompliant ? 1 : 0);
-        result = 31 * result + (profile != null ? profile.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        if (profile != null) {
-            sb.append(profile).append(":");
-        }
         if (moduleName != null) {
             sb.append(moduleName);
         } else {
@@ -238,9 +229,5 @@ public final class InstalledDriver {
 
     public String getXaDataSourceClassName() {
         return xaDataSourceClassName;
-    }
-
-    public String getProfile() {
-        return profile;
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/services/driver/registry/DriverRegistry.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/driver/registry/DriverRegistry.java
@@ -47,7 +47,7 @@ public interface DriverRegistry {
      * Get the installed drivers
      * @return The set of drivers
      */
-    Set<InstalledDriver> getInstalledDrivers(String profileName);
+    Set<InstalledDriver> getInstalledDrivers();
 
-    InstalledDriver getInstalledDriver(String name, String profileName);
+    InstalledDriver getInstalledDriver(String name);
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -308,21 +308,18 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
 
         private final org.jboss.jca.common.api.metadata.ds.DataSource dataSourceConfig;
         private final XaDataSource xaDataSourceConfig;
-        private final String profile;
 
-        public AS7DataSourceDeployer(XaDataSource xaDataSourceConfig, final String profile) {
+        public AS7DataSourceDeployer(XaDataSource xaDataSourceConfig) {
             super();
             this.xaDataSourceConfig = xaDataSourceConfig;
             this.dataSourceConfig = null;
-            this.profile = profile;
 
         }
 
-        public AS7DataSourceDeployer(org.jboss.jca.common.api.metadata.ds.DataSource dataSourceConfig, final String profile) {
+        public AS7DataSourceDeployer(org.jboss.jca.common.api.metadata.ds.DataSource dataSourceConfig) {
             super();
             this.dataSourceConfig = dataSourceConfig;
             this.xaDataSourceConfig = null;
-            this.profile = profile;
 
         }
 
@@ -338,7 +335,7 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
                 DataSources dataSources = null;
                 if (dataSourceConfig != null) {
                     String driverName = dataSourceConfig.getDriver();
-                    InstalledDriver installedDriver = driverRegistry.getValue().getInstalledDriver(driverName, profile);
+                    InstalledDriver installedDriver = driverRegistry.getValue().getInstalledDriver(driverName);
                     if (installedDriver != null) {
                         String moduleName = installedDriver.getModuleName() != null ? installedDriver.getModuleName().getName()
                                 : null;
@@ -351,7 +348,7 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
                     dataSources = new DatasourcesImpl(Arrays.asList(dataSourceConfig), null, drivers);
                 } else if (xaDataSourceConfig != null) {
                     String driverName = xaDataSourceConfig.getDriver();
-                    InstalledDriver installedDriver = driverRegistry.getValue().getInstalledDriver(driverName, profile);
+                    InstalledDriver installedDriver = driverRegistry.getValue().getInstalledDriver(driverName);
                     if (installedDriver != null) {
                         String moduleName = installedDriver.getModuleName() != null ? installedDriver.getModuleName().getName()
                                 : null;

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/Constants.java
@@ -235,9 +235,11 @@ public class Constants {
             .setAllowNull(true)
             .build();
 
+    @Deprecated
     static final SimpleAttributeDefinition PROFILE = SimpleAttributeDefinitionBuilder.create("profile", ModelType.STRING)
                 .setAllowNull(true)
-                .build();
+                .setDeprecated(ModelVersion.create(4, 0, 0))
+            .build();
 
     public static final String STATISTICS = "statistics";
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/DataSourceModelNodeUtil.java
@@ -101,8 +101,6 @@ import java.util.Map;
 import org.jboss.as.connector.util.ModelNodeUtil;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.common.api.metadata.common.Capacity;
@@ -135,9 +133,6 @@ class DataSourceModelNodeUtil {
 
     static ModifiableDataSource from(final OperationContext operationContext, final ModelNode dataSourceNode, final String dsName) throws OperationFailedException, ValidateException {
         final Map<String, String> connectionProperties= Collections.emptyMap();
-        Resource rootNode = operationContext.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
-        ModelNode rootModel = rootNode.getModel();
-        String profile = rootModel.hasDefined("profile-name") ? rootModel.get("profile-name").asString() : null;
 
         final String connectionUrl = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, CONNECTION_URL);
         final String driverClass = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, DRIVER_CLASS);
@@ -225,15 +220,12 @@ class DataSourceModelNodeUtil {
 
         return new ModifiableDataSource(connectionUrl, driverClass, dataSourceClass, driver, transactionIsolation, connectionProperties, timeOut,
                 security, statement, validation, urlDelimiter, urlSelectorStrategyClassName, newConnectionSql, useJavaContext,
-                poolName, enabled, jndiName, spy, useCcm, jta, connectable, tracking, mcp, enlistmentTrace,  pool, profile);
+                poolName, enabled, jndiName, spy, useCcm, jta, connectable, tracking, mcp, enlistmentTrace,  pool);
     }
 
     static ModifiableXaDataSource xaFrom(final OperationContext operationContext, final ModelNode dataSourceNode, final String dsName) throws OperationFailedException, ValidateException {
         final Map<String, String> xaDataSourceProperty;
         xaDataSourceProperty = Collections.emptyMap();
-        Resource rootNode = operationContext.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
-        ModelNode rootModel = rootNode.getModel();
-        String profile = rootModel.hasDefined("profile-name") ? rootModel.get("profile-name").asString() : null;
 
         final String xaDataSourceClass = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, XA_DATASOURCE_CLASS);
         final String jndiName = ModelNodeUtil.getResolvedStringIfSetOrGetDefault(operationContext, dataSourceNode, JNDI_NAME);
@@ -343,7 +335,7 @@ class DataSourceModelNodeUtil {
         return new ModifiableXaDataSource(transactionIsolation, timeOut, security, statement, validation, urlDelimiter, urlProperty,
                 urlSelectorStrategyClassName, useJavaContext, poolName, enabled, jndiName, spy, useCcm,
                 connectable, tracking, mcp, enlistmentTrace, xaDataSourceProperty,
-                xaDataSourceClass, module, newConnectionSql, xaPool, recovery, profile);
+                xaDataSourceClass, module, newConnectionSql, xaPool, recovery);
     }
 
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/GetInstalledDriverOperationHandler.java
@@ -41,10 +41,8 @@ import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.validation.ParametersValidator;
 import org.jboss.as.controller.operations.validation.StringLengthValidator;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceController;
 
@@ -73,15 +71,12 @@ public class GetInstalledDriverOperationHandler implements OperationStepHandler 
 
                 @Override
                 public void execute(final OperationContext context, final ModelNode operation) throws OperationFailedException {
-                    Resource rootNode = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
-                    ModelNode rootModel = rootNode.getModel();
-                    String profile = rootModel.hasDefined("profile-name") ? rootModel.get("profile-name").asString() : null;
 
                     ServiceController<?> sc = context.getServiceRegistry(false).getRequiredService(
                             ConnectorServices.JDBC_DRIVER_REGISTRY_SERVICE);
                     DriverRegistry driverRegistry = DriverRegistry.class.cast(sc.getValue());
                     ModelNode result = new ModelNode();
-                    InstalledDriver driver = driverRegistry.getInstalledDriver(name, profile);
+                    InstalledDriver driver = driverRegistry.getInstalledDriver(name);
                     ModelNode driverNode = new ModelNode();
                     driverNode.get(DRIVER_NAME.getName()).set(driver.getDriverName());
                     if (driver.isFromDeployment()) {
@@ -103,11 +98,8 @@ public class GetInstalledDriverOperationHandler implements OperationStepHandler 
                     result.add(driverNode);
 
                     context.getResult().set(result);
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
         }
-
-        context.stepCompleted();
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/InstalledDriversListOperationHandler.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/InstalledDriversListOperationHandler.java
@@ -72,7 +72,7 @@ public class InstalledDriversListOperationHandler implements OperationStepHandle
                     String profile = rootModel.hasDefined("profile-name") ? rootModel.get("profile-name").asString() : null;
 
                     ModelNode result = context.getResult();
-                    for (InstalledDriver driver : driverRegistry.getInstalledDrivers(profile)) {
+                    for (InstalledDriver driver : driverRegistry.getInstalledDrivers()) {
                         ModelNode driverNode = new ModelNode();
                         driverNode.get(DRIVER_NAME.getName()).set(driver.getDriverName());
                         if (driver.isFromDeployment()) {
@@ -97,18 +97,15 @@ public class InstalledDriversListOperationHandler implements OperationStepHandle
                         driverNode.get(DRIVER_MAJOR_VERSION.getName()).set(driver.getMajorVersion());
                         driverNode.get(DRIVER_MINOR_VERSION.getName()).set(driver.getMinorVersion());
                         driverNode.get(JDBC_COMPLIANT.getName()).set(driver.isJdbcCompliant());
-                        if (driver.getProfile() != null) {
-                            driverNode.get(PROFILE.getName()).set(driver.getProfile());
+                        if (profile != null) {
+                            driverNode.get(PROFILE.getName()).set(profile);
                         }
                         result.add(driverNode);
                     }
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
         } else {
             context.getResult().set(ConnectorLogger.ROOT_LOGGER.noMetricsAvailable());
         }
-
-        context.stepCompleted();
     }
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverAdd.java
@@ -47,7 +47,6 @@ import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -88,10 +87,6 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
         final String dataSourceClassName = model.hasDefined(DRIVER_DATASOURCE_CLASS_NAME.getName()) ? DRIVER_DATASOURCE_CLASS_NAME.resolveModelAttribute(context, model).asString() : null;
         final String xaDataSourceClassName = model.hasDefined(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()) ? DRIVER_XA_DATASOURCE_CLASS_NAME.resolveModelAttribute(context, model).asString() : null;
 
-        Resource rootNode = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
-        ModelNode rootModel = rootNode.getModel();
-        String profile = rootModel.hasDefined("profile-name") ? rootModel.get("profile-name").asString() : null;
-
         final ServiceTarget target = context.getServiceTarget();
 
         final ModuleIdentifier moduleId;
@@ -110,7 +105,7 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
             boolean driverLoaded = false;
             if (serviceLoader != null) {
                 for (Driver driver : serviceLoader) {
-                    startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName, profile);
+                    startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName);
                     driverLoaded = true;
                     //just consider first definition and create service for this. User can use different implementation only
                     // w/ explicit declaration of driver-class attribute
@@ -125,7 +120,7 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
                         .asSubclass(Driver.class);
                 final Constructor<? extends Driver> constructor = driverClass.getConstructor();
                 final Driver driver = constructor.newInstance();
-                startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName, profile);
+                startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName);
             } catch (Exception e) {
                 SUBSYSTEM_DATASOURCES_LOGGER.cannotInstantiateDriverClass(driverClassName, e);
                 throw new OperationFailedException(ConnectorLogger.ROOT_LOGGER.cannotInstantiateDriverClass(driverClassName));
@@ -134,8 +129,7 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
     }
 
     public static void startDriverServices(final ServiceTarget target, final ModuleIdentifier moduleId, Driver driver, final String driverName, final Integer majorVersion,
-                                           final Integer minorVersion, final String dataSourceClassName, final String xaDataSourceClassName,
-                                           final String profile) throws IllegalStateException {
+                                           final Integer minorVersion, final String dataSourceClassName, final String xaDataSourceClassName) throws IllegalStateException {
         final int majorVer = driver.getMajorVersion();
         final int minorVer = driver.getMinorVersion();
         if ((majorVersion != null && majorVersion != majorVer)
@@ -150,7 +144,7 @@ public class JdbcDriverAdd extends AbstractAddStepHandler {
             SUBSYSTEM_DATASOURCES_LOGGER.deployingNonCompliantJdbcDriver(driver.getClass(), majorVer, minorVer);
         }
         InstalledDriver driverMetadata = new InstalledDriver(driverName, moduleId, driver.getClass().getName(),
-                dataSourceClassName, xaDataSourceClassName, majorVer, minorVer, compliant, profile);
+                dataSourceClassName, xaDataSourceClassName, majorVer, minorVer, compliant);
         DriverService driverService = new DriverService(driverMetadata, driver);
         final ServiceBuilder<Driver> builder = target.addService(ServiceName.JBOSS.append("jdbc-driver", driverName.replaceAll("\\.", "_")), driverService)
                 .addDependency(ConnectorServices.JDBC_DRIVER_REGISTRY_SERVICE, DriverRegistry.class,

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverRemove.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/JdbcDriverRemove.java
@@ -40,8 +40,6 @@ import org.jboss.as.connector.logging.ConnectorLogger;
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 import org.jboss.modules.Module;
 import org.jboss.modules.ModuleIdentifier;
@@ -79,10 +77,6 @@ public class JdbcDriverRemove extends AbstractRemoveStepHandler {
         final String xaDataSourceClassName = model.hasDefined(DRIVER_XA_DATASOURCE_CLASS_NAME.getName()) ? model.get(
                 DRIVER_XA_DATASOURCE_CLASS_NAME.getName()).asString() : null;
 
-        Resource rootNode = context.readResourceFromRoot(PathAddress.EMPTY_ADDRESS, false);
-        ModelNode rootModel = rootNode.getModel();
-        String profile = rootModel.hasDefined("profile-name") ? rootModel.get("profile-name").asString() : null;
-
         final ServiceTarget target = context.getServiceTarget();
 
         final ModuleIdentifier moduleId;
@@ -99,7 +93,7 @@ public class JdbcDriverRemove extends AbstractRemoveStepHandler {
             final ServiceLoader<Driver> serviceLoader = module.loadService(Driver.class);
             if (serviceLoader != null)
                 for (Driver driver : serviceLoader) {
-                    startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName, profile);
+                    startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName);
                 }
         } else {
             try {
@@ -107,7 +101,7 @@ public class JdbcDriverRemove extends AbstractRemoveStepHandler {
                         .asSubclass(Driver.class);
                 final Constructor<? extends Driver> constructor = driverClass.getConstructor();
                 final Driver driver = constructor.newInstance();
-                startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName, profile);
+                startDriverServices(target, moduleId, driver, driverName, majorVersion, minorVersion, dataSourceClassName, xaDataSourceClassName);
             } catch (Exception e) {
                 SUBSYSTEM_DATASOURCES_LOGGER.cannotInstantiateDriverClass(driverClassName, e);
 

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/LocalDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/LocalDataSourceService.java
@@ -46,7 +46,7 @@ public class LocalDataSourceService extends AbstractDataSourceService {
 
     @Override
     public AS7DataSourceDeployer getDeployer() throws ValidateException {
-        return new AS7DataSourceDeployer(dataSourceConfig.getValue().getUnModifiableInstance(), dataSourceConfig.getValue().getProfile());
+        return new AS7DataSourceDeployer(dataSourceConfig.getValue().getUnModifiableInstance());
     }
 
     public Injector<ModifiableDataSource> getDataSourceConfigInjector() {

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableDataSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableDataSource.java
@@ -68,8 +68,6 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
 
     private final DsPool pool;
 
-    private final String profile;
-
 
     /**
      * Create a new DataSourceImpl.
@@ -97,7 +95,6 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
      * @param mcp mcp
      * @param enlistmentTrace enlistmentTrace
      * @param pool                         pool
-     * @param profile                      profile
      * @throws org.jboss.jca.common.api.validator.ValidateException
      *          ValidateException
      */
@@ -107,7 +104,7 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
                                 String urlDelimiter, String urlSelectorStrategyClassName, String newConnectionSql,
                                 Boolean useJavaContext, String poolName, Boolean enabled, String jndiName,
                                 Boolean spy, Boolean useccm, Boolean jta, final Boolean connectable, final Boolean tracking, String mcp,
-                                Boolean enlistmentTrace, DsPool pool, final String profile)
+                                Boolean enlistmentTrace, DsPool pool)
             throws ValidateException {
         super(transactionIsolation, timeOut, security, statement, validation, urlDelimiter,
                 urlSelectorStrategyClassName, useJavaContext, poolName, enabled, jndiName, spy, useccm, driver,
@@ -123,7 +120,6 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
             this.connectionProperties = new HashMap<String, String>(0);
         }
         this.pool = pool;
-        this.profile = profile;
         this.validate();
     }
 
@@ -247,10 +243,6 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
         return pool;
     }
 
-    public final String getProfile() {
-        return profile;
-    }
-
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -262,7 +254,6 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
         result = prime * result + ((dataSourceClass == null) ? 0 : dataSourceClass.hashCode());
         result = prime * result + ((newConnectionSql == null) ? 0 : newConnectionSql.hashCode());
         result = prime * result + ((pool == null) ? 0 : pool.hashCode());
-        result = prime * result + ((profile == null) ? 0 : profile.hashCode());
 
         return result;
     }
@@ -310,11 +301,6 @@ public class ModifiableDataSource extends DataSourceAbstractImpl implements Data
             if (other.pool != null)
                 return false;
         } else if (!pool.equals(other.pool))
-            return false;
-        if (profile == null) {
-            if (other.profile != null)
-                return false;
-        } else if (!profile.equals(other.profile))
             return false;
         return true;
     }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableXaDataSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/ModifiableXaDataSource.java
@@ -53,8 +53,6 @@ public class ModifiableXaDataSource extends XADataSourceImpl implements XaDataSo
      */
     private static CommonBundle bundle = Messages.getBundle(CommonBundle.class);
 
-    private final String profile;
-
 
     /**
      * Create a new XADataSourceImpl.
@@ -87,23 +85,17 @@ public class ModifiableXaDataSource extends XADataSourceImpl implements XaDataSo
                                   Boolean useJavaContext, String poolName, Boolean enabled, String jndiName, Boolean spy, Boolean useCcm,
                                   final Boolean connectable, final Boolean tracking, String mcp, Boolean enlistmentTrace,
                                   Map<String, String> xaDataSourceProperty, String xaDataSourceClass, String driver, String newConnectionSql,
-                                  DsXaPool xaPool, Recovery recovery, final String profile) throws ValidateException {
+                                  DsXaPool xaPool, Recovery recovery) throws ValidateException {
         super(transactionIsolation, timeOut, security, statement, validation, urlDelimiter,
                 urlProperty, urlSelectorStrategyClassName, useJavaContext, poolName, enabled, jndiName, spy, useCcm,
                 connectable, tracking, mcp, enlistmentTrace,
                 xaDataSourceProperty, xaDataSourceClass, driver, newConnectionSql,
                 xaPool, recovery);
-        this.profile = profile;
     }
 
 
     public final void addXaDataSourceProperty(String name, String value) {
         xaDataSourceProperty.put(name, value);
-    }
-
-
-    public final String getProfile() {
-        return profile;
     }
 
     @Override

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/XaDataSourceService.java
@@ -74,7 +74,7 @@ public class XaDataSourceService extends AbstractDataSourceService {
 
     @Override
     public AS7DataSourceDeployer getDeployer() throws ValidateException {
-        return new AS7DataSourceDeployer(dataSourceConfig.getValue().getUnModifiableInstance(), dataSourceConfig.getValue().getProfile());
+        return new AS7DataSourceDeployer(dataSourceConfig.getValue().getUnModifiableInstance());
     }
 
     public Injector<ModifiableXaDataSource> getDataSourceConfigInjector() {

--- a/connector/src/main/resources/org/jboss/as/connector/subsystems/datasources/LocalDescriptions.properties
+++ b/connector/src/main/resources/org/jboss/as/connector/subsystems/datasources/LocalDescriptions.properties
@@ -35,6 +35,8 @@ datasources.jdbc-driver.jdbc-compliant=Whether or not the driver is JDBC complia
 datasources.jdbc-driver.module-slot=The slot of the module from which the driver was loaded, if it was loaded from the module path
 datasources.jdbc-driver.xa-datasource-class=XA datasource class
 datasources.jdbc-driver.profile=Domain Profile in which driver is defined. Null in case of standalone server
+datasources.jdbc-driver.profile.deprecated=The server's profile can be determined by the profile-name attribute on the server's root resource.
+
 datasources.get-installed-driver=Get a description of an installed driver
 datasources.installed-drivers-list=List of JDBC drivers that have been installed in the runtime
 datasources.installed-drivers.installed-driver=JDBC driver that have been installed in the runtime
@@ -52,8 +54,7 @@ datasources.installed-drivers.jdbc-compliant=Whether or not the driver is JDBC c
 datasources.installed-drivers.module-slot=The slot of the module from which the driver was loaded, if it was loaded from the module path
 datasources.installed-drivers.xa-datasource-class=XA datasource class
 datasources.installed-drivers.profile=Domain Profile in which driver is defined. Null in case of standalone server
-
-
+datasources.installed-drivers.profile.deprecated=The server's profile can be determined by the profile-name attribute on the server's root resource.
 
 datasources.data-source=A JDBC data-source configuration
 datasources.data-source.add=Add a new data-source


### PR DESCRIPTION
…s introduced as part of WFLY-3634. Also deprecate the profile attribute on the installed-drivers-list operation and installed-drivers attribute.

This mostly reverts https://github.com/wildfly/wildfly/pull/7033 and https://github.com/wildfly/wildfly/pull/8215. The tests added were valid and just reverting the commits resulted in some conflicts. Manually removed the profile concept, but kept the profile attribute where needed and deprecated it.
