### PR TITLE
[WFLY-5555] JMS Bridge ambiguous error reporting on module load failure

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/bridge/JMSBridgeAdd.java
@@ -53,6 +53,7 @@ import org.jboss.msc.service.ServiceController.Mode;
 import org.jboss.msc.service.ServiceName;
 import org.wildfly.extension.messaging.activemq.CommonAttributes;
 import org.wildfly.extension.messaging.activemq.MessagingServices;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.wildfly.security.manager.WildFlySecurityManager;
 
 /**
@@ -173,7 +174,7 @@ public class JMSBridgeAdd extends AbstractAddStepHandler {
                     clientID,
                     addMessageIDInHeader);
         } catch (ModuleLoadException e) {
-            throw new OperationFailedException(e);
+            throw MessagingLogger.ROOT_LOGGER.unableToLoadModule(moduleName, e);
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
         }

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -47,6 +47,7 @@ import org.jboss.logging.annotations.Cause;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.modules.ModuleLoadException;
 import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceName;
 import org.jboss.msc.service.StartException;
@@ -811,4 +812,7 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 85, value = "Unable to load class %s from module %s")
     OperationFailedException unableToLoadClassFromModule(String className, String moduleName);
+
+    @Message(id = 86, value = "Unable to load module %s")
+    OperationFailedException unableToLoadModule(String moduleName, @Cause ModuleLoadException cause);
 }


### PR DESCRIPTION
- provide a clear error failure when a module can not be loaded during
  the jms-bridge :add operation

JIRA: https://issues.jboss.org/browse/WFLY-5555
