### PR TITLE
[WFLY-5885] Fail fast if missing client jar

### DIFF
--- a/feature-pack/src/main/resources/content/bin/jconsole.sh
+++ b/feature-pack/src/main/resources/content/bin/jconsole.sh
@@ -76,6 +76,15 @@ CLASSPATH=$JAVA_HOME/lib/jconsole.jar
 CLASSPATH=$CLASSPATH:$JAVA_HOME/lib/tools.jar
 CLASSPATH=$CLASSPATH:./bin/client/jboss-cli-client.jar
 
+echo JBOSS_HOME $JBOSS_HOME
+
+# Do some sanity checking of our classpath
+if [ ! -f "$JBOSS_HOME/bin/client/jboss-cli-client.jar" ]; then
+    echo "Jar not found: \"$JBOSS_HOME/bin/client/jboss-cli-client.jar\""
+    echo "If this jar is missing, jconsole will fail to connect to Wildfly."
+    exit 2
+fi
+
 echo CLASSPATH $CLASSPATH
 
 cd "$JBOSS_HOME"


### PR DESCRIPTION
If the path to the jboss-cli-client.jar is incorrect (because JBOSS_HOME is set incorrectly) JConsole is still launched.  It then fails to connect, but it's not obvious that it failed because the classpath was incorrect.

Make the jconsole.sh shell script fail fast when this happens, with a message to the user.
