### PR TITLE
AbstractDatasourceCapacityPoliciesTestCase: Increase sleep value for slow machines.

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/capacitypolicies/AbstractDatasourceCapacityPoliciesTestCase.java
@@ -127,7 +127,7 @@ public abstract class AbstractDatasourceCapacityPoliciesTestCase extends JcaMgmt
 
         // sometimes InUseCount is 2 and AvailableCount is 3 when statistics are checked right after
         // ds.getConnection, hence this sleep. I guess it's caused by CapacityFiller
-        Thread.sleep(50);
+        Thread.sleep(500);
 
         checkStatistics(4, 1, 5, 0);
 


### PR DESCRIPTION
This testcase failed in my slow Solaris box, the sleep-value for this work around was too small.
Increasing the value from 50 to 500 it solved the problem for me.
