### PR TITLE
WFLY-3639 default-web-module doesn't work for non default hosts & servers

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/VirtualHostTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/wildfly/test/integration/web/VirtualHostTestCase.java
@@ -1,0 +1,139 @@
+package org.wildfly.test.integration.web;
+
+import static org.jboss.as.controller.client.helpers.ClientConstants.OUTCOME;
+import static org.jboss.as.controller.client.helpers.ClientConstants.SUCCESS;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OPERATION_HEADERS;
+import static org.jboss.as.test.integration.management.util.ModelUtil.createOpNode;
+
+import java.io.IOException;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.arquillian.api.ServerSetup;
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.dmr.ModelNode;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Test that default-web-module works as it should for scenarios:
+ * - default host on of single server
+ * - non-default host of single server
+ * - non default server
+ *
+ * @author Tomaz Cerar (c) 2015 Red Hat Inc.
+ */
+
+@RunWith(Arquillian.class)
+@RunAsClient
+@ServerSetup(VirtualHostTestCase.VirtualHostSetupTask.class)
+//todo this test could probably be done in manual mode test with wildfly runner
+public class VirtualHostTestCase {
+
+    public static class VirtualHostSetupTask implements ServerSetupTask {
+        @Override
+        public void setup(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient client = managementClient.getControllerClient();
+            ModelNode addOp = createOpNode("subsystem=undertow/server=default-server/host=test", "add");
+            addOp.get("default-web-module").set("test.war");
+            addOp.get("alias").add(TestSuiteEnvironment.getServerAddress()); //either 127.0.0.1 or ::1
+            execute(client, addOp);
+
+            addOp = createOpNode("socket-binding-group=standard-sockets/socket-binding=myserver", "add");
+            addOp.get("port").set(8181);
+            execute(client, addOp);
+
+            addOp = createOpNode("subsystem=undertow/server=myserver", "add");
+            addOp.get("default-host").set("another");
+            execute(client, addOp);
+
+            addOp = createOpNode("subsystem=undertow/server=myserver/http-listener=myserver", "add");
+            addOp.get("socket-binding").set("myserver");
+            execute(client, addOp);
+
+            addOp = createOpNode("subsystem=undertow/server=myserver/host=another", "add");
+            addOp.get("default-web-module").set("another-server.war");
+            execute(client, addOp);
+
+        }
+
+        private void execute(ModelControllerClient client, ModelNode op) throws IOException {
+            op.get(OPERATION_HEADERS, ALLOW_RESOURCE_SERVICE_RESTART).set(true);
+            ModelNode response = client.execute(op);
+            if (!SUCCESS.equals(response.get(OUTCOME).asString())) {
+                Assert.fail("Could not execute op: '" + op + "', result: " + response);
+            }
+        }
+
+        @Override
+        public void tearDown(ManagementClient managementClient, String containerId) throws Exception {
+            ModelControllerClient client = managementClient.getControllerClient();
+            execute(client, createOpNode("subsystem=undertow/server=default-server/host=test", "remove"));
+            execute(client, createOpNode("subsystem=undertow/server=myserver/host=another", "remove"));
+            execute(client, createOpNode("subsystem=undertow/server=myserver/http-listener=myserver", "remove"));
+            execute(client, createOpNode("subsystem=undertow/server=myserver", "remove"));
+            execute(client, createOpNode("socket-binding-group=standard-sockets/socket-binding=myserver", "remove"));
+        }
+    }
+
+    private static WebArchive createDeployment(String name) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class, name + ".war");
+        war.addAsWebResource(new StringAsset(name), "index.html");
+        return war;
+    }
+
+    @Deployment(name = "ROOT")
+    public static Archive<?> getDefaultHostDeployment() {
+        return createDeployment("ROOT");
+    }
+
+    @Deployment(name = "test")
+    public static Archive<?> getAnotherHostDeployment() {
+        return createDeployment("test");
+    }
+
+    @Deployment(name = "another-server")
+    public static Archive<?> getAnotherServerDeployment() {
+        return createDeployment("another-server");
+    }
+
+    private void callAndTest(String uri, String expectedResult) throws IOException {
+        HttpClient client = HttpClients.createDefault();
+        HttpGet get = new HttpGet(uri);
+        HttpResponse response = client.execute(get);
+        Assert.assertEquals(200, response.getStatusLine().getStatusCode());
+        String result = EntityUtils.toString(response.getEntity());
+        Assert.assertEquals("Got response from wrong deployment", expectedResult, result);
+    }
+
+    @Test
+    public void testDefaultHost() throws IOException {
+        callAndTest("http://localhost:8080/", "ROOT");
+    }
+
+    @Test
+    public void testNonDefaultHost() throws IOException {
+        callAndTest("http://" + TestSuiteEnvironment.getServerAddress() + ":8080/", "test");
+    }
+
+    @Test
+    public void testAnotherServerHost() throws IOException {
+        callAndTest("http://localhost:8181/", "another-server");
+    }
+
+}

