### PR TITLE
WFLY-5880 org.infinispan.util.concurrent.TimeoutException: Timed out waiting for topology after failover

### DIFF
--- a/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
+++ b/clustering/server/src/main/java/org/wildfly/clustering/server/registry/CacheRegistry.java
@@ -62,7 +62,7 @@ import org.wildfly.clustering.service.concurrent.StampedLockServiceExecutor;
  * @param <K> key type
  * @param <V> value type
  */
-@org.infinispan.notifications.Listener
+@org.infinispan.notifications.Listener(sync = false)
 public class CacheRegistry<K, V> implements Registry<K, V>, KeyFilter<Object> {
 
     private final List<Registry.Listener<K, V>> listeners = new CopyOnWriteArrayList<>();


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5880
