### PR TITLE
[WFLY-5081] RA-based JMSConnectionFactoryDefinition

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/AdministeredObjectDefinitionInjectionSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/AdministeredObjectDefinitionInjectionSource.java
@@ -68,6 +68,10 @@ public class AdministeredObjectDefinitionInjectionSource extends ResourceDefinit
         this.resourceAdapter = resourceAdapter;
     }
 
+    public void addProperty(String key, String value) {
+        properties.put(key, value);
+    }
+
     public void getResourceValue(final ResolutionContext context, final ServiceBuilder<?> serviceBuilder, final DeploymentPhaseContext phaseContext, final Injector<ManagedReferenceFactory> injector) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final Module module = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE);

--- a/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionInjectionSource.java
+++ b/connector/src/main/java/org/jboss/as/connector/deployers/ra/ConnectionFactoryDefinitionInjectionSource.java
@@ -74,6 +74,10 @@ public class ConnectionFactoryDefinitionInjectionSource extends ResourceDefiniti
         this.resourceAdapter = resourceAdapter;
     }
 
+    public void addProperty(String key, String value) {
+        properties.put(key, value);
+    }
+
     public void getResourceValue(final ResolutionContext context, final ServiceBuilder<?> serviceBuilder, final DeploymentPhaseContext phaseContext, final Injector<ManagedReferenceFactory> injector) throws DeploymentUnitProcessingException {
         final DeploymentUnit deploymentUnit = phaseContext.getDeploymentUnit();
         final Module module = deploymentUnit.getAttachment(org.jboss.as.server.deployment.Attachments.MODULE);

--- a/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
+++ b/connector/src/main/java/org/jboss/as/connector/services/resourceadapters/ResourceAdapterActivatorService.java
@@ -209,8 +209,8 @@ public final class ResourceAdapterActivatorService extends AbstractResourceAdapt
                     Set<String> ijMcfClasses = new HashSet<String>();
                     Set<String> ijAoClasses = new HashSet<String>();
 
-                    boolean mcfSingle = false;
-                    boolean aoSingle = false;
+                    boolean mcfSingle = raMcfClasses.size() == 1;
+                    boolean aoSingle = raAoClasses.size() == 1;
 
                     boolean mcfOk = true;
                     boolean aoOk = true;
@@ -218,22 +218,17 @@ public final class ResourceAdapterActivatorService extends AbstractResourceAdapt
                     if (activation.getConnectionDefinitions() != null) {
                         for (ConnectionDefinition def : activation.getConnectionDefinitions()) {
                             String clz = def.getClassName();
-
-                            if (clz == null) {
-                                if (raMcfClasses.size() == 1) {
-                                    mcfSingle = true;
-                                }
-                            } else {
+                            if (clz != null) {
                                 ijMcfClasses.add(clz);
                             }
                         }
                     }
 
                     if (!mcfSingle) {
-                        Iterator<String> it = raMcfClasses.iterator();
+                        Iterator<String> it = ijMcfClasses.iterator();
                         while (mcfOk && it.hasNext()) {
                             String clz = it.next();
-                            if (!ijMcfClasses.contains(clz))
+                            if (!raMcfClasses.contains(clz))
                                 mcfOk = false;
                         }
                     }
@@ -241,21 +236,17 @@ public final class ResourceAdapterActivatorService extends AbstractResourceAdapt
                     if (activation.getAdminObjects() != null) {
                         for (AdminObject def : activation.getAdminObjects()) {
                             String clz = def.getClassName();
-                            if (clz == null) {
-                                if (raAoClasses.size() == 1) {
-                                    aoSingle = true;
-                                }
-                            } else {
+                            if (clz != null) {
                                 ijAoClasses.add(clz);
                             }
                         }
                     }
 
                     if (!aoSingle) {
-                        Iterator<String> it = raAoClasses.iterator();
+                        Iterator<String> it = ijAoClasses.iterator();
                         while (aoOk && it.hasNext()) {
                             String clz = it.next();
-                            if (!ijAoClasses.contains(clz))
+                            if (!raAoClasses.contains(clz))
                                 aoOk = false;
                         }
                     }

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/extension/messaging-activemq/main/module.xml
@@ -39,6 +39,7 @@
         <module name="javax.api"/>
         <module name="javax.enterprise.api"/>
         <module name="javax.jms.api"/>
+        <module name="javax.resource.api" />
         <module name="javax.transaction.api"/>
         <module name="org.apache.activemq.artemis"/>
         <module name="org.apache.activemq.artemis.ra"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/deployment/ra.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jca/deployment/ra.xml
@@ -38,12 +38,24 @@
             <connection-interface>org.jboss.as.test.integration.jca.rar.MultipleConnection1</connection-interface>
             <connection-impl-class>org.jboss.as.test.integration.jca.rar.MultipleConnection1Impl</connection-impl-class>
          </connection-definition>
+
+         <connection-definition>
+            <managedconnectionfactory-class>org.jboss.as.test.integration.jca.rar.MultipleManagedConnectionFactory2</managedconnectionfactory-class>
+            <connectionfactory-interface>org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory2</connectionfactory-interface>
+            <connectionfactory-impl-class>org.jboss.as.test.integration.jca.rar.MultipleConnectionFactory2Impl</connectionfactory-impl-class>
+            <connection-interface>org.jboss.as.test.integration.jca.rar.MultipleConnection2</connection-interface>
+            <connection-impl-class>org.jboss.as.test.integration.jca.rar.MultipleConnection2Impl</connection-impl-class>
+         </connection-definition>
          <transaction-support>NoTransaction</transaction-support>
          <reauthentication-support>false</reauthentication-support>
       </outbound-resourceadapter>
       <adminobject>
          <adminobject-interface>org.jboss.as.test.integration.jca.rar.MultipleAdminObject1</adminobject-interface>
          <adminobject-class>org.jboss.as.test.integration.jca.rar.MultipleAdminObject1Impl</adminobject-class>
+      </adminobject>
+      <adminobject>
+         <adminobject-interface>org.jboss.as.test.integration.jca.rar.MultipleAdminObject2</adminobject-interface>
+         <adminobject-class>org.jboss.as.test.integration.jca.rar.MultipleAdminObject2Impl</adminobject-class>
       </adminobject>
    </resourceadapter>
 </connector>


### PR DESCRIPTION
[WFLY-5081] RA-based JMSConnectionFactoryDefinition …
If the resourceAdapter property is not set, the default behaviour is to
create a messaging-activemq's pooled-connection-factory.
Else, we delegate to the connectors subsystem to create the connection
factory based on its more generic definition.
The same behaviour applies to the JMSDestinationDefinition.

The code handles definitions coming from annotations and XML deployment
descriptors.

JIRA: https://issues.jboss.org/browse/WFLY-5081
