### PR TITLE
[WFLY-5823] Register callbacks for messaging paths

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ActiveMQServerService.java
@@ -170,6 +170,7 @@ class ActiveMQServerService implements Service<ActiveMQServer> {
         configuration.setLargeMessagesDirectory(pathConfig.resolveLargeMessagePath(pathManager));
         configuration.setJournalDirectory(pathConfig.resolveJournalPath(pathManager));
         configuration.setPagingDirectory(pathConfig.resolvePagingPath(pathManager));
+        pathConfig.registerCallbacks(pathManager);
 
         try {
             // Update the acceptor/connector port/host values from the


### PR DESCRIPTION
When the ActiveMQServerService is started, register callbacks for the 4
messaging paths (the callbacks were already removed when the service is
stopped).

JIRA: https://issues.jboss.org/browse/WFLY-5823
