### PR TITLE
HibernateJarsInDeploymentTestCase fail with security manager

### DIFF
--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/HibernateJarsInDeploymentTestCase.java
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/HibernateJarsInDeploymentTestCase.java
@@ -78,6 +78,7 @@ public class HibernateJarsInDeploymentTestCase {
         JavaArchive lib = ShrinkWrap.create(JavaArchive.class, "beans.jar");
         lib.addClasses(SFSB1.class, HibernateJarsInDeploymentTestCase.class);
         lib.addAsManifestResource(HibernateJarsInDeploymentTestCase.class.getPackage(), "persistence.xml", "persistence.xml");
+        ear.addAsManifestResource(HibernateJarsInDeploymentTestCase.class.getPackage(), "permissions.xml", "permissions.xml");
         ear.addAsManifestResource(new StringAsset("Dependencies: org.jboss.jandex\n"), "MANIFEST.MF");
         ear.addAsModule(lib);
 

--- a/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/permissions.xml
+++ b/testsuite/compat/src/test/java/org/jboss/as/test/compat/jpa/hibernate/permissions.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright 2015, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+
+<permissions xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
+        http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd"
+    version="7">
+  <permission>
+    <class-name>java.lang.RuntimePermission</class-name>
+    <name>createClassLoader</name>
+    <actions>read</actions>
+  </permission>
+  <permission>
+    <class-name>java.lang.RuntimePermission</class-name>
+    <name>getClassLoader</name>
+    <actions>read</actions>
+  </permission>
+  <permission>
+    <class-name>org.jboss.vfs.VirtualFilePermission</class-name>
+    <name>/-</name>
+    <actions>read</actions>
+  </permission>
+  <permission>
+    <class-name>java.lang.reflect.ReflectPermission</class-name>
+    <name>suppressAccessChecks</name>
+  </permission>
+
+
+
+</permissions>


### PR DESCRIPTION
Minor failure that occurs when running the HibernateJarsInDeploymentTestCase test with the Java security manager enabled.  Workaround is including an application permissions.xml that allows the packaged Hibernate jar to create classloaders/access vfs/do reflection".  
https://issues.jboss.org/browse/JBEAP-2739
