### PR TITLE
[WFLY-5656]: No warning is shown when deploying web application with defined valves.

### DIFF
--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/JBossWebParsingDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/JBossWebParsingDeploymentProcessor.java
@@ -41,6 +41,7 @@ import org.jboss.as.web.common.WarMetaData;
 import org.jboss.metadata.parser.jbossweb.JBossWebMetaDataParser;
 import org.jboss.metadata.parser.util.NoopXMLResolver;
 import org.jboss.metadata.web.jboss.JBossWebMetaData;
+import org.jboss.metadata.web.jboss.ValveMetaData;
 import org.jboss.vfs.VirtualFile;
 import org.wildfly.extension.undertow.logging.UndertowLogger;
 
@@ -74,6 +75,11 @@ public class JBossWebParsingDeploymentProcessor implements DeploymentUnitProcess
                 warMetaData.setJBossWebMetaData(jBossWebMetaData);
                 // if the jboss-web.xml has a distinct-name configured, then attach the value to this
                 // deployment unit
+                if(jBossWebMetaData.getValves() != null) {
+                    for(ValveMetaData valve : jBossWebMetaData.getValves()) {
+                        UndertowLogger.ROOT_LOGGER.unsupportedValveFeature(valve.getValveClass());
+                    }
+                }
                 if (jBossWebMetaData.getDistinctName() != null) {
                     deploymentUnit.putAttachment(org.jboss.as.ee.structure.Attachments.DISTINCT_NAME, jBossWebMetaData.getDistinctName());
                 }

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -338,4 +338,8 @@ public interface UndertowLogger extends BasicLogger {
 
     @Message(id = 79, value = "No SSL Context available from security realm. Either the realm is not configured for SSL, or the server has not been reloaded since the SSL config was added.")
     IllegalStateException noSslContextInSecurityRealm();
+
+    @LogMessage(level = WARN)
+    @Message(id = 80, value = "Valves are no longer supported, %s is not activated.")
+    void unsupportedValveFeature(String valve);
 }


### PR DESCRIPTION
Adding warning traces if valves are defined.

Jira: https://issues.jboss.org/browse/WFLY-5656
https://issues.jboss.org/browse/JBEAP-1865
