### PR TITLE
WFLY-5595 NPE during serialization of HttpSession metadata when using <transaction mode="NONE"/>

### DIFF
--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionCreationMetaData.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/SimpleSessionCreationMetaData.java
@@ -31,7 +31,7 @@ import java.time.Instant;
 public class SimpleSessionCreationMetaData implements SessionCreationMetaData {
 
     private final Instant creationTime;
-    private volatile Duration maxInactiveInterval;
+    private volatile Duration maxInactiveInterval = Duration.ZERO;
 
     public SimpleSessionCreationMetaData() {
         this(Instant.now());


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5594

In this case, the maxInactiveInterval is set in a subsequent step.
