### PR TITLE
[WFLY-6141]: Migrating access log valve results always in migration warning.

### DIFF
--- a/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
+++ b/legacy/web/src/test/resources/org/jboss/as/web/test/subsystem-migrate-2.2.0.xml
@@ -117,6 +117,10 @@
                 <param param-name="sessionInactiveInterval" param-value="1" />
                 <param param-name="crawlerUserAgents" param-value="Google" />
             </valve>
+            <valve name="stuck" class-name="org.apache.catalina.valves.StuckThreadDetectionValve" module="org.jboss.as.web" >
+                <param param-name="threshold" param-value="1000" />
+                <param param-name="interruptThreadThreshold" param-value="2000" />
+            </valve>
             <valve name="proxy" class-name="org.apache.catalina.valves.RemoteIpValve" module="org.jboss.as.web" >
                 <param param-name="internalProxies" param-value="192\.168\.0\.10|192\.168\.0\.11" />
                 <param param-name="remoteIpHeader" param-value="x-forwarded-for" />


### PR DESCRIPTION
[WFLY-6142]: StuckThreadDetectionValve is not automatically migrated.
[WFLY-6153]: RemoteIpValve is not correctly migrated
[WFLY-6154]: RemoteAddrValve and RemoteHostValve are incorrectly migrated
[WFLY-6155]: RemoteIpValve - protocolHeaderHttpsValue and proxiesHeader are neither migrated and neither migration warning is shown

Jira: https://issues.jboss.org/browse/WFLY-6141 
https://issues.jboss.org/browse/WFLY-6142
https://issues.jboss.org/browse/WFLY-6153
https://issues.jboss.org/browse/WFLY-6154
https://issues.jboss.org/browse/WFLY-6155
