### PR TITLE
WFLY-5494 Fix Infinispan subsystem cache store properties transformations and improve testing

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/AddStepHandler.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.BiPredicate;
 
+import org.jboss.as.clustering.controller.transform.InitialAttributeValueOperationContextAttachment;
 import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.OperationContext;
@@ -40,6 +41,7 @@ import org.jboss.as.controller.operations.common.Util;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.as.controller.registry.Resource;
+import org.jboss.as.controller.transform.TransformerOperationAttachment;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -57,7 +59,22 @@ public class AddStepHandler extends AbstractAddStepHandler implements Registrati
     }
 
     public AddStepHandler(AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler) {
-        this(descriptor, handler, new ReloadRequiredWriteAttributeHandler(descriptor.getAttributes()));
+        this(descriptor, handler, new ReloadRequiredWriteAttributeHandler(descriptor.getAttributes()) {
+            @Override
+            protected void finishModelStage(OperationContext context, ModelNode operation, String attributeName, ModelNode newValue, ModelNode oldValue, Resource model) throws OperationFailedException {
+                super.finishModelStage(context, operation, attributeName, newValue, oldValue, model);
+
+                if (!context.isBooting()) {
+                    TransformerOperationAttachment attachment = TransformerOperationAttachment.getOrCreate(context);
+                    InitialAttributeValueOperationContextAttachment valuesAttachment = attachment.getAttachment(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT);
+                    if (valuesAttachment == null) {
+                        valuesAttachment = new InitialAttributeValueOperationContextAttachment();
+                        attachment.attach(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT, valuesAttachment);
+                    }
+                    valuesAttachment.putIfAbsentInitialValue(Operations.getPathAddress(operation), attributeName, oldValue);
+                }
+            }
+        });
     }
 
     AddStepHandler(AddStepHandlerDescriptor descriptor, ResourceServiceHandler handler, OperationStepHandler writeAttributeHandler) {

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/LegacyPropertyWriteOperationTransformer.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/transform/LegacyPropertyWriteOperationTransformer.java
@@ -58,6 +58,20 @@ public class LegacyPropertyWriteOperationTransformer implements OperationTransfo
             InitialAttributeValueOperationContextAttachment attachment = context.getAttachment(InitialAttributeValueOperationContextAttachment.INITIAL_VALUES_ATTACHMENT);
             assert attachment != null;
 
+            // Workaround aliases limitations!
+            // we need to painstakingly undo path alias translations, since we need to know the address of the real resource,
+            // since the readResourceFromRoot() will not work on the aliased address
+            Map<String, String> undoAliases = new HashMap<>();
+            undoAliases.put("BINARY_KEYED_JDBC_STORE", "binary-jdbc");
+            undoAliases.put("STORE", "custom");
+            undoAliases.put("FILE_STORE", "file");
+            undoAliases.put("MIXED_KEYED_JDBC_STORE", "mixed-jdbc");
+            undoAliases.put("REMOTE_STORE", "remote");
+            undoAliases.put("STRING_KEYED_JDBC_STORE", "string-jdbc");
+            if (undoAliases.containsKey(address.getLastElement().getValue())) {
+                address = address.subAddress(0, address.size() - 1).append("store", undoAliases.get(address.getLastElement().getValue()));
+            }
+
             ModelNode initialValue = attachment.getInitialValue(address, Operations.getAttributeName(operation));
             ModelNode newValue = context.readResourceFromRoot(address).getModel().get(PROPERTIES).clone();
 

--- a/clustering/common/src/test/java/org/jboss/as/clustering/controller/PropertiesTestUtil.java
+++ b/clustering/common/src/test/java/org/jboss/as/clustering/controller/PropertiesTestUtil.java
@@ -1,0 +1,135 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.clustering.controller;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.INCLUDE_DEFAULTS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RECURSIVE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.controller.transform.OperationTransformer;
+import org.jboss.as.model.test.ModelTestUtils;
+import org.jboss.as.subsystem.test.KernelServices;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+
+/**
+ * Set of utility methods for testing properties transformations for EAP 6.x versions.
+ *
+ * @author Kabir Khan
+ * @author Radoslav Husar
+ * @version October 2015
+ */
+public class PropertiesTestUtil {
+
+    private PropertiesTestUtil() {
+        // Hide utility class
+    }
+
+    public static void checkMapResults(KernelServices services, ModelNode expected, ModelVersion version, ModelNode operation) throws Exception {
+        ModelNode main = ModelTestUtils.checkOutcome(services.executeOperation(operation.clone())).get(ModelDescriptionConstants.RESULT);
+        ModelNode legacyResult = services.executeOperation(version, services.transformOperation(version, operation.clone()));
+        ModelNode legacy;
+        if (expected.isDefined()) {
+            legacy = ModelTestUtils.checkOutcome(legacyResult).get(ModelDescriptionConstants.RESULT);
+        } else {
+            ModelTestUtils.checkFailed(legacyResult);
+            legacy = new ModelNode();
+        }
+        Assert.assertEquals(main, legacy);
+        Assert.assertEquals(expected, legacy);
+    }
+
+    public static void checkMainMapModel(ModelNode model, String... properties) {
+        Assert.assertEquals(0, properties.length % 2);
+
+        ModelNode props = model.get("properties");
+        Assert.assertEquals(properties.length / 2, props.isDefined() ? props.keys().size() : 0);
+        for (int i = 0; i < properties.length; i += 2) {
+            Assert.assertEquals(properties[i + 1], props.get(properties[i]).asString());
+        }
+    }
+
+    public static void checkLegacyChildResourceModel(ModelNode model, String... properties) {
+        Assert.assertEquals(0, properties.length % 2);
+
+        ModelNode props = model.get("property");
+        Assert.assertEquals(properties.length / 2, props.isDefined() ? props.keys().size() : 0);
+        for (int i = 0; i < properties.length; i += 2) {
+            ModelNode property = props.get(properties[i]);
+            Assert.assertTrue(property.isDefined());
+            Assert.assertEquals(1, property.keys().size());
+            Assert.assertEquals(properties[i + 1], property.get("value").asString());
+        }
+    }
+
+    public static void checkMapModels(KernelServices services, ModelVersion version, PathAddress address, String... properties) throws Exception {
+        final ModelNode readResource = Util.createEmptyOperation(READ_RESOURCE_OPERATION, address);
+        readResource.get(RECURSIVE).set(true);
+        readResource.get(INCLUDE_DEFAULTS).set(false);
+        ModelNode mainModel = services.executeForResult(readResource.clone());
+        checkMainMapModel(mainModel, properties);
+
+        final ModelNode legacyModel;
+        if (address.getLastElement().getKey().equals("transport")) {
+            //TODO get rid of this once the PathAddress transformer works properly
+            //Temporary workaround
+            readResource.get(OP_ADDR).set(address.subAddress(0, address.size() - 1).append("transport", "TRANSPORT").toModelNode());
+            legacyModel = services.getLegacyServices(version).executeForResult(readResource);
+        } else {
+            legacyModel = ModelTestUtils.checkResultAndGetContents(services.executeOperation(version, services.transformOperation(version, readResource.clone())));
+        }
+
+        checkLegacyChildResourceModel(legacyModel, properties);
+    }
+
+    public static ModelNode success() {
+        final ModelNode result = new ModelNode();
+        result.get(OUTCOME).set(SUCCESS);
+        result.get(RESULT);
+        return result;
+    }
+
+    /**
+     * Executes a given operation asserting that an attachment has been created. Given {@link KernelServices} must have enabled attachment grabber.
+     *
+     * @return {@link ModelNode} result of the transformed operation
+     */
+    public static ModelNode executeOpInBothControllersWithAttachments(KernelServices services, ModelVersion version, ModelNode operation) throws Exception {
+        OperationTransformer.TransformedOperation op = services.executeInMainAndGetTheTransformedOperation(operation, version);
+        Assert.assertFalse(op.rejectOperation(success()));
+//        System.out.println(operation + "\nbecomes\n" + op.getTransformedOperation());
+        if (op.getTransformedOperation() != null) {
+            return ModelTestUtils.checkOutcome(services.getLegacyServices(version).executeOperation(op.getTransformedOperation()));
+        }
+        return null;
+    }
+
+}

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryKeyedJDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/BinaryKeyedJDBCStoreResourceDefinition.java
@@ -33,6 +33,7 @@ import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
+import org.jboss.as.clustering.controller.transform.LegacyPropertyResourceTransformer;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -107,7 +108,11 @@ public class BinaryKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDef
                         model.get(DeprecatedAttribute.TABLE.getDefinition().getName()).set(binaryTableModel);
                     }
 
