### PR TITLE
WFLY-5788 EJB client can fail with CNFE when deserializing EJBException since wrapped cause might not be on classpath such as CacheException

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 import org.infinispan.Cache;
 import org.infinispan.affinity.KeyAffinityService;
 import org.infinispan.affinity.KeyGenerator;
+import org.infinispan.commons.CacheException;
 import org.infinispan.context.Flag;
 import org.infinispan.distribution.DistributionManager;
 import org.infinispan.notifications.Listener;
@@ -173,6 +174,11 @@ public class InfinispanBeanManager<G, I, T> implements BeanManager<G, I, T, Tran
             this.scheduler.close();
             this.affinityServices.forEach(service -> service.stop());
         });
+    }
+
+    @Override
+    public boolean isRemotable(Throwable throwable) {
+        return !(throwable instanceof CacheException);
     }
 
     @Override

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManager.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/BeanManager.java
@@ -46,4 +46,6 @@ public interface BeanManager<G, I, T, B extends Batch> extends AffinitySupport<I
 
     void start();
     void stop();
+
+    boolean isRemotable(Throwable throwable);
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/Component.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/Component.java
@@ -66,4 +66,11 @@ public interface Component {
 
     NamespaceContextSelector getNamespaceContextSelector();
 
+    /**
+     * Checks whether the supplied {@link Throwable} is remotable meaning it can be safely sent to the client over the wire.
+     */
+    default boolean isRemotable(Throwable throwable) {
+        return true;
+    }
+
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
@@ -95,4 +95,11 @@ public interface Cache<K, V extends Identifiable<K>> extends AffinitySupport<K>,
     int getPassivatedCount();
 
     int getTotalSize();
+
+    /**
+     * Checks whether the supplied {@link Throwable} is remotable meaning it can be safely sent to the client over the wire.
+     */
+    default boolean isRemotable(Throwable throwable) {
+        return true;
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/distributable/DistributableCache.java
@@ -197,4 +197,9 @@ public class DistributableCache<K, V extends Identifiable<K> & Contextual<Batch>
     public int getTotalSize() {
         return this.manager.getActiveCount() + this.manager.getPassiveCount();
     }
+
+    @Override
+    public boolean isRemotable(Throwable throwable) {
+        return this.manager.isRemotable(throwable);
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateful/StatefulSessionComponent.java
@@ -394,4 +394,8 @@ public class StatefulSessionComponent extends SessionBeanComponent implements St
         }
         return AccessController.doPrivileged(CurrentServiceContainer.GET_ACTION);
     }
+
+    public boolean isRemotable(Throwable throwable) {
+        return cache.isRemotable(throwable);
+    }
 }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/remote/protocol/versionone/MethodInvocationMessageHandler.java
@@ -61,6 +61,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import javax.ejb.EJBException;
 
 /**
  * @author Jaikiran Pai
@@ -208,7 +209,16 @@ public class MethodInvocationMessageHandler extends EJBIdentifierBasedMessageHan
                                 MethodInvocationMessageHandler.this.writeNoSuchEJBFailureMessage(channelAssociation, invocationId, appName, moduleName, distinctName, beanName, viewClassName);
                             } else {
                                 // write out the failure
-                                MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, throwable, attachments);
+                                Throwable throwableToWrite = throwable;
+                                final Throwable cause = throwable.getCause();
+                                if (componentView.getComponent() instanceof StatefulSessionComponent && throwable instanceof EJBException && cause != null) {
+                                    if (!(componentView.getComponent().isRemotable(cause))) {
+                                        // Avoid serializing the cause of the exception in case it is not remotable
+                                        // Client might not be able to deserialize and throw ClassNotFoundException
+                                        throwableToWrite = new EJBException(throwable.getLocalizedMessage());
+                                    }
+                                }
+                                MethodInvocationMessageHandler.this.writeException(channelAssociation, MethodInvocationMessageHandler.this.marshallerFactory, invocationId, throwableToWrite, attachments);
                             }
                         } catch (Throwable ioe) {
                             // we couldn't write out a method invocation failure message. So let's at least log the

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/InfinispanExceptionThrowingIncrementorBean.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/cluster/ejb/remote/bean/InfinispanExceptionThrowingIncrementorBean.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,16 +19,26 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.jboss.as.test.clustering.cluster.ejb.remote.bean;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import javax.ejb.Remote;
+import javax.ejb.Stateful;
 
-public abstract class IncrementorBean implements Incrementor {
+import org.infinispan.statetransfer.OutdatedTopologyException;
 
-    private final AtomicInteger count = new AtomicInteger();
+/**
+ * Implementation of {@link Incrementor} which always throws a {@link RuntimeException}: an Infinispan's {@link OutdatedTopologyException}.
+ *
+ * @author Radoslav Husar
+ * @version January 2016
+ */
+@Stateful
+@Remote(Incrementor.class)
+public class InfinispanExceptionThrowingIncrementorBean implements Incrementor {
 
     @Override
     public Result<Integer> increment() {
-        return new Result<>(this.count.incrementAndGet());
+        throw new OutdatedTopologyException("Remote values are missing because of a topology change");
     }
 }


### PR DESCRIPTION
Jira
https://issues.jboss.org/browse/WFLY-5788
