### PR TITLE
[WFLY-4478] Stop running batch jobs when a shutdown is issued for the…

### DIFF
--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/BatchLogger.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/_private/BatchLogger.java
@@ -142,4 +142,27 @@ public interface BatchLogger extends BasicLogger {
     @Message(id = 13, value = "Only one job repository can be defined in the jboss-all.xml deployment descriptor. The first job repository will be used.")
     void multipleJobRepositoriesFound();
 
+    /**
+     * Logs a warning message indicating a job is stopping.
+     *
+     * @param executionId    the execution id of the job
+     * @param jobName        the name of the job
+     * @param deploymentName the name of the deployment stopping the job
+     */
+    @LogMessage(level = Level.WARN)
+    @Message(id = 14, value = "Stopping execution %d of %s for deployment %s")
+    void stoppingJob(long executionId, String jobName, String deploymentName);
+
+
+    /**
+     * Logs an error message indicating a job is stopping.
+     *
+     * @param cause          the cause of the error
+     * @param executionId    the execution id of the job
+     * @param jobName        the name of the job
+     * @param deploymentName the name of the deployment
+     */
+    @LogMessage(level = Level.ERROR)
+    @Message(id = 15, value = "Failed to stop execution %d for job %s on deployment %s")
+    void stoppingJobFailed(@Cause Throwable cause, long executionId, String jobName, String deploymentName);
 }

--- a/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentProcessor.java
+++ b/batch/extension-jberet/src/main/java/org/wildfly/extension/batch/jberet/deployment/BatchEnvironmentProcessor.java
@@ -30,11 +30,13 @@ import org.jberet.spi.BatchEnvironment;
 import org.jberet.spi.JobExecutor;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.weld.WeldDeploymentMarker;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceBuilder;
@@ -128,7 +130,11 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
                 serviceBuilder.addDependency(RequestController.SERVICE_NAME, RequestController.class, service.getRequestControllerInjector());
             }
 
-            serviceBuilder.install();
+            // Add the executor service for async context processing and install the service
+            Services.addServerExecutorDependency(
+                    serviceBuilder.addDependency(SuspendController.SERVICE_NAME, SuspendController.class, service.getSuspendControllerInjector()),
+                    service.getExecutorServiceInjector(), false)
+                    .install();
         }
     }
 

--- a/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchEnvironmentProcessor.java
+++ b/batch/extension/src/main/java/org/wildfly/extension/batch/deployment/BatchEnvironmentProcessor.java
@@ -30,11 +30,13 @@ import org.jberet.spi.JobExecutor;
 import org.jboss.as.controller.capability.CapabilityServiceSupport;
 import org.jboss.as.ee.component.EEModuleDescription;
 import org.jboss.as.ee.weld.WeldDeploymentMarker;
+import org.jboss.as.server.Services;
 import org.jboss.as.server.deployment.Attachments;
 import org.jboss.as.server.deployment.DeploymentPhaseContext;
 import org.jboss.as.server.deployment.DeploymentUnit;
 import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.as.server.suspend.SuspendController;
 import org.jboss.as.txn.service.TxnServices;
 import org.jboss.modules.Module;
 import org.jboss.msc.service.ServiceBuilder;
@@ -94,7 +96,11 @@ public class BatchEnvironmentProcessor implements DeploymentUnitProcessor {
                 serviceBuilder.addDependency(RequestController.SERVICE_NAME, RequestController.class, service.getRequestControllerInjector());
             }
 
-            serviceBuilder.install();
+            // Add the executor service for async context processing and install the service
+            Services.addServerExecutorDependency(
+                    serviceBuilder.addDependency(SuspendController.SERVICE_NAME, SuspendController.class, service.getSuspendControllerInjector()),
+                    service.getExecutorServiceInjector(), false)
+                    .install();
         }
     }
 


### PR DESCRIPTION
… container. This ensures the container won't wait to shutdown until the batch jobs are fully completed.

@chengfang could you give the stop logic a review to make sure it looks okay?

Once this is okayed, I'll port to EAP.

---

One thing to note is when shutting down a job that uses a JDBC connection I see the following exception. It looks like the JCA resource is deregistered before the stopping of the service is complete. I don't think there's much that batch can do about this however.

