### PR TITLE
[WFLY-5782] Upgrade Artemis 1.1.0.wildfly-010

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.1.0.wildfly-009</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.1.0.wildfly-010</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.1.4</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.5</version.org.apache.cxf.xjcplugins>


### PR DESCRIPTION
The default global thread pool used by Artemis client is now fixed (it
was unbounded before). Default size is 500.
To use an unbounded thread pool, the
ActiveMQClient.GLOBAL_THREAD_POOL_MAX_SIZE must be set to -1 (or use the sysprop
activemq.artemis.client.global.thread.pool.max.size)

JIRA: https://issues.jboss.org/browse/WFLY-5872
