### PR TITLE
WFLY-5981 Upgrade JGroups to 3.6.7.Final

### DIFF
--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/JChannelFactory.java
@@ -161,11 +161,11 @@ public class JChannelFactory implements ChannelFactory, ProtocolStackConfigurato
             private Object handle(Message message) {
                 Header header = (Header) message.getHeader(this.id);
                 // If this is a request expecting a response, don't leave the requester hanging - send an identifiable response on which it can filter
-                if ((header != null) && (header.type == Header.REQ) && header.rsp_expected) {
+                if ((header != null) && (header.type == Header.REQ) && header.rspExpected()) {
                     Message response = message.makeReply().setFlag(message.getFlags()).clearFlag(Message.Flag.RSVP, Message.Flag.SCOPED);
 
                     response.putHeader(FORK.ID, message.getHeader(FORK.ID));
-                    response.putHeader(this.id, new Header(Header.RSP, header.id, false, this.id));
+                    response.putHeader(this.id, new Header(Header.RSP, 0, header.corrId));
                     response.setBuffer(UNKNOWN_FORK_RESPONSE.array());
 
                     channel.down(new Event(Event.MSG, response));

--- a/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
+++ b/clustering/jgroups/extension/src/main/java/org/jboss/as/clustering/jgroups/ManagedSocketFactory.java
@@ -99,7 +99,7 @@ public class ManagedSocketFactory implements SocketFactory {
 
     @Override
     public DatagramSocket createDatagramSocket(String name, SocketAddress address) throws SocketException {
-        return this.manager.createDatagramSocket(name, address);
+        return (address != null) ? this.manager.createDatagramSocket(name, address) : this.manager.createDatagramSocket(name);
     }
 
     @Override
@@ -124,7 +124,7 @@ public class ManagedSocketFactory implements SocketFactory {
 
     @Override
     public MulticastSocket createMulticastSocket(String name, SocketAddress address) throws IOException {
-        return this.manager.createMulticastSocket(name, address);
+        return (address != null) ? this.manager.createMulticastSocket(name, address) : this.manager.createMulticastSocket(name);
     }
 
     @Override

--- a/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
+++ b/clustering/jgroups/extension/src/main/resources/jgroups-defaults.xml
@@ -34,6 +34,10 @@
         send_buf_size="640k"
         sock_conn_timeout="300"
     />
+    <TCP_NIO2
+        send_buf_size="640k"
+        sock_conn_timeout="300"
+    />
     <MPING ip_ttl="2"/>
     <MERGE3
         min_interval="10000"

--- a/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
+++ b/clustering/jgroups/extension/src/test/java/org/jboss/as/clustering/jgroups/ManagedSocketFactoryTest.java
@@ -119,6 +119,7 @@ public class ManagedSocketFactoryTest {
         DatagramSocket socket2 = mock(DatagramSocket.class);
         DatagramSocket socket3 = mock(DatagramSocket.class);
         DatagramSocket socket4 = mock(DatagramSocket.class);
+        DatagramSocket socket5 = mock(DatagramSocket.class);
         InetAddress localhost = InetAddress.getLocalHost();
         SocketAddress socketAddress = new InetSocketAddress(localhost, 2);
 
@@ -126,16 +127,19 @@ public class ManagedSocketFactoryTest {
         when(this.manager.createDatagramSocket("test", new InetSocketAddress(1))).thenReturn(socket2);
         when(this.manager.createDatagramSocket("test", socketAddress)).thenReturn(socket3);
         when(this.manager.createDatagramSocket("test", new InetSocketAddress(localhost, 1))).thenReturn(socket4);
+        when(this.manager.createDatagramSocket("test")).thenReturn(socket5);
 
         DatagramSocket result1 = this.subject.createDatagramSocket("test");
         DatagramSocket result2 = this.subject.createDatagramSocket("test", 1);
         DatagramSocket result3 = this.subject.createDatagramSocket("test", socketAddress);
         DatagramSocket result4 = this.subject.createDatagramSocket("test", 1, localhost);
+        DatagramSocket result5 = this.subject.createDatagramSocket("test", null);
 
         assertSame(socket1, result1);
         assertSame(socket2, result2);
         assertSame(socket3, result3);
         assertSame(socket4, result4);
+        assertSame(socket5, result5);
     }
 
     @Test
@@ -144,19 +148,23 @@ public class ManagedSocketFactoryTest {
         MulticastSocket socket1 = mock(MulticastSocket.class);
         MulticastSocket socket2 = mock(MulticastSocket.class);
         MulticastSocket socket3 = mock(MulticastSocket.class);
+        MulticastSocket socket4 = mock(MulticastSocket.class);
         SocketAddress address = new InetSocketAddress(InetAddress.getLocalHost(), 1);
 
         when(this.manager.createMulticastSocket("test", new InetSocketAddress(0))).thenReturn(socket1);
         when(this.manager.createMulticastSocket("test", new InetSocketAddress(1))).thenReturn(socket2);
         when(this.manager.createMulticastSocket("test", address)).thenReturn(socket3);
+        when(this.manager.createMulticastSocket("test")).thenReturn(socket4);
 
         MulticastSocket result1 = this.subject.createMulticastSocket("test");
         MulticastSocket result2 = this.subject.createMulticastSocket("test", 1);
         MulticastSocket result3 = this.subject.createMulticastSocket("test", address);
+        MulticastSocket result4 = this.subject.createMulticastSocket("test", null);
 
         assertSame(socket1, result1);
         assertSame(socket2, result2);
         assertSame(socket3, result3);
+        assertSame(socket4, result4);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <version.org.jboss.ws.common.tools>1.2.2.Final</version.org.jboss.ws.common.tools>
         <version.org.jboss.ws.cxf>5.1.3.Final</version.org.jboss.ws.cxf>
         <version.org.jboss.ws.jaxws-undertow-httpspi>1.0.1.Final</version.org.jboss.ws.jaxws-undertow-httpspi>
-        <version.org.jgroups>3.6.6.Final</version.org.jgroups>
+        <version.org.jgroups>3.6.7.Final</version.org.jgroups>
         <version.org.jipijapa>1.0.1.Final</version.org.jipijapa>
         <version.org.opensaml.opensaml>3.1.1</version.org.opensaml.opensaml>
         <version.org.picketbox.picketbox-commons>1.0.0.final</version.org.picketbox.picketbox-commons>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5981

Also fixes, WFLY-4936
JGroups: failed setting ip_ttl on windows with dual-stack IPv6 with "Method not implemented!"
https://issues.jboss.org/browse/WFLY-4936
