### PR TITLE
WFLY-5170 WildFlySecurityManager throws exception by some tests with security manager

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/batch/common/AbstractBatchTestCase.java
@@ -29,6 +29,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.PropertyPermission;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -50,25 +51,13 @@ import org.jboss.shrinkwrap.descriptor.api.Descriptors;
 import org.jboss.shrinkwrap.descriptor.api.spec.se.manifest.ManifestDescriptor;
 import org.junit.Assert;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 /**
  * @author <a href="mailto:jperkins@redhat.com">James R. Perkins</a>
  */
 public abstract class AbstractBatchTestCase {
     static final String ENCODING = "utf-8";
-
-
-    public static WebArchive createDefaultWar(final String warName, final Package pkg, final String jobXml) {
-        return ShrinkWrap.create(WebArchive.class, warName)
-                .addPackage(AbstractBatchTestCase.class.getPackage())
-                .addClasses(TimeoutUtil.class)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-                .addAsWebInfResource(pkg, jobXml, "classes/META-INF/batch-jobs/" + jobXml)
-                .setManifest(new StringAsset(
-                        Descriptors.create(ManifestDescriptor.class)
-                                .attribute("Dependencies", "org.jboss.msc,org.wildfly.security.manager")
-                                .exportAsString()));
-    }
-
 
     public static WebArchive createDefaultWar(final String warName, final Package pkg, final String... jobXmls) {
         final WebArchive deployment = ShrinkWrap.create(WebArchive.class, warName)
@@ -78,7 +67,8 @@ public abstract class AbstractBatchTestCase {
                 .setManifest(new StringAsset(
                         Descriptors.create(ManifestDescriptor.class)
                                 .attribute("Dependencies", "org.jboss.msc,org.wildfly.security.manager")
-                                .exportAsString()));
+                                .exportAsString()))
+                .addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "permissions.xml");
         for (String jobXml : jobXmls) {
             deployment.addAsWebInfResource(pkg, jobXml, "classes/META-INF/batch-jobs/" + jobXml);
         }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/BootStrapValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/BootStrapValidationTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -56,6 +57,8 @@ public class BootStrapValidationTestCase {
     public static Archive<?> deploy() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "testbootstrapvalidation.war");
         war.addPackage(BootStrapValidationTestCase.class.getPackage());
+        // Hibernate Validator needs the following runtime permission
+        war.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessDeclaredMembers")), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ConstraintValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ConstraintValidationTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -55,6 +56,8 @@ public class ConstraintValidationTestCase {
     public static Archive<?> deploy() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "testconstraintvalidation.war");
         war.addPackage(ConstraintValidationTestCase.class.getPackage());
+        // Hibernate Validator needs the following runtime permission
+        war.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessDeclaredMembers")), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ExpressionLanguageTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/ExpressionLanguageTestCase.java
@@ -36,6 +36,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -49,7 +50,9 @@ public class ExpressionLanguageTestCase {
     @Deployment
     public static Archive<?> deploy() {
         return ShrinkWrap.create(WebArchive.class, "expression-language-validation.war").addClass(
-                ExpressionLanguageTestCase.class);
+                ExpressionLanguageTestCase.class)
+                // Hibernate Validator needs the following runtime permission
+                .addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessDeclaredMembers")), "permissions.xml");
     }
 
     @Test

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/GroupandGroupSequenceValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/GroupandGroupSequenceValidationTestCase.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -52,6 +53,8 @@ public class GroupandGroupSequenceValidationTestCase {
     public static Archive<?> deploy() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "testgroupvalidation.war");
         war.addPackage(GroupandGroupSequenceValidationTestCase.class.getPackage());
