### PR TITLE
WFLY-5772 Upgrade Infinispan to 8.1.0.Final

### DIFF
--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/DefaultCacheContainer.java
@@ -116,22 +116,9 @@ public class DefaultCacheContainer extends AbstractDelegatingEmbeddedCacheManage
 
     @Override
     public <K, V> Cache<K, V> getCache(String cacheName, String configurationName) {
-        Cache<K, V> cache;
-        if (System.getSecurityManager() == null) {
-            cache = this.getCacheInternal(cacheName, configurationName);
-        } else {
-            cache = AccessController.doPrivileged(new PrivilegedAction<Cache<K, V>>() {
-                @Override
-                public Cache<K, V> run() {
-                    return getCacheInternal(cacheName, configurationName);
-                }
-            });
-        }
+        PrivilegedAction<Cache<K, V>> action = () -> this.cm.<K, V>getCache(this.getCacheName(cacheName), this.getCacheName(configurationName));
+        Cache<K, V> cache = (System.getSecurityManager() == null) ? action.run() : AccessController.doPrivileged(action);
         return (cache != null) ? new DefaultCache<>(this, this.batcherFactory, cache.getAdvancedCache()) : null;
-    }
-
-    private <K, V> Cache<K, V> getCacheInternal(String cacheName, String configurationName) {
-        return cm.<K, V>getCache(this.getCacheName(cacheName), this.getCacheName(configurationName));
     }
 
     @Override

--- a/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionBuilder.java
+++ b/clustering/infinispan/extension/src/main/java/org/jboss/as/clustering/infinispan/subsystem/EvictionBuilder.java
@@ -29,6 +29,7 @@ import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.cache.EvictionConfiguration;
 import org.infinispan.configuration.cache.EvictionConfigurationBuilder;
 import org.infinispan.eviction.EvictionStrategy;
+import org.infinispan.eviction.EvictionType;
 import org.jboss.as.clustering.controller.ResourceServiceBuilder;
 import org.jboss.as.clustering.dmr.ModelNodes;
 import org.jboss.as.controller.OperationContext;
@@ -51,7 +52,9 @@ public class EvictionBuilder extends CacheComponentBuilder<EvictionConfiguration
     public Builder<EvictionConfiguration> configure(OperationContext context, ModelNode model) throws OperationFailedException {
         EvictionStrategy strategy = ModelNodes.asEnum(STRATEGY.getDefinition().resolveModelAttribute(context, model), EvictionStrategy.class);
         this.builder.strategy(strategy);
-        this.builder.maxEntries(strategy.isEnabled() ? MAX_ENTRIES.getDefinition().resolveModelAttribute(context, model).asLong() : -1L);
+        if (strategy.isEnabled()) {
+            this.builder.type(EvictionType.COUNT).size(MAX_ENTRIES.getDefinition().resolveModelAttribute(context, model).asLong());
+        }
         return this;
     }
 

--- a/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
+++ b/clustering/infinispan/extension/src/test/java/org/jboss/as/clustering/infinispan/subsystem/TransformersTestCase.java
@@ -47,7 +47,6 @@ import org.jboss.as.controller.extension.ExtensionRegistryType;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
 import org.jboss.as.model.test.FailedOperationTransformationConfig;
-import org.jboss.as.model.test.ModelFixer;
 import org.jboss.as.model.test.ModelTestControllerVersion;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AdditionalInitialization;

--- a/pom.xml
+++ b/pom.xml
@@ -145,9 +145,9 @@
         <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
         <version.org.hibernate.validator>5.2.2.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
-        <version.org.hibernate.search>5.5.0.Final</version.org.hibernate.search>
+        <version.org.hibernate.search>5.5.1.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>
-        <version.org.infinispan>8.0.2.Final</version.org.infinispan>
+        <version.org.infinispan>8.1.0.Final</version.org.infinispan>
         <version.org.jasypt>1.9.1</version.org.jasypt>
         <version.org.javassist>3.18.1-GA</version.org.javassist>
         <version.org.jberet>1.2.0.Final</version.org.jberet>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5772

Requires Hibernate ORM 5.0.6.Final upgrade: https://github.com/wildfly/wildfly/pull/8503
See: https://hibernate.atlassian.net/browse/HHH-10344

Pulls in several bug fixes that would otherwise require backport to 8.0.x.
See: https://issues.jboss.org/browse/ISPN-5944
