### PR TITLE
Fix issues resulting from javax.ejb.api no longer exporting modules

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbDependencyDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/EjbDependencyDeploymentUnitProcessor.java
@@ -54,6 +54,7 @@ public class EjbDependencyDeploymentUnitProcessor implements DeploymentUnitProce
     private static final ModuleIdentifier EJB_IIOP_CLIENT = ModuleIdentifier.create("org.jboss.iiop-client");
     private static final ModuleIdentifier IIOP_OPENJDK = ModuleIdentifier.create("org.wildfly.iiop-openjdk");
     private static final ModuleIdentifier EJB_API = ModuleIdentifier.create("javax.ejb.api");
+    private static final ModuleIdentifier JAX_RPC_API = ModuleIdentifier.create("javax.xml.rpc.api");
 
 
     /**
@@ -75,6 +76,8 @@ public class EjbDependencyDeploymentUnitProcessor implements DeploymentUnitProce
 
         //always add EE API
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_API, false, false, true, false));
+        // previously exported by EJB_API prior to WFLY-5922 TODO WFLY-5967 look into moving this to WS subsystem
+        moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, JAX_RPC_API, false, false, true, false));
         //we always give them the EJB client
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_CLIENT, false, false, true, false));
         moduleSpecification.addSystemDependency(new ModuleDependency(moduleLoader, EJB_IIOP_CLIENT, false, false, false, false));

--- a/feature-pack/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/sun/jsf-impl/main/module.xml
@@ -35,6 +35,13 @@
         <module name="org.apache.xalan" services="import"/>
         <module name="org.jboss.weld.core"/>
         <module name="org.jboss.weld.spi"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api and
+             reexported by javaee.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 
     <resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javaee/api/main/module.xml
@@ -56,6 +56,11 @@
         <module name="javax.xml.ws.api" export="true"/>
         <module name="org.glassfish.javax.el" export="true"/>
 
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api" export="true"/>
+        <module name="org.omg.api" export="true"/>
+
         <!-- This one always goes last. -->
         <module name="javax.api" export="true"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
@@ -26,8 +26,9 @@
     <resources>
         <artifact name="${org.jboss.spec.javax.management.j2ee:jboss-j2eemgmt-api_1.1_spec}"/>
     </resources>
-    
+
     <dependencies>
+        <module name="javax.api"/>
         <module name="javax.ejb.api"/>
         <module name="org.jboss.ejb-client"/>
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/javax/management/j2ee/api/main/module.xml
@@ -31,6 +31,13 @@
         <module name="javax.api"/>
         <module name="javax.ejb.api"/>
         <module name="org.jboss.ejb-client"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jberet/jberet-core/main/module.xml
@@ -42,5 +42,12 @@
         <module name="com.google.guava"/>
         <module name="com.h2database.h2" optional="true"/>
 
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api and
+             reexported by javaee.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
+
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/ejb3/main/module.xml
@@ -105,5 +105,10 @@
         <module name="org.omg.api"/>
         <module name="org.picketbox"/>
         <module name="javax.xml.rpc.api"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api"/>
+        <module name="javax.rmi.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/main/module.xml
@@ -76,5 +76,11 @@
         <module name="org.jboss.weld.core"/>
         <module name="org.wildfly.clustering.infinispan.spi"/>
         <module name="org.wildfly.clustering.service"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jpa/spi/main/module.xml
@@ -40,5 +40,12 @@
         <module name="org.jboss.jandex"/>
         <module name="org.jboss.logging"/>
         <module name="org.jboss.msc"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/jsr77/main/module.xml
@@ -50,5 +50,12 @@
 
         <!-- Only here temporarily -->
         <module name="org.jboss.ejb-client"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/webservices/main/module.xml
@@ -70,5 +70,12 @@
         <module name="org.jboss.ws.spi" />
         <module name="org.picketbox" />
         <module name="org.wildfly.extension.undertow" />
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -81,6 +81,7 @@
         <module name="org.jboss.weld.api" />
         <module name="org.jboss.weld.core" />
         <module name="org.jboss.weld.spi" />
+        <module name="org.omg.api"/>
         <module name="org.slf4j" />
         <module name="org.slf4j.ext" />
     </dependencies>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/weld/main/module.xml
@@ -84,5 +84,10 @@
         <module name="org.omg.api"/>
         <module name="org.slf4j" />
         <module name="org.slf4j.ext" />
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/as/xts/main/module.xml
@@ -71,5 +71,10 @@
         <module name="org.jboss.as.web-common"/>
         <module name="org.jboss.narayana.compensations" />
         <module name="org.omg.api"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb-client/main/module.xml
@@ -36,5 +36,11 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river"/>
         <module name="javax.transaction.api"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ejb3/main/module.xml
@@ -38,5 +38,13 @@
         <module name="org.jboss.marshalling"/>
         <module name="org.jboss.marshalling.river"/>
         <module name="org.jboss.metadata.ejb"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.api"/>
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/iiop-client/main/module.xml
@@ -34,5 +34,11 @@
         <module name="javax.ejb.api"/>
         <module name="org.omg.api"/>
         <module name="javax.interceptor.api"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/appclient/main/module.xml
@@ -46,5 +46,12 @@
         <module name="org.jboss.ejb3" optional="true"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api" optional="true"/>
+        <module name="javax.xml.rpc.api" optional="true"/>
+        <module name="javax.rmi.api" optional="true"/>
+        <module name="org.omg.api" optional="true"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/metadata/ejb/main/module.xml
@@ -44,5 +44,12 @@
         <module name="org.jboss.ejb3" optional="true"/>
         <module name="org.jboss.staxmapper"/>
         <module name="org.jboss.logging"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api" optional="true"/>
+        <module name="javax.xml.rpc.api" optional="true"/>
+        <module name="javax.rmi.api" optional="true"/>
+        <module name="org.omg.api" optional="true"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/compensations/main/module.xml
@@ -43,5 +43,12 @@
         <module name="javax.servlet.api" />
         <module name="javax.annotation.api" export="true" />
         <module name="javax.interceptor.api"  export="true" />
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/rts/main/module.xml
@@ -43,5 +43,11 @@
         <module name="javax.ejb.api"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.logging"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/narayana/txframework/main/module.xml
@@ -43,5 +43,12 @@
         <module name="javax.servlet.api" />
         <module name="javax.annotation.api" export="true" />
         <module name="javax.interceptor.api"  export="true" />
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/weld/core/main/module.xml
@@ -51,5 +51,11 @@
         <module name="org.jboss.weld.spi" />
         <module name="org.jboss.logging" />
         <module name="sun.jdk" optional="true" />
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/ws/common/main/module.xml
@@ -46,5 +46,12 @@
         <module name="org.jboss.logging"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.jboss.jaxbintros"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.transaction.api"/>
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/xts/main/module.xml
@@ -65,5 +65,11 @@
         <module name="javax.annotation.api"  export="true" />
         <module name="javax.interceptor.api"  export="true" />
         <module name="org.jboss.weld.spi" />
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/rts/main/module.xml
@@ -62,5 +62,11 @@
         <module name="org.jboss.resteasy.resteasy-jettison-provider"/>
 
         <module name="org.jboss.narayana.rts"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/jberet/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/jberet/main/module.xml
@@ -38,5 +38,12 @@
         <module name="org.jberet.jberet-core" services="import"/>
         <module name="org.jboss.logging"/>
         <module name="org.wildfly.security.elytron"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api and
+             reexported by javaee.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 </module>

--- a/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/mojarra-impl-module.xml
@@ -33,6 +33,13 @@
         <module name="javax.servlet.jstl.api"/>
         <module name="org.apache.xerces" services="import"/>
         <module name="org.apache.xalan" services="import"/>
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api and
+             reexported by javaee.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 
     <resources>

--- a/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
+++ b/jsf/multi-jsf-installer/src/main/resources/myfaces-impl-module.xml
@@ -48,6 +48,13 @@
         <module name="org.apache.commons.logging"/>
         <module name="org.apache.commons.el"/>
         <module name="org.apache.commons.lang"/> -->
+
+        <!-- TODO WFLY-5966 validate the need for these and remove if not needed.
+             Prior to WFLY-5922 they were exported by javax.ejb.api and
+             reexported by javaee.api. -->
+        <module name="javax.xml.rpc.api"/>
+        <module name="javax.rmi.api"/>
+        <module name="org.omg.api"/>
     </dependencies>
 
     <resources>


### PR DESCRIPTION
First 3 commits fix observed TCK issues.

Last two commits are a kind of brute-force "add dependencies to ensure nothing was lost" until WFLY-5966 is done.
