### PR TITLE
WFLY-5581/WFLY-5591 Clustering performance fixes for web/ejb

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/ClientMappingsCacheBuilderProvider.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/ClientMappingsCacheBuilderProvider.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ejb.infinispan;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
+import org.wildfly.clustering.infinispan.spi.service.CacheBuilder;
+import org.wildfly.clustering.infinispan.spi.service.TemplateConfigurationBuilder;
+import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.SubGroupServiceNameFactory;
+import org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider;
+import org.wildfly.clustering.spi.CacheGroupBuilderProvider;
+
+/**
+ * Creates routing services.
+ * @author Paul Ferraro
+ */
+public class ClientMappingsCacheBuilderProvider implements CacheGroupBuilderProvider, CacheGroupAliasBuilderProvider {
+
+    private final Class<? extends CacheGroupBuilderProvider> providerClass;
+
+    ClientMappingsCacheBuilderProvider(Class<? extends CacheGroupBuilderProvider> providerClass) {
+        this.providerClass = providerClass;
+    }
+
+    @Override
+    public Collection<Builder<?>> getBuilders(String containerName, String cacheName) {
+        List<Builder<?>> builders = new LinkedList<>();
+        if (containerName.equals(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME) && cacheName.equals(SubGroupServiceNameFactory.DEFAULT_SUB_GROUP)) {
+            builders.add(new TemplateConfigurationBuilder(containerName, BeanManagerFactoryBuilderConfiguration.CLIENT_MAPPINGS_CACHE_NAME, cacheName) {
+                @Override
+                public ConfigurationBuilder createConfigurationBuilder() {
+                    ConfigurationBuilder builder = super.createConfigurationBuilder();
+                    CacheMode mode = builder.clustering().cacheMode();
+                    builder.clustering().cacheMode(mode.isClustered() ? CacheMode.REPL_SYNC : CacheMode.LOCAL);
+                    builder.persistence().clearStores();
+                    return builder;
+                }
+            });
+            builders.add(new CacheBuilder<>(containerName, BeanManagerFactoryBuilderConfiguration.CLIENT_MAPPINGS_CACHE_NAME));
+            for (CacheGroupBuilderProvider provider : ServiceLoader.load(this.providerClass, this.providerClass.getClassLoader())) {
+                builders.addAll(provider.getBuilders(containerName, BeanManagerFactoryBuilderConfiguration.CLIENT_MAPPINGS_CACHE_NAME));
+            }
+        }
+        return builders;
+    }
+
+    @Override
+    public Collection<Builder<?>> getBuilders(String containerName, String aliasCacheName, String targetCacheName) {
+        return this.getBuilders(containerName, aliasCacheName);
+    }
+}

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/DistributedClientMappingsCacheBuilderProvider.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/DistributedClientMappingsCacheBuilderProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,16 +19,17 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.ejb;
+
+package org.wildfly.clustering.ejb.infinispan;
+
+import org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider;
 
 /**
- * Configuration of a bean manager factory builder.
  * @author Paul Ferraro
  */
