### PR TITLE
WFLY-5683 Default jgroups thread pool keep-alive times are…

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/ThreadPoolResourceDefinition.java
@@ -68,12 +68,12 @@ import org.wildfly.clustering.infinispan.spi.service.CacheContainerServiceName;
  */
 public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registration<ManagementResourceRegistration>, ThreadPoolDefinition {
 
-    ASYNC_OPERATIONS("async-operations", 25, 25, 1000, 60000),
-    LISTENER("listener", 1, 1, 100000, 60000),
-    PERSISTENCE("persistence", 1, 4, 0, 60000),
-    REMOTE_COMMAND("remote-command", 1, 200, 0, 60000),
-    STATE_TRANSFER("state-transfer", 1, 60, 0, 60000),
-    TRANSPORT("transport", 25, 25, 100000, 60000),
+    ASYNC_OPERATIONS("async-operations", 25, 25, 1000, 60000L),
+    LISTENER("listener", 1, 1, 100000, 60000L),
+    PERSISTENCE("persistence", 1, 4, 0, 60000L),
+    REMOTE_COMMAND("remote-command", 1, 200, 0, 60000L),
+    STATE_TRANSFER("state-transfer", 1, 60, 0, 60000L),
+    TRANSPORT("transport", 25, 25, 100000, 60000L),
     ;
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/subsystem/ThreadPoolResourceDefinition.java
@@ -61,10 +61,10 @@ import org.wildfly.clustering.jgroups.spi.TransportConfiguration;
  */
 public enum ThreadPoolResourceDefinition implements ResourceDefinition, Registration<ManagementResourceRegistration> {
 
-    DEFAULT("default", "thread_pool", 20, 300, 100, 60L),
-    OOB("oob", "oob_thread_pool", 20, 300, 0, 60L),
-    INTERNAL("internal", "internal_thread_pool", 2, 4, 100, 60L),
-    TIMER("timer", "timer", 2, 4, 500, 5L),
+    DEFAULT("default", "thread_pool", 20, 300, 100, 60000L),
+    OOB("oob", "oob_thread_pool", 20, 300, 0, 60000L),
+    INTERNAL("internal", "internal_thread_pool", 2, 4, 100, 60000L),
+    TIMER("timer", "timer", 2, 4, 500, 5000L),
     ;
 
     static final PathElement WILDCARD_PATH = pathElement(PathElement.WILDCARD_VALUE);


### PR DESCRIPTION
… much too small; clarify units for infinispan

Jira
https://issues.jboss.org/browse/WFLY-5683

Downstream
https://github.com/jbossas/jboss-eap7/pull/33
