### PR TITLE
[WFLY-6081]: Undertow migration operation doesn't migrate Access log valves

### DIFF
--- a/legacy/web/src/test/java/org/jboss/as/web/test/WebMigrateTestCase.java
+++ b/legacy/web/src/test/java/org/jboss/as/web/test/WebMigrateTestCase.java
@@ -200,15 +200,25 @@ public class WebMigrateTestCase extends AbstractSubsystemTest {
         assertEquals("extended", accessLog.get(Constants.PATTERN).asString());
         assertEquals("toto", accessLog.get(Constants.DIRECTORY).asString());
         assertEquals("jboss.server.base.dir", accessLog.get(Constants.RELATIVE_TO).asString());
-
+        
         //sso
         ModelNode sso = virtualHost.get(Constants.SETTING, Constants.SINGLE_SIGN_ON);
         assertEquals("${prop.domain:myDomain}", sso.get(Constants.DOMAIN).asString());
         assertEquals("${prop.http-only:true}", sso.get(Constants.HTTP_ONLY).asString());
+        
+        //global access log valve
+        virtualHost = newServer.get(Constants.HOST, "vs1");
+        assertTrue(virtualHost.hasDefined(Constants.FILTER_REF, "request-dumper"));
+        assertTrue(virtualHost.hasDefined(Constants.FILTER_REF, "remote-addr"));
+        assertFalse(virtualHost.hasDefined(Constants.FILTER_REF, "myvalve"));
+        accessLog = virtualHost.get(Constants.SETTING, Constants.ACCESS_LOG);
 
-
-
-
+        assertEquals("myapp_access_log.", accessLog.get(Constants.PREFIX).asString());
+        assertEquals(".log", accessLog.get(Constants.SUFFIX).asString());
+        assertEquals("true", accessLog.get(Constants.ROTATE).asString());
+        assertEquals("common", accessLog.get(Constants.PATTERN).asString());
+        assertEquals("${jboss.server.log.dir}", accessLog.get(Constants.DIRECTORY).asString());
+        assertEquals("exists(%{r,log-enabled})", accessLog.get(Constants.PREDICATE).asString());
     }
 
     private static class NewSubsystemAdditionalInitialization extends AdditionalInitialization {

--- a/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
+++ b/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
@@ -91,6 +91,16 @@
             </virtual-server>
             <virtual-server name="vs1" />
             <virtual-server name="vs2" />
+            <valve name="accessLog" module="org.jboss.as.web" class-name="org.apache.catalina.valves.AccessLogValve">        
+                <param param-name="prefix" param-value="myapp_access_log." />
+                <param param-name="suffix" param-value=".log" />
+                <param param-name="rotatable" param-value="true" />
+                <param param-name="fileDateFormat" param-value="yyyy-MM-dd" />
+                <param param-name="pattern" param-value="common" />
+                <param param-name="directory" param-value="${jboss.server.log.dir}" />
+                <param param-name="resolveHosts" param-value="false"/>
+                <param param-name="conditionIf" param-value="log-enabled"/>
+            </valve>
             <valve name="myvalve" module="org.jboss.some.module" class-name="org.jboss.some.class" enabled="${prop.valve-enabled:true}">
                <param param-name="param-name" param-value="${prop.valve-param:some-value}"/>
             </valve>


### PR DESCRIPTION
Global AccessLogValves are migrated to virtual-hosts if no access-log configuration exist.

Jira: https://issues.jboss.org/browse/WFLY-6081
