### PR TITLE
[WFLY-5804] Add jboss.api=private to extension modules

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.rts">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
         <artifact name="${org.wildfly:wildfly-rts}"/>
     </resources>

--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/undertow/main/module.xml
@@ -23,6 +23,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.wildfly.extension.undertow">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <exports>
         <exclude path="org/wildfly/extension/undertow/logging"/>


### PR DESCRIPTION
@tomjenkinson @stuartwdouglas Please approve

The RTS one seems a no-brainer; I didn't see any code in there directly useful to users. Undertow extension module was too big for me to bother looking.
