### PR TITLE
[WFLY-5609] Upgrade Artemis to 1.1.0.wildlfy.008

### DIFF
--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -58,7 +58,7 @@
         <!-- required to allow Artemis client to connect to HornetQ servers -->
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>artemis-hornetq-protocol</artifactId>
+            <artifactId>artemis-hqclient-protocol</artifactId>
         </dependency>
 
         <dependency>

--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -1579,6 +1579,17 @@
 
         <dependency>
             <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-hqclient-protocol</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-client</artifactId>
             <exclusions>
                 <exclusion>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -31,6 +31,7 @@
         <artifact name="${org.apache.activemq:artemis-cli}"/>
         <artifact name="${org.apache.activemq:artemis-commons}"/>
         <artifact name="${org.apache.activemq:artemis-dto}"/>
+        <artifact name="${org.apache.activemq:artemis-hqclient-protocol}"/>
         <artifact name="${org.apache.activemq:artemis-journal}"/>
         <artifact name="${org.apache.activemq:artemis-jms-client}"/>
         <artifact name="${org.apache.activemq:artemis-jms-server}"/>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
@@ -173,8 +173,8 @@ public class JMSService implements Service<JMSServerManager> {
             jmsServer.start();
         } catch(StartException e){
             throw e;
-        } catch (Exception e) {
-            throw MessagingLogger.ROOT_LOGGER.failedToStartService(e);
+        } catch (Throwable t) {
+            throw MessagingLogger.ROOT_LOGGER.failedToStartService(t);
         } finally {
             WildFlySecurityManager.setCurrentContextClassLoaderPrivileged(oldTccl);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.1.0.wildfly.007</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.1.0.wildfly-008</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.1.2-jbossorg-2</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.3</version.org.apache.cxf.xjcplugins>
@@ -1794,6 +1794,12 @@
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-hornetq-protocol</artifactId>
+                <version>${version.org.apache.activemq.artemis}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-hqclient-protocol</artifactId>
                 <version>${version.org.apache.activemq.artemis}</version>
             </dependency>
 


### PR DESCRIPTION
- use the artifact artemis-hqclient-protocol for HornetQ core
  compatibility from Artemis client

JIRA: https://issues.jboss.org/browse/WFLY-5609
