### PR TITLE
Ignore PassivationTestCase.testPassivationMaxSize

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationTestCase.java
@@ -34,6 +34,7 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -73,6 +74,7 @@ public class PassivationTestCase {
     }
 
     @Test
+    @Ignore("Too many intermittent failures")
     public void testPassivationMaxSize() throws Exception {
         PassivationInterceptor.reset();
         TestPassivationRemote remote1 = (TestPassivationRemote) ctx.lookup("java:module/"


### PR DESCRIPTION
@pferraro 
this is failing in about 5-6% of times.
http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WildFlyCore&testNameId=4394566496148113930&tab=testDetails
http://brontes.lab.eng.brq.redhat.com/project.html?projectId=WF&testNameId=4394566496148113930&tab=testDetails
