### PR TITLE
[WFLY-5178] Check for stopped StatefulSessionComponent when processing requests to create sessions

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
@@ -235,6 +235,10 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
     }
 
     public SessionID createSession() {
+        // check to see that StatefulSessionComponent.stop() has not been called concurrent with the request; this can happen on undeploy (see WFLY-5178)
+        if (getCache() == null)
+            throw EjbLogger.ROOT_LOGGER.componentIsShuttingDown();
+
         return this.cache.create().getId();
     }
 


### PR DESCRIPTION
This PR does the following:
- when a request to create a new SFSB session instance is received, checks to see if the corresponding SFSB session cache has been stopped (due to undeploy) before trying to create a new SFSB session in the cache; throws an appropriate exception if the cache is stopped
- without this fix, if a component is being undeployed while session creation requests are arriving concurrently, this can result in NPE on the cache instance in the StatefulSessionComponent 

See issue for more details:  https://issues.jboss.org/browse/WFLY-5178
