### PR TITLE
[WFLY-5536] Recovery manager is not able to recover MDB

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -50,7 +50,7 @@
         <module name="org.jboss.invocation" optional="true"/>
         <module name="org.jboss.jboss-transaction-spi"/>
         <!--this reverse dependency is here so integration classes in the AS code base can be instantiated by Artemis-->
-        <module name="org.wildfly.extension.messaging-activemq"/>
+        <module name="org.wildfly.extension.messaging-activemq" services="import"/>
         <module name="org.jboss.as.security"/>
         <module name="org.picketbox"/>
         <!-- this optional dependency is required to be able to use this module from a jms-bridge to connect to a remote

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/ra/main/module.xml
@@ -45,6 +45,6 @@
         <!-- allow to create a RA that connects to a remote Artemis server -->
         <module name="org.jboss.remote-naming" optional="true"/>
         <module name="org.jgroups"/>
-        <module name="org.wildfly.extension.messaging-activemq"/>
+        <module name="org.wildfly.extension.messaging-activemq" services="import"/>
     </dependencies>
 </module>


### PR DESCRIPTION
- add services="import" to the org.wildfly.extension.messaging-activemq
  dependency so that the Artemis server and resource adapters can load
  services defined by the messaging-activemq extension.

JIRA: https://issues.jboss.org/browse/WFLY-5536
