### PR TITLE
WFLY-5999 Remove redundant immutable-entity cache configuration.

### DIFF
--- a/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
+++ b/clustering/infinispan/extension/src/main/resources/subsystem-templates/infinispan.xml
@@ -42,11 +42,6 @@
                     <eviction strategy="LRU" max-entries="10000"/>
                     <expiration max-idle="100000"/>
                 </local-cache>
-                <local-cache name="immutable-entity">
-                    <transaction mode="NON_XA"/>
-                    <eviction strategy="LRU" max-entries="10000"/>
-                    <expiration max-idle="100000"/>
-                </local-cache>
                 <local-cache name="local-query">
                     <eviction strategy="LRU" max-entries="10000"/>
                     <expiration max-idle="100000"/>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5999

As of Hibernate ORM 5.0.7.Final, this will default to the entity cache configuration.
This is a rollback of this commit: https://github.com/wildfly/wildfly/commit/b633ab2bf081d6e9da2ee4dc663ae9b2d021b4ff
