### PR TITLE
[WFLY-5875] fix secmgr in mixed domain for EAP6x, fix secmgr in domai…

### DIFF
--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ReadEnvironmentVariablesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/suites/ReadEnvironmentVariablesTestCase.java
@@ -30,6 +30,7 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SER
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
 import static org.jboss.as.test.integration.domain.management.util.DomainTestSupport.validateResponse;
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -94,6 +95,7 @@ public class ReadEnvironmentVariablesTestCase {
             //Deploy the archive
             WebArchive archive = ShrinkWrap.create(WebArchive.class, "env-test.war").addClass(EnvironmentTestServlet.class);
             archive.addAsResource(new StringAsset("Manifest-Version: 1.0\nDependencies: org.jboss.dmr \n"),"META-INF/MANIFEST.MF");
+            archive.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("getenv.*")), "permissions.xml");
 
             final InputStream contents = archive.as(ZipExporter.class).exportAsInputStream();
             try {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSupport.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSupport.java
@@ -56,10 +56,12 @@ import org.junit.Assert;
 public class MixedDomainTestSupport extends DomainTestSupport {
 
     public static final String STANDARD_DOMAIN_CONFIG = "copied-master-config/domain.xml";
+    private static final String JBOSS_DOMAIN_SERVER_ARGS = "jboss.domain.server.args";
 
     private final Version.AsVersion version;
     private final boolean adjustDomain;
     private final boolean legacyConfig;
+
 
     private MixedDomainTestSupport(Version.AsVersion version, String testClass, String domainConfig, String masterConfig, String slaveConfig,
                                    String jbossHome, boolean adjustDomain, boolean legacyConfig)
@@ -137,7 +139,15 @@ public class MixedDomainTestSupport extends DomainTestSupport {
 
     private void startAndAdjust() {
 
+        String jbossDomainServerArgsValue = null;
         try {
+            if (version.isEAP6Version()) {
+                jbossDomainServerArgsValue = System.getProperty(JBOSS_DOMAIN_SERVER_ARGS);
+                if (jbossDomainServerArgsValue != null) {
+                    System.setProperty(JBOSS_DOMAIN_SERVER_ARGS, "-DnotUsed");
+                }
+            }
+
             //Start the master in admin only  and reconfigure the domain with what
             //we want to test in the mixed domain and have the DomainAdjuster
             //strip down the domain model to something more workable. The domain
@@ -167,6 +177,10 @@ public class MixedDomainTestSupport extends DomainTestSupport {
 
         } catch (Exception e) {
             throw new RuntimeException(e);
+        } finally {
+            if (version.isEAP6Version() && jbossDomainServerArgsValue != null) {
+                System.setProperty(JBOSS_DOMAIN_SERVER_ARGS, jbossDomainServerArgsValue);
+            }
         }
     }
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/Version.java
@@ -72,8 +72,13 @@ public @interface Version {
         public String getFullVersionName() {
             return basename + version;
         }
+
         public String getZipFileName() {
             return  getFullVersionName() + ".zip";
+        }
+
+        public boolean isEAP6Version() {
+            return (this == EAP_6_2_0 || this == EAP_6_3_0 || this == EAP_6_4_0);
         }
 
         public int getMajor() {


### PR DESCRIPTION
…n mode

Fix tests for https://issues.jboss.org/browse/WFLY-5875
I disabled secmgr for mixed domain old hosts (EAP6x)
