### PR TITLE
[WFLY-6821] Not possible to overlay non existing file in WAR - mark the sub deployment which will be mounted exploded

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/structure/EarStructureProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/structure/EarStructureProcessor.java
@@ -40,6 +40,7 @@ import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
 import org.jboss.as.server.deployment.DeploymentUnitProcessor;
 import org.jboss.as.server.deployment.MountedDeploymentOverlay;
 import org.jboss.as.server.deployment.SubDeploymentMarker;
+import org.jboss.as.server.deployment.SubExplodedDeploymentMarker;
 import org.jboss.as.server.deployment.module.ModuleRootMarker;
 import org.jboss.as.server.deployment.module.MountHandle;
 import org.jboss.as.server.deployment.module.ResourceRoot;
@@ -277,6 +278,7 @@ public class EarStructureProcessor implements DeploymentUnitProcessor {
         }
         if (war) {
             resourceRoot.putAttachment(Attachments.INDEX_RESOURCE_ROOT, false);
+            SubExplodedDeploymentMarker.mark(resourceRoot);
         }
         return resourceRoot;
     }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/EarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/EarOverlayTestBase.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.ear;
+
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * @author baranowb
+ *
+ */
+public class EarOverlayTestBase extends JarOverlayTestBase{
+
+    public static Archive<?> createEARWithOverlayedArchive(final boolean resourcePresent, String deploymentOverlayedArchive, final String deploymentTopArchve){
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, deploymentTopArchve);
+                Archive<?> jar = createOverlayedArchive(resourcePresent,deploymentOverlayedArchive);
+        ear.addAsModule(jar);
+        return ear;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/EarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/EarOverlayTestBase.java
@@ -22,24 +22,100 @@
 
 package org.jboss.as.test.integration.deployment.deploymentoverlay.ear;
 
-import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import javax.servlet.ServletException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.war.WarOverlayTestBase;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 /**
  * @author baranowb
+ * @author lgao
  *
  */
-public class EarOverlayTestBase extends JarOverlayTestBase{
+public class EarOverlayTestBase extends WarOverlayTestBase {
+
+    public static final String WEB = "web";
+    public static final String WEB_ARCHIVE = WEB + ".war";
+    public static final String WEB_OVERLAY = WEB_ARCHIVE + "/" + OVERLAY_HTML;
+
+    public static final String RESOURCE_IN_JAR_OVERLAY = "jar/overlay.txt";
+    public static final String META_RESOURCE_IN_JAR_OVERLAY = "META-INF/" + RESOURCE_IN_JAR_OVERLAY;
+
+    public static final String RESOURCE_IN_JAR_STATIC = "jar/static.txt";
+    public static final String META_RESOURCE_IN_JAR_STATIC = "META-INF/" + RESOURCE_IN_JAR_STATIC;
+
+    public static final String SERVLETS_JAR = "echoservlet.jar";
+
+    public static final String JAR_IN_WAR_OVERLAY_PATH = WEB_ARCHIVE + "/" + SERVLETS_JAR + "/" + META_RESOURCE_IN_JAR_OVERLAY;
 
     public static Archive<?> createEARWithOverlayedArchive(final boolean resourcePresent, String deploymentOverlayedArchive, final String deploymentTopArchve){
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, deploymentTopArchve);
                 Archive<?> jar = createOverlayedArchive(resourcePresent,deploymentOverlayedArchive);
         ear.addAsModule(jar);
+        WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_ARCHIVE);
+        war.add(new StringAsset(OverlayableInterface.STATIC), STATIC_HTML);
+        if (resourcePresent) {
+            war.add(new StringAsset(OverlayableInterface.ORIGINAL), OVERLAY_HTML);
+        }
+        JavaArchive servlets = ShrinkWrap.create(JavaArchive.class, SERVLETS_JAR);
+        servlets.addClasses(EchoStaticServlet.class, EchoOverlayServlet.class);
+        servlets.addAsManifestResource(new StringAsset(OverlayableInterface.STATIC), RESOURCE_IN_JAR_STATIC);
+        if (resourcePresent) {
+            servlets.addAsManifestResource(new StringAsset(OverlayableInterface.ORIGINAL), RESOURCE_IN_JAR_OVERLAY);
+        }
+        war.addAsLibraries(servlets);
+        ear.addAsModule(war);
         return ear;
+    }
+
+    @SuppressWarnings("serial")
+    @WebServlet("/echoStatic")
+    public static class EchoStaticServlet extends HttpServlet {
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            try (InputStream input = getClass().getClassLoader().getResourceAsStream(META_RESOURCE_IN_JAR_STATIC);
+                 InputStreamReader inputReader = new InputStreamReader(input);
+                 BufferedReader reader = new BufferedReader(inputReader)) {
+                resp.getWriter().write(reader.readLine());
+                resp.flushBuffer();
+            }
+        }
+    }
+
+    @SuppressWarnings("serial")
+    @WebServlet("/echoOverlay")
+    public static class EchoOverlayServlet extends HttpServlet {
+
+        @Override
+        protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+            try (InputStream input = getClass().getClassLoader().getResourceAsStream(META_RESOURCE_IN_JAR_OVERLAY)) {
+                if (input == null) {
+                    resp.sendError(404);
+                    return;
+                }
+                try (InputStreamReader inputReader = new InputStreamReader(input);
+                     BufferedReader reader = new BufferedReader(inputReader)) {
+                    resp.getWriter().write(reader.readLine());
+                    resp.flushBuffer();
+                }
+            }
+        }
     }
 
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayExistingResourceTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.ear;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayEJB;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayUtils;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author baranowb
+ * 
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OverlayExistingResourceTestCase extends EarOverlayTestBase {
+    private static final String OVERLAY = "HAL9000";
+    private static final String DEPLOYMENT_OVERLAYED = "overlayed";
+    private static final String DEPLOYMENT_OVERLAYED_ARCHIVE = DEPLOYMENT_OVERLAYED + ".jar";
+    
+    private static final String DEPLOYMENT_SHELL = "shell";
+    private static final String DEPLOYMENT_SHELL_ARCHIVE = DEPLOYMENT_SHELL + ".ear";
+    
+    private static final String RESOURCE = "/"+DEPLOYMENT_OVERLAYED_ARCHIVE+"//"+OverlayableInterface.RESOURCE;
+    
+    @Deployment(name = DEPLOYMENT_SHELL)
+    public static Archive createDeployment() throws Exception {
+        return createEARWithOverlayedArchive(true, DEPLOYMENT_OVERLAYED_ARCHIVE,DEPLOYMENT_SHELL_ARCHIVE);
+    }
+
+    @Test
+    public void testOverlay() throws Exception {
+        final InitialContext ctx = getInitialContext();
+        try{
+        OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding(DEPLOYMENT_SHELL, DEPLOYMENT_OVERLAYED, "",
+                OverlayEJB.class, OverlayableInterface.class));
+        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", OverlayableInterface.ORIGINAL, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE, OverlayableInterface.OVERLAYED);
+        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        } finally {
+            try{
+                ctx.close();
+            }catch(Exception e){
+            }
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayExistingResourceTestCase.java
@@ -22,13 +22,15 @@
 
 package org.jboss.as.test.integration.deployment.deploymentoverlay.ear;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayEJB;
-import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
 import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayUtils;
 import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
 import org.jboss.shrinkwrap.api.Archive;
@@ -38,7 +40,8 @@ import org.junit.runner.RunWith;
 
 /**
  * @author baranowb
- * 
+ * @author lgao
+ *
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -60,20 +63,41 @@ public class OverlayExistingResourceTestCase extends EarOverlayTestBase {
     @Test
     public void testOverlay() throws Exception {
         final InitialContext ctx = getInitialContext();
+        Map<String, String> overlay = new HashMap<String, String>();
         try{
         OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding(DEPLOYMENT_SHELL, DEPLOYMENT_OVERLAYED, "",
                 OverlayEJB.class, OverlayableInterface.class));
         Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", OverlayableInterface.ORIGINAL, iface.fetchResource());
         Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
-        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE, OverlayableInterface.OVERLAYED);
-        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
-        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+
+        Assert.assertEquals("HTML resource in ear/war does not match pre-overlay expectations!", OverlayableInterface.ORIGINAL,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + OVERLAY_HTML));
+        Assert.assertEquals("HTML Static in ear/war resource does not match pre-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + STATIC_HTML));
+
+        Assert.assertEquals("Static resource in ear/war/jar does not match pre-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/echoStatic"));
+        Assert.assertEquals("Resource in ear/war/jar does not match pre-overlay expectations!", OverlayableInterface.ORIGINAL,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/echoOverlay"));
+
+        overlay.put(RESOURCE, OverlayableInterface.OVERLAYED);
+        overlay.put(WEB_OVERLAY, OverlayableInterface.OVERLAYED);
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, overlay);
+
+        Assert.assertEquals("Overlayed resource in ear/jar does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource in ear/jar does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+
+        Assert.assertEquals("HTML static resource in ear/war does not match post-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + STATIC_HTML));
+        Assert.assertEquals("HTML resource in ear/war does not match post-overlay expectations!", OverlayableInterface.OVERLAYED,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + OVERLAY_HTML));
+
         } finally {
             try{
                 ctx.close();
             }catch(Exception e){
             }
-            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE);
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, overlay.keySet());
         }
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayNonExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayNonExistingResourceTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.ear;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayEJB;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayUtils;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author baranowb
+ * 
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OverlayNonExistingResourceTestCase extends EarOverlayTestBase {
+    private static final String OVERLAY = "HAL9000";
+    private static final String DEPLOYMENT_OVERLAYED = "overlayed";
+    private static final String DEPLOYMENT_OVERLAYED_ARCHIVE = DEPLOYMENT_OVERLAYED + ".jar";
+    
+    private static final String DEPLOYMENT_SHELL = "shell";
+    private static final String DEPLOYMENT_SHELL_ARCHIVE = DEPLOYMENT_SHELL + ".ear";
+    
+    private static final String RESOURCE = "/"+DEPLOYMENT_OVERLAYED_ARCHIVE+"//"+OverlayableInterface.RESOURCE;
+    
+    @Deployment(name = DEPLOYMENT_SHELL)
+    public static Archive createDeployment() throws Exception {
+        return createEARWithOverlayedArchive(false, DEPLOYMENT_OVERLAYED_ARCHIVE,DEPLOYMENT_SHELL_ARCHIVE);
+    }
+
+    @Test
+    public void testOverlay() throws Exception {
+        final InitialContext ctx = getInitialContext();
+        try{
+        OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding(DEPLOYMENT_SHELL, DEPLOYMENT_OVERLAYED, "",
+                OverlayEJB.class, OverlayableInterface.class));
+        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", null, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE, OverlayableInterface.OVERLAYED);
+        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        } finally {
+            try{
+                ctx.close();
+            }catch(Exception e){
+            }
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayNonExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/ear/OverlayNonExistingResourceTestCase.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.test.integration.deployment.deploymentoverlay.ear;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -37,7 +40,8 @@ import org.junit.runner.RunWith;
 
 /**
  * @author baranowb
- * 
+ * @author lgao
+ *
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -59,20 +63,41 @@ public class OverlayNonExistingResourceTestCase extends EarOverlayTestBase {
     @Test
     public void testOverlay() throws Exception {
         final InitialContext ctx = getInitialContext();
+        Map<String, String> overlay = new HashMap<String, String>();
         try{
         OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding(DEPLOYMENT_SHELL, DEPLOYMENT_OVERLAYED, "",
                 OverlayEJB.class, OverlayableInterface.class));
-        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", null, iface.fetchResource());
-        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
-        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE, OverlayableInterface.OVERLAYED);
-        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
-        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        Assert.assertEquals("Overlayed resource in ear/jar does not match pre-overlay expectations!", null, iface.fetchResource());
+        Assert.assertEquals("Static resource in ear/jar does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+
+        Assert.assertEquals("HTML resource in ear/war does not match pre-overlay expectations!", null,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + OVERLAY_HTML));
+        Assert.assertEquals("HTML Static resource in ear/war does not match pre-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + STATIC_HTML));
+
+        Assert.assertEquals("Static resource in ear/war/jar does not match pre-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/echoStatic"));
+        Assert.assertEquals("Resource in ear/war/jar does not match pre-overlay expectations!", null,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/echoOverlay"));
+
+        overlay.put(RESOURCE, OverlayableInterface.OVERLAYED);
+        overlay.put(WEB_OVERLAY, OverlayableInterface.OVERLAYED);
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, overlay);
+
+        Assert.assertEquals("Overlayed resource in ear/jar does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource in ear/jar does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+
+        Assert.assertEquals("HTML static resource in ear/war does not match post-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + STATIC_HTML));
+        Assert.assertEquals("HTML resource in ear/war does not match post-overlay expectations!", OverlayableInterface.OVERLAYED,
+                readContent(managementClient.getWebUri() + "/" + WEB + "/" + OVERLAY_HTML));
+
         } finally {
             try{
                 ctx.close();
             }catch(Exception e){
             }
-            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE);
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, overlay.keySet());
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/JarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/JarOverlayTestBase.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
+
+import java.util.Hashtable;
+
+import javax.naming.Context;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+
+import org.jboss.arquillian.container.test.api.Deployer;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * @author baranowb
+ *
+ */
+public class JarOverlayTestBase {
+
+    @ArquillianResource
+    protected ManagementClient managementClient;
+
+    @ArquillianResource
+    protected Deployer deployer;
+    
+    public static Archive<?> createOverlayedArchive(final boolean resourcePresent, final String deploymentOverlayedArchive){
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, deploymentOverlayedArchive);
+        jar.addClasses(OverlayableInterface.class, OverlayEJB.class);
+        jar.addAsManifestResource(new StringAsset(OverlayableInterface.STATIC), OverlayableInterface.RESOURCE_STATIC_META_INF);
+        
+        if(resourcePresent){
+            jar.addAsManifestResource(new StringAsset(OverlayableInterface.ORIGINAL), OverlayableInterface.RESOURCE_META_INF);
+        }
+        return jar;
+    }
+
+    protected static InitialContext getInitialContext() throws NamingException {
+        final Hashtable env = new Hashtable();
+        env.put(Context.URL_PKG_PREFIXES, "org.jboss.ejb.client.naming");
+        env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
+        env.put(Context.PROVIDER_URL, "remote://" + TestSuiteEnvironment.getServerAddress() + ":" + 4447);
+        return new InitialContext(env);
+    }
+
+    protected static String getEjbBinding(final String rtModuleName, final String module, final String distinct, final Class bean,
+            final Class iface) {
+
+        final String appName = rtModuleName;
+        final String moduleName = module;
+        final String distinctName = distinct;
+        final String beanName = bean.getSimpleName();
+        final String viewClassName = iface.getName();
+        return "ejb:" + appName + "/" + moduleName + "/" + distinctName + "/" + beanName + "!" + viewClassName;
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayEJB.java
@@ -1,0 +1,63 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+import javax.ejb.Singleton;
+
+/**
+ * @author baranowb
+ * 
+ */
+@Singleton
+public class OverlayEJB implements OverlayableInterface {
+
+    @Override
+    public String fetchResource() throws Exception {
+        return fetch(RESOURCE);
+    }
+
+    @Override
+    public String fetchResourceStatic() throws Exception {
+        return fetch(RESOURCE_STATIC);
+    }
+    
+    protected String fetch(final String res) throws Exception {
+        final InputStream is = this.getClass().getClassLoader().getResourceAsStream(res);
+
+        if (is == null) {
+            return null;
+        }
+        final InputStreamReader isr = new InputStreamReader(is);
+        final BufferedReader br = new BufferedReader(isr);
+        try {
+            final String line = br.readLine();
+            return line;
+        } finally {
+            br.close();
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayEJB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayEJB.java
@@ -46,18 +46,14 @@ public class OverlayEJB implements OverlayableInterface {
     }
     
     protected String fetch(final String res) throws Exception {
-        final InputStream is = this.getClass().getClassLoader().getResourceAsStream(res);
-
-        if (is == null) {
-            return null;
-        }
-        final InputStreamReader isr = new InputStreamReader(is);
-        final BufferedReader br = new BufferedReader(isr);
-        try {
-            final String line = br.readLine();
-            return line;
-        } finally {
-            br.close();
+        try (InputStream is = this.getClass().getClassLoader().getResourceAsStream(res)) {
+            if (is == null) {
+                return null;
+            }
+            try (InputStreamReader isr = new InputStreamReader(is);
+                 BufferedReader br = new BufferedReader(isr);) {
+                return br.readLine();
+            }
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayExistingResourceTestCase.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author baranowb
+ * 
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OverlayExistingResourceTestCase extends JarOverlayTestBase {
+    private static final String OVERLAY = "HAL9000";
+    private static final String DEPLOYMENT_OVERLAYED = "overlayed";
+    private static final String DEPLOYMENT_OVERLAYED_ARCHIVE = DEPLOYMENT_OVERLAYED + ".jar";
+    
+    @Deployment(name = DEPLOYMENT_OVERLAYED)
+    public static Archive createDeployment() throws Exception {
+        return createOverlayedArchive(true, DEPLOYMENT_OVERLAYED_ARCHIVE);
+    }
+
+    @Test
+    public void testOverlay() throws Exception {
+        final InitialContext ctx = getInitialContext();
+        try{
+        OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding("", DEPLOYMENT_OVERLAYED, "",
+                OverlayEJB.class, OverlayableInterface.class));
+        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", OverlayableInterface.ORIGINAL, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_OVERLAYED_ARCHIVE, OVERLAY, OverlayableInterface.RESOURCE, OverlayableInterface.OVERLAYED);
+        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        } finally {
+            try{
+                ctx.close();
+            }catch(Exception e){
+            }
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_OVERLAYED_ARCHIVE, OVERLAY, OverlayableInterface.RESOURCE);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayNonExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayNonExistingResourceTestCase.java
@@ -1,0 +1,71 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author baranowb
+ * 
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OverlayNonExistingResourceTestCase extends JarOverlayTestBase {
+    private static final String OVERLAY = "HAL9000";
+    private static final String DEPLOYMENT_OVERLAYED = "overlayed";
+    private static final String DEPLOYMENT_OVERLAYED_ARCHIVE = DEPLOYMENT_OVERLAYED + ".jar";
+    
+    @Deployment(name = DEPLOYMENT_OVERLAYED)
+    public static Archive createDeployment() throws Exception {
+        return createOverlayedArchive(false, DEPLOYMENT_OVERLAYED_ARCHIVE);
+    }
+
+    @Test
+    public void testOverlay() throws Exception {
+        final InitialContext ctx = getInitialContext();
+        try{
+        OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding("", DEPLOYMENT_OVERLAYED, "",
+                OverlayEJB.class, OverlayableInterface.class));
+        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", null, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_OVERLAYED_ARCHIVE, OVERLAY, OverlayableInterface.RESOURCE, OverlayableInterface.OVERLAYED);
+        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        } finally {
+            try{
+                ctx.close();
+            }catch(Exception e){
+            }
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_OVERLAYED_ARCHIVE, OVERLAY, OverlayableInterface.RESOURCE);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayUtils.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayUtils.java
@@ -1,0 +1,121 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2014, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
+import java.io.IOException;
+
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+/**
+ * @author baranowb
+ *
+ */
+public final class OverlayUtils {
+
+    public static void setupOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final String overlayPath,final String overlayedContent) throws Exception {
+    
+            // create overlay
+            ModelNode op = new ModelNode();
+            op.get(ModelDescriptionConstants.OP_ADDR).set(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+    
+            // add content
+            op = new ModelNode();
+            op.get(ModelDescriptionConstants.OP_ADDR).set(new ModelNode());
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UPLOAD_DEPLOYMENT_BYTES);
+            op.get(ModelDescriptionConstants.BYTES).set(overlayedContent.getBytes());
+            ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+    
+            // link content to specific file
+            op = new ModelNode();
+            ModelNode addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
+            addr.add(ModelDescriptionConstants.CONTENT, overlayPath);
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.HASH).set(result);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+    
+            // add link
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
+            addr.add(ModelDescriptionConstants.DEPLOYMENT, deployment);
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.DEPLOYMENT, deployment);
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REDEPLOY);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        }
+        
+    public static  void removeOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final String overlayPath) throws Exception {
+            //TODO: proper cleanup
+            try {
+                removeContentItem(managementClient, overlayName, overlayPath);
+                removeDeploymentItem(managementClient, overlayName, deployment);
+    
+                ModelNode op = new ModelNode();
+                op.get(ModelDescriptionConstants.OP_ADDR).set(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
+                op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+                ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    
+        protected static void removeContentItem(final ManagementClient managementClient, final String w, final String a) throws IOException, MgmtOperationException {
+            final ModelNode op;
+            final ModelNode addr;
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, w);
+            addr.add(ModelDescriptionConstants.CONTENT, a);
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        }
+    
+    
+        protected static void removeDeploymentItem(final ManagementClient managementClient, final String w, final String a) throws IOException, MgmtOperationException {
+            final ModelNode op;
+            final ModelNode addr;
+            op = new ModelNode();
+            addr = new ModelNode();
+            addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, w);
+            addr.add(ModelDescriptionConstants.DEPLOYMENT, a);
+            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+        }
+
+    
+    
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayUtils.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayUtils.java
@@ -22,74 +22,87 @@
 
 package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 
 import org.jboss.as.arquillian.container.ManagementClient;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.test.integration.management.ManagementOperations;
 import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.jboss.dmr.ModelNode;
+
 /**
  * @author baranowb
+ * @author lgao
  *
  */
 public final class OverlayUtils {
 
-    public static void setupOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final String overlayPath,final String overlayedContent) throws Exception {
-    
-            // create overlay
-            ModelNode op = new ModelNode();
-            op.get(ModelDescriptionConstants.OP_ADDR).set(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
-            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-    
+    public static void setupOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final Map<String, String> overlay) throws Exception {
+
+        // create overlay
+        ModelNode op = new ModelNode();
+        op.get(ModelDescriptionConstants.OP_ADDR).set(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+
+        for (Map.Entry<String, String> overlayItem: overlay.entrySet()) {
             // add content
             op = new ModelNode();
             op.get(ModelDescriptionConstants.OP_ADDR).set(new ModelNode());
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.UPLOAD_DEPLOYMENT_BYTES);
-            op.get(ModelDescriptionConstants.BYTES).set(overlayedContent.getBytes());
+            op.get(ModelDescriptionConstants.BYTES).set(overlayItem.getValue().getBytes());
             ModelNode result = ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-    
+
             // link content to specific file
             op = new ModelNode();
             ModelNode addr = new ModelNode();
             addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
-            addr.add(ModelDescriptionConstants.CONTENT, overlayPath);
+            addr.add(ModelDescriptionConstants.CONTENT, overlayItem.getKey());
             op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
             op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
             op.get(ModelDescriptionConstants.CONTENT).get(ModelDescriptionConstants.HASH).set(result);
             ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-    
-            // add link
-            op = new ModelNode();
-            addr = new ModelNode();
-            addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
-            addr.add(ModelDescriptionConstants.DEPLOYMENT, deployment);
-            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
 
-            op = new ModelNode();
-            addr = new ModelNode();
-            addr.add(ModelDescriptionConstants.DEPLOYMENT, deployment);
-            op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
-            op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REDEPLOY);
-            ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
         }
-        
-    public static  void removeOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final String overlayPath) throws Exception {
-            //TODO: proper cleanup
-            try {
-                removeContentItem(managementClient, overlayName, overlayPath);
-                removeDeploymentItem(managementClient, overlayName, deployment);
-    
-                ModelNode op = new ModelNode();
-                op.get(ModelDescriptionConstants.OP_ADDR).set(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
-                op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
-                ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+
+        // add link
+        op = new ModelNode();
+        ModelNode addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
+        addr.add(ModelDescriptionConstants.DEPLOYMENT, deployment);
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.ADD);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+
+        op = new ModelNode();
+        addr = new ModelNode();
+        addr.add(ModelDescriptionConstants.DEPLOYMENT, deployment);
+        op.get(ModelDescriptionConstants.OP_ADDR).set(addr);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REDEPLOY);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+    }
+
+    public static void setupOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final String overlayPath,final String overlayedContent) throws Exception {
+        setupOverlay(managementClient, deployment, overlayName, Collections.singletonMap(overlayPath, overlayedContent));
+    }
+
+    public static void removeOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final Set<String> overlayPaths) throws Exception {
+        for (String overlayPath: overlayPaths) {
+            removeContentItem(managementClient, overlayName, overlayPath);
         }
+        removeDeploymentItem(managementClient, overlayName, deployment);
+
+        ModelNode op = new ModelNode();
+        op.get(ModelDescriptionConstants.OP_ADDR).set(ModelDescriptionConstants.DEPLOYMENT_OVERLAY, overlayName);
+        op.get(ModelDescriptionConstants.OP).set(ModelDescriptionConstants.REMOVE);
+        ManagementOperations.executeOperation(managementClient.getControllerClient(), op);
+    }
+
+    public static void removeOverlay(final ManagementClient managementClient, final String deployment,final String overlayName, final String overlayPath) throws Exception {
+        removeOverlay(managementClient, deployment, overlayName, Collections.singleton(overlayPath));
+    }
     
         protected static void removeContentItem(final ManagementClient managementClient, final String w, final String a) throws IOException, MgmtOperationException {
             final ModelNode op;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayableInterface.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/jar/OverlayableInterface.java
@@ -1,0 +1,47 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.jar;
+
+import javax.ejb.Remote;
+
+/**
+ * @author baranowb
+ * 
+ */
+@Remote
+public interface OverlayableInterface {
+    String ORIGINAL = "ORIGINAL";
+    String OVERLAYED = "OVERLAYED";
+    String RESOURCE_NAME = "file.txt";
+    String RESOURCE_META_INF = "x/"+RESOURCE_NAME;
+    String RESOURCE = "META-INF/"+RESOURCE_META_INF;
+
+    String STATIC = "STATIC";
+    String RESOURCE_STATIC_NAME = "static.txt";
+    String RESOURCE_STATIC_META_INF = "x/"+RESOURCE_STATIC_NAME;
+    String RESOURCE_STATIC = "META-INF/"+RESOURCE_STATIC_META_INF;
+
+    String fetchResource() throws Exception;
+    
+    String fetchResourceStatic() throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/OverlayExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/OverlayExistingResourceTestCase.java
@@ -1,0 +1,80 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.war;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayEJB;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayUtils;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author baranowb
+ * 
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OverlayExistingResourceTestCase extends WarOverlayTestBase {
+    private static final String OVERLAY = "HAL9000";
+    private static final String DEPLOYMENT_OVERLAYED = "overlayed";
+    private static final String DEPLOYMENT_OVERLAYED_ARCHIVE = DEPLOYMENT_OVERLAYED + ".jar";
+    
+    private static final String DEPLOYMENT_SHELL = "shell";
+    private static final String DEPLOYMENT_SHELL_ARCHIVE = DEPLOYMENT_SHELL + ".war";
+    
+    private static final String RESOURCE = "/WEB-INF/lib/"+DEPLOYMENT_OVERLAYED_ARCHIVE+"//"+OverlayableInterface.RESOURCE;
+    
+    @Deployment(name = DEPLOYMENT_SHELL)
+    public static Archive createDeployment() throws Exception {
+        return createWARWithOverlayedArchive(true, DEPLOYMENT_OVERLAYED_ARCHIVE,DEPLOYMENT_SHELL_ARCHIVE);
+    }
+
+    @Test
+    public void testOverlay() throws Exception {
+        final InitialContext ctx = getInitialContext();
+        try{
+        OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding("", DEPLOYMENT_SHELL, "",
+                OverlayEJB.class, OverlayableInterface.class));
+        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", OverlayableInterface.ORIGINAL, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE, OverlayableInterface.OVERLAYED);
+        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        } finally {
+            try{
+                ctx.close();
+            }catch(Exception e){
+            }
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/OverlayNonExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/OverlayNonExistingResourceTestCase.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.war;
+
+import javax.naming.InitialContext;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayEJB;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayUtils;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author baranowb
+ * 
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class OverlayNonExistingResourceTestCase extends WarOverlayTestBase {
+    private static final String OVERLAY = "HAL9000";
+    private static final String DEPLOYMENT_OVERLAYED = "overlayed";
+    private static final String DEPLOYMENT_OVERLAYED_ARCHIVE = DEPLOYMENT_OVERLAYED + ".jar";
+    
+    private static final String DEPLOYMENT_SHELL = "shell";
+    private static final String DEPLOYMENT_SHELL_ARCHIVE = DEPLOYMENT_SHELL + ".war";
+    
+    private static final String RESOURCE = "/WEB-INF/lib/"+DEPLOYMENT_OVERLAYED_ARCHIVE+"//"+OverlayableInterface.RESOURCE;
+    
+    @Deployment(name = DEPLOYMENT_SHELL)
+    public static Archive createDeployment() throws Exception {
+        return createWARWithOverlayedArchive(false, DEPLOYMENT_OVERLAYED_ARCHIVE,DEPLOYMENT_SHELL_ARCHIVE);
+    }
+
+    @Test
+    public void testOverlay() throws Exception {
+        final InitialContext ctx = getInitialContext();
+        try{
+        OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding("", DEPLOYMENT_SHELL, "",
+                OverlayEJB.class, OverlayableInterface.class));
+        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", null, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE, OverlayableInterface.OVERLAYED);
+        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        } finally {
+            try{
+                ctx.close();
+            }catch(Exception e){
+            }
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE);
+        }
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/OverlayNonExistingResourceTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/OverlayNonExistingResourceTestCase.java
@@ -22,6 +22,9 @@
 
 package org.jboss.as.test.integration.deployment.deploymentoverlay.war;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.naming.InitialContext;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -37,7 +40,8 @@ import org.junit.runner.RunWith;
 
 /**
  * @author baranowb
- * 
+ * @author lgao
+ *
  */
 @RunWith(Arquillian.class)
 @RunAsClient
@@ -59,20 +63,36 @@ public class OverlayNonExistingResourceTestCase extends WarOverlayTestBase {
     @Test
     public void testOverlay() throws Exception {
         final InitialContext ctx = getInitialContext();
+        Map<String, String> overlay = new HashMap<String, String>();
         try{
         OverlayableInterface iface = (OverlayableInterface) ctx.lookup(getEjbBinding("", DEPLOYMENT_SHELL, "",
                 OverlayEJB.class, OverlayableInterface.class));
-        Assert.assertEquals("Overlayed resource does not match pre-overlay expectations!", null, iface.fetchResource());
-        Assert.assertEquals("Static resource does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
-        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE, OverlayableInterface.OVERLAYED);
-        Assert.assertEquals("Overlayed resource does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
-        Assert.assertEquals("Static resource does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+        Assert.assertEquals("Overlayed resource in war/jar does not match pre-overlay expectations!", null, iface.fetchResource());
+        Assert.assertEquals("Static resource in war/jar does not match pre-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+
+        Assert.assertEquals("HTML resource in war does not match pre-overlay expectations!", null,
+                readContent(managementClient.getWebUri() + "/" + DEPLOYMENT_SHELL + "/" + OVERLAY_HTML));
+        Assert.assertEquals("HTML Static resource in war does not match pre-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + DEPLOYMENT_SHELL + "/" + STATIC_HTML));
+
+        overlay.put(RESOURCE, OverlayableInterface.OVERLAYED);
+        overlay.put(OVERLAY_HTML, OverlayableInterface.OVERLAYED);
+        OverlayUtils.setupOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, overlay);
+
+        Assert.assertEquals("Overlayed resource in war/jar does not match post-overlay expectations!", OverlayableInterface.OVERLAYED, iface.fetchResource());
+        Assert.assertEquals("Static resource in war/jar does not match post-overlay expectations!", OverlayableInterface.STATIC, iface.fetchResourceStatic());
+
+        Assert.assertEquals("HTML static resource in war does not match post-overlay expectations!", OverlayableInterface.STATIC,
+                readContent(managementClient.getWebUri() + "/" + DEPLOYMENT_SHELL + "/" + STATIC_HTML));
+        Assert.assertEquals("HTML resource in war does not match post-overlay expectations!", OverlayableInterface.OVERLAYED,
+                readContent(managementClient.getWebUri() + "/" + DEPLOYMENT_SHELL + "/" + OVERLAY_HTML));
+
         } finally {
             try{
                 ctx.close();
             }catch(Exception e){
             }
-            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, RESOURCE);
+            OverlayUtils.removeOverlay(managementClient, DEPLOYMENT_SHELL_ARCHIVE, OVERLAY, overlay.keySet());
         }
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/WarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/WarOverlayTestBase.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2015, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.deployment.deploymentoverlay.war;
+
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+/**
+ * @author baranowb
+ *
+ */
+public class WarOverlayTestBase extends JarOverlayTestBase{
+
+    public static Archive<?> createWARWithOverlayedArchive(final boolean resourcePresent, String deploymentOverlayedArchive, final String deploymentTopArchve){
+        WebArchive war = ShrinkWrap.create(WebArchive.class, deploymentTopArchve);
+        Archive<?> jar = createOverlayedArchive(resourcePresent,deploymentOverlayedArchive);
+        war.addAsLibrary(jar);
+        return war;
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/WarOverlayTestBase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/deployment/deploymentoverlay/war/WarOverlayTestBase.java
@@ -22,7 +22,15 @@
 
 package org.jboss.as.test.integration.deployment.deploymentoverlay.war;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
 import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.JarOverlayTestBase;
+import org.jboss.as.test.integration.deployment.deploymentoverlay.jar.OverlayableInterface;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
@@ -30,15 +38,46 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 /**
  * @author baranowb
+ * @author lgao
  *
  */
 public class WarOverlayTestBase extends JarOverlayTestBase{
 
+    public static final String OVERLAY_HTML = "overlay.html";
+    public static final String STATIC_HTML = "static.html";
+
     public static Archive<?> createWARWithOverlayedArchive(final boolean resourcePresent, String deploymentOverlayedArchive, final String deploymentTopArchve){
         WebArchive war = ShrinkWrap.create(WebArchive.class, deploymentTopArchve);
         Archive<?> jar = createOverlayedArchive(resourcePresent,deploymentOverlayedArchive);
+        if (resourcePresent) {
+            war.add(new StringAsset(OverlayableInterface.ORIGINAL), OVERLAY_HTML);
+        }
+        war.add(new StringAsset(OverlayableInterface.STATIC), STATIC_HTML);
         war.addAsLibrary(jar);
         return war;
+    }
+
+    public static String readContent(String url) throws IOException {
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection)new URL(url).openConnection();
+            conn.connect();
+            int httpCode = conn.getResponseCode();
+            if (httpCode == 200) {
+                try (InputStream input = conn.getInputStream();
+                     InputStreamReader inputReader = new InputStreamReader(input);
+                     BufferedReader reader = new BufferedReader(inputReader)) {
+                    return reader.readLine();
+                }
+            } else if (httpCode == 404) {
+                return null;
+            }
+            throw new RuntimeException("Un expected response code: " + httpCode);
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-6821

The linked WildFly core Jira: https://issues.jboss.org/browse/WFCORE-761

This is second part of fix and the test cases on overlay issues, the test cases contain following situations:

1). replace/new files in jar, like: ejb.jar/META-INF/jboss-ejb3.xml
2). replace/new files in war, like: web.war/index.html
3). replace/new files in war/jar, like: web.war/WEB-INF/lib/mylib.jar/META-INF/config.properties
4). replace/new files in ear/jar, like: app.ear/lib/earlib.jar/META-INF/config.properties
5). replace/new files in ear/war, like: app.ear/web.war/index.html
~~6). replace/new files in ear/war/jar, like: app.ear/web.war/WEB-INF/lib/mylib.jar/META-INF/config.properties~~

Test case No.6 above is disabled now, because PR in wildfly-core does not fix this case, and it needs more discussion.
