### PR TITLE
[WFLY-5074] Unspecified MDB transaction attributes

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/logging/EjbLogger.java
@@ -3103,4 +3103,8 @@ public interface EjbLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 484, value = "Could not send a cluster removal message for cluster: (%s) to the client on channel %s")
     void couldNotSendClusterRemovalMessage(@Cause Throwable cause, Group group, Channel channel);
+
+    @LogMessage(level = WARN)
+    @Message(id = 485, value = "Transaction type %s is unspecified for the %s method of the %s message-driven bean. It will be handled as NOT_SUPPORTED.")
+    void invalidTransactionTypeForMDB(TransactionAttributeType transactionAttributeType, String methond, String componentName);
 }


### PR DESCRIPTION
The EJB3 specification only defines behaviour for REQUIRED and
NOT_SUPPORTED tx attributes for Message-Driven Bean.
For any other tx attributes types, log a warning that they are
unspecified and will be handled as NOT_SUPPORTED.

JIRA: https://issues.jboss.org/browse/WFLY-5074
