### PR TITLE
WFLY-5594 ISE when configuring web/ejb clustering with invalidation cache

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/KeyAffinityServiceFactoryBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/KeyAffinityServiceFactoryBuilder.java
@@ -32,6 +32,7 @@ import org.infinispan.Cache;
 import org.infinispan.affinity.KeyAffinityService;
 import org.infinispan.affinity.KeyGenerator;
 import org.infinispan.affinity.impl.KeyAffinityServiceImpl;
+import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.remoting.transport.Address;
 import org.wildfly.clustering.infinispan.spi.affinity.KeyAffinityServiceFactory;
 import org.wildfly.clustering.infinispan.spi.service.CacheContainerServiceName;
@@ -105,8 +106,8 @@ public class KeyAffinityServiceFactoryBuilder implements Builder<KeyAffinityServ
 
     @Override
     public <K> KeyAffinityService<K> createService(Cache<K, ?> cache, KeyGenerator<K> generator) {
-        boolean clustered = cache.getCacheConfiguration().clustering().cacheMode().isClustered();
-        return clustered ? new KeyAffinityServiceImpl<>(this.executor, cache, generator, this.bufferSize, Collections.singleton(cache.getCacheManager().getAddress()), false) : new SimpleKeyAffinityService<>(generator);
+        CacheMode mode = cache.getCacheConfiguration().clustering().cacheMode();
+        return mode.isDistributed() || mode.isReplicated() ? new KeyAffinityServiceImpl<>(this.executor, cache, generator, this.bufferSize, Collections.singleton(cache.getCacheManager().getAddress()), false) : new SimpleKeyAffinityService<>(generator);
     }
 
     private static class SimpleKeyAffinityService<K> implements KeyAffinityService<K> {

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
@@ -99,8 +99,7 @@ public class ManagedSocketFactory implements SocketFactory {
 
     @Override
     public DatagramSocket createDatagramSocket(String name, SocketAddress address) throws SocketException {
-        // Creating the socket using the name throws an ISE, See WFCORE-1063
-        return this.manager.createDatagramSocket(address);
+        return this.manager.createDatagramSocket(name, address);
     }
 
     @Override

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
@@ -122,10 +122,10 @@ public class ManagedSocketFactoryTest {
         InetAddress localhost = InetAddress.getLocalHost();
         SocketAddress socketAddress = new InetSocketAddress(localhost, 2);
 
-        when(this.manager.createDatagramSocket(new InetSocketAddress(0))).thenReturn(socket1);
-        when(this.manager.createDatagramSocket(new InetSocketAddress(1))).thenReturn(socket2);
-        when(this.manager.createDatagramSocket(socketAddress)).thenReturn(socket3);
-        when(this.manager.createDatagramSocket(new InetSocketAddress(localhost, 1))).thenReturn(socket4);
+        when(this.manager.createDatagramSocket("test", new InetSocketAddress(0))).thenReturn(socket1);
+        when(this.manager.createDatagramSocket("test", new InetSocketAddress(1))).thenReturn(socket2);
+        when(this.manager.createDatagramSocket("test", socketAddress)).thenReturn(socket3);
+        when(this.manager.createDatagramSocket("test", new InetSocketAddress(localhost, 1))).thenReturn(socket4);
 
         DatagramSocket result1 = this.subject.createDatagramSocket("test");
         DatagramSocket result2 = this.subject.createDatagramSocket("test", 1);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5594

Also, now that we're using wildfly-core 2.0.0.CR8, drop workaround for WFCORE-1063.
