### PR TITLE
[WFLY-5667] Migration: do not migrate parameters ignored by new subsystem

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -823,4 +823,7 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 86, value = "Could not migrate attribute %s from resource %s. The attribute uses an expression that can be resolved differently depending on system properties. To be able to migrate this property, replace the expression by an actual value.")
     String couldNotMigrateResourceAttributeWithExpression(String attribute, PathAddress address);
+
+    @Message(id = 87, value = "Could not migrate parameter %s from resource %s. This parameter is ignored in the new messaging-activemq subsystem.")
+    String couldNotMigrateIgnoredParameter(String attribute, PathAddress address);
 }

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -164,7 +164,8 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         // 2 warnings about interceptors that can not be migrated.
         // 1 warning about HA migration (attributes have expressions)
         // 1 warning about cluster-connection forward-when-no-consumers attribute having an expression.
-        int expectedNumberOfWarnings = 6 + 2 + 5 + 2 + 2 + 1 + 1;
+        // 1 warning about use-nio being ignored for netty-throughput remote-connector resource.
+        int expectedNumberOfWarnings = 6 + 2 + 5 + 2 + 2 + 1 + 1 + 1;
         // 1 warning if add-legacy-entries is true because an in-vm connector can not be used in a legacy-connection-factory
         if (addLegacyEntries) {
             expectedNumberOfWarnings += 1;

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -78,6 +78,7 @@
             <netty-connector name="netty" socket-binding="messaging" />
             <netty-connector name="netty-throughput" socket-binding="messaging-throughput">
                 <param key="batch-delay" value="${batch.delay:50}"/>
+                <param key="use-nio" value="true"/>
             </netty-connector>
             <in-vm-connector name="in-vm" server-id="${my.server-id:0}" />
             <connector name="myconnector">


### PR DESCRIPTION
During migration, do not migrate the use-nio parameter for remote/http
connector/acceptor resources in the new messaging-activemq subsystem and
add a warnings to the :migrate operation result.

JIRA: https://issues.jboss.org/browse/WFLY-5667
