### PR TITLE
WFLY-5617 JGroups thread pool properties are never applied

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
@@ -138,8 +138,9 @@ public class JChannelFactory implements ChannelFactory, ProtocolStackConfigurato
                     }
                 }
             }
-            Configurator.resolveAndAssignFields(relay, relayConfig.getProperties());
-            Configurator.resolveAndInvokePropertyMethods(relay, relayConfig.getProperties());
+            Map<String, String> relayProperties = new HashMap<>(relayConfig.getProperties());
+            Configurator.resolveAndAssignFields(relay, relayProperties);
+            Configurator.resolveAndInvokePropertyMethods(relay, relayProperties);
             stack.addProtocol(relay);
             relay.init();
         }

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolConfigurationBuilder.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/AbstractProtocolConfigurationBuilder.java
@@ -108,7 +108,7 @@ public abstract class AbstractProtocolConfigurationBuilder<P extends ProtocolCon
 
     @Override
     public Map<String, String> getProperties() {
-        return new HashMap<>(this.properties);
+        return this.properties;
     }
 
     @Override

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/TransportResourceDefinition.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.Operations;
+import org.jboss.as.clustering.controller.ParentResourceServiceHandler;
 import org.jboss.as.clustering.controller.ReloadRequiredWriteAttributeHandler;
 import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.ResourceDescriptor;
@@ -39,7 +40,6 @@ import org.jboss.as.clustering.controller.ResourceServiceBuilderFactory;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.RestartParentResourceAddStepHandler;
 import org.jboss.as.clustering.controller.RestartParentResourceRemoveStepHandler;
-import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
 import org.jboss.as.clustering.controller.transform.ChainedOperationTransformer;
 import org.jboss.as.clustering.controller.transform.ImplicitlyAddedResourceDynamicDiscardPolicy;
 import org.jboss.as.clustering.controller.transform.LegacyPropertyAddOperationTransformer;
@@ -296,7 +296,7 @@ public class TransportResourceDefinition extends ProtocolResourceDefinition {
                 .addCapabilities(Capability.class)
                 .addCapabilities(ProtocolResourceDefinition.Capability.class)
                 ;
-        ResourceServiceHandler handler = new SimpleResourceServiceHandler<>(new TransportConfigurationBuilderFactory());
+        ResourceServiceHandler handler = new ParentResourceServiceHandler<>(new TransportConfigurationBuilderFactory());
         new RestartParentResourceAddStepHandler<ChannelFactory>(this.parentBuilderFactory, descriptor, handler) {
             @Override
             protected void populateModel(ModelNode operation, ModelNode model) throws OperationFailedException {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5617

This a a blocker and causes our thread pool sizes to assume JGroups defaults instead of our own defaults.  For example, the OOB thread pool uses a max size of 10 instead of 300.  This has huge performance implications.
