### PR TITLE
[WFLY-4850] Enabling extended cluster passivation test failed by assertion

### DIFF
--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/extended/ejb2/stateful/passivation/ClusterPassivationTestCase.java
@@ -38,7 +38,6 @@ import org.jboss.logging.Logger;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -124,7 +123,6 @@ public class ClusterPassivationTestCase extends ClusterPassivationTestBase {
         log.info("URL2 nodename: " + nodeName2);
     }
 
-    @Ignore("JBPAPP-8774")
     @Test
     @InSequence(1)
     public void testPassivationBeanAnnotated(


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-4850

There was an issue with assertion errors being thrown when server was not available at time. But it could be expected situation and check for isActive could then fail with assertion exception instead of returning a boolean.

After some fixes in wfcore this seems not happening anymore and the test could be enabled.

`./integration-tests.sh clean install -Dts.noSmoke -Dts.clustering -Djboss.dist=$JBOSS_HOME -Dtest=ClusterPassivationTestCase -DextendedTests`