-                    context.addTransformedResource(PathAddress.EMPTY_ADDRESS, resource);
+                    final ModelNode properties = model.remove(StoreResourceDefinition.Attribute.PROPERTIES.getDefinition().getName());
+                    final ResourceTransformationContext childContext = context.addTransformedResource(PathAddress.EMPTY_ADDRESS, resource);
+
+                    LegacyPropertyResourceTransformer.transformPropertiesToChildrenResources(properties, address, childContext);
+
                     context.processChildren(resource);
                 }
             });

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/JDBCStoreResourceDefinition.java
@@ -29,8 +29,10 @@ import javax.sql.DataSource;
 import org.infinispan.persistence.jdbc.DatabaseType;
 import org.jboss.as.clustering.controller.CapabilityReference;
 import org.jboss.as.clustering.controller.RequiredCapability;
+import org.jboss.as.clustering.controller.transform.LegacyPropertyAddOperationTransformer;
 import org.jboss.as.clustering.controller.transform.SimpleAttributeConverter;
 import org.jboss.as.clustering.controller.transform.SimpleAttributeConverter.Converter;
+import org.jboss.as.clustering.controller.transform.SimpleOperationTransformer;
 import org.jboss.as.clustering.controller.validation.EnumValidatorBuilder;
 import org.jboss.as.clustering.controller.validation.ParameterValidatorBuilder;
 import org.jboss.as.clustering.infinispan.InfinispanLogger;
@@ -155,6 +157,11 @@ public abstract class JDBCStoreResourceDefinition extends StoreResourceDefinitio
                     .addRename(Attribute.DATA_SOURCE.getDefinition().getName(), DeprecatedAttribute.DATASOURCE.getDefinition().getName())
                     .setValueConverter(new SimpleAttributeConverter(converter), Attribute.DATA_SOURCE.getDefinition())
             ;
