### PR TITLE
[WFLY-5649] Change the javax.json.api module to export the API from t…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/json/api/main/module.xml
@@ -22,4 +22,21 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module-alias xmlns="urn:jboss:module:1.3" name="javax.json.api" target-name="org.glassfish.javax.json"/>
+<module xmlns="urn:jboss:module:1.3" name="javax.json.api">
+
+    <properties>
+        <property name="jboss.api" value="public"/>
+    </properties>
+
+    <dependencies>
+        <module name="org.glassfish.javax.json" export="false">
+            <exports>
+                <include-set>
+                    <path name="javax/json"/>
+                    <path name="javax/json/spi"/>
+                    <path name="javax/json/stream"/>
+                </include-set>
+            </exports>
+        </module>
+    </dependencies>
+</module>


### PR DESCRIPTION
…he implementation module rather than be an alias for the implementation model.

Downstream: https://issues.jboss.org/browse/JBEAP-1798
