### PR TITLE
[WFLY-5802] Restore jboss.api=private

### DIFF
--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.metadata">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <dependencies>
         <module name="org.jboss.metadata.appclient" optional="true" export="true"/>
         <module name="org.jboss.metadata.common" optional="true" export="true"/>


### PR DESCRIPTION
Wasn't carried forward when the module was restored via WFLY-3806