+        }
+
+        if (InfinispanModel.VERSION_3_0_0.requiresTransformation(version)) {
+            builder.addOperationTransformationOverride(ModelDescriptionConstants.ADD)
+                    .setCustomOperationTransformer(new SimpleOperationTransformer(new LegacyPropertyAddOperationTransformer())).inheritResourceAttributeDefinitions();
         }
 
         if (InfinispanModel.VERSION_2_0_0.requiresTransformation(version)) {

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
@@ -101,9 +101,7 @@ public abstract class StoreResourceDefinition extends ChildResourceDefinition {
         }
 
         if (InfinispanModel.VERSION_3_0_0.requiresTransformation(version)) {
-
             builder.addRawOperationTransformationOverride(MapOperations.MAP_GET_DEFINITION.getName(), new SimpleOperationTransformer(new LegacyPropertyMapGetOperationTransformer()));
-
             for (String opName : Operations.getAllWriteAttributeOperationNames()) {
                 builder.addOperationTransformationOverride(opName)
                         .inheritResourceAttributeDefinitions()

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StringKeyedJDBCStoreResourceDefinition.java
@@ -33,6 +33,7 @@ import org.jboss.as.clustering.controller.ResourceDescriptor;
 import org.jboss.as.clustering.controller.ResourceServiceHandler;
 import org.jboss.as.clustering.controller.SimpleAliasEntry;
 import org.jboss.as.clustering.controller.SimpleResourceServiceHandler;
+import org.jboss.as.clustering.controller.transform.LegacyPropertyResourceTransformer;
 import org.jboss.as.controller.AttributeDefinition;
 import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.ObjectTypeAttributeDefinition;
@@ -109,7 +110,10 @@ public class StringKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDef
                         model.get(DeprecatedAttribute.TABLE.getDefinition().getName()).set(stringTableModel);
                     }
 
-                    context.addTransformedResource(PathAddress.EMPTY_ADDRESS, resource);
+                    final ModelNode properties = model.remove(StoreResourceDefinition.Attribute.PROPERTIES.getDefinition().getName());
+                    final ResourceTransformationContext childContext = context.addTransformedResource(PathAddress.EMPTY_ADDRESS, resource);
+
+                    LegacyPropertyResourceTransformer.transformPropertiesToChildrenResources(properties, address, childContext);
                     context.processChildren(resource);
                 }
             });

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationTestCaseBase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/OperationTestCaseBase.java
@@ -1,3 +1,25 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 package org.jboss.as.clustering.infinispan.subsystem;
 
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
@@ -17,11 +39,11 @@ import org.jboss.as.subsystem.test.KernelServicesBuilder;
 import org.jboss.dmr.ModelNode;
 
 /**
-* Base test case for testing management operations.
-*
-* @author Richard Achmatowicz (c) 2011 Red Hat Inc.
-*/
-
+ * Base test case for testing management operations.
+ *
+ * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+ * @author Radoslav Husar
+ */
 public class OperationTestCaseBase extends AbstractSubsystemTest {
 
     static final String SUBSYSTEM_XML_FILE = String.format("subsystem-infinispan-%d_%d.xml", InfinispanSchema.CURRENT.major(), InfinispanSchema.CURRENT.minor());
@@ -40,37 +62,31 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
 
     // cache container access
     protected static ModelNode getCacheContainerAddOperation(String containerName) {
-        // create the address of the cache
         PathAddress address = getCacheContainerAddress(containerName);
         return Operations.createAddOperation(address, Collections.<Attribute, ModelNode>singletonMap(CacheContainerResourceDefinition.Attribute.DEFAULT_CACHE, new ModelNode("default")));
     }
 
     protected static ModelNode getCacheContainerReadOperation(String containerName, Attribute attribute) {
-        // create the address of the subsystem
         return Operations.createReadAttributeOperation(getCacheContainerAddress(containerName), attribute);
     }
 
     protected static ModelNode getCacheContainerWriteOperation(String containerName, Attribute attribute, String value) {
-        // create the address of the subsystem
         PathAddress cacheAddress = getCacheContainerAddress(containerName);
         return Operations.createWriteAttributeOperation(cacheAddress, attribute, new ModelNode(value));
     }
 
     protected static ModelNode getCacheContainerRemoveOperation(String containerName) {
-        // create the address of the cache
         PathAddress containerAddr = getCacheContainerAddress(containerName);
         return Util.createRemoveOperation(containerAddr);
     }
 
     // cache access
     protected static ModelNode getCacheAddOperation(String containerName, String cacheType, String cacheName) {
-        // create the address of the cache
         PathAddress address = getCacheAddress(containerName, cacheType, cacheName);
         return Operations.createAddOperation(address, Collections.<Attribute, ModelNode>singletonMap(CacheResourceDefinition.Attribute.JNDI_NAME, new ModelNode("java:/fred/was/here")));
     }
 
     protected static ModelNode getCacheReadOperation(String containerName, String cacheType, String cacheName, Attribute attribute) {
-        // create the address of the subsystem
         return Operations.createReadAttributeOperation(getCacheAddress(containerName, cacheType, cacheName), attribute);
     }
 
@@ -84,7 +100,6 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
 
     // cache store access
     protected static ModelNode getCacheStoreReadOperation(String containerName, String cacheType, String cacheName, Attribute attribute) {
-        // create the address of the subsystem
         return Operations.createReadAttributeOperation(getCustomCacheStoreAddress(containerName, cacheType, cacheName), attribute);
     }
 
@@ -93,7 +108,6 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
     }
 
     protected static ModelNode getMixedKeyedJDBCCacheStoreReadOperation(String containerName, String cacheType, String cacheName, Attribute attribute) {
-        // create the address of the subsystem
         return Operations.createReadAttributeOperation(getMixedKeyedJDBCCacheStoreAddress(containerName, cacheType, cacheName), attribute);
     }
 
