### PR TITLE
[WFLY-6071] Test legacy configs in the mixed domain tests

### DIFF
--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/KernelBehaviorTestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/KernelBehaviorTestSuite.java
@@ -37,6 +37,6 @@ public class KernelBehaviorTestSuite extends MixedDomainTestSuite {
      * @param testClass the test/suite class
      */
     protected static MixedDomainTestSupport getSupport(Class<?> testClass) {
-        return getSupport(testClass, "master-config/domain-minimal.xml", false);
+        return getSupport(testClass, "master-config/domain-minimal.xml", false, false);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigAdjuster.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigAdjuster.java
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.mixed.eap620.LegacyConfigAdjuster620;
+import org.jboss.as.test.integration.domain.mixed.eap630.LegacyConfigAdjuster630;
+import org.jboss.as.test.integration.domain.mixed.eap640.LegacyConfigAdjuster640;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Analogue to {@link DomainAdjuster}, but for use when the domain is running with a legacy domain.xml
+ * rather than the current standard domain.xml. So the scope of expected adjustments is expected to be
+ * considerably smaller.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster {
+
+    protected LegacyConfigAdjuster() {
+    }
+
+    static void adjustForVersion(final DomainClient client, final Version.AsVersion asVersion) throws Exception {
+
+        final LegacyConfigAdjuster adjuster;
+        switch (asVersion) {
+            case EAP_6_2_0:
+                adjuster = new LegacyConfigAdjuster620();
+                break;
+            case EAP_6_3_0:
+                adjuster = new LegacyConfigAdjuster630();
+                break;
+            case EAP_6_4_0:
+                adjuster = new LegacyConfigAdjuster640();
+                break;
+            default:
+                adjuster = new LegacyConfigAdjuster();
+        }
+
+        adjuster.adjust(client);
+    }
+
+    final void adjust(final DomainClient client) throws Exception {
+
+        removeIpv4SystemProperty(client);
+
+        //Version specific changes
+        ModelNode read = Util.createEmptyOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
+        read.get(CHILD_TYPE).set(PROFILE);
+        ModelNode result = DomainTestUtils.executeForResult(read, client);
+        for (ModelNode profile : result.asList()) {
+            final List<ModelNode> adjustments = adjustForVersion(client, PathAddress.pathAddress(PROFILE, profile.asString()));
+            applyVersionAdjustments(client, adjustments);
+        }
+    }
+
+    private void removeIpv4SystemProperty(final DomainClient client) throws Exception {
+        //The standard domain configuration contains -Djava.net.preferIPv4Stack=true, remove that
+        DomainTestUtils.executeForResult(
+                Util.createRemoveOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, "java.net.preferIPv4Stack")), client);
+
+    }
+
+    protected List<ModelNode> adjustForVersion(final DomainClient client, final PathAddress profileAddress) throws  Exception {
+        return new ArrayList<>();
+    }
+
+    private void applyVersionAdjustments(DomainClient client, List<ModelNode> operations) throws Exception {
+        if (operations.size() == 0) {
+            return;
+        }
+        for (ModelNode op : operations) {
+            //System.out.println("Adjusting using " + op);
+            DomainTestUtils.executeForResult(op, client);
+        }
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
@@ -1,0 +1,165 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests slave behavior in a mixed domain when the master has booted with a legacy domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public abstract class LegacyConfigTest {
+
+    private static final PathElement SLAVE = PathElement.pathElement("host", "slave");
+    private static final PathAddress TEST_SERVER_CONFIG = PathAddress.pathAddress(SLAVE,
+            PathElement.pathElement("server-config", "legacy-server"));
+    private static final PathAddress TEST_SERVER = PathAddress.pathAddress(SLAVE,
+            PathElement.pathElement("server", "legacy-server"));
+    private static final PathAddress TEST_SERVER_GROUP = PathAddress.pathAddress("server-group", "legacy-group");
+
+    private static final Map<String, String> STD_PROFILES;
+
+    static {
+        final Map<String, String> stdProfiles = new HashMap<>();
+        stdProfiles.put("default", "standard-sockets");
+        stdProfiles.put("ha", "ha-sockets");
+        stdProfiles.put("full", "full-sockets");
+        stdProfiles.put("full-ha", "full-ha-sockets");
+        STD_PROFILES = Collections.unmodifiableMap(stdProfiles);
+    }
+
+    private static DomainTestSupport support;
+
+    @Before
+    public void init() throws Exception {
+        support = MixedDomainTestSuite.getSupport(this.getClass());
+    }
+
+    @Test
+    public void testServerLaunching() throws IOException, MgmtOperationException, InterruptedException {
+
+        DomainClient client = support.getDomainMasterLifecycleUtil().getDomainClient();
+        for (Map.Entry<String, String> entry : getProfilesToTest().entrySet()) {
+            String profile = entry.getKey();
+            String sbg = entry.getValue();
+            try {
+                installTestServer(client, profile, sbg);
+                awaitServerLaunch(client, profile);
+                validateServerProfile(client, profile);
+                verifyHttp(profile);
+            } finally {
+                cleanTestServer(client);
+            }
+        }
+    }
+
+    private void installTestServer(ModelControllerClient client, String profile, String sbg) throws IOException, MgmtOperationException {
+        ModelNode op = Util.createAddOperation(TEST_SERVER_GROUP);
+        op.get("profile").set(profile);
+        op.get("socket-binding-group").set(sbg);
+        DomainTestUtils.executeForResult(op, client);
+
+        op = Util.createAddOperation(TEST_SERVER_CONFIG);
+        op.get("group").set("legacy-group");
+        DomainTestUtils.executeForResult(op, client);
+
+        DomainTestUtils.executeForResult(Util.createEmptyOperation("start", TEST_SERVER_CONFIG), client);
+    }
+
+    private void awaitServerLaunch(ModelControllerClient client, String profile) throws InterruptedException {
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        ModelNode op = Util.getReadAttributeOperation(TEST_SERVER, "server-state");
+        do {
+            try {
+                ModelNode state = DomainTestUtils.executeForResult(op, client);
+                if ("running".equalsIgnoreCase(state.asString())) {
+                    return;
+                }
+            } catch (IOException | MgmtOperationException e) {
+                // ignore and try again
+            }
+
+            TimeUnit.MILLISECONDS.sleep(250L);
+        } while (System.currentTimeMillis() < timeout);
+
+        Assert.fail("Server did not start using " + profile);
+    }
+
+    private void validateServerProfile(ModelControllerClient client, String profile) throws IOException, MgmtOperationException {
+        ModelNode op = Util.getReadAttributeOperation(TEST_SERVER, "profile-name");
+        ModelNode result = DomainTestUtils.executeForResult(op, client);
+        Assert.assertEquals(profile, result.asString());
+    }
+
+    private void verifyHttp(String profile) {
+        try {
+            URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.slaveAddress) + ":8080").openConnection();
+            connection.connect();
+        } catch (IOException e) {
+            Assert.fail("Cannot connect to profile " + profile + " " + e.toString());
+        }
+    }
+
+    private void cleanTestServer(ModelControllerClient client) {
+        try {
+            ModelNode op = Util.createEmptyOperation("stop", TEST_SERVER_CONFIG);
+            op.get("blocking").set(true);
+            DomainTestUtils.executeForResult(op, client);
+        } catch (MgmtOperationException | IOException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                DomainTestUtils.executeForResult(Util.createRemoveOperation(TEST_SERVER_CONFIG), client);
+            } catch (MgmtOperationException | IOException e) {
+                e.printStackTrace();
+            } finally {
+                try {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(TEST_SERVER_GROUP), client);
+                } catch (MgmtOperationException | IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+
+    protected Map<String, String> getProfilesToTest() {
+        return new HashMap<>(STD_PROFILES);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
@@ -23,6 +23,8 @@ package org.jboss.as.test.integration.domain.mixed;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+
 import org.junit.AfterClass;
 
 /**
@@ -54,19 +56,34 @@ public class MixedDomainTestSuite {
     protected static MixedDomainTestSupport getSupport(Class<?> testClass) {
         if (support == null) {
             final String copiedDomainXml = MixedDomainTestSupport.copyDomainFile();
-            return getSupport(testClass, copiedDomainXml, true);
+            return getSupport(testClass, copiedDomainXml, true, false);
         } else {
             return support;
         }
     }
 
-    static MixedDomainTestSupport getSupport(Class<?> testClass, String domainConfig, boolean adjustDomain) {
+    /**
+     * Call this from a @BeforeClass method
+     *
+     * @param testClass the test/suite class
+     */
+    protected static MixedDomainTestSupport getSupportForLegacyConfig(Class<?> testClass, Version.AsVersion version) {
+        if (support == null) {
+            final File originalDomainXml = MixedDomainTestSupport.loadLegacyDomainXml(version);
+            final String copiedDomainXml = MixedDomainTestSupport.copyDomainFile(originalDomainXml);
+            return getSupport(testClass, copiedDomainXml, true, true);
+        } else {
+            return support;
+        }
+    }
+
+    static MixedDomainTestSupport getSupport(Class<?> testClass, String domainConfig, boolean adjustDomain, boolean legacyConfig) {
         if (support == null) {
             final Version.AsVersion version = getVersion(testClass);
             final MixedDomainTestSupport testSupport;
             try {
                 if (domainConfig != null) {
-                    testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version, domainConfig, adjustDomain);
+                    testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version, domainConfig, adjustDomain, legacyConfig);
                 } else {
                     testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version);
                 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestCase.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap620;
+
+import java.util.Map;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 6.2 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_6_2_0)
+public class LegacyConfig620TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig620TestSuite.initializeDomain();
+    }
+
+    @Override
+    protected Map<String, String> getProfilesToTest() {
+        Map<String, String> result =  super.getProfilesToTest();
+
+        // Due to WFLY-2335, EAP 6.2 full-ha servers won't launch on JDK 8,
+        // so skip testing that profile
+        result.remove("full-ha");
+        return result;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestSuite.java
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap620;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 6.2 domain.xml with a current DC and a 6.2 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig620TestCase.class})
+@Version(Version.AsVersion.EAP_6_2_0)
+public class LegacyConfig620TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig620TestSuite.class, Version.AsVersion.EAP_6_2_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfigAdjuster620.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfigAdjuster620.java
@@ -1,0 +1,65 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap620;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.mixed.eap630.LegacyConfigAdjuster630;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 6.2 domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster620 extends LegacyConfigAdjuster630 {
+
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        enableDatasourceStatistics(profileAddress, result);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+        return result;
+    }
+
+    /**
+     * EAP 6.3 switched the default behavior for datasource statistics from enabled to a configurable
+     * disabled. If a config is being migrated, we want the new behavior, so we don't use the parser
+     * to enable statistics when a legacy xsd is found. But the 6.2 slave cannot boot if the config
+     * has statistics disabled, so we need to specifically enable them for the mixed domain case.
+     */
+    private void enableDatasourceStatistics(PathAddress profileAddress, List<ModelNode> ops) {
+        PathAddress ds = profileAddress.append(
+                PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "datasources"),
+                PathElement.pathElement("data-source", "ExampleDS")
+        );
+        ModelNode op = Util.getWriteAttributeOperation(ds, "statistics-enabled", true);
+        ops.add(op);
+
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestCase.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap630;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap620.LegacyConfig620TestSuite;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 6.3 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_6_3_0)
+public class LegacyConfig630TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig630TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestSuite.java
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap630;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 6.3 domain.xml with a current DC and a 6.3 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig630TestCase.class})
+@Version(Version.AsVersion.EAP_6_3_0)
+public class LegacyConfig630TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig630TestSuite.class, Version.AsVersion.EAP_6_3_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfigAdjuster630.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfigAdjuster630.java
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap630;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.mixed.eap640.LegacyConfigAdjuster640;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 6.3 or earlier domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster630 extends LegacyConfigAdjuster640 {
+
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+        return result;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestCase.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap640;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap620.LegacyConfig620TestSuite;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 6.4 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_6_4_0)
+public class LegacyConfig640TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig640TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestSuite.java
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap640;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap630.LegacyConfig630TestCase;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 6.4 domain.xml with a current DC and a 6.4 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig640TestCase.class})
+@Version(Version.AsVersion.EAP_6_4_0)
+public class LegacyConfig640TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig640TestSuite.class, Version.AsVersion.EAP_6_4_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfigAdjuster640.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfigAdjuster640.java
@@ -1,0 +1,109 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap640;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigAdjuster;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 6.4 or earlier domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster640 extends LegacyConfigAdjuster {
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        configureCDI10(profileAddress, result);
+        removeBV(client, profileAddress, result);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+
+        return result;
+    }
+
+    /**
+     *  EAP 6.x uses CDI 1.0 while later releases use later CDI spec versions. If a
+     *  profile config uses CDI, it's unclear whether what's wanted is CDI 1.0 behavior
+     *  or later behavior, so we require the user to be explicit via setting 2 attributes
+     *  to get the 1.0 behavior.
+     *
+     *  The CDI subsystem parser could do this automatically when a legacy xsd is found, but
+     *  then if the user goal is to migrate to the later behavior, they won't get it.
+     */
+    private void configureCDI10(PathAddress profileAddress, List<ModelNode> ops) {
+        PathAddress weld = profileAddress.append(
+                PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "weld")
+        );
+        ModelNode op = Util.getWriteAttributeOperation(weld, "require-bean-descriptor", true);
+        ops.add(op);
+
+        op = op.clone();
+        op.get("name").set("non-portable-mode");
+        ops.add(op);
+    }
+
+    /**
+     * WildFly 9 and later broke BV out from the ee subsystem, allowing it to be removed. If a later
+     * DC/standalone server sees ee with a legacy xsd, it adds BV into the config, thus assuring that
+     * a migrated config does not, perhaps not noticeably, lose existing behavior. But a 6.x slave
+     * will not recognize the BV extension/subsystem, so it needs to be removed.
+     */
+    private void removeBV(DomainClient client, PathAddress profileAddress, List<ModelNode> ops) throws IOException, MgmtOperationException {
+        PathAddress bv = profileAddress.append(
+                PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "bean-validation")
+        );
+        ops.add(Util.createRemoveOperation(bv));
+
+        // If no other profiles still use this extension, we can remove it
+        String ourProfile = profileAddress.getLastElement().getValue();
+        ModelNode read = Util.createEmptyOperation("read-children-names", PathAddress.EMPTY_ADDRESS);
+        read.get("child-type").set("profile");
+        for (ModelNode profileMN : DomainTestUtils.executeForResult(read, client).asList()) {
+            String profile = profileMN.asString();
+            if (!ourProfile.equals(profile)) {
+                read = Util.createEmptyOperation("read-children-names", PathAddress.pathAddress("profile", profile));
+                read.get("child-type").set("subsystem");
+                for (ModelNode sub : DomainTestUtils.executeForResult(read, client).asList()) {
+                    if ("bean-validation".equals(sub.asString())) {
+                        // this profile still has a subsystem; don't remove extension yet
+                        return;
+                    }
+                }
+            }
+        }
+
+        // If we got here, no profile has the bv subsystem so we can remove the extension
+        ops.add(Util.createRemoveOperation(PathAddress.pathAddress("extension", "org.wildfly.extension.bean-validation")));
+
+    }
+}

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -80,7 +80,7 @@
  	</jvms>
 
     <servers>