```
15:24:56,847 INFO  [org.wildfly.extension.undertow] (ServerService Thread Pool -- 8) WFLYUT0022: Unregistered web context: /batch-chunk
15:24:56,850 WARN  [org.wildfly.extension.batch] (ServerService Thread Pool -- 12) WFLYBATCH000014: Stopping execution 2 of reader-3 for deployment batch-jdbc-chunk.war
15:24:56,854 WARN  [org.wildfly.extension.batch] (ServerService Thread Pool -- 18) WFLYBATCH000014: Stopping execution 1 of simple for deployment batch-chunk.war
15:24:56,874 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-5) WFLYUT0019: Host default-host stopping
15:24:56,876 INFO  [org.jboss.weld.deployer] (MSC service thread 1-1) WFLYWELD0010: Stopping weld service for deployment batch-chunk.war
15:24:56,876 INFO  [org.jboss.weld.deployer] (MSC service thread 1-6) WFLYWELD0010: Stopping weld service for deployment batch-jdbc-chunk.war
15:24:56,888 INFO  [org.jboss.as.connector.subsystems.datasources] (MSC service thread 1-7) WFLYJCA0010: Unbound data source [java:jboss/datasources/ExampleDS]
15:24:56,888 WARN  [org.jboss.jca.core.connectionmanager.pool.strategy.OnePool] (ServerService Thread Pool -- 21) IJ000615: Destroying active connection in pool: chunk (org.jboss.jca.adapters.jdbc.local.LocalManagedConnection@1fee3d9)
15:24:56,889 INFO  [org.jboss.as.connector.deployers.jdbc] (MSC service thread 1-1) WFLYJCA0019: Stopped Driver service with driver-name = h2
15:24:56,894 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-5) WFLYUT0008: Undertow HTTP listener default suspending
15:24:56,896 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-5) WFLYUT0007: Undertow HTTP listener default stopped, was bound to 127.0.0.1:8080
15:24:56,895 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-6) WFLYSRV0028: Stopped deployment batch-jdbc-chunk.war (runtime-name: batch-jdbc-chunk.war) in 47ms
15:24:56,895 INFO  [org.jboss.as.server.deployment] (MSC service thread 1-7) WFLYSRV0028: Stopped deployment batch-chunk.war (runtime-name: batch-chunk.war) in 48ms
15:24:56,896 INFO  [org.wildfly.extension.undertow] (MSC service thread 1-8) WFLYUT0004: Undertow 1.3.9.Final stopping
15:24:57,118 ERROR [org.jberet] (Batch Thread - 2) ProcessingInfo{count=2, timerExpired=false, itemState=RUNNING, chunkState=RUNNING, checkpointPosition=-1, readPosition=2, failurePoint=null}
15:24:57,123 ERROR [org.jberet] (Batch Thread - 2) item-count=3, time-limit=0, skip-limit=-1, skipCount=0, retry-limit=-1, retryCount=0
15:24:57,123 ERROR [org.jberet] (Batch Thread - 2) JBERET000007: Failed to run job reader-3, step1, org.jberet.job.model.Chunk@16ec6a49: java.sql.SQLException: IJ031040: Connection is not associated with a managed connection: org.jboss.jca.adapters.jdbc.jdk7.WrappedConnectionJDK7@525aa120
    at org.jboss.jca.adapters.jdbc.WrappedConnection.lock(WrappedConnection.java:164)
    at org.jboss.jca.adapters.jdbc.WrappedStatement.lock(WrappedStatement.java:138)
    at org.jboss.jca.adapters.jdbc.WrappedResultSet.lock(WrappedResultSet.java:6022)
    at org.jboss.jca.adapters.jdbc.WrappedResultSet.getString(WrappedResultSet.java:1974)
    at org.jboss.example.batch.chunk.JdbcItemReader.readItem(JdbcItemReader.java:83)
    at org.jberet.runtime.runner.ChunkRunner.readItem(ChunkRunner.java:353)
    at org.jberet.runtime.runner.ChunkRunner.readProcessWriteItems(ChunkRunner.java:305)
    at org.jberet.runtime.runner.ChunkRunner.run(ChunkRunner.java:201)
    at org.jberet.runtime.runner.StepExecutionRunner.runBatchletOrChunk(StepExecutionRunner.java:219)
    at org.jberet.runtime.runner.StepExecutionRunner.run(StepExecutionRunner.java:140)
    at org.jberet.runtime.runner.CompositeExecutionRunner.runStep(CompositeExecutionRunner.java:164)
    at org.jberet.runtime.runner.CompositeExecutionRunner.runFromHeadOrRestartPoint(CompositeExecutionRunner.java:88)
    at org.jberet.runtime.runner.JobExecutionRunner.run(JobExecutionRunner.java:59)
    at org.wildfly.extension.batch.jberet.impl.BatchEnvironmentService$WildFlyBatchEnvironment$1.run(BatchEnvironmentService.java:241)
    at org.jberet.spi.JobExecutor$1.run(JobExecutor.java:99)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
    at java.lang.Thread.run(Thread.java:745)
    at org.jboss.threads.JBossThread.run(JBossThread.java:320)

```
