### PR TITLE
[JBEAP-372] Run license plugin before feature pack zip is created

### DIFF
--- a/feature-pack/pom.xml
+++ b/feature-pack/pom.xml
@@ -2767,7 +2767,7 @@
                                 <goals>
                                     <goal>download-licenses</goal>
                                 </goals>
-                                <phase>package</phase>
+                                <phase>prepare-package</phase>
                                 <configuration>
                                     <licensesOutputDirectory>
                                         ${project.build.directory}/${project.build.finalName}/content/docs/licenses


### PR DESCRIPTION
Otherwise the downloaded license files are not included in the distribution
