### PR TITLE
WFLY-5813 Fix race condition that can cause erroneous entry removal.

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/logging/ClusteringServerLogger.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/logging/ClusteringServerLogger.java
@@ -28,6 +28,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 import org.infinispan.commons.CacheException;
 import org.infinispan.notifications.cachelistener.event.Event;
@@ -93,4 +94,8 @@ public interface ClusteringServerLogger {
     @LogMessage(level = WARN)
     @Message(id = 11, value = "Failed to notify %s/%s registry listener of %s(%s) event")
     void registryListenerFailed(@Cause Throwable e, String containerName, String cacheName, Event.Type type, Map<?, ?> entries);
+
+    @LogMessage(level = WARN)
+    @Message(id = 12, value = "Failed to notify %s/%s service provider registration listener of new providers: %s")
+    void serviceProviderRegistrationListenerFailed(@Cause Throwable e, String containerName, String cacheName, Set<Node> providers);
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/provider/CacheServiceProviderRegistry.java
@@ -47,6 +47,7 @@ import org.wildfly.clustering.provider.ServiceProviderRegistration.Listener;
 import org.wildfly.clustering.service.concurrent.ServiceExecutor;
 import org.wildfly.clustering.service.concurrent.StampedLockServiceExecutor;
 import org.wildfly.clustering.provider.ServiceProviderRegistry;
+import org.wildfly.clustering.server.logging.ClusteringServerLogger;
 
 /**
  * Infinispan {@link Cache} based {@link ServiceProviderRegistrationFactory}.
@@ -180,7 +181,11 @@ public class CacheServiceProviderRegistry<T> implements ServiceProviderRegistry<
         this.executor.execute(() -> {
             Listener listener = this.listeners.get(event.getKey());
             if (listener != null) {
-                listener.providersChanged(event.getValue());
+                try {
+                    listener.providersChanged(event.getValue());
+                } catch (Throwable e) {
+                    ClusteringServerLogger.ROOT_LOGGER.serviceProviderRegistrationListenerFailed(e, this.cache.getCacheManager().getCacheManagerConfiguration().globalJmxStatistics().cacheManagerName(), this.cache.getName(), event.getValue());
+                }
             }
         });
     }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
@@ -62,10 +62,9 @@ import org.wildfly.clustering.service.concurrent.StampedLockServiceExecutor;
  * @param <K> key type
  * @param <V> value type
  */
-@org.infinispan.notifications.Listener(sync = false)
+@org.infinispan.notifications.Listener
 public class CacheRegistry<K, V> implements Registry<K, V>, KeyFilter<Object> {
 
-    private final String containerName;
     private final List<Registry.Listener<K, V>> listeners = new CopyOnWriteArrayList<>();
     private final Cache<Node, Map.Entry<K, V>> cache;
     private final Batcher<? extends Batch> batcher;
@@ -75,7 +74,6 @@ public class CacheRegistry<K, V> implements Registry<K, V>, KeyFilter<Object> {
     private final ServiceExecutor executor = new StampedLockServiceExecutor();
 
     public CacheRegistry(CacheRegistryFactoryConfiguration<K, V> config, RegistryEntryProvider<K, V> provider) {
-        this.containerName = config.getContainerName();
         this.cache = config.getCache();
         this.batcher = config.getBatcher();
         this.group = config.getGroup();
@@ -158,7 +156,7 @@ public class CacheRegistry<K, V> implements Registry<K, V>, KeyFilter<Object> {
                             }
                         }
                     } catch (CacheException e) {
-                        ClusteringServerLogger.ROOT_LOGGER.registryPurgeFailed(e, this.containerName, event.getCache().getName(), nodes);
+                        ClusteringServerLogger.ROOT_LOGGER.registryPurgeFailed(e, event.getCache().getCacheManager().getCacheManagerConfiguration().globalJmxStatistics().cacheManagerName(), event.getCache().getName(), nodes);
                     }
                     // Invoke listeners outside above tx context
                     if (!removed.isEmpty()) {
@@ -218,7 +216,7 @@ public class CacheRegistry<K, V> implements Registry<K, V>, KeyFilter<Object> {
                     }
                 }
             } catch (Throwable e) {
-                ClusteringServerLogger.ROOT_LOGGER.registryListenerFailed(e, this.containerName, this.cache.getName(), type, entries);
+                ClusteringServerLogger.ROOT_LOGGER.registryListenerFailed(e, this.cache.getCacheManager().getCacheManagerConfiguration().globalJmxStatistics().cacheManagerName(), this.cache.getName(), type, entries);
             }
         }
     }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFactoryBuilder.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFactoryBuilder.java
@@ -74,11 +74,6 @@ public class CacheRegistryFactoryBuilder<K, V> extends RegistryFactoryServiceNam
     }
 
     @Override
-    public String getContainerName() {
-        return this.containerName;
-    }
-
-    @Override
     public Batcher<? extends Batch> getBatcher() {
         return new InfinispanBatcher(this.getCache());
     }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFactoryConfiguration.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistryFactoryConfiguration.java
@@ -38,7 +38,6 @@ import org.wildfly.clustering.group.NodeFactory;
 public interface CacheRegistryFactoryConfiguration<K, V> {
     Batcher<? extends Batch> getBatcher();
     Group getGroup();
-    String getContainerName();
     Cache<Node, Map.Entry<K, V>> getCache();
     NodeFactory<Address> getNodeFactory();
 }

--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/LocalRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/LocalRegistry.java
@@ -24,7 +24,6 @@ package org.wildfly.clustering.server.registry;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.wildfly.clustering.group.Group;
 import org.wildfly.clustering.group.Node;
@@ -39,12 +38,12 @@ import org.wildfly.clustering.registry.RegistryEntryProvider;
  */
 public class LocalRegistry<K, V> implements Registry<K, V> {
 
-    private final AtomicReference<Map.Entry<K, V>> entryRef;
     private final Group group;
+    private volatile Map.Entry<K, V> entry;
 
     public LocalRegistry(Group group, RegistryEntryProvider<K, V> provider) {
         this.group = group;
-        this.entryRef = new AtomicReference<>(new AbstractMap.SimpleImmutableEntry<>(provider.getKey(), provider.getValue()));
+        this.entry = new AbstractMap.SimpleImmutableEntry<>(provider.getKey(), provider.getValue());
     }
 
     @Override
@@ -64,17 +63,17 @@ public class LocalRegistry<K, V> implements Registry<K, V> {
 
     @Override
     public Map<K, V> getEntries() {
-        Map.Entry<K, V> entry = this.entryRef.get();
+        Map.Entry<K, V> entry = this.entry;
         return (entry != null) ? Collections.singletonMap(entry.getKey(), entry.getValue()) : Collections.emptyMap();
     }
 
     @Override
     public Map.Entry<K, V> getEntry(Node node) {
-        return this.entryRef.get();
+        return this.entry;
     }
 
     @Override
     public void close() {
-        this.entryRef.set(null);
+        this.entry = null;
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5813

This fixes intermittent failures in RegistryTestCase.
