### PR TITLE
Tests of "[WFCORE-1340] Provide domain-wide exclusion data for use by DC in managing mixed domains"

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -174,8 +174,9 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
 
     @Override
     protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
         // TODO: delete this once optional requirements no longer require the existence of a capability
-        context.registerCapability(CLUSTERED_SINGLETON_CAPABILITY, null);
+        context.registerCapability(CLUSTERED_SINGLETON_CAPABILITY);
     }
 
     @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRemove.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemRemove.java
@@ -22,9 +22,12 @@
 
 package org.jboss.as.ejb3.subsystem;
 
+import static org.jboss.as.ejb3.subsystem.EJB3SubsystemRootResourceDefinition.CLUSTERED_SINGLETON_CAPABILITY;
+
 import org.jboss.as.controller.AbstractRemoveStepHandler;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
+import org.jboss.as.controller.registry.Resource;
 import org.jboss.dmr.ModelNode;
 
 /**
@@ -37,6 +40,14 @@ public class EJB3SubsystemRemove extends AbstractRemoveStepHandler {
     public static final EJB3SubsystemRemove INSTANCE = new EJB3SubsystemRemove();
 
     private EJB3SubsystemRemove() {
+    }
+
+    @Override
+    protected void recordCapabilitiesAndRequirements(OperationContext context, ModelNode operation, Resource resource) throws OperationFailedException {
+        super.recordCapabilitiesAndRequirements(context, operation, resource);
+        // TODO: delete this once optional requirements no longer require the existence of a capability
+        context.deregisterCapability(CLUSTERED_SINGLETON_CAPABILITY.getName());
+
     }
 
     @Override

--- a/legacy/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem10TestCase.java
+++ b/legacy/cmp/src/test/java/org/jboss/as/cmp/subsystem/CmpKeyGeneratorSubsystem10TestCase.java
@@ -90,13 +90,13 @@ public class CmpKeyGeneratorSubsystem10TestCase extends AbstractSubsystemBaseTes
     }
 
     // TODO WFCORE-1353 means this doesn't have to always fail now; consider just deleting this
-    @Override
-    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
+//    @Override
+//    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
 //        final ModelNode operation = createDescribeOperation();
 //        final ModelNode result = hc.executeOperation(operation);
 //        Assert.assertTrue("The subsystem describe operation must fail",
 //                result.hasDefined(ModelDescriptionConstants.FAILURE_DESCRIPTION));
-    }
+//    }
 
     @Test
     public void testParseSubsystem() throws Exception {

--- a/legacy/configadmin/src/test/java/org/jboss/as/configadmin/parser/ConfigAdminSubsystemTestCase.java
+++ b/legacy/configadmin/src/test/java/org/jboss/as/configadmin/parser/ConfigAdminSubsystemTestCase.java
@@ -28,7 +28,6 @@ import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
-import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
@@ -119,11 +118,11 @@ public class ConfigAdminSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     // TODO WFCORE-1353 means this doesn't have to always fail now; consider just deleting this
-    @Override
-    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
+//    @Override
+//    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
 //        final ModelNode operation = createDescribeOperation();
 //        final ModelNode result = hc.executeOperation(operation);
 //        Assert.assertTrue("The subsystem describe operation must fail",
 //                result.hasDefined(ModelDescriptionConstants.FAILURE_DESCRIPTION));
-    }
+//    }
 }

--- a/legacy/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
+++ b/legacy/jacorb/src/test/java/org/jboss/as/jacorb/JacORBSubsystemTestCase.java
@@ -36,7 +36,6 @@ import org.jboss.as.controller.PathElement;
 import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
-import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.dmr.ModelNode;
 import org.junit.Assert;
 import org.junit.Test;
@@ -203,12 +202,12 @@ public class JacORBSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     // TODO WFCORE-1353 means this doesn't have to always fail now; consider just deleting this
-    @Override
-    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
+//    @Override
+//    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
 //        final ModelNode operation = createDescribeOperation();
 //        final ModelNode result = hc.executeOperation(operation);
 //        Assert.assertTrue("The subsystem describe operation must fail",
 //                result.hasDefined(ModelDescriptionConstants.FAILURE_DESCRIPTION));
-    }
+//    }
 
 }

--- a/legacy/jaxr/src/test/java/org/jboss/as/jaxr/extension/JaxrSubsystemTestCase.java
+++ b/legacy/jaxr/src/test/java/org/jboss/as/jaxr/extension/JaxrSubsystemTestCase.java
@@ -27,8 +27,6 @@ import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
-import org.jboss.as.subsystem.test.KernelServices;
-import org.jboss.dmr.ModelNode;
 import org.junit.Test;
 
 /**
@@ -152,13 +150,13 @@ public class JaxrSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     // TODO WFCORE-1353 means this doesn't have to always fail now; consider just deleting this
-    @Override
-    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
+//    @Override
+//    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
 //        final ModelNode operation = createDescribeOperation();
 //        final ModelNode result = hc.executeOperation(operation);
 //        Assert.assertTrue("The subsystem describe operation must fail",
 //                result.hasDefined(ModelDescriptionConstants.FAILURE_DESCRIPTION));
-    }
+//    }
 
 
 }

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/AbstractLegacySubsystemBaseTest.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/AbstractLegacySubsystemBaseTest.java
@@ -25,8 +25,6 @@ package org.jboss.as.messaging.test;
 import org.jboss.as.controller.Extension;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
-import org.jboss.as.subsystem.test.KernelServices;
-import org.jboss.dmr.ModelNode;
 
 /**
  * @author <a href="http://jmesnil.net/">Jeff Mesnil</a> (c) 2015 Red Hat inc.
@@ -43,11 +41,11 @@ public abstract class AbstractLegacySubsystemBaseTest extends AbstractSubsystemB
     }
 
     // TODO WFCORE-1353 means this doesn't have to always fail now; consider just deleting this
-    @Override
-    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
+//    @Override
+//    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
 //        final ModelNode operation = createDescribeOperation();
 //        final ModelNode result = hc.executeOperation(operation);
 //        Assert.assertTrue("The subsystem describe operation must fail",
 //                result.hasDefined(ModelDescriptionConstants.FAILURE_DESCRIPTION));
-    }
+//    }
 }

--- a/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemBareTestCase.java
+++ b/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemBareTestCase.java
@@ -27,9 +27,7 @@ import org.jboss.as.controller.ProcessType;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
-import org.jboss.as.subsystem.test.KernelServices;
 import org.jboss.as.web.WebExtension;
-import org.jboss.dmr.ModelNode;
 
 /**
  * @author Jean-Frederic Clere
@@ -57,13 +55,13 @@ public class WebSubsystemBareTestCase extends AbstractSubsystemBaseTest {
     }
 
     // TODO WFCORE-1353 means this doesn't have to always fail now; consider just deleting this
-    @Override
-    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
+//    @Override
+//    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
 //        final ModelNode operation = createDescribeOperation();
 //        final ModelNode result = hc.executeOperation(operation);
 //        Assert.assertTrue("The subsystem describe operation must fail",
 //                result.hasDefined(ModelDescriptionConstants.FAILURE_DESCRIPTION));
-    }
+//    }
 
     @Override
     protected AdditionalInitialization createAdditionalInitialization() {

--- a/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
+++ b/legacy/web/src/test/java/org/jboss/as/web/test/WebSubsystemTestCase.java
@@ -354,13 +354,13 @@ public class WebSubsystemTestCase extends AbstractSubsystemBaseTest {
     }
 
     // TODO WFCORE-1353 means this doesn't have to always fail now; consider just deleting this
-    @Override
-    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
+//    @Override
+//    protected void validateDescribeOperation(KernelServices hc, AdditionalInitialization serverInit, ModelNode expectedModel) throws Exception {
 //        final ModelNode operation = createDescribeOperation();
 //        final ModelNode result = hc.executeOperation(operation);
 //        Assert.assertTrue("The subsystem describe operation must fail",
 //                result.hasDefined(ModelDescriptionConstants.FAILURE_DESCRIPTION));
-    }
+//    }
 
     private static class SSLConfigurationNameFixer implements ModelFixer {
         private static final ModelFixer INSTANCE = new SSLConfigurationNameFixer();

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainAdjuster.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainAdjuster.java
@@ -121,6 +121,10 @@ public class DomainAdjuster {
 
         removeIpv4SystemProperty(client);
 
+        // We don't want any standard host-excludes as the tests are meant to see what happens
+        // with the current configs on legacy slaves
+        removeHostExcludes(client);
+
         //Add a jaspi test security domain used later by the tests
         addJaspiTestSecurityDomain(client);
 
@@ -134,6 +138,14 @@ public class DomainAdjuster {
         DomainTestUtils.executeForResult(
                 Util.createRemoveOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, "java.net.preferIPv4Stack")), client);
 
+    }
+
+    private void removeHostExcludes(DomainClient client) throws Exception {
+        final List<String> allHostExcludes = getAllChildrenOfType(client, PathAddress.EMPTY_ADDRESS, "host-exclude");
+        for (String exclude : allHostExcludes) {
+            DomainTestUtils.executeForResult(
+                    Util.createRemoveOperation(PathAddress.pathAddress("host-exclude", exclude)), client);
+        }
     }
 
     protected List<ModelNode> adjustForVersion(final DomainClient client, final PathAddress profileAddress) throws  Exception {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainHostExcludesTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/DomainHostExcludesTest.java
@@ -1,0 +1,311 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CLONE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.EXTENSION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PORT;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.RUNNING_SERVER;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SERVER_CONFIG;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SOCKET_BINDING_GROUP;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.TO_PROFILE;
+import static org.jboss.as.controller.operations.common.Util.createRemoveOperation;
+import static org.jboss.as.test.integration.domain.management.util.DomainTestUtils.executeForResult;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainLifecycleUtil;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+/**
+ * Base class for tests of the ability of a DC to exclude resources from visibility to a slave.
+ *
+ * @author Brian Stansberry
+ */
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public abstract class DomainHostExcludesTest {
+
+    private static final String[] EXCLUDED_EXTENSIONS = {
+            "org.wildfly.extension.batch.jberet",
+            "org.wildfly.extension.bean-validation",
+            "org.wildfly.extension.clustering.singleton",
+            "org.wildfly.extension.io",
+            "org.wildfly.extension.messaging-activemq",
+            "org.wildfly.extension.request-controller",
+            "org.wildfly.extension.security.manager",
+            "org.wildfly.extension.undertow",
+            "org.wildfly.iiop-openjdk"
+    };
+
+    public static final Set<String> EXTENSIONS_SET = new HashSet<>(Arrays.asList(EXCLUDED_EXTENSIONS));
+
+    private static final PathElement HOST = PathElement.pathElement("host", "slave");
+    private static final PathAddress HOST_EXCLUDE = PathAddress.pathAddress("host-exclude", "test");
+    private static final PathElement SOCKET = PathElement.pathElement(SOCKET_BINDING, "http");
+    private static final PathAddress CLONE_PROFILE = PathAddress.pathAddress(PROFILE, CLONE);
+
+    private static DomainTestSupport testSupport;
+
+    /** Subclasses call from a @BeforeClass method */
+    protected static void setup(Class<?> clazz, String hostRelease, ModelVersion slaveApiVersion) throws IOException, MgmtOperationException, TimeoutException, InterruptedException {
+
+        testSupport = MixedDomainTestSuite.getSupport(clazz);
+
+        testSupport.getDomainSlaveLifecycleUtil().stop();
+
+        ModelControllerClient client = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        setupExclude(client, hostRelease, slaveApiVersion);
+
+        // Add some ignored extensions to verify they are ignored
+        addExtensions(true, client);
+
+        startSlave();
+    }
+
+    private static void setupExclude(ModelControllerClient client, String hostRelease, ModelVersion hostVersion) throws IOException, MgmtOperationException {
+
+        ModelNode addOp = Util.createAddOperation(HOST_EXCLUDE);
+        if (hostRelease != null) {
+            addOp.get("host-release").set(hostRelease);
+        } else {
+            addOp.get("management-major-version").set(hostVersion.getMajor());
+            addOp.get("management-minor-version").set(hostVersion.getMinor());
+            if (hostVersion.getMicro() != 0) {
+                addOp.get("management-micro-version").set(hostVersion.getMicro());
+            }
+        }
+        addOp.get("active-server-groups").add("other-server-group");
+
+        ModelNode asbgs = addOp.get("active-socket-binding-groups");
+        asbgs.add("full-sockets");
+        asbgs.add("full-ha-sockets");
+
+        ModelNode extensions = addOp.get("excluded-extensions");
+        for (String ext : EXCLUDED_EXTENSIONS) {
+            extensions.add(ext);
+        }
+
+        executeForResult(addOp, client);
+    }
+
+    private static void addExtensions(boolean evens, ModelControllerClient client) throws IOException, MgmtOperationException {
+        for (int i = 0; i < EXCLUDED_EXTENSIONS.length; i++) {
+            if ((i % 2 == 0) == evens) {
+                executeForResult(Util.createAddOperation(PathAddress.pathAddress(EXTENSION, EXCLUDED_EXTENSIONS[i])), client);
+            }
+        }
+    }
+
+    private static void startSlave() throws TimeoutException, InterruptedException {
+
+        DomainLifecycleUtil legacyUtil = testSupport.getDomainSlaveLifecycleUtil();
+        long start = System.currentTimeMillis();
+        legacyUtil.start();
+        legacyUtil.awaitServers(start);
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException, MgmtOperationException, TimeoutException, InterruptedException {
+        try {
+            executeForResult(createRemoveOperation(HOST_EXCLUDE), testSupport.getDomainMasterLifecycleUtil().getDomainClient());
+        } finally {
+            restoreSlave();
+        }
+    }
+
+
+    @Test
+    public void test001SlaveBoot() throws Exception {
+
+        ModelControllerClient slaveClient = testSupport.getDomainSlaveLifecycleUtil().getDomainClient();
+
+        checkExtensions(slaveClient);
+        checkProfiles(slaveClient);
+        checkSocketBindingGroups(slaveClient);
+
+        checkSockets(slaveClient, PathAddress.pathAddress(SOCKET_BINDING_GROUP, "full-sockets"));
+        checkSockets(slaveClient, PathAddress.pathAddress(SOCKET_BINDING_GROUP, "full-ha-sockets"));
+    }
+
+    @Test
+    public void test002ServerBoot() throws IOException, MgmtOperationException, InterruptedException {
+
+        ModelControllerClient masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+
+        PathAddress serverCfgAddr = PathAddress.pathAddress(HOST,
+                PathElement.pathElement(SERVER_CONFIG, "server-one"));
+        ModelNode op = Util.createEmptyOperation("start", serverCfgAddr);
+        executeForResult(op, masterClient);
+
+        PathAddress serverAddr = PathAddress.pathAddress(HOST,
+                PathElement.pathElement(RUNNING_SERVER, "server-one"));
+        awaitServerLaunch(masterClient, serverAddr);
+        checkSockets(masterClient, serverAddr.append(PathElement.pathElement(SOCKET_BINDING_GROUP, "full-ha-sockets")));
+
+    }
+
+    private void awaitServerLaunch(ModelControllerClient client, PathAddress serverAddr) throws InterruptedException {
+        long timeout = TimeoutUtil.adjust(20000);
+        long expired = System.currentTimeMillis() + timeout;
+        ModelNode op = Util.getReadAttributeOperation(serverAddr, "server-state");
+        do {
+            try {
+                ModelNode state = DomainTestUtils.executeForResult(op, client);
+                if ("running".equalsIgnoreCase(state.asString())) {
+                    return;
+                }
+            } catch (IOException | MgmtOperationException e) {
+                // ignore and try again
+            }
+
+            TimeUnit.MILLISECONDS.sleep(250L);
+        } while (System.currentTimeMillis() < expired);
+
+        Assert.fail("Server did not start in " + timeout + " ms");
+    }
+
+    @Test
+    public void test003PostBootUpdates() throws IOException, MgmtOperationException {
+
+        ModelControllerClient masterClient = testSupport.getDomainMasterLifecycleUtil().getDomainClient();
+        ModelControllerClient slaveClient = testSupport.getDomainSlaveLifecycleUtil().getDomainClient();
+
+        // Tweak an ignored profile and socket-binding-group to prove slave doesn't see it
+        updateExcludedProfile(masterClient);
+        updateExcludedSocketBindingGroup(masterClient);
+
+        // Verify profile cloning is ignored when the cloned profile is excluded
+        testProfileCloning(masterClient, slaveClient);
+
+        // Add more ignored extensions to verify slave doesn't see the ops
+        addExtensions(false, masterClient);
+        checkExtensions(slaveClient);
+
+    }
+
+    private void checkExtensions(ModelControllerClient client) throws IOException, MgmtOperationException {
+        ModelNode op = Util.createEmptyOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
+        op.get(CHILD_TYPE).set(EXTENSION);
+        ModelNode result = executeForResult(op, client);
+        Assert.assertTrue(result.isDefined());
+        Assert.assertTrue(result.asInt() > 0);
+        for (ModelNode ext : result.asList()) {
+            Assert.assertFalse(ext.asString(), EXTENSIONS_SET.contains(ext.asString()));
+        }
+    }
+
+    private void checkProfiles(ModelControllerClient client) throws IOException, MgmtOperationException {
+        ModelNode result = readChildrenNames(client, PathAddress.EMPTY_ADDRESS, PROFILE);
+        Assert.assertTrue(result.isDefined());
+        Assert.assertEquals(result.toString(), 1, result.asInt());
+        Assert.assertEquals(result.toString(), "full-ha", result.get(0).asString());
+    }
+
+    private void checkSocketBindingGroups(ModelControllerClient client) throws IOException, MgmtOperationException {
+        ModelNode result = readChildrenNames(client, PathAddress.EMPTY_ADDRESS, SOCKET_BINDING_GROUP);
+        Assert.assertTrue(result.isDefined());
+        Assert.assertEquals(result.toString(), 2, result.asInt());
+        Set<String> expected = new HashSet<>(Arrays.asList("full-sockets", "full-ha-sockets"));
+        for (ModelNode sbg : result.asList()) {
+            expected.remove(sbg.asString());
+        }
+        Assert.assertTrue(result.toString(), expected.isEmpty());
+    }
+
+    private void checkSockets(ModelControllerClient client, PathAddress baseAddress) throws IOException, MgmtOperationException {
+        ModelNode result = readChildrenNames(client, baseAddress, SOCKET_BINDING);
+        Assert.assertTrue(result.isDefined());
+        Assert.assertTrue(result.toString(), result.asInt() > 1);
+
+        ModelNode op = Util.getReadAttributeOperation(baseAddress.append(SOCKET), PORT);
+        result = executeForResult(op, client);
+        Assert.assertTrue(result.isDefined());
+        Assert.assertEquals(result.toString(), 8080, result.asInt());
+    }
+
+    private void updateExcludedProfile(ModelControllerClient client) throws IOException, MgmtOperationException {
+        ModelNode op = Util.getWriteAttributeOperation(PathAddress.pathAddress(PathElement.pathElement(PROFILE, "default"),
+                PathElement.pathElement(SUBSYSTEM, "jmx")), "non-core-mbean-sensitivity", false);
+        executeForResult(op, client);
+    }
+
+    private void updateExcludedSocketBindingGroup(ModelControllerClient client) throws IOException, MgmtOperationException {
+        ModelNode op = Util.getWriteAttributeOperation(PathAddress.pathAddress(PathElement.pathElement(SOCKET_BINDING_GROUP, "standard-sockets"),
+                PathElement.pathElement(SOCKET_BINDING, "http")), PORT, 8080);
+        executeForResult(op, client);
+    }
+
+    private ModelNode readChildrenNames(ModelControllerClient client, PathAddress pathAddress, String childType) throws IOException, MgmtOperationException {
+        ModelNode op = Util.createEmptyOperation(READ_CHILDREN_NAMES_OPERATION, pathAddress);
+        op.get(CHILD_TYPE).set(childType);
+        return executeForResult(op, client);
+    }
+
+    private void testProfileCloning(ModelControllerClient masterClient, ModelControllerClient slaveClient) throws IOException, MgmtOperationException {
+        ModelNode profiles = readChildrenNames(masterClient, PathAddress.EMPTY_ADDRESS, PROFILE);
+        Assert.assertTrue(profiles.isDefined());
+        Assert.assertTrue(profiles.toString(), profiles.asInt() > 0);
+
+        for (ModelNode mn : profiles.asList()) {
+            String profile = mn.asString();
+            cloneProfile(masterClient, profile);
+            try {
+                checkProfiles(slaveClient);
+            } finally {
+                executeForResult(Util.createRemoveOperation(CLONE_PROFILE), masterClient);
+            }
+        }
+    }
+
+    private void cloneProfile(ModelControllerClient client, String toClone) throws IOException, MgmtOperationException {
+        ModelNode op = Util.createEmptyOperation(CLONE, PathAddress.pathAddress(PROFILE, toClone));
+        op.get(TO_PROFILE).set(CLONE);
+        executeForResult(op, client);
+    }
+
+    private static void restoreSlave() throws TimeoutException, InterruptedException {
+        DomainLifecycleUtil slaveUtil = testSupport.getDomainSlaveLifecycleUtil();
+        if (!slaveUtil.isHostControllerStarted()) {
+            startSlave();
+        }
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/KernelBehaviorTestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/KernelBehaviorTestSuite.java
@@ -37,6 +37,6 @@ public class KernelBehaviorTestSuite extends MixedDomainTestSuite {
      * @param testClass the test/suite class
      */
     protected static MixedDomainTestSupport getSupport(Class<?> testClass) {
-        return getSupport(testClass, "master-config/domain-minimal.xml", false);
+        return getSupport(testClass, "master-config/domain-minimal.xml", false, false);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigAdjuster.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigAdjuster.java
@@ -1,0 +1,102 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed;
+
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.CHILD_TYPE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.PROFILE;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.READ_CHILDREN_NAMES_OPERATION;
+import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SYSTEM_PROPERTY;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.mixed.eap620.LegacyConfigAdjuster620;
+import org.jboss.as.test.integration.domain.mixed.eap630.LegacyConfigAdjuster630;
+import org.jboss.as.test.integration.domain.mixed.eap640.LegacyConfigAdjuster640;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Analogue to {@link DomainAdjuster}, but for use when the domain is running with a legacy domain.xml
+ * rather than the current standard domain.xml. So the scope of expected adjustments is expected to be
+ * considerably smaller.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster {
+
+    protected LegacyConfigAdjuster() {
+    }
+
+    static void adjustForVersion(final DomainClient client, final Version.AsVersion asVersion) throws Exception {
+
+        final LegacyConfigAdjuster adjuster;
+        switch (asVersion) {
+            case EAP_6_2_0:
+                adjuster = new LegacyConfigAdjuster620();
+                break;
+            case EAP_6_3_0:
+                adjuster = new LegacyConfigAdjuster630();
+                break;
+            case EAP_6_4_0:
+                adjuster = new LegacyConfigAdjuster640();
+                break;
+            default:
+                adjuster = new LegacyConfigAdjuster();
+        }
+
+        adjuster.adjust(client);
+    }
+
+    final void adjust(final DomainClient client) throws Exception {
+
+        removeIpv4SystemProperty(client);
+
+        //Version specific changes
+        ModelNode read = Util.createEmptyOperation(READ_CHILDREN_NAMES_OPERATION, PathAddress.EMPTY_ADDRESS);
+        read.get(CHILD_TYPE).set(PROFILE);
+        ModelNode result = DomainTestUtils.executeForResult(read, client);
+        for (ModelNode profile : result.asList()) {
+            final List<ModelNode> adjustments = adjustForVersion(client, PathAddress.pathAddress(PROFILE, profile.asString()));
+            applyVersionAdjustments(client, adjustments);
+        }
+    }
+
+    private void removeIpv4SystemProperty(final DomainClient client) throws Exception {
+        //The standard domain configuration contains -Djava.net.preferIPv4Stack=true, remove that
+        DomainTestUtils.executeForResult(
+                Util.createRemoveOperation(PathAddress.pathAddress(SYSTEM_PROPERTY, "java.net.preferIPv4Stack")), client);
+
+    }
+
+    protected List<ModelNode> adjustForVersion(final DomainClient client, final PathAddress profileAddress) throws  Exception {
+        return new ArrayList<>();
+    }
+
+    private void applyVersionAdjustments(DomainClient client, List<ModelNode> operations) throws Exception {
+        if (operations.size() == 0) {
+            return;
+        }
+        for (ModelNode op : operations) {
+            //System.out.println("Adjusting using " + op);
+            DomainTestUtils.executeForResult(op, client);
+        }
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/LegacyConfigTest.java
@@ -1,0 +1,165 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.ModelControllerClient;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestSupport;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.as.test.shared.TestSuiteEnvironment;
+import org.jboss.as.test.shared.TimeoutUtil;
+import org.jboss.dmr.ModelNode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Tests slave behavior in a mixed domain when the master has booted with a legacy domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public abstract class LegacyConfigTest {
+
+    private static final PathElement SLAVE = PathElement.pathElement("host", "slave");
+    private static final PathAddress TEST_SERVER_CONFIG = PathAddress.pathAddress(SLAVE,
+            PathElement.pathElement("server-config", "legacy-server"));
+    private static final PathAddress TEST_SERVER = PathAddress.pathAddress(SLAVE,
+            PathElement.pathElement("server", "legacy-server"));
+    private static final PathAddress TEST_SERVER_GROUP = PathAddress.pathAddress("server-group", "legacy-group");
+
+    private static final Map<String, String> STD_PROFILES;
+
+    static {
+        final Map<String, String> stdProfiles = new HashMap<>();
+        stdProfiles.put("default", "standard-sockets");
+        stdProfiles.put("ha", "ha-sockets");
+        stdProfiles.put("full", "full-sockets");
+        stdProfiles.put("full-ha", "full-ha-sockets");
+        STD_PROFILES = Collections.unmodifiableMap(stdProfiles);
+    }
+
+    private static DomainTestSupport support;
+
+    @Before
+    public void init() throws Exception {
+        support = MixedDomainTestSuite.getSupport(this.getClass());
+    }
+
+    @Test
+    public void testServerLaunching() throws IOException, MgmtOperationException, InterruptedException {
+
+        DomainClient client = support.getDomainMasterLifecycleUtil().getDomainClient();
+        for (Map.Entry<String, String> entry : getProfilesToTest().entrySet()) {
+            String profile = entry.getKey();
+            String sbg = entry.getValue();
+            try {
+                installTestServer(client, profile, sbg);
+                awaitServerLaunch(client, profile);
+                validateServerProfile(client, profile);
+                verifyHttp(profile);
+            } finally {
+                cleanTestServer(client);
+            }
+        }
+    }
+
+    private void installTestServer(ModelControllerClient client, String profile, String sbg) throws IOException, MgmtOperationException {
+        ModelNode op = Util.createAddOperation(TEST_SERVER_GROUP);
+        op.get("profile").set(profile);
+        op.get("socket-binding-group").set(sbg);
+        DomainTestUtils.executeForResult(op, client);
+
+        op = Util.createAddOperation(TEST_SERVER_CONFIG);
+        op.get("group").set("legacy-group");
+        DomainTestUtils.executeForResult(op, client);
+
+        DomainTestUtils.executeForResult(Util.createEmptyOperation("start", TEST_SERVER_CONFIG), client);
+    }
+
+    private void awaitServerLaunch(ModelControllerClient client, String profile) throws InterruptedException {
+        long timeout = System.currentTimeMillis() + TimeoutUtil.adjust(20000);
+        ModelNode op = Util.getReadAttributeOperation(TEST_SERVER, "server-state");
+        do {
+            try {
+                ModelNode state = DomainTestUtils.executeForResult(op, client);
+                if ("running".equalsIgnoreCase(state.asString())) {
+                    return;
+                }
+            } catch (IOException | MgmtOperationException e) {
+                // ignore and try again
+            }
+
+            TimeUnit.MILLISECONDS.sleep(250L);
+        } while (System.currentTimeMillis() < timeout);
+
+        Assert.fail("Server did not start using " + profile);
+    }
+
+    private void validateServerProfile(ModelControllerClient client, String profile) throws IOException, MgmtOperationException {
+        ModelNode op = Util.getReadAttributeOperation(TEST_SERVER, "profile-name");
+        ModelNode result = DomainTestUtils.executeForResult(op, client);
+        Assert.assertEquals(profile, result.asString());
+    }
+
+    private void verifyHttp(String profile) {
+        try {
+            URLConnection connection = new URL("http://" + TestSuiteEnvironment.formatPossibleIpv6Address(DomainTestSupport.slaveAddress) + ":8080").openConnection();
+            connection.connect();
+        } catch (IOException e) {
+            Assert.fail("Cannot connect to profile " + profile + " " + e.toString());
+        }
+    }
+
+    private void cleanTestServer(ModelControllerClient client) {
+        try {
+            ModelNode op = Util.createEmptyOperation("stop", TEST_SERVER_CONFIG);
+            op.get("blocking").set(true);
+            DomainTestUtils.executeForResult(op, client);
+        } catch (MgmtOperationException | IOException e) {
+            e.printStackTrace();
+        } finally {
+            try {
+                DomainTestUtils.executeForResult(Util.createRemoveOperation(TEST_SERVER_CONFIG), client);
+            } catch (MgmtOperationException | IOException e) {
+                e.printStackTrace();
+            } finally {
+                try {
+                    DomainTestUtils.executeForResult(Util.createRemoveOperation(TEST_SERVER_GROUP), client);
+                } catch (MgmtOperationException | IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+
+    protected Map<String, String> getProfilesToTest() {
+        return new HashMap<>(STD_PROFILES);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
@@ -23,6 +23,8 @@ package org.jboss.as.test.integration.domain.mixed;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+
 import org.junit.AfterClass;
 
 /**
@@ -54,19 +56,34 @@ public class MixedDomainTestSuite {
     protected static MixedDomainTestSupport getSupport(Class<?> testClass) {
         if (support == null) {
             final String copiedDomainXml = MixedDomainTestSupport.copyDomainFile();
-            return getSupport(testClass, copiedDomainXml, true);
+            return getSupport(testClass, copiedDomainXml, true, false);
         } else {
             return support;
         }
     }
 
-    static MixedDomainTestSupport getSupport(Class<?> testClass, String domainConfig, boolean adjustDomain) {
+    /**
+     * Call this from a @BeforeClass method
+     *
+     * @param testClass the test/suite class
+     */
+    protected static MixedDomainTestSupport getSupportForLegacyConfig(Class<?> testClass, Version.AsVersion version) {
+        if (support == null) {
+            final File originalDomainXml = MixedDomainTestSupport.loadLegacyDomainXml(version);
+            final String copiedDomainXml = MixedDomainTestSupport.copyDomainFile(originalDomainXml);
+            return getSupport(testClass, copiedDomainXml, true, true);
+        } else {
+            return support;
+        }
+    }
+
+    static MixedDomainTestSupport getSupport(Class<?> testClass, String domainConfig, boolean adjustDomain, boolean legacyConfig) {
         if (support == null) {
             final Version.AsVersion version = getVersion(testClass);
             final MixedDomainTestSupport testSupport;
             try {
                 if (domainConfig != null) {
-                    testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version, domainConfig, adjustDomain);
+                    testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version, domainConfig, adjustDomain, legacyConfig);
                 } else {
                     testSupport = MixedDomainTestSupport.create(testClass.getSimpleName(), version);
                 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/MixedDomainTestSuite.java
@@ -66,6 +66,7 @@ public class MixedDomainTestSuite {
      * Call this from a @BeforeClass method
      *
      * @param testClass the test/suite class
+     * @param version the version of the legacy slave.
      */
     protected static MixedDomainTestSupport getSupportForLegacyConfig(Class<?> testClass, Version.AsVersion version) {
         if (support == null) {

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/DomainHostExcludes620TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/DomainHostExcludes620TestCase.java
@@ -16,35 +16,27 @@ limitations under the License.
 
 package org.jboss.as.test.integration.domain.mixed.eap620;
 
-import java.util.Map;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
 
-import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.test.integration.domain.mixed.DomainHostExcludesTest;
 import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap640.LegacyConfig640TestSuite;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.junit.BeforeClass;
 
 /**
- * EAP 6.2 variant of the superclass.
+ * Tests of the ability of a DC to exclude resources from visibility to an EAP 6.2 slave.
  *
  * @author Brian Stansberry
  */
 @Version(Version.AsVersion.EAP_6_2_0)
-public class LegacyConfig620TestCase extends LegacyConfigTest {
+public class DomainHostExcludes620TestCase extends DomainHostExcludesTest {
 
     @BeforeClass
-    public static void beforeClass() {
+    public static void beforeClass() throws InterruptedException, TimeoutException, MgmtOperationException, IOException {
         LegacyConfig620TestSuite.initializeDomain();
-    }
-
-    @Override
-    protected Map<String, String> getProfilesToTest() {
-        Map<String, String> result =  super.getProfilesToTest();
-
-        // The following is unnecessary following addition of LegacyConfigAdjuster620.workAroundWFLY2335
-        // but is just commented out in case that proves unreliable
-
-//        // Due to WFLY-2335, EAP 6.2 full-ha servers won't launch on JDK 8,
-//        // so skip testing that profile
-//        result.remove("full-ha");
-        return result;
+        setup(DomainHostExcludes620TestCase.class, "EAP6.2", ModelVersion.create(1, 5));
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestCase.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap620;
+
+import java.util.Map;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 6.2 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_6_2_0)
+public class LegacyConfig620TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig620TestSuite.initializeDomain();
+    }
+
+    @Override
+    protected Map<String, String> getProfilesToTest() {
+        Map<String, String> result =  super.getProfilesToTest();
+
+        // Due to WFLY-2335, EAP 6.2 full-ha servers won't launch on JDK 8,
+        // so skip testing that profile
+        result.remove("full-ha");
+        return result;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestSuite.java
@@ -28,7 +28,7 @@ import org.junit.runners.Suite;
  * @author Brian Stansberry
  */
 @RunWith(Suite.class)
-@Suite.SuiteClasses(value= {LegacyConfig620TestCase.class})
+@Suite.SuiteClasses(value= {LegacyConfig620TestCase.class, DomainHostExcludes620TestCase.class})
 @Version(Version.AsVersion.EAP_6_2_0)
 public class LegacyConfig620TestSuite extends MixedDomainTestSuite {
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfig620TestSuite.java
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap620;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 6.2 domain.xml with a current DC and a 6.2 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig620TestCase.class})
+@Version(Version.AsVersion.EAP_6_2_0)
+public class LegacyConfig620TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig620TestSuite.class, Version.AsVersion.EAP_6_2_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfigAdjuster620.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfigAdjuster620.java
@@ -1,0 +1,65 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap620;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.mixed.eap630.LegacyConfigAdjuster630;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 6.2 domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster620 extends LegacyConfigAdjuster630 {
+
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        enableDatasourceStatistics(profileAddress, result);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+        return result;
+    }
+
+    /**
+     * EAP 6.3 switched the default behavior for datasource statistics from enabled to a configurable
+     * disabled. If a config is being migrated, we want the new behavior, so we don't use the parser
+     * to enable statistics when a legacy xsd is found. But the 6.2 slave cannot boot if the config
+     * has statistics disabled, so we need to specifically enable them for the mixed domain case.
+     */
+    private void enableDatasourceStatistics(PathAddress profileAddress, List<ModelNode> ops) {
+        PathAddress ds = profileAddress.append(
+                PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "datasources"),
+                PathElement.pathElement("data-source", "ExampleDS")
+        );
+        ModelNode op = Util.getWriteAttributeOperation(ds, "statistics-enabled", true);
+        ops.add(op);
+
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfigAdjuster620.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/LegacyConfigAdjuster620.java
@@ -39,6 +39,10 @@ public class LegacyConfigAdjuster620 extends LegacyConfigAdjuster630 {
 
         enableDatasourceStatistics(profileAddress, result);
 
+        if ("full-ha".equals(profileAddress.getLastElement().getValue())) {
+            workAroundWFLY2335(profileAddress, result);
+        }
+
         // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
         // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
         // If an adjustment is needed here, that means our users will need to do the same
@@ -61,5 +65,12 @@ public class LegacyConfigAdjuster620 extends LegacyConfigAdjuster630 {
         ModelNode op = Util.getWriteAttributeOperation(ds, "statistics-enabled", true);
         ops.add(op);
 
+    }
+
+    private void workAroundWFLY2335(PathAddress profileAddress, List<ModelNode> ops) {
+        ModelNode connectorRefs = new ModelNode();
+        connectorRefs.add("in-vm");
+        ModelNode op = Util.getWriteAttributeOperation(profileAddress.append("subsystem", "messaging").append("hornetq-server", "default").append("broadcast-group", "bg-group1"), "connectors", connectorRefs);
+        ops.add(op);
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/MixedDomain620TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap620/MixedDomain620TestSuite.java
@@ -34,7 +34,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(Suite.class)
-@SuiteClasses(value= {SimpleMixedDomain620TestCase.class, MixedDomainDeployment620TestCase.class})
+@SuiteClasses(value= {SimpleMixedDomain620TestCase.class, MixedDomainDeployment620TestCase.class, DomainHostExcludes620TestCase.class})
 @Version(AsVersion.EAP_6_2_0)
 public class MixedDomain620TestSuite extends MixedDomainTestSuite {
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/DomainHostExcludes630TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/DomainHostExcludes630TestCase.java
@@ -16,24 +16,27 @@ limitations under the License.
 
 package org.jboss.as.test.integration.domain.mixed.eap630;
 
-import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.test.integration.domain.mixed.DomainHostExcludesTest;
 import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap640.LegacyConfig640TestSuite;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 /**
- * Tests of using EAP 6.3 domain.xml with a current DC and a 6.3 slave.
+ * Tests of the ability of a DC to exclude resources from visibility to an EAP 6.3 slave.
  *
  * @author Brian Stansberry
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses(value= {LegacyConfig630TestCase.class, DomainHostExcludes630TestCase.class})
 @Version(Version.AsVersion.EAP_6_3_0)
-public class LegacyConfig630TestSuite extends MixedDomainTestSuite {
+public class DomainHostExcludes630TestCase extends DomainHostExcludesTest {
 
     @BeforeClass
-    public static void initializeDomain() {
-        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig630TestSuite.class, Version.AsVersion.EAP_6_3_0);
+    public static void beforeClass() throws InterruptedException, TimeoutException, MgmtOperationException, IOException {
+        LegacyConfig630TestSuite.initializeDomain();
+        setup(DomainHostExcludes630TestCase.class, "EAP6.3", ModelVersion.create(1, 6));
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestCase.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap630;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap620.LegacyConfig620TestSuite;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 6.3 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_6_3_0)
+public class LegacyConfig630TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig630TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfig630TestSuite.java
@@ -1,0 +1,39 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap630;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 6.3 domain.xml with a current DC and a 6.3 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig630TestCase.class})
+@Version(Version.AsVersion.EAP_6_3_0)
+public class LegacyConfig630TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig630TestSuite.class, Version.AsVersion.EAP_6_3_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfigAdjuster630.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/LegacyConfigAdjuster630.java
@@ -1,0 +1,44 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap630;
+
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.test.integration.domain.mixed.eap640.LegacyConfigAdjuster640;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 6.3 or earlier domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster630 extends LegacyConfigAdjuster640 {
+
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+        return result;
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/MixedDomain630TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap630/MixedDomain630TestSuite.java
@@ -35,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(Suite.class)
-@SuiteClasses(value= {SimpleMixedDomain630TestCase.class, MixedDomainDeployment630TestCase.class})
+@SuiteClasses(value= {SimpleMixedDomain630TestCase.class, MixedDomainDeployment630TestCase.class, DomainHostExcludes630TestCase.class})
 @Version(AsVersion.EAP_6_3_0)
 public class MixedDomain630TestSuite extends MixedDomainTestSuite {
 

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/DomainHostExcludes640TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/DomainHostExcludes640TestCase.java
@@ -16,24 +16,27 @@ limitations under the License.
 
 package org.jboss.as.test.integration.domain.mixed.eap640;
 
-import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import java.io.IOException;
+import java.util.concurrent.TimeoutException;
+
+import org.jboss.as.controller.ModelVersion;
+import org.jboss.as.test.integration.domain.mixed.DomainHostExcludesTest;
 import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap630.MixedDomain630TestSuite;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
 import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Suite;
 
 /**
- * Tests of using EAP 6.4 domain.xml with a current DC and a 6.4 slave.
+ * Tests of the ability of a DC to exclude resources from visibility to an EAP 6.2 slave.
  *
  * @author Brian Stansberry
  */
-@RunWith(Suite.class)
-@Suite.SuiteClasses(value= {LegacyConfig640TestCase.class, DomainHostExcludes640TestCase.class})
 @Version(Version.AsVersion.EAP_6_4_0)
-public class LegacyConfig640TestSuite extends MixedDomainTestSuite {
+public class DomainHostExcludes640TestCase extends DomainHostExcludesTest {
 
     @BeforeClass
-    public static void initializeDomain() {
-        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig640TestSuite.class, Version.AsVersion.EAP_6_4_0);
+    public static void beforeClass() throws InterruptedException, TimeoutException, MgmtOperationException, IOException {
+        LegacyConfig640TestSuite.initializeDomain();
+        setup(DomainHostExcludes640TestCase.class, "EAP6.4", ModelVersion.create(1, 7));
     }
 }

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestCase.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestCase.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap640;
+
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigTest;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap620.LegacyConfig620TestSuite;
+import org.junit.BeforeClass;
+
+/**
+ * EAP 6.4 variant of the superclass.
+ *
+ * @author Brian Stansberry
+ */
+@Version(Version.AsVersion.EAP_6_4_0)
+public class LegacyConfig640TestCase extends LegacyConfigTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        LegacyConfig640TestSuite.initializeDomain();
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfig640TestSuite.java
@@ -1,0 +1,40 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap640;
+
+import org.jboss.as.test.integration.domain.mixed.MixedDomainTestSuite;
+import org.jboss.as.test.integration.domain.mixed.Version;
+import org.jboss.as.test.integration.domain.mixed.eap630.LegacyConfig630TestCase;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+/**
+ * Tests of using EAP 6.4 domain.xml with a current DC and a 6.4 slave.
+ *
+ * @author Brian Stansberry
+ */
+@RunWith(Suite.class)
+@Suite.SuiteClasses(value= {LegacyConfig640TestCase.class})
+@Version(Version.AsVersion.EAP_6_4_0)
+public class LegacyConfig640TestSuite extends MixedDomainTestSuite {
+
+    @BeforeClass
+    public static void initializeDomain() {
+        MixedDomainTestSuite.getSupportForLegacyConfig(LegacyConfig640TestSuite.class, Version.AsVersion.EAP_6_4_0);
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfigAdjuster640.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/LegacyConfigAdjuster640.java
@@ -1,0 +1,109 @@
+/*
+Copyright 2016 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package org.jboss.as.test.integration.domain.mixed.eap640;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
+import org.jboss.as.controller.client.helpers.domain.DomainClient;
+import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
+import org.jboss.as.controller.operations.common.Util;
+import org.jboss.as.test.integration.domain.management.util.DomainTestUtils;
+import org.jboss.as.test.integration.domain.mixed.LegacyConfigAdjuster;
+import org.jboss.as.test.integration.management.util.MgmtOperationException;
+import org.jboss.dmr.ModelNode;
+
+/**
+ * Adjusts a config produced from the EAP 6.4 or earlier domain.xml.
+ *
+ * @author Brian Stansberry
+ */
+public class LegacyConfigAdjuster640 extends LegacyConfigAdjuster {
+    @Override
+    protected List<ModelNode> adjustForVersion(DomainClient client, PathAddress profileAddress) throws Exception {
+        List<ModelNode> result = super.adjustForVersion(client, profileAddress);
+
+        configureCDI10(profileAddress, result);
+        removeBV(client, profileAddress, result);
+
+        // DO NOT INTRODUCE NEW ADJUSTMENTS HERE WITHOUT SOME SORT OF PUBLIC DISCUSSION.
+        // CAREFULLY DOCUMENT IN THIS CLASS WHY ANY ADJUSTMENT IS NEEDED AND IS THE BEST APPROACH.
+        // If an adjustment is needed here, that means our users will need to do the same
+        // just to get an existing profile to work, and we want to minimize that.
+
+
+        return result;
+    }
+
+    /**
+     *  EAP 6.x uses CDI 1.0 while later releases use later CDI spec versions. If a
+     *  profile config uses CDI, it's unclear whether what's wanted is CDI 1.0 behavior
+     *  or later behavior, so we require the user to be explicit via setting 2 attributes
+     *  to get the 1.0 behavior.
+     *
+     *  The CDI subsystem parser could do this automatically when a legacy xsd is found, but
+     *  then if the user goal is to migrate to the later behavior, they won't get it.
+     */
+    private void configureCDI10(PathAddress profileAddress, List<ModelNode> ops) {
+        PathAddress weld = profileAddress.append(
+                PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "weld")
+        );
+        ModelNode op = Util.getWriteAttributeOperation(weld, "require-bean-descriptor", true);
+        ops.add(op);
+
+        op = op.clone();
+        op.get("name").set("non-portable-mode");
+        ops.add(op);
+    }
+
+    /**
+     * WildFly 9 and later broke BV out from the ee subsystem, allowing it to be removed. If a later
+     * DC/standalone server sees ee with a legacy xsd, it adds BV into the config, thus assuring that
+     * a migrated config does not, perhaps not noticeably, lose existing behavior. But a 6.x slave
+     * will not recognize the BV extension/subsystem, so it needs to be removed.
+     */
+    private void removeBV(DomainClient client, PathAddress profileAddress, List<ModelNode> ops) throws IOException, MgmtOperationException {
+        PathAddress bv = profileAddress.append(
+                PathElement.pathElement(ModelDescriptionConstants.SUBSYSTEM, "bean-validation")
+        );
+        ops.add(Util.createRemoveOperation(bv));
+
+        // If no other profiles still use this extension, we can remove it
+        String ourProfile = profileAddress.getLastElement().getValue();
+        ModelNode read = Util.createEmptyOperation("read-children-names", PathAddress.EMPTY_ADDRESS);
+        read.get("child-type").set("profile");
+        for (ModelNode profileMN : DomainTestUtils.executeForResult(read, client).asList()) {
+            String profile = profileMN.asString();
+            if (!ourProfile.equals(profile)) {
+                read = Util.createEmptyOperation("read-children-names", PathAddress.pathAddress("profile", profile));
+                read.get("child-type").set("subsystem");
+                for (ModelNode sub : DomainTestUtils.executeForResult(read, client).asList()) {
+                    if ("bean-validation".equals(sub.asString())) {
+                        // this profile still has a subsystem; don't remove extension yet
+                        return;
+                    }
+                }
+            }
+        }
+
+        // If we got here, no profile has the bv subsystem so we can remove the extension
+        ops.add(Util.createRemoveOperation(PathAddress.pathAddress("extension", "org.wildfly.extension.bean-validation")));
+
+    }
+}

--- a/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/MixedDomain640TestSuite.java
+++ b/testsuite/mixed-domain/src/test/java/org/jboss/as/test/integration/domain/mixed/eap640/MixedDomain640TestSuite.java
@@ -35,7 +35,7 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author <a href="kabir.khan@jboss.com">Kabir Khan</a>
  */
 @RunWith(Suite.class)
-@SuiteClasses(value= {SimpleMixedDomain640TestCase.class, MixedDomainDeployment640TestCase.class})
+@SuiteClasses(value= {SimpleMixedDomain640TestCase.class, MixedDomainDeployment640TestCase.class, DomainHostExcludes640TestCase.class})
 @Version(AsVersion.EAP_6_4_0)
 public class MixedDomain640TestSuite extends MixedDomainTestSuite {
 

--- a/testsuite/mixed-domain/src/test/resources/master-config/host.xml
+++ b/testsuite/mixed-domain/src/test/resources/master-config/host.xml
@@ -80,7 +80,7 @@
  	</jvms>
 
     <servers>
-        <server name="server-one" group="other-server-group">
+        <server name="server-one" group="other-server-group" auto-start="false">
             <socket-bindings port-offset="100"/>
         </server>
         <server name="server-two" group="other-server-group" auto-start="false"/>

--- a/testsuite/mixed-domain/src/test/resources/slave-config/host-slave.xml
+++ b/testsuite/mixed-domain/src/test/resources/slave-config/host-slave.xml
@@ -94,7 +94,7 @@
 
 
     <servers>
-        <server name="server-one" group="other-server-group"/>
+        <server name="server-one" group="other-server-group" auto-start="false"/>
         <server name="server-two" group="other-server-group" auto-start="false"/>
     </servers>
 </host>


### PR DESCRIPTION
Requires a core upgrade that includes https://github.com/wildfly/wildfly-core/pull/1407

The primary purpose of this PR is to add testing of the functionality in the core PR.

This PR includes the changes from #8618 as the new tests build on the infrastructure added in that PR.

This PR also fixes WFLY-6118 as that issues was preventing effective testing of profile clone handling, which I wanted to test in the WFCORE-1340 scenario.

http://brontes.lab.eng.brq.redhat.com/viewLog.html?buildId=89310&tab=buildResultsDiv&buildTypeId=WF_WildFlyCoreIntegrationExperiments is a custom test of the core and full PRs together.
