### PR TITLE
[WFLY-5640] Update the ejb2 test case RemoteStatelessFailoverTestCase to use correct Remoting port

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateless/RemoteStatelessFailoverTestCase.java
@@ -78,7 +78,7 @@ public class RemoteStatelessFailoverTestCase {
     private static final String ARCHIVE_NAME = "stateless-ejb2-failover-test";
     private static final String ARCHIVE_NAME_DD = "stateless-ejb2-failover-dd-test";
 
-    private static final Integer PORT_2 = 4547;
+    private static final Integer PORT_2 = 8080;
     private static final String HOST_2 = System.getProperty("node1");
     private static final String REMOTE_PORT_PROPERTY_NAME = "remote.connection.default.port";
     private static final String REMOTE_HOST_PROPERTY_NAME = "remote.connection.default.host";


### PR DESCRIPTION
This PR does the following:
- adjusts the Remoting port for the EJBClient test from the old and now incorrect localhost:4547 to the new localhost:8080

Upstream JIRA issue: https://issues.jboss.org/browse/WFLY-5640
