### PR TITLE
WFLY-5815  Read resource of deployment with faulty datasource fails

### DIFF
--- a/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateCollectionStatistics.java
+++ b/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateCollectionStatistics.java
@@ -25,7 +25,6 @@ package org.jboss.as.jpa.hibernate4.management;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -74,11 +73,17 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        return Collections.unmodifiableCollection(Arrays.asList(
-                getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getCollectionRoleNames()));
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getCollectionRoleNames()));
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
@@ -88,6 +93,9 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     }
 
     private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, String collectionName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {

--- a/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityCacheStatistics.java
+++ b/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityCacheStatistics.java
@@ -25,7 +25,6 @@ package org.jboss.as.jpa.hibernate4.management;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -74,11 +73,17 @@ public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics 
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        return Collections.unmodifiableCollection(Arrays.asList(
-                getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getEntityNames()));
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getEntityNames()));
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
@@ -90,6 +95,9 @@ public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics 
     org.hibernate.stat.SecondLevelCacheStatistics getStatistics(EntityManagerFactoryAccess entityManagerFactoryaccess, PathAddress pathAddress) {
         String scopedPersistenceUnitName = pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL);
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactoryaccess.entityManagerFactory(scopedPersistenceUnitName);
+        if (entityManagerFactoryImpl == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
             // The entity class name is prefixed by the application scoped persistence unit name

--- a/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityStatistics.java
+++ b/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityStatistics.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -74,6 +73,9 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {

--- a/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateQueryCacheStatistics.java
+++ b/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateQueryCacheStatistics.java
@@ -26,7 +26,6 @@ package org.jboss.as.jpa.hibernate4.management;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -86,17 +85,23 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        Set<String> result = new HashSet<String>();
-        String[] queries = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getQueries();
-        if (queries != null) {
-            for (String query : queries) {
-                result.add(QueryName.queryName(query).getDisplayName());
+        Set<String> result = new HashSet<>();
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats != null) {
+            String[] queries = stats.getQueries();
+            if (queries != null) {
+                for (String query : queries) {
+                    result.add(QueryName.queryName(query).getDisplayName());
+                }
             }
         }
         return result;
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
@@ -106,6 +111,9 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.QueryStatistics getStatistics(EntityManagerFactory entityManagerFactory, String displayQueryName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         // convert displayed (transformed by QueryNames) query name to original query name to look up query statistics

--- a/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateStatistics.java
+++ b/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateStatistics.java
@@ -218,6 +218,9 @@ public class HibernateStatistics extends HibernateAbstractStatistics {
     }
 
     static final org.hibernate.stat.Statistics getStatistics(final EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null){
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {

--- a/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateCollectionStatistics.java
+++ b/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateCollectionStatistics.java
@@ -25,7 +25,6 @@ package org.jboss.as.jpa.hibernate4.management;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -74,11 +73,17 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        return Collections.unmodifiableCollection(Arrays.asList(
-                getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getCollectionRoleNames()));
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getCollectionRoleNames()));
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
@@ -88,6 +93,9 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     }
 
     private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, String collectionName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {

--- a/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityCacheStatistics.java
+++ b/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityCacheStatistics.java
@@ -25,7 +25,6 @@ package org.jboss.as.jpa.hibernate4.management;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -74,11 +73,17 @@ public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics 
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        return Collections.unmodifiableCollection(Arrays.asList(
-                getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getEntityNames()));
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getEntityNames()));
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
@@ -90,6 +95,9 @@ public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics 
     org.hibernate.stat.SecondLevelCacheStatistics getStatistics(EntityManagerFactoryAccess entityManagerFactoryaccess, PathAddress pathAddress) {
         String scopedPersistenceUnitName = pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL);
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactoryaccess.entityManagerFactory(scopedPersistenceUnitName);
+        if (entityManagerFactoryImpl == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
             // The entity class name is prefixed by the application scoped persistence unit name

--- a/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityStatistics.java
+++ b/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateEntityStatistics.java
@@ -27,7 +27,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -74,6 +73,9 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
@@ -83,6 +85,9 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.EntityStatistics getStatistics(EntityManagerFactory entityManagerFactory, String entityName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {

--- a/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateQueryCacheStatistics.java
+++ b/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateQueryCacheStatistics.java
@@ -26,7 +26,6 @@ package org.jboss.as.jpa.hibernate4.management;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -86,17 +85,23 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        Set<String> result = new HashSet<String>();
-        String[] queries = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getQueries();
-        if (queries != null) {
-            for (String query : queries) {
-                result.add(QueryName.queryName(query).getDisplayName());
+        Set<String> result = new HashSet<>();
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats != null) {
+            String[] queries = stats.getQueries();
+            if (queries != null) {
+                for (String query : queries) {
+                    result.add(QueryName.queryName(query).getDisplayName());
+                }
             }
         }
         return result;
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {
@@ -106,6 +111,9 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.QueryStatistics getStatistics(EntityManagerFactory entityManagerFactory, String displayQueryName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         // convert displayed (transformed by QueryNames) query name to original query name to look up query statistics

--- a/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateStatistics.java
+++ b/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/management/HibernateStatistics.java
@@ -26,7 +26,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.persistence.Cache;
 import javax.persistence.EntityManagerFactory;
 
@@ -217,6 +216,9 @@ public class HibernateStatistics extends HibernateAbstractStatistics {
     }
 
     static final org.hibernate.stat.Statistics getStatistics(final EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         HibernateEntityManagerFactory entityManagerFactoryImpl = (HibernateEntityManagerFactory) entityManagerFactory;
         SessionFactory sessionFactory = entityManagerFactoryImpl.getSessionFactory();
         if (sessionFactory != null) {

--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateCollectionStatistics.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateCollectionStatistics.java
@@ -20,7 +20,6 @@ package org.jboss.as.jpa.hibernate5.management;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -68,11 +67,17 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        return Collections.unmodifiableCollection(Arrays.asList(
-                getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getCollectionRoleNames()));
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getCollectionRoleNames()));
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
             return sessionFactory.getStatistics();
@@ -81,6 +86,9 @@ public class HibernateCollectionStatistics extends HibernateAbstractStatistics {
     }
 
     private CollectionStatistics getStatistics(final EntityManagerFactory entityManagerFactory, String collectionName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
             return sessionFactory.getStatistics().getCollectionStatistics(collectionName);

--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateEntityCacheStatistics.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateEntityCacheStatistics.java
@@ -20,7 +20,6 @@ package org.jboss.as.jpa.hibernate5.management;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -68,11 +67,17 @@ public class HibernateEntityCacheStatistics extends HibernateAbstractStatistics 
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        return Collections.unmodifiableCollection(Arrays.asList(
-                getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getEntityNames()));
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats == null) {
+            return Collections.emptyList();
+        }
+        return Collections.unmodifiableCollection(Arrays.asList(stats.getEntityNames()));
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
             return sessionFactory.getStatistics();

--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateEntityStatistics.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateEntityStatistics.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -68,6 +67,9 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
             return sessionFactory.getStatistics();
@@ -76,6 +78,9 @@ public class HibernateEntityStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.EntityStatistics getStatistics(EntityManagerFactory entityManagerFactory, String entityName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
             return sessionFactory.getStatistics().getEntityStatistics(entityName);

--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateQueryCacheStatistics.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateQueryCacheStatistics.java
@@ -21,7 +21,6 @@ package org.jboss.as.jpa.hibernate5.management;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-
 import javax.persistence.EntityManagerFactory;
 
 import org.hibernate.SessionFactory;
@@ -80,17 +79,23 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
 
     @Override
     public Collection<String> getDynamicChildrenNames(EntityManagerFactoryAccess entityManagerFactoryLookup, PathAddress pathAddress) {
-        Set<String> result = new HashSet<String>();
-        String[] queries = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL))).getQueries();
-        if (queries != null) {
-            for (String query : queries) {
-                result.add(QueryName.queryName(query).getDisplayName());
+        Set<String> result = new HashSet<>();
+        org.hibernate.stat.Statistics stats = getBaseStatistics(entityManagerFactoryLookup.entityManagerFactory(pathAddress.getValue(HibernateStatistics.PROVIDER_LABEL)));
+        if (stats != null) {
+            String[] queries = stats.getQueries();
+            if (queries != null) {
+                for (String query : queries) {
+                    result.add(QueryName.queryName(query).getDisplayName());
+                }
             }
         }
         return result;
     }
 
     private org.hibernate.stat.Statistics getBaseStatistics(EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
             return sessionFactory.getStatistics();
@@ -99,6 +104,9 @@ public class HibernateQueryCacheStatistics extends HibernateAbstractStatistics {
     }
 
     private org.hibernate.stat.QueryStatistics getStatistics(EntityManagerFactory entityManagerFactory, String displayQueryName) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         // convert displayed (transformed by QueryNames) query name to original query name to look up query statistics
         if (sessionFactory != null) {

--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateStatistics.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/management/HibernateStatistics.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.persistence.Cache;
 import javax.persistence.EntityManagerFactory;
 
@@ -211,6 +210,9 @@ public class HibernateStatistics extends HibernateAbstractStatistics {
     }
 
     static final org.hibernate.stat.Statistics getStatistics(final EntityManagerFactory entityManagerFactory) {
+        if (entityManagerFactory == null) {
+            return null;
+        }
         SessionFactory sessionFactory = entityManagerFactory.unwrap(SessionFactory.class);
         if (sessionFactory != null) {
             return sessionFactory.getStatistics();

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/DynamicManagementStatisticsResource.java
@@ -243,7 +243,7 @@ public class DynamicManagementStatisticsResource extends PlaceholderResource.Pla
 
     @Override
     public boolean isRuntime() {
-        return false;
+        return true;
     }
 
     @Override

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/EntityManagerFactoryLookup.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/management/EntityManagerFactoryLookup.java
@@ -24,7 +24,6 @@ package org.jboss.as.jpa.management;
 
 import javax.persistence.EntityManagerFactory;
 
-import org.jboss.as.jpa.messages.JpaLogger;
 import org.jboss.as.jpa.subsystem.PersistenceUnitRegistryImpl;
 import org.jipijapa.management.spi.EntityManagerFactoryAccess;
 import org.jipijapa.plugin.spi.PersistenceUnitService;
@@ -40,7 +39,7 @@ public class EntityManagerFactoryLookup implements EntityManagerFactoryAccess {
     public EntityManagerFactory entityManagerFactory(final String scopedPersistenceUnitName) {
         PersistenceUnitService persistenceUnitService = PersistenceUnitRegistryImpl.INSTANCE.getPersistenceUnitService(scopedPersistenceUnitName);
         if (persistenceUnitService == null) {
-            throw JpaLogger.ROOT_LOGGER.PersistenceUnitNotAvailable(scopedPersistenceUnitName);
+            return null;
         }
         return persistenceUnitService.getEntityManagerFactory();
 

--- a/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentServletDefinition.java
+++ b/undertow/src/main/java/org/wildfly/extension/undertow/DeploymentServletDefinition.java
@@ -141,10 +141,8 @@ public class DeploymentServletDefinition extends SimpleResourceDefinition {
                         }
                         context.getResult().set(response);
                     }
-                    context.stepCompleted();
                 }
             }, OperationContext.Stage.RUNTIME);
-            context.stepCompleted();
         }
     }
 


### PR DESCRIPTION
- deployment JPA resource should marked as runtime = true, so validation works properly
- jpa & undertow runtime resources should properly handle failed deployment.
