### PR TITLE
WFLY-4939: The request was rejected as the container is suspended during server shutdown

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/LoggingInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/interceptors/LoggingInterceptor.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Method;
 
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ejb3.logging.EjbLogger;
+import org.jboss.as.ejb3.component.EJBComponentUnavailableException;
 import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.ejb3.tx.ApplicationExceptionDetails;
 import org.jboss.invocation.ImmediateInterceptorFactory;
@@ -64,6 +65,10 @@ public class LoggingInterceptor implements Interceptor {
         try {
             // we just pass on the control and do our work only when an exception occurs
             return interceptorContext.proceed();
+        } catch ( EJBComponentUnavailableException ex) {
+            if ( EjbLogger.EJB3_INVOCATION_LOGGER.isTraceEnabled() )
+                EjbLogger.EJB3_INVOCATION_LOGGER.trace(ex.getMessage());
+            throw ex;
         } catch (Throwable t) {
             final Method invokedMethod = interceptorContext.getMethod();
             // check if it's an application exception. If yes, then *don't* log


### PR DESCRIPTION
[WFLY-4939](https://issues.jboss.org/browse/WFLY-4939) - The request was rejected as the container is suspended during server shutdown

_Sidenote: seems to me that this fix is the less intrusive,  but if you feel this could be enhanced, feel free to comment !_
