### PR TITLE
[WFLY-6068] Migration warning for failback-delay.

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -657,11 +657,11 @@ public class MigrateOperation implements OperationStepHandler {
                 haPolicyAddress = serverAddress.append(HA_POLICY, "shared-store-slave");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, ALLOW_FAILBACK, "allow-failback");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, FAILOVER_ON_SHUTDOWN, "failover-on-server-shutdown");
-                discardUnsupportedAttribute(haPolicyAddOperation, FAILBACK_DELAY, warnings);
+                discardFailbackDelay(haPolicyAddOperation, warnings);
             } else {
                 haPolicyAddress = serverAddress.append(HA_POLICY, "shared-store-master");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, FAILOVER_ON_SHUTDOWN, "failover-on-server-shutdown");
-                discardUnsupportedAttribute(haPolicyAddOperation, FAILBACK_DELAY, warnings);
+                discardFailbackDelay(haPolicyAddOperation, warnings);
             }
         } else {
             if (backup) {
@@ -669,7 +669,7 @@ public class MigrateOperation implements OperationStepHandler {
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, ALLOW_FAILBACK, "allow-failback");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, MAX_SAVED_REPLICATED_JOURNAL_SIZE, "max-saved-replicated-journal-size");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, BACKUP_GROUP_NAME, "group-name");
-                discardUnsupportedAttribute(haPolicyAddOperation, FAILBACK_DELAY, warnings);
+                discardFailbackDelay(haPolicyAddOperation, warnings);
             } else {
                 haPolicyAddress = serverAddress.append(HA_POLICY, "replication-master");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, CHECK_FOR_LIVE_SERVER, "check-for-live-server");
@@ -705,6 +705,13 @@ public class MigrateOperation implements OperationStepHandler {
         if (newAddOp.hasDefined(legacyAttributeDefinition.getName())) {
             newAddOp.remove(legacyAttributeDefinition.getName());
             warnings.add(MessagingLogger.ROOT_LOGGER.couldNotMigrateUnsupportedAttribute(legacyAttributeDefinition.getName(), pathAddress(newAddOp.get(OP_ADDR))));
+        }
+    }
+
+    private void discardFailbackDelay(ModelNode newAddOp, List<String> warnings) {
+        if (newAddOp.hasDefined(FAILBACK_DELAY.getName())) {
+            newAddOp.remove(FAILBACK_DELAY.getName());
+            warnings.add(MessagingLogger.ROOT_LOGGER.couldNotMigrateFailbackDelayAttribute(pathAddress(newAddOp.get(OP_ADDR))));
         }
     }
 }

--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -826,4 +826,7 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 87, value = "Can not migrate attribute %s from resource %s. This attribute is not supported by the new messaging-activemq subsystem.")
     String couldNotMigrateUnsupportedAttribute(String attribute, PathAddress address);
+
+    @Message(id = 88, value = "Can not migrate attribute failback-delay from resource %s. Artemis detects failback deterministically and it no longer requires to specify a delay for failback to occur.")
+    String couldNotMigrateFailbackDelayAttribute(PathAddress address);
 }


### PR DESCRIPTION
Warn that the failback-delay attribute is not migrated as Artemis
detects failback in a deterministic way.

JIRA: https://issues.jboss.org/browse/WFLY-6068
