### PR TITLE
Optimize catch block

### DIFF
--- a/weld/src/main/java/org/jboss/as/weld/WeldModuleResourceLoader.java
+++ b/weld/src/main/java/org/jboss/as/weld/WeldModuleResourceLoader.java
@@ -68,11 +68,7 @@ public class WeldModuleResourceLoader implements ResourceLoader {
             final Class<?> clazz = module.getClassLoader().loadClass(name);
             classes.put(name, clazz);
             return clazz;
-        } catch (NoClassDefFoundError e) {
-            throw new ResourceLoadingException(e);
-        } catch (ClassNotFoundException e) {
-            throw new ResourceLoadingException(e);
-        } catch (LinkageError e) {
+        } catch (ClassNotFoundException | LinkageError e) {
             throw new ResourceLoadingException(e);
         }
     }


### PR DESCRIPTION
There is no need of using NoClassDefFoundError in the catch block, because it is a subclass of the LinkageError class
