### PR TITLE
[WFLY-5531] Fix intermittent failure in messaging HA tests

### DIFF
--- a/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
+++ b/testsuite/integration/manualmode/src/test/config/arq/arquillian.xml
@@ -89,7 +89,7 @@
         <container qualifier="jbossas-messaging-ha-server1" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-messaging-ha-server1</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-messaging-ha-server1 -Djboss.node.name=default-jbossas-messaging-ha-server1</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.inst=${basedir}/target/jbossas-messaging-ha-server1 -Djboss.node.name=default-jbossas-messaging-ha-server1  -Djboss.messaging.cluster.password=pwd</property>
                 <property name="serverConfig">standalone-full-ha.xml</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>
@@ -105,7 +105,7 @@
         <container qualifier="jbossas-messaging-ha-server2" default="false" mode="manual">
             <configuration>
                 <property name="jbossHome">${basedir}/target/jbossas-messaging-ha-server2</property>
-                <property name="javaVmArguments">${server.jvm.args} -Djboss.socket.binding.port-offset=100 -Djboss.inst=${basedir}/target/jbossas-messaging-ha-server2 -Djboss.node.name=default-jbossas-messaging-ha-server2</property>
+                <property name="javaVmArguments">${server.jvm.args} -Djboss.socket.binding.port-offset=100 -Djboss.inst=${basedir}/target/jbossas-messaging-ha-server2 -Djboss.node.name=default-jbossas-messaging-ha-server2 -Djboss.messaging.cluster.password=pwd</property>
                 <property name="serverConfig">standalone-full-ha.xml</property>
                 <property name="jbossArguments">${jboss.args}</property>
                 <property name="allowConnectingToRunningServer">true</property>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/MulticastReplicatedFailoverTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/MulticastReplicatedFailoverTestCase.java
@@ -26,24 +26,30 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.NAME;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REMOVE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.VALUE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.WRITE_ATTRIBUTE_OPERATION;
-import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 
 import org.jboss.as.controller.client.ModelControllerClient;
 import org.jboss.dmr.ModelNode;
 import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
 
 /**
  * Failover and failback tests using 2 Artemis nodes (with replication).
  *
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
  */
