### PR TITLE
[master] Add a testcase to ensure the server doesn't serve the source (code) of an incorrectly accessed resource

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultServletTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/DefaultServletTestCase.java
@@ -1,0 +1,77 @@
+package org.jboss.as.test.integration.web.response;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import javax.servlet.http.HttpServletResponse;
+import java.net.URL;
+
+/**
+ * Tests the "default servlet" of the web container
+ *
+ * @author Jaikiran Pai
+ */
+@RunWith(Arquillian.class)
+@RunAsClient
+public class DefaultServletTestCase {
+
+    private static final String WEB_APP_CONTEXT = "default-servlet-test";
+    private static final String APP_XHTML_FILE_NAME = "app.xhtml";
+    private static final Logger logger = Logger.getLogger(DefaultServletTestCase.class);
+
+    @ArquillianResource
+    URL url;
+
+    private HttpClient httpclient;
+
+    @Deployment
+    public static WebArchive deployment() {
+        final WebArchive war = ShrinkWrap.create(WebArchive.class, WEB_APP_CONTEXT + ".war");
+        war.addAsWebResource(DefaultServletTestCase.class.getPackage(), APP_XHTML_FILE_NAME, APP_XHTML_FILE_NAME);
+        logger.info("War " + WEB_APP_CONTEXT + ".war contents: " + war.toString(true));
+        return war;
+    }
+
+    @Before
+    public void setup() {
+        this.httpclient = HttpClientBuilder.create().build();
+    }
+
+    /**
+     * Tests that the default servlet doesn't show the source (code) of a resource when an incorrect URL is used to access that resource.
+     *
+     * @throws Exception
+     * @see https://developer.jboss.org/thread/266805 for more details
+     */
+    @Test
+    public void testForbidSourceFileAccess() throws Exception {
+        // first try accessing the valid URL and expect it to serve the right content
+        final String correctURL = url.toString() + APP_XHTML_FILE_NAME;
+        final HttpGet httpGetCorrectURL = new HttpGet(correctURL);
+        final HttpResponse response = this.httpclient.execute(httpGetCorrectURL);
+        Assert.assertEquals("Unexpected response code for URL " + correctURL, HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
+        final String content = EntityUtils.toString(response.getEntity());
+        Assert.assertTrue("Unexpected content served at " + correctURL, content.contains("Hello World"));
+
+        // now try accessing the same URL with a "." at the end of the resource name.
+        // This should throw a 404 error and NOT show up the "source" content of the resource
+        final String nonExistentURL = url.toString() + APP_XHTML_FILE_NAME + ".";
+        final HttpGet httpGetNonExistentURL = new HttpGet(nonExistentURL);
+        final HttpResponse responseForNonExistentURL = this.httpclient.execute(httpGetNonExistentURL);
+        Assert.assertEquals("Unexpected response code for URL " + nonExistentURL, HttpServletResponse.SC_NOT_FOUND, responseForNonExistentURL.getStatusLine().getStatusCode());
+    }
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/app.xhtml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/response/app.xhtml
@@ -1,0 +1,15 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:ui="http://java.sun.com/jsf/facelets"
+      xmlns:h="http://java.sun.com/jsf/html"
+      xmlns:f="http://java.sun.com/jsf/core">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+    <title>Test</title>
+</head>
+<body>
+Hello World!
+</body>
+</html>


### PR DESCRIPTION
An user in the forums has reported that WildFly serves the source code of a resource if the resource is accessed incorrectly with a "." (dot) at the end of the URL. The report specifically states that this happens on 8.x, 9.x and 10.x versions of WildFly on a Windows OS environment. More details are in the forum thread here https://developer.jboss.org/thread/266805.

I don't have access to a Windows system so haven't been able to reproduce this myself. James tried 10.0.0.CR5 on a Windows system and states that it isn't reproducible there.

This commit here just adds a testcase to verify the right behaviour and also see if this issue gets reproduced (and fails this test) on a Windows system in the CI environment.