--- a/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/Host.java
@@ -184,7 +184,7 @@ public class Host implements Service<Host>, FilterLocation {
         String path = getDeployedContextPath(deploymentInfo);
         registerHandler(path, handler);
         deployments.add(deployment);
-        UndertowLogger.ROOT_LOGGER.registerWebapp(path);
+        UndertowLogger.ROOT_LOGGER.registerWebapp(path, getServer().getName());
         undertowService.getValue().fireEvent(new EventInvoker() {
             @Override
             public void invoke(UndertowEventListener listener) {
@@ -204,7 +204,7 @@ public class Host implements Service<Host>, FilterLocation {
         });
         unregisterHandler(path);
         deployments.remove(deployment);
-        UndertowLogger.ROOT_LOGGER.unregisterWebapp(path);
+        UndertowLogger.ROOT_LOGGER.unregisterWebapp(path, getServer().getName());
     }
 
     public void registerHandler(String path, HttpHandler handler) {

--- a/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/HostAdd.java
@@ -77,7 +77,7 @@ class HostAdd extends AbstractAddStepHandler {
                 .addDependency(UndertowService.SERVER.append(serverName), Server.class, service.getServerInjection())
                 .addDependency(UndertowService.UNDERTOW, UndertowService.class, service.getUndertowService());
 
-        builder.setInitialMode(Mode.ON_DEMAND);
+        builder.setInitialMode(Mode.ACTIVE);
 
         if (isDefaultHost) {
             addCommonHost(context, name, aliases, serverName, virtualHostServiceName);

--- a/undertow/src/main/java/org/wildfly/extension/undertow/ServerAdd.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/ServerAdd.java
@@ -22,7 +22,7 @@
 
 package org.wildfly.extension.undertow;
 
-import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
+import org.jboss.as.controller.AbstractAddStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
@@ -38,16 +38,16 @@ import org.jboss.msc.service.ServiceName;
 /**
  * @author <a href="mailto:tomaz.cerar@redhat.com">Tomaz Cerar</a> (c) 2013 Red Hat Inc.
  */
-class ServerAdd extends AbstractBoottimeAddStepHandler {
+class ServerAdd extends AbstractAddStepHandler {
 
     ServerAdd() {
         super(ServerDefinition.ATTRIBUTES);
     }
 
     @Override
-    protected void performBoottime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+    protected void performRuntime(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
         final PathAddress address = context.getCurrentAddress();
-        final PathAddress parentAddress = address.subAddress(0, address.size() - 1);
+        final PathAddress parentAddress = address.getParent();
         final ModelNode subsystemModel = Resource.Tools.readModel(context.readResourceFromRoot(parentAddress));
 
         final String name = context.getCurrentAddressValue();

--- a/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/deployment/UndertowDeploymentProcessor.java
@@ -25,7 +25,6 @@ package org.wildfly.extension.undertow.deployment;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.SessionManagerFactory;
 import io.undertow.servlet.core.InMemorySessionManagerFactory;
-
 import org.apache.jasper.Constants;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.ee.component.ComponentRegistry;
@@ -75,10 +74,11 @@ import org.wildfly.extension.requestcontroller.ControlPointService;
 import org.wildfly.extension.requestcontroller.RequestControllerActivationMarker;
 import org.wildfly.extension.undertow.DeploymentDefinition;
 import org.wildfly.extension.undertow.Host;
+import org.wildfly.extension.undertow.Server;
 import org.wildfly.extension.undertow.ServletContainerService;
 import org.wildfly.extension.undertow.UndertowExtension;
-import org.wildfly.extension.undertow.logging.UndertowLogger;
 import org.wildfly.extension.undertow.UndertowService;
+import org.wildfly.extension.undertow.logging.UndertowLogger;
 import org.wildfly.extension.undertow.security.jacc.WarJACCDeployer;
 import org.wildfly.extension.undertow.session.DistributableSessionIdentifierCodecBuilder;
 import org.wildfly.extension.undertow.session.DistributableSessionIdentifierCodecBuilderValue;
@@ -129,12 +129,43 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
         if (warMetaData == null) {
             return;
         }
-        String hostName = hostNameOfDeployment(warMetaData, defaultHost);
-        processDeployment(warMetaData, deploymentUnit, phaseContext.getServiceTarget(), hostName);
+        String deploymentName;
+        if (deploymentUnit.getParent() == null) {
+            deploymentName = deploymentUnit.getName();
+        } else {
+            deploymentName = deploymentUnit.getParent().getName() + "." + deploymentUnit.getName();
+        }
+        final UndertowService undertowService = (UndertowService) phaseContext.getServiceRegistry().getService(UndertowService.UNDERTOW).getValue();
+        final Set<Server> servers = undertowService.getServers();
+        final Host host = getHostForDeployment(servers, deploymentName);
+        String defaultHostForDeployment;
+        String defaultServerForDeployment;
+        if (host != null) {
+            defaultHostForDeployment = host.getName();
+            defaultServerForDeployment = host.getServer().getName();
+        } else {
+            defaultHostForDeployment = this.defaultHost;
+            defaultServerForDeployment = this.defaultServer;
+        }
+
+        String serverInstanceName = warMetaData.getMergedJBossWebMetaData().getServerInstanceName() == null ? defaultServerForDeployment : warMetaData.getMergedJBossWebMetaData().getServerInstanceName();
+        String hostName = hostNameOfDeployment(warMetaData, defaultHostForDeployment);
+        processDeployment(warMetaData, deploymentUnit, phaseContext.getServiceTarget(), deploymentName, hostName, serverInstanceName);
+    }
+
+    private Host getHostForDeployment(Set<Server> servers, final String deploymentName) {
+        for (Server server : servers) {
+            for (Host host : server.getHosts()) {
+                if (deploymentName.equals(host.getDefaultWebModule())) {
+                    return host;
+                }
+            }
+        }
+        return null;
     }
 
 
-    static String hostNameOfDeployment(final WarMetaData metaData, final String defaultHost) {
+    private String hostNameOfDeployment(final WarMetaData metaData, String defaultHost) {
         Collection<String> hostNames = null;
         if (metaData.getMergedJBossWebMetaData() != null) {
             hostNames = metaData.getMergedJBossWebMetaData().getVirtualHosts();
@@ -151,11 +182,11 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
 
     @Override
     public void undeploy(final DeploymentUnit context) {
-        //AbstractSecurityDeployer<?> deployer = new WarJACCDeployer();
-        //deployer.undeploy(context);
+
     }
 
-    private void processDeployment(final WarMetaData warMetaData, final DeploymentUnit deploymentUnit, final ServiceTarget serviceTarget, String hostName)
+    private void processDeployment(final WarMetaData warMetaData, final DeploymentUnit deploymentUnit, final ServiceTarget serviceTarget,
+                                   final String deploymentName, final String hostName, final String serverInstanceName)
             throws DeploymentUnitProcessingException {
         ResourceRoot deploymentResourceRoot = deploymentUnit.getAttachment(Attachments.DEPLOYMENT_ROOT);
         final VirtualFile deploymentRoot = deploymentResourceRoot.getRoot();
@@ -204,13 +235,6 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
             jaccContextId = deploymentUnit.getParent().getName() + "!" + jaccContextId;
         }
 
-        String deploymentName;
-        if (deploymentUnit.getParent() == null) {
-            deploymentName = deploymentUnit.getName();
-        } else {
-            deploymentName = deploymentUnit.getParent().getName() + "." + deploymentUnit.getName();
-        }
-
         final String pathName = pathNameOfDeployment(deploymentUnit, metaData);
 
         boolean securityEnabled = deploymentUnit.hasAttachment(SecurityAttachments.SECURITY_ENABLED);
@@ -230,9 +254,6 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
         } else {
             securityDomain = null;
         }
-
-        String serverInstanceName = metaData.getServerInstanceName() == null ? defaultServer : metaData.getServerInstanceName();
-        final ServiceName deploymentServiceName = UndertowService.deploymentServiceName(serverInstanceName, hostName, pathName);
 
         final Set<ServiceName> additionalDependencies = new HashSet<>();
         for (final SetupAction setupAction : setupActions) {
@@ -256,6 +277,7 @@ public class UndertowDeploymentProcessor implements DeploymentUnitProcessor {
         additionalDependencies.addAll(warMetaData.getAdditionalDependencies());
 
         final ServiceName hostServiceName = UndertowService.virtualHostName(serverInstanceName, hostName);
+        final ServiceName deploymentServiceName = UndertowService.deploymentServiceName(serverInstanceName, hostName, pathName);
         TldsMetaData tldsMetaData = deploymentUnit.getAttachment(TldsMetaData.ATTACHMENT_KEY);
         UndertowDeploymentInfoService undertowDeploymentInfoService = UndertowDeploymentInfoService.builder()
                 .setAttributes(deploymentUnit.getAttachmentList(ServletContextAttribute.ATTACHMENT_KEY))

--- a/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/logging/UndertowLogger.java
@@ -151,12 +151,12 @@ public interface UndertowLogger extends BasicLogger {
 
 
     @LogMessage(level = INFO)
-    @Message(id = 21, value = "Registered web context: %s")
-    void registerWebapp(String webappPath);
+    @Message(id = 21, value = "Registered web context: '%s' for server '%s'")
+    void registerWebapp(String webappPath, String serverName);
 
     @LogMessage(level = INFO)
-    @Message(id = 22, value = "Unregistered web context: %s")
-    void unregisterWebapp(String webappPath);
+    @Message(id = 22, value = "Unregistered web context: '%s' from server '%s'")
+    void unregisterWebapp(String webappPath, String serverName);
 
     @LogMessage(level = INFO)
     @Message(id = 23, value = "Skipped SCI for jar: %s.")


### PR DESCRIPTION
- make adding hosts after boot without reload-required
- improve deployment message to include server on which it was deployed to
- add test to verify default-web-module works for all possible scenarios
