### PR TITLE
WFLY-6049 Modules should be marked private / unsupported

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/com/github/spullara/mustache/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/com/github/spullara/mustache/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="com.github.spullara.mustache">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
         <artifact name="${com.github.spullara.mustache.java:compiler}"/>
     </resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/netty/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="io.netty">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
     <resources>
         <artifact name="${io.netty:netty-all}"/>
     </resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
@@ -23,6 +23,10 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="io.undertow.js">
+    <properties>
+        <property name="jboss.api" value="unsupported"/>
+    </properties>
+
     <resources>
         <artifact name="${io.undertow.js:undertow-js}"/>
     </resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/infinispan/main/module.xml
@@ -23,6 +23,12 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.hibernate.infinispan">
+
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
+
+
     <resources>
         <artifact name="${org.hibernate:hibernate-infinispan}"/>
     </resources>


### PR DESCRIPTION
jira: https://issues.jboss.org/browse/WFLY-6049

io.undertow.js unsupported
com.github.spullara.mustache private
io.netty module should be private
org.hibernate.infinispan module should be private