@@ -101,7 +115,27 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return Operations.createWriteAttributeOperation(getMixedKeyedJDBCCacheStoreAddress(containerName, cacheType, cacheName), attribute, new ModelNode(value));
     }
 
-    //cache store property access
+    // cache store property access
+    protected static ModelNode getCacheStoreGetPropertyOperation(PathAddress cacheStoreAddress, String propertyName) {
+        return Operations.createMapGetOperation(cacheStoreAddress, StoreResourceDefinition.Attribute.PROPERTIES, propertyName);
+    }
+
+    protected static ModelNode getCacheStorePutPropertyOperation(PathAddress cacheStoreAddress, String propertyName, String propertyValue) {
+        return Operations.createMapPutOperation(cacheStoreAddress, StoreResourceDefinition.Attribute.PROPERTIES, propertyName, propertyValue);
+    }
+
+    protected static ModelNode getCacheStoreRemovePropertyOperation(PathAddress cacheStoreAddress, String propertyName) {
+        return Operations.createMapRemoveOperation(cacheStoreAddress, StoreResourceDefinition.Attribute.PROPERTIES, propertyName);
+    }
+
+    protected static ModelNode getCacheStoreClearPropertiesOperation(PathAddress cacheStoreAddress) {
+        return Operations.createMapClearOperation(cacheStoreAddress, StoreResourceDefinition.Attribute.PROPERTIES);
+    }
+
+    protected static ModelNode getCacheStoreUndefinePropertiesOperation(PathAddress cacheStoreAddress) {
+        return Util.getUndefineAttributeOperation(cacheStoreAddress, StoreResourceDefinition.Attribute.PROPERTIES.getDefinition().getName());
+    }
+
     protected static ModelNode getCacheStorePropertyAddOperation(String containerName, String cacheName, String cacheType, String propertyName, String value) {
         ModelNode operation = Util.createAddOperation(getCacheStorePropertyAddress(containerName,  cacheType, cacheName, propertyName));
         // required attributes
@@ -123,24 +157,48 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
         return getCacheAddress(containerName, cacheType, cacheName).append(MixedKeyedJDBCStoreResourceDefinition.PATH);
     }
 
+    protected static PathAddress getMixedKeyedJDBCCacheStoreLegacyAddress(String containerName, String cacheType, String cacheName) {
+        return getCacheAddress(containerName, cacheType, cacheName).append(MixedKeyedJDBCStoreResourceDefinition.LEGACY_PATH);
+    }
+
     protected static PathAddress getBinaryKeyedJDBCCacheStoreAddress(String containerName, String cacheType, String cacheName) {
         return getCacheAddress(containerName, cacheType, cacheName).append(BinaryKeyedJDBCStoreResourceDefinition.PATH);
+    }
+
+    protected static PathAddress getBinaryKeyedJDBCCacheStoreLegacyAddress(String containerName, String cacheType, String cacheName) {
+        return getCacheAddress(containerName, cacheType, cacheName).append(BinaryKeyedJDBCStoreResourceDefinition.LEGACY_PATH);
     }
 
     protected static PathAddress getStringKeyedJDBCCacheStoreAddress(String containerName, String cacheType, String cacheName) {
         return getCacheAddress(containerName, cacheType, cacheName).append(StringKeyedJDBCStoreResourceDefinition.PATH);
     }
 
+    protected static PathAddress getStringKeyedJDBCCacheStoreLegacyAddress(String containerName, String cacheType, String cacheName) {
+        return getCacheAddress(containerName, cacheType, cacheName).append(StringKeyedJDBCStoreResourceDefinition.LEGACY_PATH);
+    }
+
     protected static PathAddress getRemoteCacheStoreAddress(String containerName, String cacheType, String cacheName) {
         return getCacheAddress(containerName, cacheType, cacheName).append(RemoteStoreResourceDefinition.PATH);
+    }
+
+    protected static PathAddress getRemoteCacheStoreLegacyAddress(String containerName, String cacheType, String cacheName) {
+        return getCacheAddress(containerName, cacheType, cacheName).append(RemoteStoreResourceDefinition.LEGACY_PATH);
     }
 
     protected static PathAddress getFileCacheStoreAddress(String containerName, String cacheType, String cacheName) {
         return getCacheAddress(containerName, cacheType, cacheName).append(FileStoreResourceDefinition.PATH);
     }
 
