### PR TITLE
[WFLY-6125] Migration warning for remoting-interceptors

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -626,6 +626,7 @@ public class MigrateOperation implements OperationStepHandler {
 
 
     private void migrateServer(ModelNode addOperation, Map<PathAddress, ModelNode> newAddOperations, List<String> warnings) {
+        discardInterceptors(addOperation, CommonAttributes.REMOTING_INTERCEPTORS.getName(), warnings);
         discardInterceptors(addOperation, CommonAttributes.REMOTING_INCOMING_INTERCEPTORS.getName(), warnings);
         discardInterceptors(addOperation, CommonAttributes.REMOTING_OUTGOING_INTERCEPTORS.getName(), warnings);
 

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -160,11 +160,11 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         // 2 warnings about broadcast-group attributes not migrated because they have an expression.
         // 5 warnings about discovery-group attributes that can not be migrated.
         // 2 warnings about discovery-group attributes not migrated because they have an expression.
-        // 2 warnings about interceptors that can not be migrated.
+        // 3 warnings about interceptors that can not be migrated (for remoting-interceptors, remoting-incoming-interceptors & remoting-outgoing-interceptors attributes)
         // 1 warning about HA migration (attributes have expressions)
         // 1 warning about cluster-connection forward-when-no-consumers attribute having an expression.
         // 1 warning about use-nio being ignored for netty-throughput remote-connector resource.
-        int expectedNumberOfWarnings = 6 + 2 + 5 + 2 + 2 + 1 + 1 + 1;
+        int expectedNumberOfWarnings = 6 + 2 + 5 + 2 + 3 + 1 + 1 + 1;
         // 1 warning if add-legacy-entries is true because an in-vm connector can not be used in a legacy-connection-factory
         if (addLegacyEntries) {
             expectedNumberOfWarnings += 1;

--- a/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
+++ b/legacy/messaging/src/test/resources/org/jboss/as/messaging/test/subsystem_migration.xml
@@ -28,6 +28,9 @@
         <message-expiry-thread-priority>${message.expiry.thread.priority:7}</message-expiry-thread-priority>
         <id-cache-size>${id.cache.size:102030}</id-cache-size>
         <persist-id-cache>${persist.id.cache:false}</persist-id-cache>
+        <remoting-interceptors>
+            <class-name>incoming.baz.Interceptor</class-name>
+        </remoting-interceptors>
         <remoting-incoming-interceptors>
             <class-name>incoming.foo.Interceptor</class-name>
             <class-name>incoming.bar.Interceptor</class-name>


### PR DESCRIPTION
During migration, discard (deprecated) remoting-interceptors attribute
and a migration-warnings that these interceptors must be updated to use
the Artemis interceptor base class instead of the HornetQ one.

JIRA: https://issues.jboss.org/browse/WFLY-6125
