### PR TITLE
WFLY-5995 Initial calculation of the first expiration time for a schduled timer is wrong if a start date is set

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/schedule/CalendarBasedTimeout.java
@@ -259,6 +259,10 @@ public class CalendarBasedTimeout {
         if (nextMinute == null) {
             return null;
         }
+        // reset second if minute was changed  (Fix WFLY-5955)
+        if( nextMinute != currentMinute) {
+            nextSecond = this.second.getNextMatch(0);
+        }
         // compute next hour
         if (nextMinute < currentMinute) {
             currentHour++;
@@ -266,6 +270,11 @@ public class CalendarBasedTimeout {
         Integer nextHour = this.hour.getNextMatch(currentHour < 24 ? currentHour : 0);
         if (nextHour == null) {
             return null;
+        }
+        if(nextHour != currentHour) {
+            // reset second/minute if hour changed  (Fix WFLY-5955)
+            nextSecond = this.second.getNextMatch(0);
+            nextMinute = this.minute.getNextMatch(0);
         }
 
         final int nextTimeInSeconds = nextHour*3600 + nextMinute*60 + nextSecond;

--- a/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/timer/schedule/CalendarBasedTimeoutTestCase.java
@@ -589,6 +589,95 @@ public class CalendarBasedTimeoutTestCase {
         Assert.assertEquals(second, firstTimeout.get(Calendar.SECOND));
     }
 
+    /**
+     * If we have an overflow for minutes, the seconds must be reseted.
+     * Test for WFLY-5995
+     */
+    @Test
+    public void testWFLY5995_MinuteOverflow() {
+        int year = 2016;
+        int month = Calendar.JANUARY;
+        int dayOfMonth = 14;
+        int hourOfDay = 9;
+        int minute = 46;
+        int second = 42;
+
+        Calendar start = new GregorianCalendar();
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+
+        ScheduleExpression expression = new ScheduleExpression().dayOfMonth("*").hour("*").minute("0-45").second("0/10").start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(firstTimeout);
+        Assert.assertEquals(year, firstTimeout.get(Calendar.YEAR));
+        Assert.assertEquals(month, firstTimeout.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, firstTimeout.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(10, firstTimeout.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, firstTimeout.get(Calendar.MINUTE));
+        Assert.assertEquals(0, firstTimeout.get(Calendar.SECOND));
+    }
+
+    /**
+     * If we have an overflow for hours, the minutes and seconds must be reseted.
+     * Test for WFLY-5995
+     */
+    @Test
+    public void testWFLY5995_HourOverflow() {
+        int year = 2016;
+        int month = Calendar.JANUARY;
+        int dayOfMonth = 14;
+        int hourOfDay = 9;
+        int minute = 45;
+        int second = 35;
+
+        Calendar start = new GregorianCalendar();
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+
+        ScheduleExpression expression = new ScheduleExpression().dayOfMonth("*").hour("20-22").minute("0/5").second("20,40").start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(firstTimeout);
+        Assert.assertEquals(year, firstTimeout.get(Calendar.YEAR));
+        Assert.assertEquals(month, firstTimeout.get(Calendar.MONTH));
+        Assert.assertEquals(dayOfMonth, firstTimeout.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(20, firstTimeout.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, firstTimeout.get(Calendar.MINUTE));
+        Assert.assertEquals(20, firstTimeout.get(Calendar.SECOND));
+    }
+
+    /**
+     * Check if the hour/minute/second is reseted correct if the day must be updated
+     */
+    @Test
+    public void testDayOverflow() {
+        int year = 2016;
+        int month = Calendar.JANUARY;
+        int dayOfMonth = 14;
+        int hourOfDay = 9;
+        int minute = 56;
+        int second = 0;
+
+        Calendar start = new GregorianCalendar();
+        start.clear();
+        start.set(year, month, dayOfMonth, hourOfDay, minute, second);
+
+        ScheduleExpression expression = new ScheduleExpression().dayOfMonth("2-13").hour("3-9").minute("0/5").second("0").start(start.getTime());
+
+        CalendarBasedTimeout calendarTimeout = new CalendarBasedTimeout(expression);
+        Calendar firstTimeout = calendarTimeout.getFirstTimeout();
+        Assert.assertNotNull(firstTimeout);
+        Assert.assertEquals(year, firstTimeout.get(Calendar.YEAR));
+        Assert.assertEquals(1, firstTimeout.get(Calendar.MONTH));
+        Assert.assertEquals(2, firstTimeout.get(Calendar.DAY_OF_MONTH));
+        Assert.assertEquals(3, firstTimeout.get(Calendar.HOUR_OF_DAY));
+        Assert.assertEquals(0, firstTimeout.get(Calendar.MINUTE));
+        Assert.assertEquals(0, firstTimeout.get(Calendar.SECOND));
+    }
+
     private ScheduleExpression getTimezoneSpecificScheduleExpression() {
         ScheduleExpression scheduleExpression = new ScheduleExpression().timezone(this.timezone.getID());
         GregorianCalendar start = new GregorianCalendar(this.timezone);


### PR DESCRIPTION
The calculation does not set the correct first expiration time if the given start date and the ScheduleExpression differ in hour/minute/second

Fix  and test cases for https://issues.jboss.org/browse/WFLY-5995