+    protected static PathAddress getFileCacheStoreLegacyAddress(String containerName, String cacheType, String cacheName) {
+        return getCacheAddress(containerName, cacheType, cacheName).append(FileStoreResourceDefinition.LEGACY_PATH);
+    }
+
     protected static PathAddress getCustomCacheStoreAddress(String containerName, String cacheType, String cacheName) {
         return getCacheAddress(containerName, cacheType, cacheName).append(CustomStoreResourceDefinition.PATH);
+    }
+
+    protected static PathAddress getCustomCacheStoreLegacyAddress(String containerName, String cacheType, String cacheName) {
+        return getCacheAddress(containerName, cacheType, cacheName).append(CustomStoreResourceDefinition.LEGACY_PATH);
     }
 
     protected static PathAddress getCacheContainerAddress(String containerName) {

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
@@ -21,8 +21,17 @@
 */
 package org.jboss.as.clustering.infinispan.subsystem;
 
+import static org.jboss.as.clustering.controller.PropertiesTestUtil.checkMapModels;
+import static org.jboss.as.clustering.controller.PropertiesTestUtil.checkMapResults;
+import static org.jboss.as.clustering.controller.PropertiesTestUtil.executeOpInBothControllersWithAttachments;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.COMPOSITE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.STEPS;
+
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.jboss.as.clustering.controller.RequiredCapability;
@@ -59,8 +68,8 @@ import org.junit.Test;
  *
  * @author <a href="tomaz.cerar@redhat.com">Tomaz Cerar</a>
  * @author Richard Achmatowicz (c) 2011 Red Hat Inc.
+ * @author Radoslav Husar
  */
-
 public class TransformersTestCase extends OperationTestCaseBase {
 
     private static String formatSubsystemArtifact(ModelTestControllerVersion version) {
@@ -104,7 +113,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testTransformer800() throws Exception {
+    public void testTransformerWF800() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.WILDFLY_8_0_0_FINAL;
         this.testTransformation(InfinispanModel.VERSION_2_0_0, version, formatSubsystemArtifact(version),
                 formatArtifact("org.wildfly:wildfly-clustering-common:%s", version),
@@ -117,7 +126,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testTransformer810() throws Exception {
+    public void testTransformerWF810() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.WILDFLY_8_1_0_FINAL;
         this.testTransformation(InfinispanModel.VERSION_2_0_0, version, formatSubsystemArtifact(version),
                 formatArtifact("org.wildfly:wildfly-clustering-common:%s", version),
@@ -130,7 +139,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testTransformer820() throws Exception {
+    public void testTransformerWF820() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.WILDFLY_8_2_0_FINAL;
         this.testTransformation(InfinispanModel.VERSION_2_0_0, version, formatSubsystemArtifact(version),
                 formatArtifact("org.wildfly:wildfly-clustering-common:%s", version),
@@ -143,7 +152,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testTransformer620() throws Exception {
+    public void testTransformerEAP620() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_2_0;
         this.testTransformation(InfinispanModel.VERSION_1_4_1, version, formatLegacySubsystemArtifact(version),
                 "org.infinispan:infinispan-core:5.2.7.Final-redhat-2",
@@ -152,7 +161,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testTransformer630() throws Exception {
+    public void testTransformerEAP630() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_3_0;
         this.testTransformation(InfinispanModel.VERSION_1_5_0, version, formatLegacySubsystemArtifact(version),
                 "org.infinispan:infinispan-core:5.2.10.Final-redhat-1",
@@ -161,7 +170,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testTransformer640() throws Exception {
+    public void testTransformerEAP640() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_4_0;
         this.testTransformation(InfinispanModel.VERSION_1_6_0, version, formatLegacySubsystemArtifact(version),
                 "org.infinispan:infinispan-core:5.2.11.Final-redhat-2",
@@ -206,6 +215,122 @@ public class TransformersTestCase extends OperationTestCaseBase {
             if (transaction.hasDefined(TransactionResourceDefinition.Attribute.MODE.getDefinition().getName())) {
                 Assert.assertEquals(TransactionMode.NONE.name(), transaction.get(TransactionResourceDefinition.Attribute.MODE.getDefinition().getName()).asString());
             }
+
+            // Test properties operations
+            propertiesMapOperationsTest(services, version);
+        }
+    }
+
+    private void propertiesMapOperationsTest(KernelServices services, ModelVersion version) throws Exception {
+        final String cacheContainer = "maximal";
+
+        final String testProperty1 = "testProperty1";
+        final String testProperty2 = "testProperty2";
+        final String testProperty3 = "testProperty3";
+        final String testProperty4 = "testProperty4";
+
+        final List<PathAddress> cacheStoreAddresses = new LinkedList<>();
+
+        // Current addresses
+        cacheStoreAddresses.add(getBinaryKeyedJDBCCacheStoreAddress(cacheContainer, ReplicatedCacheResourceDefinition.WILDCARD_PATH.getKey(), "cache-with-binary-keyed-store"));
+        cacheStoreAddresses.add(getCustomCacheStoreAddress(cacheContainer, ReplicatedCacheResourceDefinition.WILDCARD_PATH.getKey(), "repl"));
+        cacheStoreAddresses.add(getFileCacheStoreAddress(cacheContainer, LocalCacheResourceDefinition.WILDCARD_PATH.getKey(), "local"));
+        cacheStoreAddresses.add(getMixedKeyedJDBCCacheStoreAddress(cacheContainer, DistributedCacheResourceDefinition.WILDCARD_PATH.getKey(), "dist"));
+        cacheStoreAddresses.add(getRemoteCacheStoreAddress(cacheContainer, InvalidationCacheResourceDefinition.WILDCARD_PATH.getKey(), "invalid"));
+        cacheStoreAddresses.add(getStringKeyedJDBCCacheStoreAddress(cacheContainer, ReplicatedCacheResourceDefinition.WILDCARD_PATH.getKey(), "cache-with-string-keyed-store"));
+
+        // Legacy addresses
+        // TODO transformations do not kick in for legacy addresses
+//        cacheStoreAddresses.add(getBinaryKeyedJDBCCacheStoreLegacyAddress(cacheContainer, ReplicatedCacheResourceDefinition.WILDCARD_PATH.getKey(), "cache-with-binary-keyed-store"));
+//        cacheStoreAddresses.add(getCustomCacheStoreLegacyAddress(cacheContainer, ReplicatedCacheResourceDefinition.WILDCARD_PATH.getKey(), "repl"));
+//        cacheStoreAddresses.add(getFileCacheStoreLegacyAddress(cacheContainer, LocalCacheResourceDefinition.WILDCARD_PATH.getKey(), "local"));
+//        cacheStoreAddresses.add(getMixedKeyedJDBCCacheStoreLegacyAddress(cacheContainer, DistributedCacheResourceDefinition.WILDCARD_PATH.getKey(), "dist"));
+//        cacheStoreAddresses.add(getRemoteCacheStoreLegacyAddress(cacheContainer, InvalidationCacheResourceDefinition.WILDCARD_PATH.getKey(), "invalid"));
+//        cacheStoreAddresses.add(getStringKeyedJDBCCacheStoreLegacyAddress(cacheContainer, ReplicatedCacheResourceDefinition.WILDCARD_PATH.getKey(), "cache-with-string-keyed-store"));
+
+        for (PathAddress storeAddress : cacheStoreAddresses) {
+
+            // Check individual operations
+
+            executeOpInBothControllersWithAttachments(services, version, getCacheStoreUndefinePropertiesOperation(storeAddress));
+            checkMapModels(services, version, storeAddress);
+
+            executeOpInBothControllersWithAttachments(services, version, getCacheStorePutPropertyOperation(storeAddress, testProperty1, "true"));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapModels(services, version, storeAddress, testProperty1, "true");
+
+            executeOpInBothControllersWithAttachments(services, version, getCacheStorePutPropertyOperation(storeAddress, testProperty2, "false"));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapResults(services, new ModelNode("false"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty2));
+            checkMapModels(services, version, storeAddress, testProperty1, "true", testProperty2, "false");
+
+            executeOpInBothControllersWithAttachments(services, version, getCacheStorePutPropertyOperation(storeAddress, testProperty2, "true"));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty2));
+            checkMapModels(services, version, storeAddress, testProperty1, "true", testProperty2, "true");
+
+            executeOpInBothControllersWithAttachments(services, version, getCacheStoreRemovePropertyOperation(storeAddress, testProperty1));
+            checkMapResults(services, new ModelNode(), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty2));
+            checkMapModels(services, version, storeAddress, testProperty2, "true");
+
+            executeOpInBothControllersWithAttachments(services, version, getCacheStorePutPropertyOperation(storeAddress, testProperty1, "false"));
+            checkMapResults(services, new ModelNode("false"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty2));
+            checkMapModels(services, version, storeAddress, testProperty1, "false", testProperty2, "true");
+
+            executeOpInBothControllersWithAttachments(services, version, getCacheStoreClearPropertiesOperation(storeAddress));
+            checkMapResults(services, new ModelNode(), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapResults(services, new ModelNode(), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty2));
+            checkMapModels(services, version, storeAddress);
+
+
+            // Check composite operations
+            ModelNode composite = new ModelNode();
+            composite.get(OP).set(COMPOSITE);
+            composite.get(OP_ADDR).setEmptyList();
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty3, "false"));
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty4, "true"));
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty1, "true"));
+            executeOpInBothControllersWithAttachments(services, version, composite);
+            // Reread values back
+            checkMapResults(services, new ModelNode("false"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty3));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty4));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+
+            composite.get(STEPS).setEmptyList();
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty3, "true"));
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty4, "false"));
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty1, "false"));
+            executeOpInBothControllersWithAttachments(services, version, composite);
+            // Reread values back
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty3));
+            checkMapResults(services, new ModelNode("false"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty4));
+            checkMapResults(services, new ModelNode("false"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapModels(services, version, storeAddress, testProperty3, "true", testProperty4, "false", testProperty1, "false");
+
+            composite.get(STEPS).setEmptyList();
+            composite.get(STEPS).add(getCacheStoreRemovePropertyOperation(storeAddress, testProperty3));
+            composite.get(STEPS).add(getCacheStoreRemovePropertyOperation(storeAddress, testProperty4));
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty2, "false"));
+            composite.get(STEPS).add(getCacheStoreRemovePropertyOperation(storeAddress, testProperty1));
+            executeOpInBothControllersWithAttachments(services, version, composite);
+            // Reread values back
+            checkMapResults(services, new ModelNode(), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty3));
+            checkMapResults(services, new ModelNode(), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty4));
+            checkMapResults(services, new ModelNode(), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty1));
+            checkMapResults(services, new ModelNode("false"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty2));
+            checkMapModels(services, version, storeAddress, testProperty2, "false");
+
+            composite.get(STEPS).setEmptyList();
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty3, "false"));
+            composite.get(STEPS).add(getCacheStorePutPropertyOperation(storeAddress, testProperty4, "true"));
+            composite.get(STEPS).add(getCacheStoreRemovePropertyOperation(storeAddress, testProperty2));
+            executeOpInBothControllersWithAttachments(services, version, composite);
+            checkMapResults(services, new ModelNode("false"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty3));
+            checkMapResults(services, new ModelNode("true"), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty4));
+            checkMapResults(services, new ModelNode(), version, getCacheStoreGetPropertyOperation(storeAddress, testProperty2));
+            checkMapModels(services, version, storeAddress, testProperty3, "false", testProperty4, "true");
         }
     }
 
