### PR TITLE
WFLY-4939: The request was rejected as the container is suspended during server shutdown

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbSuspendInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbSuspendInterceptor.java
@@ -47,7 +47,7 @@ public class EjbSuspendInterceptor extends AbstractEJBInterceptor {
         ControlPoint entryPoint = component.getControlPoint();
         RunResult result = entryPoint.beginRequest();
         if (result == RunResult.REJECTED) {
-            throw EjbLogger.ROOT_LOGGER.containerSuspended();
+            EjbLogger.ROOT_LOGGER.containerAlreadySuspended();
         }
         try {
             return context.proceed();

--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3111,4 +3111,10 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 484, value = "Could not send a cluster removal message for cluster: (%s) to the client on channel %s")
     void couldNotSendClusterRemovalMessage(@Cause Throwable cause, Group group, Channel channel);
+
+    @LogMessage(level = WARN)
+    @Message(id = 485, value = "The request was rejected as the container is already suspended")
+    void containerAlreadySuspended();
+
+
 }


### PR DESCRIPTION
[WFLY-4939](https://issues.jboss.org/browse/WFLY-4939) - https://issues.jboss.org/browse/WFLY-4939

As commented by @pferraro those messages being printed here are harmless and should be switch to WARN. This PR is my rather naïve first take on it - so please double check I've not overlooked something here ! :)