-@Ignore("WFLY-5762")
-public class ReplicatedFailoverTestCase extends FailoverTestCase {
+public class MulticastReplicatedFailoverTestCase extends FailoverTestCase {
+
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // leave some time after servers are setup and reloaded so that the cluster is formed
+        Thread.sleep(10000);
+    }
 
     @Override
     protected void setUpServer1(ModelControllerClient client) throws Exception {
@@ -51,7 +57,8 @@ public class ReplicatedFailoverTestCase extends FailoverTestCase {
 
         addDebug(client, "SERVER #1");
         configureCluster(client);
-        useTCPStack(client);
+        addMessagingGroupSocketBinding(client);
+        useSocketBindingForDiscoveryAndBroadcastGroups(client);
 
         // /subsystem=messaging-activemq/server=default/ha-policy=replication-master:add(cluster-name=my-cluster, check-for-live-server=true)
         ModelNode operation = new ModelNode();
@@ -68,12 +75,12 @@ public class ReplicatedFailoverTestCase extends FailoverTestCase {
     protected void setUpServer2(ModelControllerClient client) throws Exception {
         super.setUpServer2(client);
 
-        addDebug(client, "SERVER #2");
+        addDebug(client, "SERVER #1");
         configureCluster(client);
-        useTCPStack(client);
+        addMessagingGroupSocketBinding(client);
+        useSocketBindingForDiscoveryAndBroadcastGroups(client);
 
         // /subsystem=messaging-activemq/server=default/ha-policy=replication-slave:add(cluster-name=my-cluster, restart-backup=true, failback-delay=2000)
-
         ModelNode operation = new ModelNode();
         operation.get(OP_ADDR).add("subsystem", "messaging-activemq");
         operation.get(OP_ADDR).add("server", "default");
@@ -83,15 +90,6 @@ public class ReplicatedFailoverTestCase extends FailoverTestCase {
         operation.get("failback-delay").set(2000);
         operation.get("restart-backup").set(true);
         execute(client, operation, true);
-    }
-
-    @Before
-    @Override
-    public void setUp() throws Exception {
-        super.setUp();
-
-        // leave some time after servers are setup and reloaded so that the cluster is formed
-        Thread.sleep(10000);
     }
 
     protected void configureCluster(ModelControllerClient client) throws Exception {
@@ -115,22 +113,46 @@ public class ReplicatedFailoverTestCase extends FailoverTestCase {
         execute(client, operation, true);
     }
 
-    private void useTCPStack(ModelControllerClient client) throws Exception {
-        // /subsystem=messaging-activemq/server=default/broadcast-group=bg-group1:write-attribute(name=jgroups-stack, value=tcp)
-        // /subsystem=messaging-activemq/server=default/discovery-group=dg-group1:write-attribute(name=jgroups-stack, value=tcp)
-        ModelNode operation = new ModelNode();
-        operation.get(OP_ADDR).add("subsystem", "messaging-activemq");
-        operation.get(OP_ADDR).add("server", "default");
-        operation.get(OP_ADDR).add("broadcast-group", "bg-group1");
-        operation.get(OP).set(WRITE_ATTRIBUTE_OPERATION);
-        operation.get(NAME).set("jgroups-stack");
-        operation.get(VALUE).set("tcp");
-        execute(client, operation, true);
+    private void useSocketBindingForDiscoveryAndBroadcastGroups(ModelControllerClient client) throws Exception {
+        // /subsystem=messaging-activemq/server=default/broadcast-group=bg-group1:remove
+        // /subsystem=messaging-activemq/server=default/broadcast-group=bg-group1:add(connectors=[http-connector], socket-binding=messaging-group)
+        // /subsystem=messaging-activemq/server=default/discovery-group=dg-group1:remove
+        // /subsystem=messaging-activemq/server=default/discovery-group=dg-group1:add(socket-binding=messaging-group)
 
-        operation.get(OP_ADDR).setEmptyList();
-        operation.get(OP_ADDR).add("subsystem", "messaging-activemq");
-        operation.get(OP_ADDR).add("server", "default");
-        operation.get(OP_ADDR).add("discovery-group", "dg-group1");
-        execute(client, operation, true);
+        ModelNode broadcastGroupOp = new ModelNode();
+        broadcastGroupOp.get(OP_ADDR).add(SUBSYSTEM, "messaging-activemq");
+        broadcastGroupOp.get(OP_ADDR).add("server", "default");
+        broadcastGroupOp.get(OP_ADDR).add("broadcast-group", "bg-group1");
+        broadcastGroupOp.get(OP).set(REMOVE);
+        execute(client, broadcastGroupOp, true);
+
+        broadcastGroupOp.get(OP).set(ADD);
+        broadcastGroupOp.get("connectors").add("http-connector");
+        broadcastGroupOp.get("socket-binding").set("messaging-group");
+        execute(client, broadcastGroupOp, true);
+
+        ModelNode discoveryGroupOp = new ModelNode();
+        discoveryGroupOp.get(OP_ADDR).add(SUBSYSTEM, "messaging-activemq");
+        discoveryGroupOp.get(OP_ADDR).add("server", "default");
+        discoveryGroupOp.get(OP_ADDR).add("discovery-group", "dg-group1");
+        discoveryGroupOp.get(OP).set(REMOVE);
+        execute(client, discoveryGroupOp, true);
+
+        discoveryGroupOp.get(OP).set(ADD);
+        discoveryGroupOp.get("socket-binding").set("messaging-group");
+        execute(client, discoveryGroupOp, true);
+    }
+
+    private void addMessagingGroupSocketBinding(ModelControllerClient client) throws Exception {
+        // /socket-binding-group=standard-sockets/socket-binding=messaging-group:add(port=0, multicast-address="${jboss.messaging.group.address:231.7.7.7}", multicast-port="${jboss.messaging.group.port:9876}")
+
+        ModelNode addOp = new ModelNode();
+        addOp.get(OP_ADDR).add("socket-binding-group", "standard-sockets");
+        addOp.get(OP_ADDR).add("socket-binding", "messaging-group");
+        addOp.get(OP).set(ADD);
+        addOp.get("port").set(0);
+        addOp.get("multicast-address").set("${jboss.messaging.group.address:231.7.7.7}");
+        addOp.get("multicast-port").set("${jboss.messaging.group.port:9876}");
+        execute(client, addOp, true);
     }
 }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/SharedStoreFailoverTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/SharedStoreFailoverTestCase.java
@@ -28,7 +28,6 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP_ADDR;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PATH;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_RESOURCE_OPERATION;
-import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 
 import java.io.File;
 
@@ -37,21 +36,15 @@ import org.jboss.as.test.integration.common.jms.JMSOperations;
 import org.jboss.as.test.integration.common.jms.JMSOperationsProvider;
 import org.jboss.dmr.ModelNode;
 import org.junit.Before;
-import org.junit.BeforeClass;
 
 /**
- * IGNORE until https://issues.apache.org/jira/browse/ARTEMIS-138 is fixed.
+ * Failover and failback tests using 2 Artemis nodes (with shared store).
  *
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
  */
 public class SharedStoreFailoverTestCase extends FailoverTestCase {
 
     private static final File SHARED_STORE_DIR = new File(System.getProperty("java.io.tmpdir"), "activemq");
-
-    @BeforeClass
-    public static void beforeClass() {
-        thisTestIsFailingIntermittently("WFLY-5531");
-    }
 
     @Before
     @Override
@@ -61,22 +54,6 @@ public class SharedStoreFailoverTestCase extends FailoverTestCase {
             SHARED_STORE_DIR.mkdirs();
         }
         super.setUp();
-
-        listSharedStoreDir();
-    }
-
-    private void listSharedStoreDir() {
-        System.out.println("<<<<@@@@@@@@@@@@@@@@@@@@@@@@@");
-        System.out.println("SHARED_STORE_DIR = " + SHARED_STORE_DIR);
-        for (File file : SHARED_STORE_DIR.listFiles()) {
-            System.out.println("+ " + file);
-            if (file.isDirectory()) {
-                for (File f : file.listFiles()) {
-                    System.out.println("    + " + f);
-                }
-            }
-        }
-        System.out.println("<<<<<@@@@@@@@@@@@@@@@@@@@@@@@@");
     }
 
     @Override
@@ -88,7 +65,7 @@ public class SharedStoreFailoverTestCase extends FailoverTestCase {
         operation.get(OP_ADDR).add("ha-policy", "shared-store-master");
         operation.get(OP).set(ADD);
         operation.get("failover-on-server-shutdown").set(true);
-        execute(client, operation);
+        execute(client, operation, true);
 
         configureSharedStore(client);
 
@@ -105,7 +82,7 @@ public class SharedStoreFailoverTestCase extends FailoverTestCase {
         operation.get(OP_ADDR).add("ha-policy", "shared-store-slave");
         operation.get(OP).set(ADD);
         operation.get("restart-backup").set(true);
-        execute(client, operation);
+        execute(client, operation, true);
 
         configureSharedStore(client);
 
@@ -128,7 +105,7 @@ public class SharedStoreFailoverTestCase extends FailoverTestCase {
         operation.get(OP_ADDR).add("server", "default");
         operation.get(OP).set(READ_RESOURCE_OPERATION);
         operation.get(INCLUDE_RUNTIME).set(true);
-        execute(client, operation);
+        execute(client, operation, true);
 
         for (String path : new String[] {"journal-directory",
                 "large-messages-directory",
@@ -143,7 +120,7 @@ public class SharedStoreFailoverTestCase extends FailoverTestCase {
             undefineRelativeToAttribute.get(OP).set(ADD);
             File f = new File(SHARED_STORE_DIR, path);
             undefineRelativeToAttribute.get(PATH).set(f.getAbsolutePath());
-            execute(client, undefineRelativeToAttribute);
+            execute(client, undefineRelativeToAttribute, true);
         }
     }
 


### PR DESCRIPTION
- reenable SharedStoreFailoverTestCase and MulticastReplicatedFailoverTestCase (that uses Artemis' own UDP stack)
- continue to @Ignore ReplicatedFailoverTestCase (that uses JGroups) as
  it is always failing (WFLY-5762)

JIRA: https://issues.jboss.org/browse/WFLY-5531
