### PR TITLE
[WFLY-6059]: Migration for valves does not work properly

### DIFF
--- a/legacy/web/src/main/java/org/jboss/as/web/WebLogger.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebLogger.java
@@ -40,4 +40,10 @@ public interface WebLogger extends BasicLogger {
 
     @Message(id = 7, value = "Could not migrate verify-client expression %s")
     String couldNotTranslateVerifyClientExpression(String s);
+
+    @Message(id = 8, value = "Could not migrate valve %s")
+    String couldNotMigrateValve(String valveName);
+
+    @Message(id = 9, value = "Could not migrate attribute %s from valve %s")
+    String couldNotMigrateValveAttribute(String attribute, String valveName);
 }

--- a/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
+++ b/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
@@ -111,9 +111,16 @@
             <valve name="request-dumper" module="org.jboss.as.web" class-name="org.apache.catalina.valves.RequestDumperValve"/>
             <valve name="remote-addr" module="org.jboss.as.web" class-name="org.apache.catalina.valves.RemoteAddrValve">
                 <param param-name="allow" param-value="127.0.0.1,127.0.0.2" />
+                <param param-name="deny" param-value="192.168.1.20" />
             </valve>
             <valve name="crawler" class-name="org.apache.catalina.valves.CrawlerSessionManagerValve" module="org.jboss.as.web" >
                 <param param-name="sessionInactiveInterval" param-value="1" />
                 <param param-name="crawlerUserAgents" param-value="Google" />
+            </valve>
+            <valve name="proxy" class-name="org.apache.catalina.valves.RemoteIpValve" module="org.jboss.as.web" >
+                <param param-name="internalProxies" param-value="192\.168\.0\.10|192\.168\.0\.11" />
+                <param param-name="remoteIpHeader" param-value="x-forwarded-for" />
+                <param param-name="proxiesHeader" param-value="x-forwarded-by" />
+                <param param-name="trustedProxies" param-value="proxy1|proxy2" />
             </valve>
         </subsystem>


### PR DESCRIPTION
Fixing valves :
- org.apache.catalina.valves.RemoteHostValve
- org.apache.catalina.valves.RemoteAddrValve
- org.apache.catalina.valves.RemoteIpValve

Jira: https://issues.jboss.org/browse/WFLY-6059
