### PR TITLE
[WFLY-5678] Do not migrate attributes that no longer accept expressions

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -803,7 +803,7 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 79, value = "The migrate operation can not be performed: the server must be in admin-only mode")
     OperationFailedException migrateOperationAllowedOnlyInAdminOnly();
 
-    @Message(id = 80, value = "Could not migrate attribute %s from resource %s. Use instead the socket-attribute to configure this broadcast-group.")
+    @Message(id = 80, value = "Can not migrate attribute %s from resource %s. Use instead the socket-attribute to configure this broadcast-group.")
     String couldNotMigrateBroadcastGroupAttribute(String attribute, PathAddress address);
 
     @Message(id = 81, value = "Migration failed, see results for more details.")
@@ -812,18 +812,18 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 82, value = "Classes providing the %s are discarded during the migration. To use them in the new messaging-activemq subsystem, you will have to extend the Artemis-based Interceptor.")
     String couldNotMigrateInterceptors(String legacyInterceptorsAttributeName);
 
-    @Message(id = 83, value = "Could not migrate the HA configuration of %s. Its shared-store and backup attributes holds expressions and it is not possible to determine unambiguously how to create the corresponding ha-policy for the messaging-activemq's server.")
+    @Message(id = 83, value = "Can not migrate the HA configuration of %s. Its shared-store and backup attributes holds expressions and it is not possible to determine unambiguously how to create the corresponding ha-policy for the messaging-activemq's server.")
     String couldNotMigrateHA(PathAddress address);
 
-    @Message(id = 84, value = "Could not migrate attribute %s from resource %s. Use instead the socket-attribute to configure this discovery-group.")
+    @Message(id = 84, value = "Can not migrate attribute %s from resource %s. Use instead the socket-attribute to configure this discovery-group.")
     String couldNotMigrateDiscoveryGroupAttribute(String attribute, PathAddress address);
 
-    @Message(id = 85, value = "Could not create a legacy-connection-factory based on connection-factory %s. It used a HornetQ in-vm connector that is not compatible with Artemis in-vm connector ")
+    @Message(id = 85, value = "Can not create a legacy-connection-factory based on connection-factory %s. It uses a HornetQ in-vm connector that is not compatible with Artemis in-vm connector ")
     String couldNotCreateLegacyConnectionFactoryUsingInVMConnector(PathAddress address);
 
-    @Message(id = 86, value = "Could not migrate attribute %s from resource %s. The attribute uses an expression that can be resolved differently depending on system properties. To be able to migrate this property, replace the expression by an actual value.")
+    @Message(id = 86, value = "Can not migrate attribute %s from resource %s. The attribute uses an expression that can be resolved differently depending on system properties. After migration, this attribute must be added back with an actual value instead of the expression.")
     String couldNotMigrateResourceAttributeWithExpression(String attribute, PathAddress address);
 
-    @Message(id = 87, value = "Could not migrate attribute %s from resource %s. This attribute is no longer supported by the new messaging-activemq subsystem.")
+    @Message(id = 87, value = "Can not migrate attribute %s from resource %s. This attribute is not supported by the new messaging-activemq subsystem.")
     String couldNotMigrateUnsupportedAttribute(String attribute, PathAddress address);
 }


### PR DESCRIPTION
Reword migration warnings so that they are more helpful when displayed
in both :migrate and :describe-migration operations

JIRA: https://issues.jboss.org/browse/WFLY-5678
