### PR TITLE
[WFCORE-313]: DefaultOperationDescriptionProvider uses incorrect call to create reply parameter description.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/TimerAttributeDefinition.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/deployment/TimerAttributeDefinition.java
@@ -96,6 +96,12 @@ public class TimerAttributeDefinition extends ListAttributeDefinition {
         addValueTypeDescription(node, resolver, locale, bundle);
     }
 
+    protected void addOperationReplyValueTypeDescription(final ModelNode node, final String operationName,
+                                                                      final ResourceDescriptionResolver resolver,
+                                                                      final Locale locale, final ResourceBundle bundle) {
+         addValueTypeDescription(node, resolver, locale, bundle);
+    }
+
     @Override
     public void marshallAsElement(ModelNode resourceModel, final boolean marshalDefault, XMLStreamWriter writer) throws XMLStreamException {
         throw EjbLogger.ROOT_LOGGER.runtimeAttributeNotMarshallable(getName());

--- a/security/subsystem/src/main/java/org/jboss/as/security/LegacySupport.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/LegacySupport.java
@@ -127,6 +127,17 @@ class LegacySupport {
             valueType.get(Constants.LOGIN_MODULE_STACK_REF, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.LOGIN_MODULE_STACK_REF));
         }
 
+        protected void addOperationReplyValueTypeDescription(final ModelNode node, final String operationName,
+                                                                      final ResourceDescriptionResolver resolver,
+                                                                      final Locale locale, final ResourceBundle bundle) {
+            final ModelNode valueType = getNoTextValueTypeDescription(node);
+            valueType.get(CODE, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, CODE));
+            valueType.get(Constants.FLAG, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.FLAG));
+            valueType.get(Constants.MODULE, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.MODULE));
+            valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.MODULE_OPTIONS));
+            valueType.get(Constants.LOGIN_MODULE_STACK_REF, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.LOGIN_MODULE_STACK_REF));
+        }
+
         @Override
         public void marshallAsElement(ModelNode resourceModel, final boolean marshalDefault, XMLStreamWriter writer) throws XMLStreamException {
             throw SecurityLogger.ROOT_LOGGER.unsupportedOperation();
@@ -210,6 +221,15 @@ class LegacySupport {
             valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.MODULE_OPTIONS));
         }
 
+        protected void addOperationReplyValueTypeDescription(final ModelNode node, final String operationName,
+                                                                      final ResourceDescriptionResolver resolver,
+                                                                      final Locale locale, final ResourceBundle bundle) {
+            final ModelNode valueType = getNoTextValueTypeDescription(node);
+            valueType.get(CODE, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, CODE));
+            valueType.get(Constants.FLAG, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.FLAG));
+            valueType.get(Constants.MODULE, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.MODULE));
+            valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.MODULE_OPTIONS));
+        }
 
         @Override
         public void marshallAsElement(ModelNode resourceModel, final boolean marshalDefault, XMLStreamWriter writer) throws XMLStreamException {
@@ -290,6 +310,15 @@ class LegacySupport {
             valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.MODULE_OPTIONS));
         }
 
+        protected void addOperationReplyValueTypeDescription(final ModelNode node, final String operationName,
+                                                                      final ResourceDescriptionResolver resolver,
+                                                                      final Locale locale, final ResourceBundle bundle) {
+            final ModelNode valueType = getNoTextValueTypeDescription(node);
+            valueType.get(CODE, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, CODE));
+            valueType.get(Constants.TYPE, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.TYPE));
+            valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.MODULE_OPTIONS));
+        }
+
         @Override
         public void marshallAsElement(ModelNode resourceModel, final boolean marshalDefault, XMLStreamWriter writer) throws XMLStreamException {
             throw SecurityLogger.ROOT_LOGGER.unsupportedOperation();
@@ -359,6 +388,13 @@ class LegacySupport {
             valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationParameterValueTypeDescription(operationName, getName(), locale, bundle, Constants.MODULE_OPTIONS));
         }
 
+        protected void addOperationReplyValueTypeDescription(final ModelNode node, final String operationName,
+                                                                      final ResourceDescriptionResolver resolver,
+                                                                      final Locale locale, final ResourceBundle bundle) {
+            final ModelNode valueType = getNoTextValueTypeDescription(node);
+            valueType.get(CODE, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, CODE));
+            valueType.get(Constants.MODULE_OPTIONS, DESCRIPTION).set(resolver.getOperationReplyValueTypeDescription(operationName, locale, bundle, Constants.MODULE_OPTIONS));
+        }
 
         @Override
         public void marshallAsElement(ModelNode resourceModel, final boolean marshalDefault, XMLStreamWriter writer) throws XMLStreamException {


### PR DESCRIPTION
Updating attribute definitions to allow for WFCORE-313 to be merged in core.

This is required to have integration builds pass after https://github.com/wildfly/wildfly-core/pull/1274 is merged.

Jira: https://issues.jboss.org/browse/WFCORE-313

http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=80520&tab=buildResultsDiv&buildTypeId=WildFlyCore_PullRequest_WildFlyCoreFullIntegration
http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=80523&tab=buildResultsDiv&buildTypeId=WildFlyCore_PullRequest_WildFlyCoreFullIntegration