+        // Hibernate Validator needs the following runtime permission
+        war.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessDeclaredMembers")), "permissions.xml");
         return war;
 
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/MessageInterpolationValidationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/MessageInterpolationValidationTestCase.java
@@ -1,5 +1,6 @@
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -34,6 +35,8 @@ public class MessageInterpolationValidationTestCase {
     public static Archive<?> deploy() {
         final WebArchive war = ShrinkWrap.create(WebArchive.class, "testmessageinterpolationvalidation.war");
         war.addPackage(MessageInterpolationValidationTestCase.class.getPackage());
+        // Hibernate Validator needs the following runtime permission
+        war.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("accessDeclaredMembers")), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureDepedenciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/ear/EarJbossStructureDepedenciesTestCase.java
@@ -32,6 +32,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 @RunWith(Arquillian.class)
 public class EarJbossStructureDepedenciesTestCase {
 
@@ -57,6 +59,7 @@ public class EarJbossStructureDepedenciesTestCase {
         JavaArchive earLib = ShrinkWrap.create(JavaArchive.class, "earLib.jar");
         earLib.addClass(TestBB.class);
         ear.addAsLibraries(earLib);
+        ear.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("getClassLoader")), "permissions.xml");
         return ear;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarChildFirstClassLoadingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarChildFirstClassLoadingTestCase.java
@@ -42,7 +42,7 @@ public class WarChildFirstClassLoadingTestCase {
     public static Archive<?> deploy() {
         WebArchive war = ShrinkWrap.create(WebArchive.class);
         war.addClasses(WarChildFirstClassLoadingTestCase.class, Stateless.class);
-        war.addAsWebInfResource(createPermissionsXmlAsset(new RuntimePermission("getClassLoader")), "permissions.xml");
+        war.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("getClassLoader")), "permissions.xml");
         return war;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarInEarChildFirstClassLoadingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/classloading/war/WarInEarChildFirstClassLoadingTestCase.java
@@ -37,6 +37,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 @RunWith(Arquillian.class)
 public class WarInEarChildFirstClassLoadingTestCase {
 
@@ -51,6 +53,7 @@ public class WarInEarChildFirstClassLoadingTestCase {
         earLib.addAsManifestResource(new StringAsset("Dependencies: \n"), "MANIFEST.MF"); //AS7-5547, make sure an empty dependencies entry is fine
         earLib.addClasses(TestBB.class, WebInfLibClass.class);
         ear.addAsLibrary(earLib);
+        ear.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("getClassLoader")), "permissions.xml");
         return ear;
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/JarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/jar/JarJBossDeploymentStructureTestCase.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 
@@ -52,6 +53,10 @@ public class JarJBossDeploymentStructureTestCase {
         jar.add(ignoredJar, "i", ZipExporter.class);
         jar.add(otherJar, "other", ZipExporter.class);
 
+        jar.addAsManifestResource(createPermissionsXmlAsset(
+                new RuntimePermission("getClassLoader"),
+                new RuntimePermission("getProtectionDomain")),
+                "permissions.xml");
 
         logger.info(jar.toString(true));
         return jar;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/structure/war/WarJBossDeploymentStructureTestCase.java
@@ -17,6 +17,7 @@ import javax.ejb.EJB;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 
 
@@ -53,6 +54,11 @@ public class WarJBossDeploymentStructureTestCase {
         war.add(ignoredJar, "i", ZipExporter.class);
 
         war.addAsWebResource(new StringAsset("Root file"), "root-file.txt");
+
+        war.addAsManifestResource(createPermissionsXmlAsset(
+                new RuntimePermission("getClassLoader"),
+                new RuntimePermission("getProtectionDomain")),
+                "permissions.xml");
 
         return war;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20MessageSelectorTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20MessageSelectorTestCase.java
@@ -41,6 +41,9 @@ import org.junit.runner.RunWith;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.naming.InitialContext;
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests EJB2.0 MDBs with message selector.
@@ -87,6 +90,7 @@ public class MDB20MessageSelectorTestCase extends AbstractMDB2xTestCase {
         ejbJar.addAsManifestResource(MDB20MessageSelectorTestCase.class.getPackage(), "ejb-jar-20-message-selector.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(MDB20MessageSelectorTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
         ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         logger.info(ejbJar.toString(true));
         return ejbJar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20QueueTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20QueueTestCase.java
@@ -41,6 +41,9 @@ import org.junit.runner.RunWith;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.naming.InitialContext;
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests EJB2.0 MDBs listening on a queue.
@@ -84,6 +87,7 @@ public class MDB20QueueTestCase extends AbstractMDB2xTestCase {
         ejbJar.addAsManifestResource(MDB20QueueTestCase.class.getPackage(), "ejb-jar-20.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(MDB20QueueTestCase.class.getPackage(), "jboss-ejb3.xml", "jboss-ejb3.xml");
         ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         logger.info(ejbJar.toString(true));
         return ejbJar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB20TopicTestCase.java
@@ -43,6 +43,9 @@ import javax.jms.Message;
 import javax.jms.Queue;
 import javax.jms.Topic;
 import javax.naming.InitialContext;
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests EJB2.0 MDBs listening on a topic.
@@ -89,6 +92,7 @@ public class MDB20TopicTestCase extends AbstractMDB2xTestCase {
         ejbJar.addAsManifestResource(MDB20TopicTestCase.class.getPackage(), "ejb-jar-20-topic.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(MDB20TopicTestCase.class.getPackage(), "jboss-ejb3-topic.xml", "jboss-ejb3.xml");
         ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         logger.info(ejbJar.toString(true));
         return ejbJar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB21TestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/ejb2x/MDB21TestCase.java
@@ -41,6 +41,9 @@ import org.junit.runner.RunWith;
 import javax.jms.Message;
 import javax.jms.Queue;
 import javax.naming.InitialContext;
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests EJB2.1 MDB deployments.
@@ -83,6 +86,7 @@ public class MDB21TestCase extends AbstractMDB2xTestCase {
         ejbJar.addClasses(JmsQueueSetup.class, TimeoutUtil.class);
         ejbJar.addAsManifestResource(MDB21TestCase.class.getPackage(), "ejb-jar-21.xml", "ejb-jar.xml");
         ejbJar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.controller-client, org.jboss.dmr \n"), "MANIFEST.MF");
+        ejbJar.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         logger.info(ejbJar.toString(true));
         return ejbJar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
@@ -17,6 +17,7 @@
 package org.jboss.as.test.integration.ejb.pool.lifecycle;
 
 import java.io.InputStream;
+import java.util.PropertyPermission;
 
 import javax.ejb.EJB;
 import javax.jms.Connection;
@@ -53,6 +54,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -96,6 +98,7 @@ public class PooledEJBLifecycleTestCase {
         archive.addClass(TimeoutUtil.class);
         archive.addClass(PointlesMathInterface.class);
         archive.addClass(Constants.class);
+        archive.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         log.info(archive.toString(true));
         return archive;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
@@ -38,6 +38,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.naming.InitialContext;
+import java.util.PropertyPermission;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests various scenarios for stateful bean passivation
@@ -64,6 +67,7 @@ public class PassivationTestCase {
                 "MANIFEST.MF");
         jar.addAsManifestResource(PassivationTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
         jar.addAsManifestResource(PassivationTestCase.class.getPackage(), "ejb-jar.xml", "ejb-jar.xml");
+        jar.addAsManifestResource(createPermissionsXmlAsset(new PropertyPermission("ts.timeout.factor", "read")), "jboss-permissions.xml");
         log.info(jar.toString(true));
         return jar;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/context/transactionscoped/TransactionScopedJMSContextTestCase.java
@@ -37,11 +37,9 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.messaging.jms.context.transactionscoped.auxiliary.AppScopedBean;
 import org.jboss.as.test.integration.messaging.jms.context.transactionscoped.auxiliary.ThreadLauncher;
-import org.jboss.as.test.shared.TimeoutUtil;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -65,7 +63,6 @@ public class TransactionScopedJMSContextTestCase {
     @Deployment
     public static JavaArchive createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class, "TransactionScopedJMSContextTestCase.jar")
-                .addClass(TimeoutUtil.class)
                 .addPackage(AppScopedBean.class.getPackage())
                 .addAsManifestResource(EmptyAsset.INSTANCE,
                         "beans.xml");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/ejb/RemoteNamingEjbTestCase.java
@@ -51,6 +51,7 @@ import org.jboss.as.test.shared.integration.ejb.security.CallbackHandler;
 import org.jboss.dmr.ModelNode;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
@@ -75,6 +76,7 @@ public class RemoteNamingEjbTestCase {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, ARCHIVE_NAME + ".jar");
         jar.addClasses(Remote.class, BinderRemote.class, Bean.class, Singleton.class, StatefulBean.class);
         jar.addAsResource(createPermissionsXmlAsset(new JndiPermission("java:jboss/exported/-", "all")), "META-INF/jboss-permissions.xml");
+        jar.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF");
         return jar;
     }
 


### PR DESCRIPTION
This adds permissions that some test-cases needs in order to run with Security Manager.

More details in:
https://issues.jboss.org/browse/WFLY-5170
https://issues.jboss.org/browse/JBEAP-823
