### PR TITLE
[WFLY-6068] Migration warning for failback-delay

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/MigrateOperation.java
@@ -657,11 +657,11 @@ public class MigrateOperation implements OperationStepHandler {
                 haPolicyAddress = serverAddress.append(HA_POLICY, "shared-store-slave");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, ALLOW_FAILBACK, "allow-failback");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, FAILOVER_ON_SHUTDOWN, "failover-on-server-shutdown");
-                discardFailbackDelay(haPolicyAddOperation, warnings);
+                discardFailbackDelay(serverAddOperation, warnings);
             } else {
                 haPolicyAddress = serverAddress.append(HA_POLICY, "shared-store-master");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, FAILOVER_ON_SHUTDOWN, "failover-on-server-shutdown");
-                discardFailbackDelay(haPolicyAddOperation, warnings);
+                discardFailbackDelay(serverAddOperation, warnings);
             }
         } else {
             if (backup) {
@@ -669,7 +669,7 @@ public class MigrateOperation implements OperationStepHandler {
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, ALLOW_FAILBACK, "allow-failback");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, MAX_SAVED_REPLICATED_JOURNAL_SIZE, "max-saved-replicated-journal-size");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, BACKUP_GROUP_NAME, "group-name");
-                discardFailbackDelay(haPolicyAddOperation, warnings);
+                discardFailbackDelay(serverAddOperation, warnings);
             } else {
                 haPolicyAddress = serverAddress.append(HA_POLICY, "replication-master");
                 setAndDiscard(haPolicyAddOperation, serverAddOperation, CHECK_FOR_LIVE_SERVER, "check-for-live-server");

--- a/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
+++ b/legacy/messaging/src/test/java/org/jboss/as/messaging/test/MigrateTestCase.java
@@ -88,7 +88,8 @@ public class MigrateTestCase extends AbstractSubsystemTest {
         ModelNode warnings = response.get(RESULT, "migration-warnings");
         // 1 warning about unmigrated-backup
         // 1 warning about shared-store
-        assertEquals(warnings.toString(), 2, warnings.asList().size());
+        // 3 warnings aboud discarded failback-delay attribute
+        assertEquals(warnings.toString(), 1 + 1 + 3, warnings.asList().size());
 
         model = services.readWholeModel();
         System.out.println("model = " + model);


### PR DESCRIPTION
Discard the failback-delay from the server's add operation during
migration (and not from the ha-policy's add).

JIRA: https://issues.jboss.org/browse/WFLY-6068
