### PR TITLE
[WFLY-6077] address-settings's auto-create|delete-jms-queues

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingAdd.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingAdd.java
@@ -140,12 +140,9 @@ class AddressSettingAdd extends AbstractAddStepHandler {
         if (config.hasDefined(AddressSettingDefinition.SLOW_CONSUMER_THRESHOLD.getName())) {
             settings.setSlowConsumerThreshold(AddressSettingDefinition.SLOW_CONSUMER_THRESHOLD.resolveModelAttribute(context, config).asLong());
         }
-        if (config.hasDefined(AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES.getName())) {
-            settings.setAutoCreateJmsQueues(AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES.resolveModelAttribute(context, config).asBoolean());
-        }
-        if (config.hasDefined(AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES.getName())) {
-            settings.setAutoDeleteJmsQueues(AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES.resolveModelAttribute(context, config).asBoolean());
-        }
+        // always set the auto-create|delete-jms-queues attributes as their default attribute values differ from Artemis defaults.
+        settings.setAutoCreateJmsQueues(AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES.resolveModelAttribute(context, config).asBoolean());
+        settings.setAutoDeleteJmsQueues(AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES.resolveModelAttribute(context, config).asBoolean());
         return settings;
     }
 

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
@@ -53,13 +53,15 @@ import org.jboss.dmr.ModelType;
 public class AddressSettingDefinition extends PersistentResourceDefinition {
 
     public static final SimpleAttributeDefinition AUTO_CREATE_JMS_QUEUES = create("auto-create-jms-queues", ModelType.BOOLEAN)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_AUTO_CREATE_QUEUES))
+            // Default value is false to have the same behaviour than the legacy messaging subsystem (Artemis defaults to true)
+            .setDefaultValue(new ModelNode(false))
             .setAllowNull(true)
             .setAllowExpression(true)
             .build();
 
     public static final SimpleAttributeDefinition AUTO_DELETE_JMS_QUEUES = create("auto-delete-jms-queues", ModelType.BOOLEAN)
-            .setDefaultValue(new ModelNode(AddressSettings.DEFAULT_AUTO_DELETE_QUEUES))
+            // Default value is false to have the same behaviour than the legacy messaging subsystem (Artemis defaults to true)
+            .setDefaultValue(new ModelNode(false))
             .setAllowNull(true)
             .setAllowExpression(true)
             .build();


### PR DESCRIPTION
Set default values to false to preserve the legacy's messaging subsystem
behaviour (while Artemis defaults to true).

JIRA: https://issues.jboss.org/browse/WFLY-6077
