### PR TITLE
WFLY-5171 - add missing Socket permission in test

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/mdb/dynamic/DynamicMessageListenerTestCase.java
@@ -88,7 +88,7 @@ public class DynamicMessageListenerTestCase {
                 new RuntimePermission("defineClassInPackage." + MyMdb.class.getPackage().getName()),
                 new RuntimePermission("getClassLoader"),
                 // TelnetServer binds socket and accepts connections
-                new SocketPermission(Utils.getDefaultHost(true), "accept,listen,resolve")),
+                new SocketPermission("*", "accept,listen")),
                 "permissions.xml");
         return ear;
     }


### PR DESCRIPTION
WFLY-5171 added missing permission for test deployment to work with security manager.

Fix for https://issues.jboss.org/browse/WFLY-5171
