### PR TITLE
[WFLY-5082] Fix injection of transacted JMSContext

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSContextProducer.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/deployment/JMSContextProducer.java
@@ -50,8 +50,6 @@ import javax.jms.TemporaryQueue;
 import javax.jms.TemporaryTopic;
 import javax.jms.TextMessage;
 import javax.jms.Topic;
-import javax.jms.XAConnectionFactory;
-import javax.jms.XAJMSContext;
 import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
@@ -59,8 +57,8 @@ import javax.transaction.Status;
 import javax.transaction.Synchronization;
 import javax.transaction.TransactionSynchronizationRegistry;
 
-import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 import org.jboss.metadata.property.PropertyReplacer;
+import org.wildfly.extension.messaging.activemq.logging.MessagingLogger;
 
 /**
  * Producer factory for JMSContext resources.
@@ -189,8 +187,7 @@ public class JMSContextProducer {
             inTransaction = inTx;
             ConnectionFactory cf = (ConnectionFactory) lookup(info.connectionFactoryLookup);
             if (inTransaction) {
-                XAJMSContext xaContext = ((XAConnectionFactory) cf).createXAContext(info.userName, info.password);
-                return xaContext.getContext();
+                return cf.createContext(info.userName, info.password);
             } else {
                 return cf.createContext(info.userName, info.password, info.ackMode);
             }
@@ -215,7 +212,7 @@ public class JMSContextProducer {
                     return (JMSContext) resource;
                 } else {
                     final JMSContext transactedContext = create(info, inTx);
-                    txSyncRegistry.putResource(TRANSACTION_KEY, resource);
+                    txSyncRegistry.putResource(TRANSACTION_KEY, transactedContext);
                     txSyncRegistry.registerInterposedSynchronization(new Synchronization() {
                         @Override
                         public void beforeCompletion() {


### PR DESCRIPTION
- Do not try to create an explicit XAJMSContext from a plain
  ConnectionFactory in a transaction.
  If the ConnectionFactory is coming from a resource adapter, it will be
  able to create the corresponding XAResource.
  The injection of the JMSContext does not need to interfer with this and
  can expect to receive a "transacted" JMSContext that supports XA by
  calling the ConnectionFactory.createJMSContext(String, String) method.
- Fix the TransactionSynchronizationRegistry.put() call that was always
  putting null instead of the created transactedContext

JIRA: https://issues.jboss.org/browse/WFLY-5082
