### PR TITLE
[WFLY-6134] JMS resource definitions backed by messaging-activemq

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/jms/definitions/MessagingBean.java
@@ -60,6 +60,8 @@ import javax.jms.TopicConnectionFactory;
                         destinationName="myTopic1"
                 ),
                 @JMSDestinationDefinition(
+                        // explicitly mention a resourceAdapter corresponding to a pooled-connection-factory resource
+                        resourceAdapter = "activemq-ra",
                         name="java:global/env/myQueue2",
                         interfaceName="javax.jms.Queue",
                         destinationName="myQueue2",
@@ -96,6 +98,8 @@ import javax.jms.TopicConnectionFactory;
         }
 )
 @JMSConnectionFactoryDefinition(
+        // explicitly mention a resourceAdapter corresponding to a pooled-connection-factory resource
+        resourceAdapter = "activemq-ra",
         name="java:global/myFactory3",
         interfaceName = "javax.jms.QueueConnectionFactory",
         properties = {


### PR DESCRIPTION
Allows JMS resource definitions to specify a pooled-connection-factory
from the messaging-activemq subsystem (using the resourceAdapter
property) in addition to regular resource adapters (configured in the
resource-adapters subsystem).

JIRA: https://issues.jboss.org/browse/WFLY-6134
