### PR TITLE
[WFLY-5238]: Migration operation] [Web to Undertow] Unable to migrate  any valve to handler.

### DIFF
--- a/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
@@ -46,6 +46,7 @@ import org.jboss.dmr.ValueExpression;
 import org.wildfly.extension.io.IOExtension;
 import org.wildfly.extension.undertow.Constants;
 import org.wildfly.extension.undertow.UndertowExtension;
+import org.wildfly.extension.undertow.filters.CustomFilterDefinition;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -85,6 +86,9 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TRU
 import static org.jboss.as.controller.operations.common.Util.createAddOperation;
 import static org.jboss.as.controller.operations.common.Util.createOperation;
 import static org.jboss.as.controller.operations.common.Util.createRemoveOperation;
+import static org.wildfly.extension.undertow.UndertowExtension.PATH_FILTERS;
+
+import java.util.stream.Collectors;
 
 /**
  * Operation to migrate from the legacy web subsystem to the new undertow subsystem.
@@ -99,7 +103,7 @@ import static org.jboss.as.controller.operations.common.Util.createRemoveOperati
  * <li>for each web resources, transform the :add operations to add the
  * corresponding resource to the new undertow subsystem.
  * In this step, changes to the resources model are taken into account</li>
- * <li>:remove the messaging subsystem</li>
+ * <li>:remove the web subsystem</li>
  * </ul>
  * <p/>
  * The companion <code>:describe-migration</code> operation will return a list of all the actual operations that would be
@@ -138,6 +142,23 @@ public class WebMigrateOperation implements OperationStepHandler {
             .setValueType(ModelType.OBJECT)
             .setAllowNull(true)
             .build();
+
+    private static final Map<String, ValveHandler> VALVES_TO_FILTERS = new HashMap<String, ValveHandler>() {{
+            put("org.apache.catalina.valves.RequestDumperValve",
+                    new ValveHandler("io.undertow.server.handlers.RequestDumpingHandler", "io.undertow.core"));
+            put("org.apache.catalina.valves.RewriteValve",
+                    new ValveHandler("io.undertow.server.handlers.SetAttributeHandler", "io.undertow.core"));
+            put("org.apache.catalina.valves.RemoteHostValve",
+                    new ValveHandler("io.undertow.server.handlers.AccessControlListHandler", "io.undertow.core"));
+            put("org.apache.catalina.valves.RemoteAddrValve",
+                    new ValveHandler("io.undertow.server.handlers.IPAddressAccessControlHandler", "io.undertow.core"));
+            put("org.apache.catalina.valves.RemoteIpValve",
+                    new ValveHandler("io.undertow.server.handlers.ProxyPeerAddressHandler", "io.undertow.core"));
+            put("org.apache.catalina.valves.StuckThreadDetectionValve",
+                    new ValveHandler("io.undertow.server.handlers.StuckThreadDetectionHandler", "io.undertow.core"));
+            put("org.apache.catalina.valves.CrawlerSessionManagerValve",
+                    new ValveHandler("io.undertow.servlet.handlers.CrawlerSessionManagerHandler", "io.undertow.servlet"));
+        }};
 
     private final boolean describe;
 
@@ -627,6 +648,8 @@ public class WebMigrateOperation implements OperationStepHandler {
                 // ignore, handled as part of connector migration
             } else if (wildcardEquals(address, pathAddress(WebExtension.SUBSYSTEM_PATH, WebExtension.HOST_PATH))) {
                 migrateVirtualHost(newAddOperations, newAddOp, address);
+            } else if (wildcardEquals(address, pathAddress(WebExtension.SUBSYSTEM_PATH, WebExtension.VALVE_PATH))) {
+                migrateValves(newAddOperations, newAddOp, address);
             } else if (wildcardEquals(address, pathAddress(WebExtension.SUBSYSTEM_PATH, WebExtension.HOST_PATH, WebExtension.ACCESS_LOG_PATH))) {
                 migrateAccessLog(newAddOperations, newAddOp, address, legacyModelDescription, warnings);
             } else if (wildcardEquals(address, pathAddress(WebExtension.SUBSYSTEM_PATH, WebExtension.HOST_PATH, WebExtension.ACCESS_LOG_PATH, WebExtension.DIRECTORY_PATH))) {
@@ -715,6 +738,34 @@ public class WebMigrateOperation implements OperationStepHandler {
         add.get(Constants.DEFAULT_WEB_MODULE).set(newAddOp.get(WebVirtualHostDefinition.DEFAULT_WEB_MODULE.getName()));
 
         newAddOperations.put(newAddress, add);
+        final PathAddress allFilterAddress = pathAddress(UndertowExtension.SUBSYSTEM_PATH, PATH_FILTERS, pathElement(CustomFilterDefinition.INSTANCE.getPathElement().getKey()));
+        List<PathAddress> filterAddresses = newAddOperations.keySet().stream().filter(newOpAddress -> {
+            return wildcardEquals(allFilterAddress, newOpAddress);
+        }).collect(Collectors.toList());
+        for (PathAddress filterAddress : filterAddresses) {
+            PathAddress filterRefAddress = pathAddress(newAddress, pathElement(Constants.FILTER_REF, filterAddress.getLastElement().getValue()));
+            ModelNode filterRefAdd = createAddOperation(filterRefAddress);
+            newAddOperations.put(filterRefAddress, filterRefAdd);
+        }
+    }
+
+    private void migrateValves(Map<PathAddress, ModelNode> newAddOperations, ModelNode newAddOp, PathAddress address) {
+        if (newAddOp.hasDefined(WebValveDefinition.CLASS_NAME.getName())) {
+            String valveClassName = newAddOp.get(WebValveDefinition.CLASS_NAME.getName()).asString();
+            if (VALVES_TO_FILTERS.containsKey(valveClassName)) {
+                newAddOperations.putIfAbsent(pathAddress(UndertowExtension.SUBSYSTEM_PATH, PATH_FILTERS), createAddOperation(pathAddress(UndertowExtension.SUBSYSTEM_PATH, PATH_FILTERS)));
+                PathAddress filterAddress = pathAddress(UndertowExtension.SUBSYSTEM_PATH, PATH_FILTERS, pathElement(CustomFilterDefinition.INSTANCE.getPathElement().getKey(), address.getLastElement().getValue()));
+                if (!newAddOperations.containsKey(filterAddress)) {
+                    ModelNode filterAdd = createAddOperation(filterAddress);
+                    filterAdd.get(MODULE).set(VALVES_TO_FILTERS.get(valveClassName).module);
+                    filterAdd.get(CustomFilterDefinition.CLASS_NAME.getName()).set(VALVES_TO_FILTERS.get(valveClassName).handlerClassName);
+                    if(newAddOp.hasDefined(WebValveDefinition.PARAMS.getName())) {
+                        filterAdd.get(CustomFilterDefinition.PARAMETERS.getName()).set(newAddOp.get(WebValveDefinition.PARAMS.getName()));
+                    }
+                    newAddOperations.put(filterAddress, filterAdd);
+                }
+            }
+        }
     }
 
     private void migrateConnector(OperationContext context, Map<PathAddress, ModelNode> newAddOperations, ModelNode newAddOp, PathAddress address, ModelNode legacyModelAddOps, List<String> warnings, boolean domainMode) throws OperationFailedException {
@@ -895,6 +946,16 @@ public class WebMigrateOperation implements OperationStepHandler {
             this.sessionTimeout = sessionTimeout;
             this.sslProtocol = sslProtocol;
             this.cipherSuites = cipherSuites;
+        }
+    }
+
+    private static class ValveHandler {
+        private String handlerClassName;
+        private String module;
+
+        private ValveHandler(String handlerClassName, String module) {
+            this.handlerClassName = handlerClassName;
+            this.module = module;
         }
     }
 }

--- a/legacy/web/src/test/java/org/jboss/as/web/test/WebMigrateTestCase.java
+++ b/legacy/web/src/test/java/org/jboss/as/web/test/WebMigrateTestCase.java
@@ -26,6 +26,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.AUT
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CORE_SERVICE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MANAGEMENT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.MODULE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SECURITY_REALM;
@@ -35,35 +36,28 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.wildfly.extension.undertow.filters.CustomFilterDefinition.CLASS_NAME;
+import static org.wildfly.extension.undertow.filters.CustomFilterDefinition.PARAMETERS;
 
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.jboss.as.controller.Extension;
-import org.jboss.as.controller.ExtensionContext;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationDefinition;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.OperationStepHandler;
-import org.jboss.as.controller.PathAddress;
 import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
-import org.jboss.as.controller.ResourceDefinition;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.access.management.DelegatingConfigurableAuthorizer;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
-import org.jboss.as.controller.descriptions.ResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.StandardResourceDescriptionResolver;
 import org.jboss.as.controller.descriptions.common.ControllerResolver;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistryType;
-import org.jboss.as.controller.extension.ExtensionResourceDefinition;
-import org.jboss.as.controller.extension.MutableRootResourceRegistrationProvider;
-import org.jboss.as.controller.parsing.ExtensionParsingContext;
-import org.jboss.as.controller.registry.AbstractModelResource;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.domain.management.CoreManagementResourceDefinition;
@@ -171,6 +165,18 @@ public class WebMigrateTestCase extends AbstractSubsystemTest {
         //trust store
         ModelNode trustStore = realm.get(AUTHENTICATION, TRUSTSTORE);
         assertEquals("${file-base}/jsse.keystore", trustStore.get(KeystoreAttributes.KEYSTORE_PATH.getName()).asString());
+        //Valves
+        ModelNode filters = newSubsystem.get(Constants.CONFIGURATION, Constants.FILTER);
+        ModelNode dumpFilter = filters.get("custom-filter", "request-dumper");
+        assertEquals("io.undertow.server.handlers.RequestDumpingHandler", dumpFilter.get(CLASS_NAME.getName()).asString());
+        assertEquals("io.undertow.core",  dumpFilter.get(MODULE).asString());
+        ModelNode remoteAddrFilter = filters.get("custom-filter", "remote-addr");
+        assertEquals("io.undertow.server.handlers.IPAddressAccessControlHandler", remoteAddrFilter.get(CLASS_NAME.getName()).asString());
+        assertEquals("io.undertow.core",  remoteAddrFilter.get(MODULE).asString());
+        assertTrue(remoteAddrFilter.hasDefined(PARAMETERS.getName()));
+        assertEquals(1, remoteAddrFilter.get(PARAMETERS.getName()).asPropertyList().size());
+        assertEquals("allow", remoteAddrFilter.get(PARAMETERS.getName()).asPropertyList().get(0).getName());
+        assertEquals("127.0.0.1,127.0.0.2", remoteAddrFilter.get(PARAMETERS.getName()).asPropertyList().get(0).getValue().asString());
 
 
         //virtual host
@@ -179,6 +185,9 @@ public class WebMigrateTestCase extends AbstractSubsystemTest {
         assertEquals("welcome-content", virtualHost.get("location", "/").get(Constants.HANDLER).asString());
 
         assertEquals("localhost", virtualHost.get("alias").asList().get(0).asString());
+        assertTrue(virtualHost.hasDefined(Constants.FILTER_REF, "request-dumper"));
+        assertTrue(virtualHost.hasDefined(Constants.FILTER_REF, "remote-addr"));
+        assertFalse(virtualHost.hasDefined(Constants.FILTER_REF, "myvalve"));
 
         ModelNode accessLog = virtualHost.get(Constants.SETTING, Constants.ACCESS_LOG);
 

--- a/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
+++ b/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
@@ -98,4 +98,8 @@
                <param param-name="param-name1" param-value="${prop.valve-param:some-value}"/>
                <param param-name="param-name2" param-value="${prop.valve-param:some-value}"/>
             </valve>
+            <valve name="request-dumper" module="org.jboss.as.web" class-name="org.apache.catalina.valves.RequestDumperValve"/>
+            <valve name="remote-addr" module="org.jboss.as.web" class-name="org.apache.catalina.valves.RemoteAddrValve">
+                <param param-name="allow" param-value="127.0.0.1,127.0.0.2" />
+            </valve>
         </subsystem>


### PR DESCRIPTION
Allow to migrate org.apache.catalina.valves.RequestDumperValve defintion to undertow io.undertow.server.handlers.RequestDumpingHandler.

Jira: https://issues.jboss.org/browse/WFLY-5238
https://issues.jboss.org/browse/JBEAP-954
