### PR TITLE
WFLY-5327 Auto-enable simple cache optimization for non-tx and non-persistent caches

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/CacheConfigurationBuilder.java
@@ -97,7 +97,10 @@ public class CacheConfigurationBuilder implements ResourceServiceBuilder<Configu
     @Override
     public Builder<Configuration> configure(OperationContext context, ModelNode model) throws OperationFailedException {
         this.module = ModelNodes.asModuleIdentifier(MODULE.getDefinition().resolveModelAttribute(context, model));
-        this.statistics = new ConfigurationBuilder().jmxStatistics().enabled(STATISTICS_ENABLED.getDefinition().resolveModelAttribute(context, model).asBoolean()).create();
+
+        boolean enabled = STATISTICS_ENABLED.getDefinition().resolveModelAttribute(context, model).asBoolean();
+        this.statistics = new ConfigurationBuilder().jmxStatistics().enabled(enabled).available(enabled).create();
+
         return this;
     }
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/LocalCacheBuilder.java
@@ -72,7 +72,8 @@ public class LocalCacheBuilder extends CacheConfigurationBuilder {
         PersistenceConfiguration persistence = this.persistence.getValue();
 
         // Auto-enable simple cache optimization if cache is non-transactional and non-persistent
-        builder.simpleCache(!transaction.transactionMode().isTransactional() && !persistence.usingStores());
+        // ISPN-5957 workaround - this doesn't work when statistics are enabled
+        builder.simpleCache(!transaction.transactionMode().isTransactional() && !persistence.usingStores() && !builder.jmxStatistics().create().available());
 
         if ((transaction.lockingMode() == LockingMode.OPTIMISTIC) && (locking.isolationLevel() == IsolationLevel.REPEATABLE_READ)) {
             builder.locking().writeSkewCheck(true);

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MixedKeyedJDBCStoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/MixedKeyedJDBCStoreResourceDefinition.java
@@ -80,7 +80,6 @@ public class MixedKeyedJDBCStoreResourceDefinition extends JDBCStoreResourceDefi
         }
     }
 
-    @SuppressWarnings("deprecation")
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder parent) {
         ResourceTransformationDescriptionBuilder builder = InfinispanModel.VERSION_4_0_0.requiresTransformation(version) ? parent.addChildRedirection(PATH, LEGACY_PATH) : parent.addChildResource(PATH);
 

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/StoreResourceDefinition.java
@@ -93,7 +93,6 @@ public abstract class StoreResourceDefinition extends ChildResourceDefinition {
 
     private final boolean allowRuntimeOnlyRegistration;
 
-    @SuppressWarnings("deprecation")
     static void buildTransformation(ModelVersion version, ResourceTransformationDescriptionBuilder builder) {
         if (InfinispanModel.VERSION_4_0_0.requiresTransformation(version)) {
             builder.discardChildResource(StoreWriteThroughResourceDefinition.PATH);

--- a/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
+++ b/clustering/infinispan/extension/src/main/resources/org/jboss/as/clustering/infinispan/subsystem/LocalDescriptions.properties
@@ -37,7 +37,7 @@ infinispan.cache-container.local-address=The local address of the node. May retu
 infinispan.cache-container.cluster-name=The name of the cluster this node belongs to. May return null if the cache manager is not started.
 # cache container children
 infinispan.cache-container.transport=A transport child of the cache container.
-infinispan.cache-container.local-cache=A replicated cache child of the cache container.
+infinispan.cache-container.local-cache=A local cache child of the cache container.
 infinispan.cache-container.invalidation-cache=An invalidation cache child of the cache container.
 infinispan.cache-container.replicated-cache=A replicated cache child of the cache container.
 infinispan.cache-container.distributed-cache=A distributed cache child of the cache container.


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5327

Requires:
WFLY-5665 Infinispan enables statistics instrumentation even though statistics-enabled is false
https://issues.jboss.org/browse/WFLY-5665

... as well as a workaround for ISPN-5957, which prevents this optimization from being used in conjunction with statistics-enabled="true".
