### PR TITLE
WFLY-5785 - EJB lookup fails with "No cluster context available"

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -311,7 +311,7 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
                 EjbLogger.REMOTE_LOGGER.debugf("Received cluster removal notification for cluster %s", registry.getGroup());
             }
             // when the membership of the cluster being left is 1, we are the last node
-            if (registry.getEntries().keySet().size() == 1) {
+            if (registry.getGroup().getNodes().size() == 1) {
                 this.sendClusterRemovedMessage(registry);
             }
         } catch (IOException ioe) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5785

Fixed sending of the CLUSTER_REMOVED message to the clients during node shutdiwn even if the node is not the last one in the cluster.
