### PR TITLE
[WFLY-5554] Fix jms-bridge XSD attributes

### DIFF
--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
@@ -756,7 +756,7 @@
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="module" type="xs:string" use="required" />
 
-        <xs:attribute name="quality-of-service" use="optional">
+        <xs:attribute name="quality-of-service" use="required">
             <xs:simpleType>
                 <xs:restriction base="xs:string">
                     <xs:enumeration value="AT_MOST_ONCE"/>
@@ -765,10 +765,10 @@
                 </xs:restriction>
             </xs:simpleType>
         </xs:attribute>
-        <xs:attribute name="failure-retry-interval" type="xs:long" use="optional" />
-        <xs:attribute name="max-retries" type="xs:int" use="optional" />
-        <xs:attribute name="max-batch-size" type="xs:int" use="optional" />
-        <xs:attribute name="max-batch-time" type="xs:long" use="optional" />
+        <xs:attribute name="failure-retry-interval" type="xs:long" use="required" />
+        <xs:attribute name="max-retries" type="xs:int" use="required" />
+        <xs:attribute name="max-batch-size" type="xs:int" use="required" />
+        <xs:attribute name="max-batch-time" type="xs:long" use="required" />
         <xs:attribute name="selector" type="xs:string" use="optional" />
         <xs:attribute name="subscription-name" type="xs:string" use="optional" />
         <xs:attribute name="client-id" type="xs:string" use="optional" />


### PR DESCRIPTION
- flag jms-bridge's XSD attributes that do not allow null in the
  management model as required.

JIRA: https://issues.jboss.org/browse/WFLY-5554
