### PR TITLE
[WFLY-5888] Add journal-pool-files attribute

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -109,6 +109,7 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                         ServerDefinition.LOG_JOURNAL_WRITE_RATE,
                                         ServerDefinition.JOURNAL_FILE_SIZE,
                                         ServerDefinition.JOURNAL_MIN_FILES,
+                                        ServerDefinition.JOURNAL_POOL_FILES,
                                         ServerDefinition.JOURNAL_COMPACT_PERCENTAGE,
                                         ServerDefinition.JOURNAL_COMPACT_MIN_FILES,
                                         ServerDefinition.JOURNAL_MAX_IO,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerAdd.java
@@ -58,6 +58,7 @@ import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_FILE_SIZE;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_MAX_IO;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_MIN_FILES;
+import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_POOL_FILES;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_SYNC_NON_TRANSACTIONAL;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_SYNC_TRANSACTIONAL;
 import static org.wildfly.extension.messaging.activemq.ServerDefinition.JOURNAL_TYPE;
@@ -364,6 +365,7 @@ class ServerAdd extends AbstractAddStepHandler {
         configuration.setJournalCompactPercentage(JOURNAL_COMPACT_PERCENTAGE.resolveModelAttribute(context, model).asInt());
         configuration.setJournalFileSize(JOURNAL_FILE_SIZE.resolveModelAttribute(context, model).asInt());
         configuration.setJournalMinFiles(JOURNAL_MIN_FILES.resolveModelAttribute(context, model).asInt());
+        configuration.setJournalPoolFiles(JOURNAL_POOL_FILES.resolveModelAttribute(context, model).asInt());
         configuration.setJournalSyncNonTransactional(JOURNAL_SYNC_NON_TRANSACTIONAL.resolveModelAttribute(context, model).asBoolean());
         configuration.setJournalSyncTransactional(JOURNAL_SYNC_TRANSACTIONAL.resolveModelAttribute(context, model).asBoolean());
         configuration.setLogJournalWriteRate(LOG_JOURNAL_WRITE_RATE.resolveModelAttribute(context, model).asBoolean());

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/ServerDefinition.java
@@ -193,6 +193,14 @@ public class ServerDefinition extends PersistentResourceDefinition {
             .setRestartAllServices()
             .setValidator(new IntRangeValidator(2, true, true))
             .build();
+    public static final SimpleAttributeDefinition JOURNAL_POOL_FILES = create("journal-pool-files", INT)
+            .setAttributeGroup("journal")
+            .setXmlName("pool-files")
+            .setDefaultValue(new ModelNode(ActiveMQDefaultConfiguration.getDefaultJournalPoolFiles()))
+            .setAllowNull(true)
+            .setAllowExpression(true)
+            .setRestartAllServices()
+            .build();
     public static final SimpleAttributeDefinition JOURNAL_SYNC_NON_TRANSACTIONAL = create("journal-sync-non-transactional", BOOLEAN)
             .setAttributeGroup("journal")
             .setXmlName("sync-non-transactional")
@@ -437,7 +445,7 @@ public class ServerDefinition extends PersistentResourceDefinition {
             PERSIST_DELIVERY_COUNT_BEFORE_DELIVERY,
             PAGE_MAX_CONCURRENT_IO, CREATE_BINDINGS_DIR, CREATE_JOURNAL_DIR, JOURNAL_TYPE, JOURNAL_BUFFER_TIMEOUT,
             JOURNAL_BUFFER_SIZE, JOURNAL_SYNC_TRANSACTIONAL, JOURNAL_SYNC_NON_TRANSACTIONAL, LOG_JOURNAL_WRITE_RATE,
-            JOURNAL_FILE_SIZE, JOURNAL_MIN_FILES, JOURNAL_COMPACT_PERCENTAGE, JOURNAL_COMPACT_MIN_FILES, JOURNAL_MAX_IO,
+            JOURNAL_FILE_SIZE, JOURNAL_MIN_FILES, JOURNAL_POOL_FILES, JOURNAL_COMPACT_PERCENTAGE, JOURNAL_COMPACT_MIN_FILES, JOURNAL_MAX_IO,
             PERF_BLAST_PAGES, RUN_SYNC_SPEED_TEST, SERVER_DUMP_INTERVAL, MEMORY_WARNING_THRESHOLD, MEMORY_MEASURE_INTERVAL,
     };
 

--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -327,6 +327,7 @@ server.journal-compact-percentage=The percentage of live data on which we consid
 server.journal-file-size=The size (in bytes) of each journal file.
 server.journal-max-io=The maximum number of write requests that can be in the AIO queue at any one time.
 server.journal-min-files=How many journal files to pre-create.
+server.journal-pool-files=The number of journal files that can be reused. ActiveMQ will create as many files as needed however when reclaiming files it will shrink back to the value (-1 means no limit).
 server.journal-sync-non-transactional=Whether to wait for non transaction data to be synced to the journal before returning a response to the client.
 server.journal-sync-transactional=Whether to wait for transaction data to be synchronized to the journal before returning a response to the client.
 server.journal-type=The type of journal to use.

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
@@ -100,6 +100,7 @@
                     <xs:attribute name="log-write-rate" type="xs:boolean" />
                     <xs:attribute name="file-size" type="xs:long" />
                     <xs:attribute name="min-files" type="xs:int" />
+                    <xs:attribute name="pool-files" type="xs:int" />
                     <xs:attribute name="compact-percentage" type="xs:int" />
                     <xs:attribute name="compact-min-files" type="xs:int" />
                     <xs:attribute name="max-io" type="xs:int" />

--- a/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
+++ b/messaging-activemq/src/test/resources/org/wildfly/extension/messaging/activemq/subsystem_1_0.xml
@@ -46,6 +46,7 @@
                 log-write-rate="${log.journal.write.rate:true}"
                 file-size="${journal.file.size:102400}"
                 min-files="${journal.min.files:2}"
+                pool-files="${journal.pool.files:5}"
                 compact-percentage="${journal.compact.percentage:83}"
                 compact-min-files="${journal.compact.min.files:2}"
                 max-io="${journal.max.io:50}"


### PR DESCRIPTION
Artemis 1.1.0.wildfly-010 has a new attribute journal-pool-files to
control the number of journal files that can be reused.

JIRA: https://issues.jboss.org/browse/WFLY-5888
