### PR TITLE
WFLY-5945/WFLY-5946 immutable-entity and naturalid cache configurations are not started by the JPA subsystem

### DIFF
--- a/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/HibernateSecondLevelCache.java
+++ b/jpa/hibernate4_1/src/main/java/org/jboss/as/jpa/hibernate4/HibernateSecondLevelCache.java
@@ -44,6 +44,7 @@ public class HibernateSecondLevelCache {
     public static final String COLLECTION = "collection";
     public static final String ENTITY = "entity";
     public static final String NAME = "name";
+    public static final String NATURAL_ID = "natural-id";
     public static final String QUERY = "query";
     public static final String TIMESTAMPS = "timestamps";
 
@@ -76,6 +77,7 @@ public class HibernateSecondLevelCache {
             cacheSettings.put(CONTAINER, container);
             cacheSettings.put(ENTITY, mutableProperties.getProperty(InfinispanRegionFactory.ENTITY_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
             cacheSettings.put(COLLECTION, mutableProperties.getProperty(InfinispanRegionFactory.COLLECTION_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
+            cacheSettings.put(NATURAL_ID, mutableProperties.getProperty(InfinispanRegionFactory.NATURAL_ID_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
             if (Boolean.parseBoolean(mutableProperties.getProperty(AvailableSettings.USE_QUERY_CACHE))) {
                 cacheSettings.put(QUERY, mutableProperties.getProperty(InfinispanRegionFactory.QUERY_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_QUERY_RESOURCE));
                 cacheSettings.put(TIMESTAMPS, mutableProperties.getProperty(InfinispanRegionFactory.TIMESTAMPS_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_QUERY_RESOURCE));

--- a/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/HibernateSecondLevelCache.java
+++ b/jpa/hibernate4_3/src/main/java/org/jboss/as/jpa/hibernate4/HibernateSecondLevelCache.java
@@ -44,6 +44,7 @@ public class HibernateSecondLevelCache {
     public static final String COLLECTION = "collection";
     public static final String ENTITY = "entity";
     public static final String NAME = "name";
+    public static final String NATURAL_ID = "natural-id";
     public static final String QUERY = "query";
     public static final String TIMESTAMPS = "timestamps";
 
@@ -76,6 +77,7 @@ public class HibernateSecondLevelCache {
             cacheSettings.put(CONTAINER, container);
             cacheSettings.put(ENTITY, mutableProperties.getProperty(InfinispanRegionFactory.ENTITY_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
             cacheSettings.put(COLLECTION, mutableProperties.getProperty(InfinispanRegionFactory.COLLECTION_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
+            cacheSettings.put(NATURAL_ID, mutableProperties.getProperty(InfinispanRegionFactory.NATURAL_ID_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
             if (Boolean.parseBoolean(mutableProperties.getProperty(AvailableSettings.USE_QUERY_CACHE))) {
                 cacheSettings.put(QUERY, mutableProperties.getProperty(InfinispanRegionFactory.QUERY_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_QUERY_RESOURCE));
                 cacheSettings.put(TIMESTAMPS, mutableProperties.getProperty(InfinispanRegionFactory.TIMESTAMPS_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_QUERY_RESOURCE));

--- a/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/HibernateSecondLevelCache.java
+++ b/jpa/hibernate5/src/main/java/org/jboss/as/jpa/hibernate5/HibernateSecondLevelCache.java
@@ -38,7 +38,9 @@ public class HibernateSecondLevelCache {
     public static final String CONTAINER = "container";
     public static final String COLLECTION = "collection";
     public static final String ENTITY = "entity";
+    public static final String IMMUTABLE_ENTITY = "immutable-entity";
     public static final String NAME = "name";
+    public static final String NATURAL_ID = "natural-id";
     public static final String QUERY = "query";
     public static final String TIMESTAMPS = "timestamps";
 
@@ -70,7 +72,9 @@ public class HibernateSecondLevelCache {
             Properties cacheSettings = new Properties();
             cacheSettings.put(CONTAINER, container);
             cacheSettings.put(ENTITY, mutableProperties.getProperty(InfinispanRegionFactory.ENTITY_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
+            cacheSettings.put(IMMUTABLE_ENTITY, mutableProperties.getProperty(InfinispanRegionFactory.IMMUTABLE_ENTITY_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
             cacheSettings.put(COLLECTION, mutableProperties.getProperty(InfinispanRegionFactory.COLLECTION_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
+            cacheSettings.put(NATURAL_ID, mutableProperties.getProperty(InfinispanRegionFactory.NATURAL_ID_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_ENTITY_RESOURCE));
             if (Boolean.parseBoolean(mutableProperties.getProperty(AvailableSettings.USE_QUERY_CACHE))) {
                 cacheSettings.put(QUERY, mutableProperties.getProperty(InfinispanRegionFactory.QUERY_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_QUERY_RESOURCE));
                 cacheSettings.put(TIMESTAMPS, mutableProperties.getProperty(InfinispanRegionFactory.TIMESTAMPS_CACHE_RESOURCE_PROP, InfinispanRegionFactory.DEF_QUERY_RESOURCE));

--- a/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/secondLevelCache/InfinispanCacheDeploymentListener.java
+++ b/jpa/subsystem/src/main/java/org/jboss/as/jpa/processor/secondLevelCache/InfinispanCacheDeploymentListener.java
@@ -55,7 +55,9 @@ public class InfinispanCacheDeploymentListener implements EventListener {
     public static final String CONTAINER = "container";
     public static final String COLLECTION = "collection";
     public static final String ENTITY = "entity";
+    public static final String IMMUTABLE_ENTITY = "immutable-entity";
     public static final String NAME = "name";
+    public static final String NATURAL_ID = "natural-id";
     public static final String QUERY = "query";
     public static final String TIMESTAMPS = "timestamps";
 
@@ -102,11 +104,15 @@ public class InfinispanCacheDeploymentListener implements EventListener {
     public void addCacheDependencies(Classification classification, Properties properties) {
         String container = properties.getProperty(CONTAINER);
         String entity = properties.getProperty(ENTITY);
+        String immutableEntity = properties.getProperty(IMMUTABLE_ENTITY);
+        String naturalId = properties.getProperty(NATURAL_ID);
         String collection = properties.getProperty(COLLECTION);
         String query = properties.getProperty(QUERY);
         String timestamps  = properties.getProperty(TIMESTAMPS);
         CacheDeploymentListener.getInternalDeploymentServiceBuilder().addDependency(CacheServiceName.CONFIGURATION.getServiceName(container, entity));
+        CacheDeploymentListener.getInternalDeploymentServiceBuilder().addDependency(CacheServiceName.CONFIGURATION.getServiceName(container, immutableEntity));
         CacheDeploymentListener.getInternalDeploymentServiceBuilder().addDependency(CacheServiceName.CONFIGURATION.getServiceName(container, collection));
+        CacheDeploymentListener.getInternalDeploymentServiceBuilder().addDependency(CacheServiceName.CONFIGURATION.getServiceName(container, naturalId));
         if (query != null) {
             CacheDeploymentListener.getInternalDeploymentServiceBuilder().addDependency(CacheServiceName.CONFIGURATION.getServiceName(container, timestamps));
             CacheDeploymentListener.getInternalDeploymentServiceBuilder().addDependency(CacheServiceName.CONFIGURATION.getServiceName(container, query));


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5945
https://issues.jboss.org/browse/WFLY-5946
