### PR TITLE
[EAP7-330] Datasource management tests of attribure enabled with expressions

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/Datasource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/Datasource.java
@@ -1,0 +1,137 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+/**
+ * @author <a href="mailto:ochaloup@redhat.com>Ondra Chaloupka</a>
+ */
+public class Datasource {
+    private final String name, jndiName, driverName, connectionUrl, userName, password, enabled;
+
+    private Datasource(Builder builder) {
+        this.name = builder.datasourceName;
+        this.jndiName = builder. jndiName;
+        this.driverName = builder. driverName;
+        this.connectionUrl = builder. connectionUrl;
+        this.userName = builder. userName;
+        this.password = builder. password;
+        this.enabled = builder. enabled;
+    }
+
+    public static Builder Builder(String datasourceName) {
+        return new Builder(datasourceName);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getJndiName() {
+        return jndiName;
+    }
+
+    public String getDriverName() {
+        return driverName;
+    }
+
+    public String getConnectionUrl() {
+        return connectionUrl;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getEnabled() {
+        return enabled;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("Datasource name: %s, jndi: %s, driver name: %s, url: %s, user name: %s, password: %s, enabled: %s",
+          name, jndiName, driverName, connectionUrl, userName, password, enabled);
+    }
+
+
+    public static final class Builder {
+        private final String datasourceName;
+        private String jndiName;
+        private String enabled = "true";
+        private String driverName = System.getProperty("ds.jdbc.driver");
+        private String connectionUrl = System.getProperty("ds.jdbc.url");
+        private String userName = System.getProperty("ds.jdbc.user");
+        private String password = System.getProperty("ds.jdbc.pass");
+
+        private Builder(String datasourceName) {
+            this.datasourceName = datasourceName;
+            this.jndiName = "java:jboss/datasources/" + datasourceName;
+            if(this.driverName == null) driverName = "h2";
+            if(this.connectionUrl == null) connectionUrl = "jdbc:h2:mem:test;DB_CLOSE_DELAY=-1";
+            if(this.userName == null) userName = "sa";
+            if(this.password == null) password = "sa";
+        }
+
+        public Builder jndiName(String jndiName) {
+            this.jndiName = jndiName;
+            return this;
+        }
+
+        public Builder driverName(String driverName) {
+            this.driverName = driverName;
+            return this;
+        }
+
+        public Builder enabled(Boolean enabled) {
+            this.enabled = enabled.toString();
+            return this;
+        }
+
+        public Builder enabled(String enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+
+        public Builder connectionUrl(String connectionUrl) {
+            this.connectionUrl = connectionUrl;
+            return this;
+        }
+
+        public Builder userName(String userName) {
+            this.userName = userName;
+            return this;
+        }
+
+        public Builder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public Datasource build() {
+            return new Datasource(this);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceEnableAttributeTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceEnableAttributeTestBase.java
@@ -1,0 +1,226 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import org.jboss.as.test.integration.management.jca.DsMgmtTestBase;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.Assert;
+import org.junit.Test;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import java.io.IOException;
+
+/**
+ * A basic testing of setting/unsetting "enable" attribute of datasource.
+ *
+ * @author <a href="mailto:ochaloup@redhat.com>Ondra Chaloupka</a>
+ */
+public abstract class DatasourceEnableAttributeTestBase extends DsMgmtTestBase {
+    private static final Logger log = Logger.getLogger(DatasourceEnableAttributeTestBase.class);
+
+    private static final String DS_ENABLED_SYSTEM_PROPERTY_NAME = "ds.enabled";
+
+    @Test
+    public void addDatasourceEnabled() throws Exception {
+        Datasource ds = Datasource.Builder("testDatasourceEnabled")
+            .enabled(true)
+            .build();
+
+        try {
+            createDataSource(ds);
+            testConnection(ds);
+        } finally {
+            removeDataSourceSilently(ds);
+        }
+    }
+
+    @Test(expected = MgmtOperationException.class)
+    public void addDatasourceDisabled() throws Exception {
+        Datasource ds = Datasource.Builder("testDatasourceDisabled")
+                .enabled(false)
+                .build();
+        
+        try {
+            createDataSource(ds);
+            testConnection(ds);
+        } finally {
+            removeDataSourceSilently(ds);
+        }
+    }
+    
+    @Test
+    public void enableLater() throws Exception {
+        Datasource ds = Datasource.Builder("testDatasourceLater")
+                .enabled(false)
+                .build();
+        
+        try {
+            createDataSource(ds);
+
+            try {
+                testConnection(ds);
+                Assert.fail("Datasource " + ds + " is disabled. Test connection can't succeed.");
+            } catch (MgmtOperationException moe) {
+                // expecting that datasource won't be available 'online'
+            }
+
+            writeAttribute(getDataSourceAddress(ds), "enabled", "true");
+            reload();
+            testConnection(ds);
+
+        } finally {
+            removeDataSourceSilently(ds);
+        }
+    }
+    
+    @Test
+    public void enableBySystemProperty() throws Exception {
+        Datasource ds = Datasource.Builder("testDatasourceEnableBySystem")
+                .enabled(wrapProp(DS_ENABLED_SYSTEM_PROPERTY_NAME))
+                .build();
+       
+        try {
+            addSystemProperty(DS_ENABLED_SYSTEM_PROPERTY_NAME, "true");
+            createDataSource(ds);
+            testConnection(ds);
+        } finally {
+            removeSystemPropertySilently(DS_ENABLED_SYSTEM_PROPERTY_NAME);
+            removeDataSourceSilently(ds);
+        }
+    }
+
+    @Test(expected = MgmtOperationException.class)
+    public void disableBySystemProperty() throws Exception {
+        Datasource ds = Datasource.Builder("testDatasourceDisableBySystem")
+                .enabled(wrapProp(DS_ENABLED_SYSTEM_PROPERTY_NAME))
+                .build();
+        
+        try {
+            addSystemProperty(DS_ENABLED_SYSTEM_PROPERTY_NAME, "false");
+            createDataSource(ds);
+            testConnection(ds);
+        } finally {
+            removeSystemPropertySilently(DS_ENABLED_SYSTEM_PROPERTY_NAME);
+            removeDataSourceSilently(ds);
+        }
+    }
+
+    @Test
+    public void allBySystemProperty() throws Exception {
+        String url = "ds.url";
+        String username = "ds.username";
+        String password = "ds.password";
+        String jndiName = "ds.jndi";
+        String driverName = "ds.drivername";
+        Datasource ds = Datasource.Builder("testAllBySystem")
+            .connectionUrl(wrapProp(url))
+            .userName(wrapProp(username))
+            .password(wrapProp(password))
+            .jndiName(wrapProp(jndiName))
+            .driverName(wrapProp(driverName))
+            .enabled(wrapProp(DS_ENABLED_SYSTEM_PROPERTY_NAME))
+            .build();
+        
+        try {
+            Datasource defaultPropertyDs = Datasource.Builder("temporary").build();
+            addSystemProperty(url, defaultPropertyDs.getConnectionUrl());
+            addSystemProperty(username, defaultPropertyDs.getUserName());
+            addSystemProperty(password, defaultPropertyDs.getPassword());
+            addSystemProperty(jndiName, defaultPropertyDs.getJndiName());
+            addSystemProperty(driverName, defaultPropertyDs.getDriverName());
+            addSystemProperty(DS_ENABLED_SYSTEM_PROPERTY_NAME, "true");
+            createDataSource(ds);
+            testConnection(ds);
+        } finally {
+            removeSystemPropertySilently(url);
+            removeSystemPropertySilently(username);
+            removeSystemPropertySilently(password);
+            removeSystemPropertySilently(jndiName);
+            removeSystemPropertySilently(driverName);
+            removeSystemPropertySilently(DS_ENABLED_SYSTEM_PROPERTY_NAME);
+            removeDataSourceSilently(ds);
+        }
+    }
+
+    /*
+     * Abstract method overriden in test subclasses
+     */
+    protected abstract ModelNode createDataSource(Datasource datasource) throws Exception;
+    protected abstract void removeDataSourceSilently(Datasource datasource);
+    protected abstract ModelNode getDataSourceAddress(Datasource datasource);
+    protected abstract void testConnection(Datasource datasource) throws Exception;
+
+    /**
+     * Common attribute for add datsource operation for non-XA and XA datasource creation.
+     */
+    protected ModelNode getDataSourceOperation(ModelNode address, Datasource datasource) {
+        ModelNode operation = new ModelNode();
+        operation.get(OP).set(ADD);
+        operation.get(OP_ADDR).set(address);
+        operation.get("jndi-name").set(datasource.getJndiName());
+        operation.get("driver-name").set(datasource.getDriverName());
+        operation.get("enabled").set(datasource.getEnabled());
+        operation.get("user-name").set(datasource.getUserName());
+        operation.get("password").set(datasource.getPassword());
+        return operation;
+    }
+
+    protected ModelNode writeAttribute(ModelNode address, String attribute, String value) throws Exception {
+        final ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).set(address);
+        operation.get(OP).set("write-attribute");
+        operation.get("name").set(attribute);
+        operation.get("value").set(value);
+        return executeOperation(operation);
+    }
+
+    private ModelNode addSystemProperty(String name, String value) throws IOException, MgmtOperationException {
+        ModelNode address = new ModelNode()
+                .add(SYSTEM_PROPERTY, name);
+        address.protect();
+        final ModelNode operation = new ModelNode();
+        operation.get(OP_ADDR).set(address);
+        operation.get(OP).set(ADD);
+        operation.get(VALUE).set(value);
+        return executeOperation(operation);
+    }
+
+    protected void removeSystemPropertySilently(String name) {
+        if(name == null) {
+            return;
+        }
+        try {
+            ModelNode address = new ModelNode()
+                    .add(SYSTEM_PROPERTY, name);
+            address.protect();
+            remove(address);
+        } catch(Exception e) {
+            log.debugf(e, "Can't remove system property '%s' by cli", name);
+        }
+    }
+
+    private String wrapProp(String propertyName) {
+        return String.format("${%s}", propertyName);
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceEnableAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceEnableAttributeTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.runner.RunWith;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+
+/**
+ * Running tests from {@link DatasourceEnableAttributeTestBase} with standard non-XA datsource.
+ *
+ * @author <a href="mailto:ochaloup@redhat.com>Ondra Chaloupka</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DatasourceEnableAttributeTestCase extends DatasourceEnableAttributeTestBase {
+    private static final Logger log = Logger.getLogger(DatasourceEnableAttributeTestBase.class);
+
+    @Override
+    protected ModelNode createDataSource(Datasource datasource) throws Exception {
+        ModelNode address = getDataSourceAddress(datasource);
+
+        ModelNode operation = getDataSourceOperation(address, datasource);
+        operation.get("connection-url").set(datasource.getConnectionUrl());
+        executeOperation(operation);
+
+        reload();
+        return address;
+    }
+
+    @Override
+    protected void removeDataSourceSilently(Datasource datasource) {
+        if(datasource == null || datasource.getName() == null) {
+            return;
+        }
+
+        ModelNode address = getDataSourceAddress(datasource);
+        try {
+            remove(address);
+            reload();
+        } catch (Exception e) {
+            log.debugf(e, "Can't remove datasource at address '%s'", address);
+        }
+    }
+
+    @Override
+    protected ModelNode getDataSourceAddress(Datasource datasource) {
+        ModelNode address = new ModelNode()
+             .add(SUBSYSTEM, "datasources")
+            .add("data-source", datasource.getName());
+        address.protect();
+        return address;
+    }
+
+    @Override
+    protected void testConnection(Datasource datasource) throws Exception {
+        testConnection(datasource.getName());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceXaEnableAttributeTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/datasource/DatasourceXaEnableAttributeTestCase.java
@@ -1,0 +1,104 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.jca.datasource;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+import org.jboss.logging.Logger;
+import org.junit.runner.RunWith;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.*;
+import java.io.IOException;
+
+/**
+ * Running tests from {@link DatasourceEnableAttributeTestBase} with XA datsource.
+ *
+ * @author <a href="mailto:ochaloup@redhat.com>Ondra Chaloupka</a>
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DatasourceXaEnableAttributeTestCase extends DatasourceEnableAttributeTestBase {
+    private static final Logger log = Logger.getLogger(DatasourceXaEnableAttributeTestCase.class);
+
+    @Override
+    protected ModelNode createDataSource(Datasource datasource) throws Exception {
+        ModelNode address = getDataSourceAddress(datasource);
+
+        ModelNode batch = new ModelNode();
+        batch.get(OP).set(COMPOSITE);
+        batch.get(OP_ADDR).setEmptyList();
+        
+        ModelNode operation = getDataSourceOperation(address, datasource);
+        batch.get(STEPS).add(operation);
+
+        ModelNode operationXAProperty = getAddXADataSourcePropertyOperation(address, "URL", datasource.getConnectionUrl());
+        batch.get(STEPS).add(operationXAProperty);
+
+        executeOperation(batch);
+        reload();
+        return address;
+    }
+
+    @Override
+    protected void removeDataSourceSilently(Datasource datasource) {
+        if(datasource == null || datasource.getName() == null) {
+            return;
+        }
+
+        ModelNode address = getDataSourceAddress(datasource);
+        try {
+            remove(address);
+            reload();
+        } catch (Exception e) {
+            log.debugf(e, "Can't remove xa datasource at address '%s'", address);
+        }
+    }
+
+    @Override
+    protected ModelNode getDataSourceAddress(Datasource datasource) {
+        ModelNode address = new ModelNode()
+                .add(SUBSYSTEM, "datasources")
+                .add("xa-data-source", datasource.getName());
+        address.protect();
+        return address;
+    }
+
+    @Override
+    protected void testConnection(Datasource datasource) throws Exception {
+        testConnectionXA(datasource.getName());
+    }
+    
+    private ModelNode getAddXADataSourcePropertyOperation(final ModelNode address, final String name, final String value) throws IOException, MgmtOperationException {
+        final ModelNode propertyAddress = address.clone();
+        propertyAddress.add("xa-datasource-properties", name);
+        propertyAddress.protect();
+        
+        final ModelNode operation = new ModelNode();
+        operation.get(OP).set("add");
+        operation.get(OP_ADDR).set(propertyAddress);
+        operation.get("value").set(value);
+        
+        return operation;
+    }
+}


### PR DESCRIPTION
Adding test of checking datasource attribute enable being used with expressions. The attribute enabled was allowed for expressions by https://issues.jboss.org/browse/WFLY-2160.

As part of the EAP7-330 I add a test to check that.

JIRA: https://issues.jboss.org/browse/EAP7-330
