### PR TITLE
[WFLY-5696] Remove broken, unnecessary server launch on master HC from mixed-domain tests

### DIFF
--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -80,7 +80,7 @@
  	</jvms>
 
     <servers>
-        <server name="server-one" group="other-server-group">
+        <server name="server-one" group="other-server-group" auto-start="false">
             <socket-bindings port-offset="100"/>
         </server>
         <server name="server-two" group="other-server-group" auto-start="false"/>


### PR DESCRIPTION
Except leave it for one test where the test wants to include reading a master server during wildcard reads.
