### PR TITLE
[WFLY-5678] Do not migrate attributes that no longer accept expressions

### DIFF
--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -158,11 +158,13 @@ public class MigrateTestCase extends AbstractSubsystemTest {
 
         ModelNode warnings = response.get(RESULT, "migration-warnings");
         // 6 warnings about broadcast-group attributes that can not be migrated.
+        // 2 warnings about broadcast-group attributes not migrated because they have an expression.
         // 5 warnings about discovery-group attributes that can not be migrated.
+        // 2 warnings about discovery-group attributes not migrated because they have an expression.
         // 2 warnings about interceptors that can not be migrated.
         // 1 warning about HA migration (attributes have expressions)
-        // 1 warning about cluster-connection forward-when-no-consumers attribute having an expresion.
-        int expectedNumberOfWarnings = 6 + 5 + 2 + 1 + 1;
+        // 1 warning about cluster-connection forward-when-no-consumers attribute having an expression.
+        int expectedNumberOfWarnings = 6 + 2 + 5 + 2 + 2 + 1 + 1;
         // 1 warning if add-legacy-entries is true because an in-vm connector can not be used in a legacy-connection-factory
         if (addLegacyEntries) {
             expectedNumberOfWarnings += 1;

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -121,8 +121,8 @@
                 <socket-binding>group-s-binding</socket-binding>
             </broadcast-group>
             <broadcast-group name="groupT">
-                <jgroups-stack>udp</jgroups-stack>
-                <jgroups-channel>hq-cluster</jgroups-channel>
+                <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
+                <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
             </broadcast-group>
         </broadcast-groups>
         <discovery-groups>
@@ -141,8 +141,8 @@
                 <socket-binding>group-t-binding</socket-binding>
             </discovery-group>
             <discovery-group name="groupU">
-                <jgroups-stack>udp</jgroups-stack>
-                <jgroups-channel>hq-cluster</jgroups-channel>
+                <jgroups-stack>${jgroups.stack:udp}</jgroups-stack>
+                <jgroups-channel>${jgroups.channel:hq-cluster}</jgroups-channel>
             </discovery-group>
         </discovery-groups>
         <diverts>


### PR DESCRIPTION
The discovery-group and broadcast-group resources in the legacy
messaging subsystem accept expressions for their jgroups-stack and
jgroups-channel resources.
The same resources in the new messaging-activemq subsystem no longer
accepts expressions for them (as they are references to other model
resources).

During migration, these attributes are ignored and removed from the new
:add operations to create the messaging-activemq resources and warnings
are added to the migration-warnings.
This allows the :migrate operation to succeed and the user will have to
fix the model afterwards by specifying a correct value for these
attributes.

JIRA: https://issues.jboss.org/browse/WFLY-5678
