### PR TITLE
[BZ-1267173] - Intermittent failures in PooledEJBLifecycleTestCase

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/pool/lifecycle/PooledEJBLifecycleTestCase.java
@@ -225,12 +225,13 @@ public class PooledEJBLifecycleTestCase {
             message.setJMSReplyTo(replyDestination);
             final Destination destination = (Destination) ctx.lookup(Constants.QUEUE_JNDI_NAME);
             final MessageProducer producer = session.createProducer(destination);
+            // create receiver
+            final QueueReceiver receiver = session.createReceiver(replyDestination);
             producer.send(message);
             producer.close();
 
-            // wait for a reply
-            final QueueReceiver receiver = session.createReceiver(replyDestination);
-            final Message reply = receiver.receive(TimeoutUtil.adjust(1000));
+            //wait for reply
+            final Message reply = receiver.receive(TimeoutUtil.adjust(5000));
             assertNotNull("Did not receive a reply on the reply queue. Perhaps the original (request) message didn't make it to the MDB?", reply);
             final String result = ((TextMessage) reply).getText();
             assertEquals("Unexpected reply messsage", Constants.REPLY_MESSAGE_PREFIX + requestMessage, result);


### PR DESCRIPTION
Upstream: https://issues.jboss.org/browse/WFLY-5784
EAP 7.x: https://issues.jboss.org/browse/JBEAP-2071
EAP 6.4.x: https://bugzilla.redhat.com/show_bug.cgi?id=1267173

PRs:
Upstream: https://github.com/wildfly/wildfly/pull/8460
EAP 7.x: https://github.com/jbossas/jboss-eap7/pull/75
EAP 6.4.x: https://github.com/jbossas/jboss-eap/pull/2635
