### PR TITLE
WFLY-5846 WaitTimeInterceptor should store the start wait time in the context only if the statistics are enabled.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/invocationmetrics/WaitTimeInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/invocationmetrics/WaitTimeInterceptor.java
@@ -21,6 +21,7 @@
  */
 package org.jboss.as.ejb3.component.invocationmetrics;
 
+import org.jboss.as.ejb3.component.EJBComponent;
 import org.jboss.as.ejb3.component.interceptors.AbstractEJBInterceptor;
 import org.jboss.invocation.ImmediateInterceptorFactory;
 import org.jboss.invocation.InterceptorContext;
@@ -39,7 +40,10 @@ public class WaitTimeInterceptor extends AbstractEJBInterceptor {
 
     @Override
     public Object processInvocation(final InterceptorContext context) throws Exception {
-        context.putPrivateData(START_WAIT_TIME, System.currentTimeMillis());
+        final EJBComponent component = getComponent(context, EJBComponent.class);
+        if (component.isStatisticsEnabled()) {
+            context.putPrivateData(START_WAIT_TIME, System.currentTimeMillis());
+        }
         return context.proceed();
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5846
