### PR TITLE
[WFLY-6107]:  WildFly AccessLog valve migration is not taking the condition parameter into account

### DIFF
--- a/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
+++ b/legacy/web/src/main/java/org/jboss/as/web/WebMigrateOperation.java
@@ -748,7 +748,7 @@ public class WebMigrateOperation implements OperationStepHandler {
             add.get(Constants.PREDICATE).set("not exists(%{r," + params.get("conditionUnless").asString() + "})");
         }
         if(params.hasDefined("condition")) {
-            add.get(Constants.PREDICATE).set("not exists(%{r," + params.get("conditionUnless").asString() + "})");
+            add.get(Constants.PREDICATE).set("not exists(%{r," + params.get("condition").asString() + "})");
         }
         final String[] unsupportedConfigParams = new String[] {"resolveHosts", "fileDateFormat", "renameOnRotate", "encoding",
             "locale", "requestAttributesEnabled", "buffered"};


### PR DESCRIPTION
Fixing parameter name.

Jira: https://issues.jboss.org/browse/WFLY-6107