-public interface BeanManagerFactoryBuilderConfiguration extends BeanPassivationConfiguration {
-    String DEFAULT_CONTAINER_NAME = "ejb";
-    String CLIENT_MAPPINGS_CACHE_NAME = "client-mappings";
+public class DistributedClientMappingsCacheBuilderProvider extends ClientMappingsCacheBuilderProvider implements DistributedCacheGroupBuilderProvider {
 
-    String getContainerName();
-    String getCacheName();
+    public DistributedClientMappingsCacheBuilderProvider() {
+        super(DistributedCacheGroupBuilderProvider.class);
+    }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilder.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilder.java
@@ -93,8 +93,8 @@ public class InfinispanBeanManagerFactoryBuilder<G, I, T> implements Builder<Bea
                 .addDependency(deploymentUnitServiceName.append(this.name, "expiration"), ScheduledExecutorService.class, this.scheduler)
                 .addDependency(deploymentUnitServiceName.append(this.name, "eviction"), Executor.class, this.executor)
                 .addDependency(GroupServiceName.COMMAND_DISPATCHER.getServiceName(containerName), CommandDispatcherFactory.class, this.dispatcherFactory)
-                .addDependency(CacheGroupServiceName.REGISTRY.getServiceName(containerName), Registry.class, this.registry)
-                .addDependency(CacheGroupServiceName.NODE_FACTORY.getServiceName(containerName), NodeFactory.class, this.nodeFactory)
+                .addDependency(CacheGroupServiceName.REGISTRY.getServiceName(containerName, BeanManagerFactoryBuilderConfiguration.CLIENT_MAPPINGS_CACHE_NAME), Registry.class, this.registry)
+                .addDependency(CacheGroupServiceName.NODE_FACTORY.getServiceName(containerName, BeanManagerFactoryBuilderConfiguration.CLIENT_MAPPINGS_CACHE_NAME), NodeFactory.class, this.nodeFactory)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
         ;
     }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/LocalClientMappingsCacheBuilderProvider.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/LocalClientMappingsCacheBuilderProvider.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2015, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,16 +19,17 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.ejb;
+
+package org.wildfly.clustering.ejb.infinispan;
+
+import org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider;
 
 /**
- * Configuration of a bean manager factory builder.
  * @author Paul Ferraro
  */
-public interface BeanManagerFactoryBuilderConfiguration extends BeanPassivationConfiguration {
-    String DEFAULT_CONTAINER_NAME = "ejb";
-    String CLIENT_MAPPINGS_CACHE_NAME = "client-mappings";
+public class LocalClientMappingsCacheBuilderProvider extends ClientMappingsCacheBuilderProvider implements LocalCacheGroupBuilderProvider {
 
-    String getContainerName();
-    String getCacheName();
+    public LocalClientMappingsCacheBuilderProvider() {
+        super(LocalCacheGroupBuilderProvider.class);
+    }
 }

--- a/clustering/ejb/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider
+++ b/clustering/ejb/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider
@@ -1,0 +1,1 @@
+org.wildfly.clustering.ejb.infinispan.DistributedClientMappingsCacheBuilderProvider

--- a/clustering/ejb/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider
+++ b/clustering/ejb/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider
@@ -1,0 +1,1 @@
+org.wildfly.clustering.ejb.infinispan.DistributedClientMappingsCacheBuilderProvider

--- a/clustering/ejb/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider
+++ b/clustering/ejb/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider
@@ -1,0 +1,1 @@
+org.wildfly.clustering.ejb.infinispan.LocalClientMappingsCacheBuilderProvider

--- a/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/ServiceLoaderTestCase.java
+++ b/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/ServiceLoaderTestCase.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.ejb.infinispan;
+
+import java.util.ServiceLoader;
+
+import org.junit.Test;
+import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderFactoryProvider;
+import org.wildfly.clustering.marshalling.Externalizer;
+import org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider;
+import org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider;
+import org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider;
+
+/**
+ * Validates loading of services.
+ * @author Paul Ferraro
+ */
+public class ServiceLoaderTestCase {
+
+    @Test
+    public void load() {
+        load(Externalizer.class);
+        load(BeanManagerFactoryBuilderFactoryProvider.class);
+        load(DistributedCacheGroupBuilderProvider.class);
+        load(LocalCacheGroupBuilderProvider.class);
+        load(CacheGroupAliasBuilderProvider.class);
+    }
+
+    private static <T> void load(Class<T> targetClass) {
+        System.out.println(targetClass.getName() + ":");
+        ServiceLoader.load(targetClass, ServiceLoaderTestCase.class.getClassLoader()).forEach(object -> System.out.println("\t" + object.getClass().getName()));
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/DistributedRouteCacheGroupBuilderProvider.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/DistributedRouteCacheGroupBuilderProvider.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan.session;
+
+import org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider;
+
+/**
+ * @author Paul Ferraro
+ */
+public class DistributedRouteCacheGroupBuilderProvider extends RouteCacheGroupBuilderProvider implements DistributedCacheGroupBuilderProvider {
+
+    public DistributedRouteCacheGroupBuilderProvider() {
+        super(DistributedCacheGroupBuilderProvider.class);
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanRouteLocatorBuilder.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanRouteLocatorBuilder.java
@@ -33,7 +33,6 @@ import org.jboss.msc.value.Value;
 import org.wildfly.clustering.group.NodeFactory;
 import org.wildfly.clustering.registry.Registry;
 import org.wildfly.clustering.service.Builder;
-import org.wildfly.clustering.spi.CacheGroupServiceName;
 import org.wildfly.clustering.web.session.RouteLocator;
 
 /**
@@ -48,6 +47,14 @@ public class InfinispanRouteLocatorBuilder implements Builder<RouteLocator>, Val
 
     public static ServiceName getCacheServiceAlias(String deploymentName) {
         return getServiceName(deploymentName).append("cache");
+    }
+
+    public static ServiceName getNodeFactoryServiceAlias(String deploymentName) {
+        return getServiceName(deploymentName).append("nodes");
+    }
+
+    public static ServiceName getRegistryServiceAlias(String deploymentName) {
+        return getServiceName(deploymentName).append("registry");
     }
 
     private final String deploymentName;
@@ -71,8 +78,8 @@ public class InfinispanRouteLocatorBuilder implements Builder<RouteLocator>, Val
     @Override
     public ServiceBuilder<RouteLocator> build(ServiceTarget target) {
         return target.addService(this.getServiceName(), new ValueService<>(this))
-                .addDependency(CacheGroupServiceName.NODE_FACTORY.getServiceName(InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER), NodeFactory.class, this.factory)
-                .addDependency(CacheGroupServiceName.REGISTRY.getServiceName(InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER), Registry.class, this.registry)
+                .addDependency(getNodeFactoryServiceAlias(this.deploymentName), NodeFactory.class, this.factory)
+                .addDependency(getRegistryServiceAlias(this.deploymentName), Registry.class, this.registry)
                 .addDependency(getCacheServiceAlias(this.deploymentName), Cache.class, this.cache)
                 .setInitialMode(ServiceController.Mode.ON_DEMAND)
         ;

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactoryBuilder.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManagerFactoryBuilder.java
@@ -38,6 +38,8 @@ import org.wildfly.clustering.infinispan.spi.service.CacheContainerServiceName;
 import org.wildfly.clustering.infinispan.spi.service.CacheBuilder;
 import org.wildfly.clustering.infinispan.spi.service.CacheServiceName;
 import org.wildfly.clustering.infinispan.spi.service.TemplateConfigurationBuilder;
+import org.wildfly.clustering.registry.Registry;
+import org.wildfly.clustering.service.AliasServiceBuilder;
 import org.wildfly.clustering.service.Builder;
 import org.wildfly.clustering.service.SubGroupServiceNameFactory;
 import org.wildfly.clustering.spi.CacheGroupServiceName;
@@ -87,6 +89,9 @@ public class InfinispanSessionManagerFactoryBuilder implements Builder<SessionMa
         new CacheBuilder<>(containerName, cacheName).build(target)
                 .addAliases(InfinispanRouteLocatorBuilder.getCacheServiceAlias(cacheName))
                 .install();
+
+        new AliasServiceBuilder<>(InfinispanRouteLocatorBuilder.getNodeFactoryServiceAlias(cacheName), CacheGroupServiceName.NODE_FACTORY.getServiceName(containerName, RouteCacheGroupBuilderProvider.CACHE_NAME), NodeFactory.class).build(target).install();
+        new AliasServiceBuilder<>(InfinispanRouteLocatorBuilder.getRegistryServiceAlias(cacheName), CacheGroupServiceName.REGISTRY.getServiceName(containerName, RouteCacheGroupBuilderProvider.CACHE_NAME), Registry.class).build(target).install();
 
         return target.addService(this.getServiceName(), new ValueService<>(this))
                 .addDependency(CacheServiceName.CACHE.getServiceName(containerName, cacheName), Cache.class, this.cache)

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/LocalRouteCacheGroupBuilderProvider.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/LocalRouteCacheGroupBuilderProvider.java
@@ -1,0 +1,35 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan.session;
+
+import org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider;
+
+/**
+ * @author Paul Ferraro
+ */
+public class LocalRouteCacheGroupBuilderProvider extends RouteCacheGroupBuilderProvider implements LocalCacheGroupBuilderProvider {
+
+    public LocalRouteCacheGroupBuilderProvider() {
+        super(LocalCacheGroupBuilderProvider.class);
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteCacheGroupBuilderProvider.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteCacheGroupBuilderProvider.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.wildfly.clustering.web.infinispan.session;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+import org.infinispan.configuration.cache.CacheMode;
+import org.infinispan.configuration.cache.ConfigurationBuilder;
+import org.wildfly.clustering.infinispan.spi.service.CacheBuilder;
+import org.wildfly.clustering.infinispan.spi.service.TemplateConfigurationBuilder;
+import org.wildfly.clustering.service.Builder;
+import org.wildfly.clustering.service.SubGroupServiceNameFactory;
+import org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider;
+import org.wildfly.clustering.spi.CacheGroupBuilderProvider;
+
+/**
+ * Creates routing services.
+ * @author Paul Ferraro
+ */
+public class RouteCacheGroupBuilderProvider implements CacheGroupBuilderProvider, CacheGroupAliasBuilderProvider {
+
+    static final String CACHE_NAME = "routing";
+
+    private final Class<? extends CacheGroupBuilderProvider> providerClass;
+
+    RouteCacheGroupBuilderProvider(Class<? extends CacheGroupBuilderProvider> providerClass) {
+        this.providerClass = providerClass;
+    }
+
+    @Override
+    public Collection<Builder<?>> getBuilders(String containerName, String cacheName) {
+        List<Builder<?>> builders = new LinkedList<>();
+        if (containerName.equals(InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER) && cacheName.equals(SubGroupServiceNameFactory.DEFAULT_SUB_GROUP)) {
+            builders.add(new TemplateConfigurationBuilder(containerName, CACHE_NAME, cacheName) {
+                @Override
+                public ConfigurationBuilder createConfigurationBuilder() {
+                    ConfigurationBuilder builder = super.createConfigurationBuilder();
+                    CacheMode mode = builder.clustering().cacheMode();
+                    builder.clustering().cacheMode(mode.isClustered() ? CacheMode.REPL_SYNC : CacheMode.LOCAL);
+                    builder.persistence().clearStores();
+                    return builder;
+                }
+            });
+            builders.add(new CacheBuilder<>(containerName, CACHE_NAME));
+            for (CacheGroupBuilderProvider provider : ServiceLoader.load(this.providerClass, this.providerClass.getClassLoader())) {
+                System.out.println(String.format("RoutingCacheGroupBuilderProvider.getBuilders(%s, %s), provider = %s", containerName, cacheName, provider.getClass().getName()));
+                builders.addAll(provider.getBuilders(containerName, CACHE_NAME));
+            }
+        }
+        return builders;
+    }
+
+    @Override
+    public Collection<Builder<?>> getBuilders(String containerName, String aliasCacheName, String targetCacheName) {
+        return this.getBuilders(containerName, aliasCacheName);
+    }
+}

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteRegistryEntryProviderBuilder.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/RouteRegistryEntryProviderBuilder.java
@@ -51,7 +51,7 @@ public class RouteRegistryEntryProviderBuilder implements Builder<RegistryEntryP
 
     @Override
     public ServiceName getServiceName() {
-        return CacheGroupServiceName.REGISTRY_ENTRY.getServiceName(InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER);
+        return CacheGroupServiceName.REGISTRY_ENTRY.getServiceName(InfinispanSessionManagerFactoryBuilder.DEFAULT_CACHE_CONTAINER, RouteCacheGroupBuilderProvider.CACHE_NAME);
     }
 
     @Override

--- a/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider
+++ b/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider
@@ -1,0 +1,1 @@
+org.wildfly.clustering.web.infinispan.session.DistributedRouteCacheGroupBuilderProvider

--- a/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider
+++ b/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider
@@ -1,0 +1,1 @@
+org.wildfly.clustering.web.infinispan.session.DistributedRouteCacheGroupBuilderProvider

--- a/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider
+++ b/clustering/web/infinispan/src/main/resources/META-INF/services/org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider
@@ -1,0 +1,1 @@
+org.wildfly.clustering.web.infinispan.session.LocalRouteCacheGroupBuilderProvider

--- a/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/ServiceLoaderTestCase.java
+++ b/clustering/web/infinispan/src/test/java/org/wildfly/clustering/web/infinispan/ServiceLoaderTestCase.java
@@ -26,6 +26,9 @@ import java.util.ServiceLoader;
 
 import org.junit.Test;
 import org.wildfly.clustering.marshalling.Externalizer;
+import org.wildfly.clustering.spi.CacheGroupAliasBuilderProvider;
+import org.wildfly.clustering.spi.DistributedCacheGroupBuilderProvider;
+import org.wildfly.clustering.spi.LocalCacheGroupBuilderProvider;
 import org.wildfly.clustering.web.session.RouteLocatorBuilderProvider;
 import org.wildfly.clustering.web.session.SessionManagerFactoryBuilderProvider;
 import org.wildfly.clustering.web.sso.SSOManagerFactoryBuilderProvider;
@@ -42,6 +45,9 @@ public class ServiceLoaderTestCase {
         load(RouteLocatorBuilderProvider.class);
         load(SessionManagerFactoryBuilderProvider.class);
         load(SSOManagerFactoryBuilderProvider.class);
+        load(DistributedCacheGroupBuilderProvider.class);
+        load(LocalCacheGroupBuilderProvider.class);
+        load(CacheGroupAliasBuilderProvider.class);
     }
 
     private static <T> void load(Class<T> targetClass) {

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryBuilderService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCacheFactoryBuilderService.java
@@ -65,11 +65,6 @@ public class DistributableCacheFactoryBuilderService<K, V extends Identifiable<K
         for (BeanManagerFactoryBuilderFactoryProvider<Batch> provider: ServiceLoader.load(BeanManagerFactoryBuilderFactoryProvider.class, BeanManagerFactoryBuilderFactoryProvider.class.getClassLoader())) {
             return provider;
         }
-        try {
-            BeanManagerFactoryBuilderFactoryProvider.class.getClassLoader().loadClass("org.wildfly.clustering.ejb.infinispan.InfinispanBeanManagerFactoryBuilderFactoryProvider").newInstance();
-        } catch (Throwable e) {
-            e.printStackTrace();
-        }
         return null;
     }
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemotingConnectorClientMappingsEntryProviderService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/EJBRemotingConnectorClientMappingsEntryProviderService.java
@@ -36,6 +36,7 @@ import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
 import org.wildfly.clustering.registry.RegistryEntryProvider;
 import org.wildfly.clustering.spi.CacheGroupServiceName;
 
@@ -49,7 +50,7 @@ public class EJBRemotingConnectorClientMappingsEntryProviderService extends Abst
     private final InjectedValue<RemotingConnectorBindingInfoService.RemotingConnectorInfo> remotingConnectorInfo = new InjectedValue<>();
 
     public ServiceBuilder<RegistryEntryProvider<String, List<ClientMapping>>> build(ServiceTarget target, String clientMappingsClusterName, ServiceName remotingServerInfoServiceName) {
-        return target.addService(CacheGroupServiceName.REGISTRY_ENTRY.getServiceName(clientMappingsClusterName), this)
+        return target.addService(CacheGroupServiceName.REGISTRY_ENTRY.getServiceName(clientMappingsClusterName, BeanManagerFactoryBuilderConfiguration.CLIENT_MAPPINGS_CACHE_NAME), this)
                 .addDependency(ServerEnvironmentService.SERVICE_NAME, ServerEnvironment.class, this.serverEnvironment)
                 .addDependency(remotingServerInfoServiceName, RemotingConnectorBindingInfoService.RemotingConnectorInfo.class, this.remotingConnectorInfo)
         ;

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/RegistryInstallerService.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/RegistryInstallerService.java
@@ -28,6 +28,7 @@ import org.jboss.msc.service.ServiceTarget;
 import org.jboss.msc.service.StartContext;
 import org.jboss.msc.service.StopContext;
 import org.jboss.msc.value.InjectedValue;
+import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
 import org.wildfly.clustering.registry.Registry;
 import org.wildfly.clustering.spi.CacheGroupServiceName;
 
@@ -48,7 +49,7 @@ public class RegistryInstallerService implements Service<Void> {
     public ServiceBuilder<Void> build(ServiceTarget target) {
         return target.addService(SERVICE_NAME, this)
                 .addDependency(RegistryCollectorService.SERVICE_NAME, RegistryCollector.class, this.collector)
-                .addDependency(CacheGroupServiceName.REGISTRY.getServiceName(this.clientMappingsClusterName), Registry.class, this.registry)
+                .addDependency(CacheGroupServiceName.REGISTRY.getServiceName(this.clientMappingsClusterName, BeanManagerFactoryBuilderConfiguration.CLIENT_MAPPINGS_CACHE_NAME), Registry.class, this.registry)
         ;
     }
 

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
@@ -36,5 +36,6 @@
         <module name="org.jboss.msc"/>
         <module name="org.wildfly.clustering.server" services="import"/>
         <module name="org.wildfly.clustering.service"/>
+        <module name="org.wildfly.clustering.web.infinispan" services="import"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/clustering/spi/main/module.xml
@@ -34,6 +34,7 @@
     <dependencies>
         <module name="org.jboss.modules"/>
         <module name="org.jboss.msc"/>
+        <module name="org.wildfly.clustering.ejb.infinispan" services="import"/>
         <module name="org.wildfly.clustering.server" services="import"/>
         <module name="org.wildfly.clustering.service"/>
         <module name="org.wildfly.clustering.web.infinispan" services="import"/>


### PR DESCRIPTION
WFLY-5581 Routing cache should always use REPL
https://issues.jboss.org/browse/WFLY-5581
WFLY-5591 Client mappings cache should always use REPL
https://issues.jboss.org/browse/WFLY-5591

These cache configurations should never use distribution mode, as this introduces the chance of an unnecessary RPC per request if the cluster size > 2, the likelihood of which increases as the cluster size increases.