@@ -223,7 +348,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testRejections800() throws Exception {
+    public void testRejectionsWF800() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.WILDFLY_8_0_0_FINAL;
         this.testRejections(InfinispanModel.VERSION_2_0_0, version, formatSubsystemArtifact(version),
                 "org.infinispan:infinispan-core:6.0.1.Final",
@@ -232,7 +357,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testRejections810() throws Exception {
+    public void testRejectionsWF810() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.WILDFLY_8_1_0_FINAL;
         this.testRejections(InfinispanModel.VERSION_2_0_0, version, formatSubsystemArtifact(version),
                 "org.infinispan:infinispan-core:6.0.2.Final",
@@ -241,7 +366,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testRejections820() throws Exception {
+    public void testRejectionsWF820() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.WILDFLY_8_2_0_FINAL;
         this.testRejections(InfinispanModel.VERSION_2_0_0, version, formatSubsystemArtifact(version),
                 "org.infinispan:infinispan-core:6.0.2.Final",
@@ -250,7 +375,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testRejections620() throws Exception {
+    public void testRejectionsEAP620() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_2_0;
         this.testRejections(InfinispanModel.VERSION_1_4_1, version, formatLegacySubsystemArtifact(version),
                 "org.infinispan:infinispan-core:5.2.7.Final-redhat-2",
@@ -259,7 +384,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testRejections630() throws Exception {
+    public void testRejectionsEAP630() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_3_0;
         this.testRejections(InfinispanModel.VERSION_1_5_0, version, formatLegacySubsystemArtifact(version),
                 "org.infinispan:infinispan-core:5.2.10.Final-redhat-1",
@@ -268,7 +393,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
     }
 
     @Test
-    public void testRejections640() throws Exception {
+    public void testRejectionsEAP640() throws Exception {
         ModelTestControllerVersion version = ModelTestControllerVersion.EAP_6_4_0;
         this.testRejections(InfinispanModel.VERSION_1_6_0, version, formatLegacySubsystemArtifact(version),
                 "org.infinispan:infinispan-core:5.2.11.Final-redhat-2",
@@ -276,7 +401,7 @@ public class TransformersTestCase extends OperationTestCaseBase {
         );
     }
 
-    private void testRejections(InfinispanModel model, ModelTestControllerVersion controller, String ... dependencies) throws Exception {
+    private void testRejections(InfinispanModel model, ModelTestControllerVersion controller, String... dependencies) throws Exception {
         ModelVersion version = model.getVersion();
 
         // create builder for current subsystem version

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-expressions.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-expressions.xml
@@ -1,5 +1,4 @@
 <!--
-  ~
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
@@ -19,7 +18,6 @@
   ~ License along with this software; if not, write to the Free
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  ~
   -->
 <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
     <cache-container name="minimal" default-cache="local" statistics-enabled="true">

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-reject.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer-reject.xml
@@ -1,5 +1,4 @@
 <!--
-  ~
   ~ JBoss, Home of Professional Open Source.
   ~ Copyright 2012, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
@@ -19,7 +18,6 @@
   ~ License along with this software; if not, write to the Free
   ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
-  ~
   -->
 <subsystem xmlns="urn:jboss:domain:infinispan:4.0">
     <cache-container name="minimal" default-cache="local" statistics-enabled="false">
@@ -53,7 +51,8 @@
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <store class="org.infinispan.configuration.cache.SingleFileStoreConfigurationBuilder" fetch-state="true" passivation="true" preload="false" purge="true" shared="false" singleton="false">
                 <write-behind modification-queue-size="2048" thread-pool-size="1"/>
-                <!--<property name="location">location</property>-->
+                <property name="location">location</property>
+                <property name="property2">location2</property>
             </store>
             <state-transfer timeout="60000" chunk-size="10000"/>
             <backups>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
@@ -33,6 +33,8 @@
             <file-store fetch-state="false" passivation="false" path="path" preload="true" purge="false" relative-to="jboss.server.temp.dir" shared="true" singleton="false">
                 <!-- Leave out flush-lock-timeout here to test transformations of the default value (to 5 seconds) -->
                 <write-behind modification-queue-size="2048" thread-pool-size="1"/>
+                <property name="test-property">test-value</property>
+                <property name="test-property2">test-value2</property>
             </file-store>
         </local-cache>
         <invalidation-cache name="invalid" mode="ASYNC" queue-flush-interval="10" queue-size="1000" statistics-enabled="true">
@@ -64,6 +66,8 @@
             <expiration interval="10000" lifespan="10" max-idle="10"/>
             <mixed-keyed-jdbc-store data-source="ExampleDS" fetch-state="false" passivation="false" preload="true" purge="false" shared="false" singleton="false">
                 <write-behind modification-queue-size="2048" thread-pool-size="1"/>
+                <property name="test-property">test-value</property>
+                <property name="test-property2">test-value2</property>
                 <binary-keyed-table prefix="ispn_entry" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>
@@ -77,10 +81,8 @@
             </mixed-keyed-jdbc-store>
             <state-transfer timeout="60000" chunk-size="10000"/>
         </distributed-cache>
-        <!-- fails EAP 6.2.0 -->
-        <!--
-        <replicated-cache name="cache-with-binary-keyed-store" mode="ASYNC">
-            <binary-keyed-jdbc-store datasource="java:jboss/jdbc/binaryDs">
+        <replicated-cache name="cache-with-binary-keyed-store" mode="ASYNC" statistics-enabled="true">
+            <binary-keyed-jdbc-store data-source="ExampleDS">
                 <binary-keyed-table prefix="ispn_entry" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>
@@ -88,8 +90,8 @@
                 </binary-keyed-table>
             </binary-keyed-jdbc-store>
         </replicated-cache>
-        <replicated-cache name="cache-with-string-keyed-store" mode="ASYNC">
-            <string-keyed-jdbc-store datasource="java:jboss/jdbc/stringDs">
+        <replicated-cache name="cache-with-string-keyed-store" mode="ASYNC" statistics-enabled="true">
+            <string-keyed-jdbc-store data-source="ExampleDS">
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
                     <data-column name="datum" type="BINARY"/>
@@ -97,6 +99,5 @@
                 </string-keyed-table>
             </string-keyed-jdbc-store>
         </replicated-cache>
-        -->
     </cache-container>
 </subsystem>

--- a/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
+++ b/clustering/infinispan/extension/src/test/resources/org/jboss/as/clustering/infinispan/subsystem/infinispan-transformer.xml
@@ -82,6 +82,13 @@
             <state-transfer timeout="60000" chunk-size="10000"/>
         </distributed-cache>
         <replicated-cache name="cache-with-binary-keyed-store" mode="ASYNC" statistics-enabled="true">
+
+            <!-- Workaround WFLY-5794 -->
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
+            <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+
             <binary-keyed-jdbc-store data-source="ExampleDS">
                 <binary-keyed-table prefix="ispn_entry" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>
@@ -91,6 +98,13 @@
             </binary-keyed-jdbc-store>
         </replicated-cache>
         <replicated-cache name="cache-with-string-keyed-store" mode="ASYNC" statistics-enabled="true">
+
+            <!-- Workaround WFLY-5794 -->
+            <locking acquire-timeout="30000" concurrency-level="2000" isolation="SERIALIZABLE" striping="true"/>
+            <transaction mode="NON_DURABLE_XA" stop-timeout="60000" locking="OPTIMISTIC"/>
+            <expiration interval="10000" lifespan="10" max-idle="10"/>
+            <state-transfer timeout="60000" chunk-size="10000"/>
+
             <string-keyed-jdbc-store data-source="ExampleDS">
                 <string-keyed-table prefix="ispn_bucket" batch-size="100" fetch-size="100">
                     <id-column name="id" type="VARCHAR"/>

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/subsystem/OperationTestCaseBase.java
@@ -22,28 +22,18 @@
 
 package org.jboss.as.clustering.jgroups.subsystem;
 
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OUTCOME;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RESULT;
-import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUCCESS;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import org.jboss.as.clustering.controller.Attribute;
 import org.jboss.as.clustering.controller.Operations;
 import org.jboss.as.clustering.controller.RequiredCapability;
 import org.jboss.as.clustering.controller.SimpleAttribute;
 import org.jboss.as.clustering.subsystem.AdditionalInitialization;
-import org.jboss.as.controller.ModelVersion;
 import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.operations.common.Util;
-import org.jboss.as.controller.transform.OperationTransformer;
-import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AbstractSubsystemTest;
 import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
-import org.junit.Assert;
 
 /**
 * Base test case for testing management operations.
@@ -286,35 +276,6 @@ public class OperationTestCaseBase extends AbstractSubsystemTest {
 
     protected KernelServices buildKernelServices() throws Exception {
         return createKernelServicesBuilder(new AdditionalInitialization().require(RequiredCapability.SOCKET_BINDING, "some-binding", "jgroups-diagnostics", "jgroups-mping", "jgroups-tcp-fd", "new-socket-binding")).setSubsystemXml(this.getSubsystemXml()).build();
-    }
-
-    protected List<ModelNode> executeOpInBothControllers(KernelServices services, ModelVersion version, ModelNode operation) throws Exception {
-        List<ModelNode> results = new ArrayList<>(2);
-        results.add(ModelTestUtils.checkOutcome(services.executeOperation(operation.clone())));
-        results.add(ModelTestUtils.checkOutcome(services.executeOperation(version, services.transformOperation(version, operation.clone()))));
-        return results;
-    }
-
-    /**
-     * Executes a given operation asserting that an attachment has been created. Given {@link KernelServices} must have enabled attachment grabber.
-     *
-     * @return {@link ModelNode} result of the transformed operation
-     */
-    protected ModelNode executeOpInBothControllersWithAttachments(KernelServices services, ModelVersion version, ModelNode operation) throws Exception {
-        OperationTransformer.TransformedOperation op = services.executeInMainAndGetTheTransformedOperation(operation, version);
-        Assert.assertFalse(op.rejectOperation(success()));
-        //System.out.println(operation + "\nbecomes\n" + op.getTransformedOperation());
-        if (op.getTransformedOperation() != null) {
-            return ModelTestUtils.checkOutcome(services.getLegacyServices(version).executeOperation(op.getTransformedOperation()));
-        }
-        return null;
-    }
-
-    private static ModelNode success() {
-        final ModelNode result = new ModelNode();
-        result.get(OUTCOME).set(SUCCESS);
-        result.get(RESULT);
-        return result;
     }
 
 }


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-5494

Changes
- fix properties transformations on Infinispan stores and add tests for
- add tests for binary and string keyed stores (added to test xml)
- fix data-source transformation and add tests for
- only run properties trasformation tests for versions where transfomations actually happen
- rename tests methods being unclear
- move properties util methods into common

Downstream PR 
TBD (after review/changes/decisions done here)