-        <server name="server-one" group="other-server-group">
+        <server name="server-one" group="other-server-group" auto-start="false">
             <socket-bindings port-offset="100"/>
         </server>
         <server name="server-two" group="other-server-group" auto-start="false"/>

--- a/testsuite/mixed-domain/src/test/resources/slave-config/host-slave.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-config/host-slave.xml
@@ -94,7 +94,7 @@
 
 
     <servers>
-        <server name="server-one" group="other-server-group"/>
+        <server name="server-one" group="other-server-group" auto-start="false"/>
         <server name="server-two" group="other-server-group" auto-start="false"/>
     </servers>
 </host>


### PR DESCRIPTION
Also includes the commits from #8520, which were necessary for the tests to pass.

I encourage reviewers to have a look at the following changes a user trying to run these legacy configs will need to make in order to have them work with a current DC managing the legacy slave. I think these are all ok. Hopefully the comments are explanatory:

https://github.com/wildfly/wildfly/pull/8618/files#diff-f17afcc7d44a8bc4f467c6a55e05b8efR50

https://github.com/wildfly/wildfly/pull/8618/files#diff-19b24dd990e3621a4feb5f0714f4c47eR53

https://github.com/wildfly/wildfly/pull/8618/files#diff-19b24dd990e3621a4feb5f0714f4c47eR88
