### PR TITLE
WFLY-5785 EJB lookup fails with "No cluster context available" in failover tests

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/VersionOneProtocolChannelReceiver.java
@@ -310,8 +310,10 @@ public class VersionOneProtocolChannelReceiver implements Channel.Receiver, Depl
             if (EjbLogger.REMOTE_LOGGER.isDebugEnabled()) {
                 EjbLogger.REMOTE_LOGGER.debugf("Received cluster removal notification for cluster %s", registry.getGroup());
             }
-            // when the membership of the cluster being left is 1, we are the last node
-            if (registry.getEntries().keySet().size() == 1) {
+            Map.Entry<String, List<ClientMapping>> localEntry = registry.getEntry(registry.getGroup().getLocalNode());
+            Map<String, List<ClientMapping>> entries = registry.getEntries();
+            // Send cluster removed message only if we are the only remaining member of the cluster that we are leaving
+            if ((localEntry != null) ? (entries.size() == 1) && entries.containsKey(localEntry.getKey()) : entries.isEmpty()) {
                 this.sendClusterRemovedMessage(registry);
             }
         } catch (IOException ioe) {

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/RemoteFailoverTestCase.java
@@ -68,7 +68,6 @@ import org.junit.runner.RunWith;
  */
 @RunWith(Arquillian.class)
 @RunAsClient
-@Ignore("WFLY-3532")
 public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
     private static final Logger log = Logger.getLogger(RemoteFailoverTestCase.class);
     private static final String MODULE_NAME = "remote-failover-test";
@@ -280,9 +279,9 @@ public class RemoteFailoverTestCase extends ClusterAbstractTestCase {
         }
     }
 
-    // @Ignore("re-enable when WFLY-3532 resoolved")
     @InSequence(3)
     @Test
+    @Ignore("WFLY-3532")
     public void testConcurrentFailover() throws Exception {
         ContextSelector<EJBClientContext> selector = EJBClientContextSelector.setup(CLIENT_PROPERTIES);
         try (EJBDirectory directory = new RemoteEJBDirectory(MODULE_NAME)) {


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5785

This PR replaces https://github.com/wildfly/wildfly/pull/8567
