### PR TITLE
WFLY-6120 SFSB PassivationTestCase fails to resolve XPC following passivation.

### DIFF
--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanFactory.java
@@ -22,7 +22,6 @@
 package org.wildfly.clustering.ejb.infinispan;
 
 import org.wildfly.clustering.ee.infinispan.Creator;
-import org.wildfly.clustering.ee.infinispan.Evictor;
 import org.wildfly.clustering.ee.infinispan.Locator;
 import org.wildfly.clustering.ejb.Bean;
 
@@ -35,7 +34,7 @@ import org.wildfly.clustering.ejb.Bean;
  * @param <I> the bean identifier type
  * @param <T> the bean type
  */
-public interface BeanFactory<I, T> extends Creator<I, BeanEntry<I>, I>, Locator<I, BeanEntry<I>>, BeanRemover<I, T>, Evictor<I> {
+public interface BeanFactory<I, T> extends Creator<I, BeanEntry<I>, I>, Locator<I, BeanEntry<I>>, BeanRemover<I, T> {
     Bean<I, T> createBean(I id, BeanEntry<I> entry);
 
     BeanKey<I> createKey(I id);

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanGroupEvictionContext.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/BeanGroupEvictionContext.java
@@ -21,28 +21,17 @@
  */
 package org.wildfly.clustering.ejb.infinispan;
 
-import org.wildfly.clustering.dispatcher.Command;
-import org.wildfly.clustering.ejb.Bean;
+import org.wildfly.clustering.ee.Batcher;
+import org.wildfly.clustering.ee.infinispan.Evictor;
+import org.wildfly.clustering.ee.infinispan.TransactionBatch;
 
 /**
- * Command that schedules a session.
+ * Encapsulates the context for session eviction.
  * @author Paul Ferraro
  */
-public class ScheduleSchedulerCommand<I> implements Command<Void, SchedulerContext<I>> {
-    private static final long serialVersionUID = -2606847692331278614L;
+public interface BeanGroupEvictionContext<I> {
 
-    private final I beanId;
-    private final I groupId;
+    Batcher<TransactionBatch> getBatcher();
 
-    public ScheduleSchedulerCommand(Bean<I, ?> bean) {
-        this.beanId = bean.getId();
-        this.groupId = bean.getGroupId();
-    }
-
-    @Override
-    public Void execute(SchedulerContext<I> context) {
-        context.getBeanScheduler().schedule(this.beanId);
-        context.getBeanGroupScheduler().schedule(this.groupId);
-        return null;
-    }
+    Evictor<I> getEvictor();
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/CancelSchedulerCommand.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/CancelSchedulerCommand.java
@@ -22,23 +22,27 @@
 package org.wildfly.clustering.ejb.infinispan;
 
 import org.wildfly.clustering.dispatcher.Command;
+import org.wildfly.clustering.ejb.Bean;
 
 /**
  * Command that cancels the scheduling of a session.
  * @author Paul Ferraro
  */
-public class CancelSchedulerCommand<I> implements Command<Void, Scheduler<I>> {
+public class CancelSchedulerCommand<I> implements Command<Void, SchedulerContext<I>> {
     private static final long serialVersionUID = -3526890046903297231L;
 
-    private final I id;
+    private final I beanId;
+    private final I groupId;
 
-    public CancelSchedulerCommand(I id) {
-        this.id = id;
+    public CancelSchedulerCommand(Bean<I, ?> bean) {
+        this.beanId = bean.getId();
+        this.groupId = bean.getGroupId();
     }
 
     @Override
-    public Void execute(Scheduler<I> scheduler) {
-        scheduler.cancel(this.id);
+    public Void execute(SchedulerContext<I> context) {
+        context.getBeanScheduler().cancel(this.beanId);
+        context.getBeanGroupScheduler().cancel(this.groupId);
         return null;
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManager.java
@@ -21,8 +21,6 @@
  */
 package org.wildfly.clustering.ejb.infinispan;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
@@ -80,9 +78,8 @@ import org.wildfly.clustering.service.concurrent.StampedLockServiceExecutor;
 @Listener(primaryOnly = true)
 public class InfinispanBeanManager<I, T> implements BeanManager<I, T, TransactionBatch> {
 
-    private final Cache<BeanGroupKey<I>, BeanGroupEntry<I, T>> groupCache;
     private final String beanName;
-    private final Cache<BeanKey<I>, BeanEntry<I>> beanCache;
+    private final Cache<BeanKey<I>, BeanEntry<I>> cache;
     private final BeanFactory<I, T> beanFactory;
     private final BeanGroupFactory<I, T> groupFactory;
     private final IdentifierFactory<I> identifierFactory;
@@ -97,22 +94,22 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
     private final Invoker invoker = new RetryingInvoker(0, 10, 100);
     private final BeanFilter<I> filter;
 
-    private volatile CommandDispatcher<Scheduler<I>> dispatcher;
-    private volatile Scheduler<I> scheduler;
+    private volatile SchedulerContext<I> schedulerContext;
+
+    private volatile CommandDispatcher<SchedulerContext<I>> dispatcher;
     private volatile ServiceExecutor executor;
 
     public InfinispanBeanManager(InfinispanBeanManagerConfiguration<T> configuration, IdentifierFactory<I> identifierFactory, Configuration<BeanKey<I>, BeanEntry<I>, BeanFactory<I, T>> beanConfiguration, Configuration<BeanGroupKey<I>, BeanGroupEntry<I, T>, BeanGroupFactory<I, T>> groupConfiguration) {
         this.beanName = configuration.getBeanName();
         this.groupFactory = groupConfiguration.getFactory();
         this.beanFactory = beanConfiguration.getFactory();
-        this.groupCache = groupConfiguration.getCache();
-        this.beanCache = beanConfiguration.getCache();
-        this.batcher = new InfinispanBatcher(this.groupCache);
+        this.cache = beanConfiguration.getCache();
+        this.batcher = new InfinispanBatcher(this.cache);
         this.filter = new BeanFilter<>(this.beanName);
-        Address address = this.groupCache.getCacheManager().getAddress();
+        Address address = this.cache.getCacheManager().getAddress();
         KeyAffinityServiceFactory affinityFactory = configuration.getAffinityFactory();
         KeyGenerator<BeanKey<I>> beanKeyGenerator = () -> beanConfiguration.getFactory().createKey(identifierFactory.createIdentifier());
-        this.affinity = affinityFactory.createService(this.beanCache, beanKeyGenerator);
+        this.affinity = affinityFactory.createService(this.cache, beanKeyGenerator);
         this.identifierFactory = () -> this.affinity.getKeyForAddress(address).getId();
         this.registry = configuration.getRegistry();
         this.nodeFactory = configuration.getNodeFactory();
@@ -125,46 +122,54 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
     public void start() {
         this.executor = new StampedLockServiceExecutor();
         this.affinity.start();
-        final List<Scheduler<I>> schedulers = new ArrayList<>(2);
         Time timeout = this.expiration.getTimeout();
-        if ((timeout != null) && (timeout.getValue() >= 0)) {
-            schedulers.add(new BeanExpirationScheduler<>(this.batcher, new ExpiredBeanRemover<>(this.beanFactory), this.expiration));
-        }
-        if (this.passivation.isEvictionAllowed()) {
-            schedulers.add(new BeanEvictionScheduler<>(this.beanName + ".eviction", this.batcher, this.beanFactory, this.dispatcherFactory, this.passivation));
-        }
-        this.scheduler = new Scheduler<I>() {
+        Scheduler<I> noopScheduler = new Scheduler<I>() {
             @Override
             public void schedule(I id) {
-                schedulers.forEach(scheduler -> scheduler.schedule(id));
             }
 
             @Override
             public void cancel(I id) {
-                schedulers.forEach(scheduler -> scheduler.cancel(id));
             }
 
             @Override
             public void cancel(Locality locality) {
-                schedulers.forEach(scheduler -> scheduler.cancel(locality));
             }
 
             @Override
             public void close() {
-                schedulers.forEach(scheduler -> scheduler.close());
             }
         };
-        this.dispatcher = this.dispatcherFactory.createCommandDispatcher(this.beanName + ".schedulers", this.scheduler);
-        this.beanCache.addListener(this, this.filter, null);
-        this.schedule(this.beanCache, new SimpleLocality(false), new ConsistentHashLocality(this.beanCache));
+        Scheduler<I> beanScheduler = (timeout != null) && (timeout.getValue() >= 0) ? new BeanExpirationScheduler<>(this.batcher, new ExpiredBeanRemover<>(this.beanFactory), this.expiration) : noopScheduler;
+        Scheduler<I> groupScheduler = this.passivation.isEvictionAllowed() ? new BeanGroupEvictionScheduler<>(this.beanName + ".eviction", this.batcher, this.groupFactory, this.dispatcherFactory, this.passivation) : noopScheduler;
+        this.schedulerContext = new SchedulerContext<I>() {
+            @Override
+            public void close() {
+                groupScheduler.close();
+                beanScheduler.close();
+            }
+
+            @Override
+            public Scheduler<I> getBeanScheduler() {
+                return beanScheduler;
+            }
+
+            @Override
+            public Scheduler<I> getBeanGroupScheduler() {
+                return groupScheduler;
+            }
+        };
+        this.dispatcher = this.dispatcherFactory.createCommandDispatcher(this.beanName + ".schedulers", this.schedulerContext);
+        this.cache.addListener(this, this.filter, null);
+        this.schedule(new SimpleLocality(false), new ConsistentHashLocality(this.cache));
     }
 
     @Override
     public void stop() {
         this.executor.close(() -> {
-            this.beanCache.removeListener(this);
+            this.cache.removeListener(this);
             this.dispatcher.close();
-            this.scheduler.close();
+            this.schedulerContext.close();
             this.affinity.stop();
         });
     }
@@ -172,12 +177,12 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
     @Override
     public Affinity getStrictAffinity() {
         Group group = this.registry.getGroup();
-        return this.beanCache.getCacheConfiguration().clustering().cacheMode().isClustered() ? new ClusterAffinity(group.getName()) : new NodeAffinity(this.registry.getEntry(group.getLocalNode()).getKey());
+        return this.cache.getCacheConfiguration().clustering().cacheMode().isClustered() ? new ClusterAffinity(group.getName()) : new NodeAffinity(this.registry.getEntry(group.getLocalNode()).getKey());
     }
 
     @Override
     public Affinity getWeakAffinity(I id) {
-        if (this.beanCache.getCacheConfiguration().clustering().cacheMode().isClustered()) {
+        if (this.cache.getCacheConfiguration().clustering().cacheMode().isClustered()) {
             Node node = this.locatePrimaryOwner(id);
             Map.Entry<String, ?> entry = this.registry.getEntry(node);
             if (entry != null) {
@@ -189,7 +194,7 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
 
     private void cancel(Bean<I, T> bean) {
         try {
-            this.executeOnPrimaryOwner(bean, new CancelSchedulerCommand<>(bean.getId()));
+            this.executeOnPrimaryOwner(bean, new CancelSchedulerCommand<>(bean));
         } catch (Exception e) {
             InfinispanEjbLogger.ROOT_LOGGER.failedToCancelBean(e, bean.getId());
         }
@@ -197,13 +202,13 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
 
     void schedule(Bean<I, T> bean) {
         try {
-            this.executeOnPrimaryOwner(bean, new ScheduleSchedulerCommand<>(bean.getId()));
+            this.executeOnPrimaryOwner(bean, new ScheduleSchedulerCommand<>(bean));
         } catch (Exception e) {
             InfinispanEjbLogger.ROOT_LOGGER.failedToScheduleBean(e, bean.getId());
         }
     }
 
-    private void executeOnPrimaryOwner(Bean<I, T> bean, final Command<Void, Scheduler<I>> command) throws Exception {
+    private void executeOnPrimaryOwner(Bean<I, T> bean, final Command<Void, SchedulerContext<I>> command) throws Exception {
         this.invoker.invoke(() -> {
             // This should only go remote following a failover
             Node node = InfinispanBeanManager.this.locatePrimaryOwner(bean.getId());
@@ -212,7 +217,7 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
     }
 
     Node locatePrimaryOwner(I id) {
-        DistributionManager dist = this.beanCache.getAdvancedCache().getDistributionManager();
+        DistributionManager dist = this.cache.getAdvancedCache().getDistributionManager();
         Address address = (dist != null) ? dist.getPrimaryLocation(id) : null;
         return (address != null) ? this.nodeFactory.createNode(address) : this.registry.getGroup().getLocalNode();
     }
@@ -241,7 +246,7 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
 
     @Override
     public boolean containsBean(I id) {
-        return this.beanCache.containsKey(this.beanFactory.createKey(id));
+        return this.cache.containsKey(this.beanFactory.createKey(id));
     }
 
     @Override
@@ -256,7 +261,7 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
 
     @Override
     public int getActiveCount() {
-        try (Stream<Map.Entry<BeanKey<I>, BeanEntry<I>>> entries = this.beanCache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL, Flag.SKIP_CACHE_LOAD).entrySet().stream()) {
+        try (Stream<Map.Entry<BeanKey<I>, BeanEntry<I>>> entries = this.cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL, Flag.SKIP_CACHE_LOAD).entrySet().stream()) {
             return (int) entries.filter(this.filter).count();
         }
     }
@@ -301,23 +306,26 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
     @DataRehashed
     public void dataRehashed(DataRehashedEvent<BeanKey<I>, BeanEntry<I>> event) {
         this.executor.execute(() -> {
-            Cache<BeanKey<I>, BeanEntry<I>> cache = event.getCache();
-            Address localAddress = cache.getCacheManager().getAddress();
+            Address localAddress = this.cache.getCacheManager().getAddress();
             Locality oldLocality = new ConsistentHashLocality(localAddress, event.getConsistentHashAtStart());
             Locality newLocality = new ConsistentHashLocality(localAddress, event.getConsistentHashAtEnd());
             if (event.isPre()) {
-                this.scheduler.cancel(newLocality);
+                this.schedulerContext.getBeanScheduler().cancel(newLocality);
+                this.schedulerContext.getBeanGroupScheduler().cancel(newLocality);
             } else {
-                this.schedule(cache, oldLocality, newLocality);
+                this.schedule(oldLocality, newLocality);
             }
         });
     }
 
-    private void schedule(Cache<BeanKey<I>, BeanEntry<I>> cache, Locality oldLocality, Locality newLocality) {
+    private void schedule(Locality oldLocality, Locality newLocality) {
         // Iterate over sessions in memory
-        try (Stream<Map.Entry<BeanKey<I>, BeanEntry<I>>> entries = this.beanCache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL, Flag.SKIP_CACHE_LOAD).entrySet().stream()) {
+        try (Stream<Map.Entry<BeanKey<I>, BeanEntry<I>>> entries = this.cache.getAdvancedCache().withFlags(Flag.CACHE_MODE_LOCAL, Flag.SKIP_CACHE_LOAD).entrySet().stream()) {
             // If we are the new primary owner of this session then schedule expiration of this session locally
-            entries.filter(this.filter).map(entry -> entry.getKey().getId()).filter(id -> !oldLocality.isLocal(id) && newLocality.isLocal(id)).forEach(id -> this.scheduler.schedule(id));
+            entries.filter(this.filter).filter(entry -> !oldLocality.isLocal(entry.getKey()) && newLocality.isLocal(entry.getKey())).forEach(entry -> {
+                this.schedulerContext.getBeanScheduler().schedule(entry.getKey().getId());
+                this.schedulerContext.getBeanGroupScheduler().schedule(entry.getValue().getGroupId());
+            });
         }
     }
 
@@ -350,6 +358,11 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
         }
 
         @Override
+        public boolean isValid() {
+            return this.bean.isValid();
+        }
+
+        @Override
         public T acquire() {
             return this.bean.acquire();
         }
@@ -362,7 +375,9 @@ public class InfinispanBeanManager<I, T> implements BeanManager<I, T, Transactio
         @Override
         public void close() {
             this.bean.close();
-            InfinispanBeanManager.this.schedule(this.bean);
+            if (this.bean.isValid()) {
+                InfinispanBeanManager.this.schedule(this.bean);
+            }
         }
     }
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactory.java
@@ -71,8 +71,6 @@ public class InfinispanBeanManagerFactory<I, T> implements BeanManagerFactory<I,
         Cache<BeanKey<I>, BeanEntry<I>> beanCache = this.configuration.getCache();
         Cache<BeanGroupKey<I>, BeanGroupEntry<I, T>> groupCache = this.configuration.getCache();
         org.infinispan.configuration.cache.Configuration config = groupCache.getCacheConfiguration();
-        BeanGroupFactory<I, T> groupFactory = new InfinispanBeanGroupFactory<>(groupCache, beanCache, factory, context);
-        Configuration<BeanGroupKey<I>, BeanGroupEntry<I, T>, BeanGroupFactory<I, T>> groupConfiguration = new SimpleConfiguration<>(groupCache, groupFactory);
         final String beanName = this.configuration.getBeanContext().getBeanName();
         // If cache is clustered or configured with a write-through cache store
         // then we need to trigger any @PrePassivate/@PostActivate per request
@@ -81,6 +79,8 @@ public class InfinispanBeanManagerFactory<I, T> implements BeanManagerFactory<I,
         final boolean passivationEnabled = evictionAllowed && config.persistence().passivation();
         final boolean persistent = config.clustering().cacheMode().isClustered() || (evictionAllowed && !passivationEnabled);
         boolean lockOnRead = config.transaction().transactionMode().isTransactional() && (config.transaction().lockingMode() == LockingMode.PESSIMISTIC) && (config.locking().isolationLevel() == IsolationLevel.REPEATABLE_READ);
+        BeanGroupFactory<I, T> groupFactory = new InfinispanBeanGroupFactory<>(groupCache, beanCache, factory, context, lockOnRead);
+        Configuration<BeanGroupKey<I>, BeanGroupEntry<I, T>, BeanGroupFactory<I, T>> groupConfiguration = new SimpleConfiguration<>(groupCache, groupFactory);
         BeanFactory<I, T> beanFactory = new InfinispanBeanFactory<>(beanName, groupFactory, beanCache, lockOnRead, this.configuration.getBeanContext().getTimeout(), persistent ? passivationListener : null);
         Configuration<BeanKey<I>, BeanEntry<I>, BeanFactory<I, T>> beanConfiguration = new SimpleConfiguration<>(beanCache, beanFactory);
         final NodeFactory<Address> nodeFactory = this.configuration.getNodeFactory();

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilderFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/InfinispanBeanManagerFactoryBuilderFactory.java
@@ -63,7 +63,7 @@ public class InfinispanBeanManagerFactoryBuilderFactory<I> implements BeanManage
         return AccessController.doPrivileged(new PrivilegedAction<ThreadFactory>() {
             @Override
             public ThreadFactory run() {
-                return new JBossThreadFactory(new ThreadGroup(BeanEvictionScheduler.class.getSimpleName()), Boolean.FALSE, null, "%G - %t", null, null);
+                return new JBossThreadFactory(new ThreadGroup(InfinispanBeanManager.class.getSimpleName()), Boolean.FALSE, null, "%G - %t", null, null);
             }
         });
     }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SchedulerContext.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/SchedulerContext.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,30 +19,16 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
+
 package org.wildfly.clustering.ejb.infinispan;
 
-import org.wildfly.clustering.dispatcher.Command;
-import org.wildfly.clustering.ejb.Bean;
-
 /**
- * Command that schedules a session.
  * @author Paul Ferraro
  */
-public class ScheduleSchedulerCommand<I> implements Command<Void, SchedulerContext<I>> {
-    private static final long serialVersionUID = -2606847692331278614L;
-
-    private final I beanId;
-    private final I groupId;
-
-    public ScheduleSchedulerCommand(Bean<I, ?> bean) {
-        this.beanId = bean.getId();
-        this.groupId = bean.getGroupId();
-    }
+public interface SchedulerContext<I> extends AutoCloseable {
+    Scheduler<I> getBeanScheduler();
+    Scheduler<I> getBeanGroupScheduler();
 
     @Override
-    public Void execute(SchedulerContext<I> context) {
-        context.getBeanScheduler().schedule(this.beanId);
-        context.getBeanGroupScheduler().schedule(this.groupId);
-        return null;
-    }
+    void close();
 }

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBean.java
@@ -84,6 +84,11 @@ public class InfinispanBean<I, T> implements Bean<I, T> {
     }
 
     @Override
+    public boolean isValid() {
+        return this.valid.get();
+    }
+
+    @Override
     public void remove(RemoveListener<T> listener) {
         if (this.valid.compareAndSet(true, false)) {
             InfinispanEjbLogger.ROOT_LOGGER.tracef("Removing bean %s", this.id);

--- a/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
+++ b/clustering/ejb/infinispan/src/main/java/org/wildfly/clustering/ejb/infinispan/bean/InfinispanBeanFactory.java
@@ -113,9 +113,4 @@ public class InfinispanBeanFactory<I, T> implements BeanFactory<I, T> {
             }
         }
     }
-
-    @Override
-    public void evict(I id) {
-        this.groupFactory.evict(id);
-    }
 }

--- a/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/BeanEvictionSchedulerTestCase.java
+++ b/clustering/ejb/infinispan/src/test/java/org/wildfly/clustering/ejb/infinispan/BeanEvictionSchedulerTestCase.java
@@ -44,21 +44,21 @@ public class BeanEvictionSchedulerTestCase {
         String evictedBeanId = "evicted";
         String activeBeanId = "active";
         CommandDispatcherFactory dispatcherFactory = mock(CommandDispatcherFactory.class);
-        CommandDispatcher<BeanEvictionContext<String>> dispatcher = mock(CommandDispatcher.class);
+        CommandDispatcher<BeanGroupEvictionContext<String>> dispatcher = mock(CommandDispatcher.class);
         Batcher<TransactionBatch> batcher = mock(Batcher.class);
         TransactionBatch batch = mock(TransactionBatch.class);
         Evictor<String> evictor = mock(Evictor.class);
         PassivationConfiguration<Bean<String, Object>> config = mock(PassivationConfiguration.class);
         BeanPassivationConfiguration passivationConfig = mock(BeanPassivationConfiguration.class);
         ArgumentCaptor<Command> capturedCommand = ArgumentCaptor.forClass(Command.class);
-        ArgumentCaptor<BeanEvictionContext> capturedContext = ArgumentCaptor.forClass(BeanEvictionContext.class);
+        ArgumentCaptor<BeanGroupEvictionContext> capturedContext = ArgumentCaptor.forClass(BeanGroupEvictionContext.class);
 
-        when(dispatcherFactory.createCommandDispatcher(same(name), (BeanEvictionContext<String>) capturedContext.capture())).thenReturn(dispatcher);
+        when(dispatcherFactory.createCommandDispatcher(same(name), (BeanGroupEvictionContext<String>) capturedContext.capture())).thenReturn(dispatcher);
         when(config.getConfiguration()).thenReturn(passivationConfig);
         when(passivationConfig.getMaxSize()).thenReturn(1);
 
-        try (Scheduler<String> scheduler = new BeanEvictionScheduler<>(name, batcher, evictor, dispatcherFactory, config)) {
-            BeanEvictionContext<String> context = capturedContext.getValue();
+        try (Scheduler<String> scheduler = new BeanGroupEvictionScheduler<>(name, batcher, evictor, dispatcherFactory, config)) {
+            BeanGroupEvictionContext<String> context = capturedContext.getValue();
 
             assertSame(scheduler, context);
             

--- a/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/Bean.java
+++ b/clustering/ejb/spi/src/main/java/org/wildfly/clustering/ejb/Bean.java
@@ -68,6 +68,12 @@ public interface Bean<I, T> extends AutoCloseable {
     void remove(RemoveListener<T> listener);
 
     /**
+     * Indicates whether this bean was removed.
+     * @return false, if this bean was removed, true otherwise.
+     */
+    boolean isValid();
+
+    /**
      * Closes any resources used by this bean.
      * A bean should only be closed when all referenced have been released,
      * i.e. {@link #release()} returned true.

--- a/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
+++ b/clustering/web/infinispan/src/main/java/org/wildfly/clustering/web/infinispan/session/InfinispanSessionManager.java
@@ -451,11 +451,14 @@ public class InfinispanSessionManager<MV, AV, L> implements SessionManager<L, Tr
 
         @Override
         public void close() {
-            if (InfinispanSessionManager.this.isPersistent()) {
+            boolean valid = this.session.isValid();
+            if (valid && InfinispanSessionManager.this.isPersistent()) {
                 InfinispanSessionManager.this.triggerPrePassivationEvents(this.immutableSession);
             }
             this.session.close();
-            InfinispanSessionManager.this.schedule(this.immutableSession.getId(), this.immutableSession.getMetaData());
+            if (valid) {
+                InfinispanSessionManager.this.schedule(this.immutableSession.getId(), this.immutableSession.getMetaData());
+            }
         }
 
         @Override

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/Cache.java
@@ -31,6 +31,7 @@ import org.wildfly.clustering.ejb.IdentifierFactory;
  * @author <a href="mailto:carlo.dewolf@jboss.com">Carlo de Wolf</a>
  */
 public interface Cache<K, V extends Identifiable<K>> extends AffinitySupport<K>, IdentifierFactory<K> {
+    ThreadLocal<Object> CURRENT_GROUP = new ThreadLocal<>();
 
     /**
      * Creates and caches a new instance of <code>T</code>.

--- a/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/cache/simple/SimpleCache.java
@@ -34,6 +34,7 @@ import org.jboss.as.ejb3.cache.Cache;
 import org.jboss.as.ejb3.cache.Identifiable;
 import org.jboss.as.ejb3.cache.StatefulObjectFactory;
 import org.jboss.as.ejb3.component.stateful.StatefulTimeoutInfo;
+import org.jboss.as.ejb3.logging.EjbLogger;
 import org.jboss.as.server.ServerEnvironment;
 import org.jboss.ejb.client.Affinity;
 import org.jboss.ejb.client.NodeAffinity;
@@ -110,6 +111,10 @@ public class SimpleCache<K, V extends Identifiable<K>> implements Cache<K, V> {
 
     @Override
     public V create() {
+        if (CURRENT_GROUP.get() != null) {
+            // An SFSB that uses a distributable cache cannot contain an SFSB that uses a simple cache
+            throw EjbLogger.ROOT_LOGGER.incompatibleCaches();
+        }
         V bean = this.factory.createInstance();
         this.entries.put(bean.getId(), new Entry<>(bean));
         return bean;

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/Bean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/Bean.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2014, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * as indicated by the @author tags. See the copyright.txt file in the
  * distribution for a full listing of individual contributors.
  *
@@ -19,36 +19,31 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-package org.wildfly.clustering.ejb.infinispan;
 
-import org.wildfly.clustering.dispatcher.Command;
-import org.wildfly.clustering.ee.Batch;
-import org.wildfly.clustering.ejb.infinispan.logging.InfinispanEjbLogger;
+package org.jboss.as.test.integration.ejb.stateful.passivation;
+
+import javax.ejb.Local;
+import javax.ejb.Remove;
 
 /**
- * Command that evicts a bean.
  * @author Paul Ferraro
  */
-public class BeanEvictionCommand<I> implements Command<Void, BeanEvictionContext<I>> {
-    private static final long serialVersionUID = -6593293772761100784L;
+@Local
+public interface Bean extends AutoCloseable {
+    /**
+     * Returns whether or not this instance has been passivated
+     */
+    boolean wasPassivated();
 
-    private final I id;
+    /**
+     * Returns whether or not this instance has been activated
+     */
+    boolean wasActivated();
 
-    public BeanEvictionCommand(I id) {
-        this.id = id;
+    default void doNothing() {
     }
 
     @Override
-    public Void execute(BeanEvictionContext<I> context) throws Exception {
-        InfinispanEjbLogger.ROOT_LOGGER.tracef("Evicting stateful session bean %s", this.id);
-        try (Batch batch = context.getBatcher().createBatch()) {
-            try {
-                context.getEvictor().evict(this.id);
-                return null;
-            } catch (Exception e) {
-                batch.discard();
-                throw e;
-            }
-        }
-    }
+    @Remove
+    void close();
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/BeanWithSerializationIssue.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/BeanWithSerializationIssue.java
@@ -25,6 +25,7 @@ package org.jboss.as.test.integration.ejb.stateful.passivation;
 
 import java.io.Serializable;
 
+import javax.ejb.EJB;
 import javax.ejb.Remote;
 import javax.ejb.Stateful;
 
@@ -39,6 +40,9 @@ import org.jboss.ejb3.annotation.Cache;
 public class BeanWithSerializationIssue extends TestPassivationBean {
 
     private Object object;
+
+    @EJB
+    private NestledBean nestledBean;
 
     public BeanWithSerializationIssue() {
         object = new Serializable() {

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/DDBasedSFSB.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/DDBasedSFSB.java
@@ -33,7 +33,7 @@ import org.jboss.ejb3.annotation.Cache;
  */
 @Stateful
 @Cache("passivating")
-public class DDBasedSFSB {
+public class DDBasedSFSB implements Bean {
 
     private boolean prePrePassivateInvoked;
     private boolean postActivateInvoked;
@@ -48,16 +48,17 @@ public class DDBasedSFSB {
         this.postActivateInvoked = true;
     }
 
-    public void doNothing() {
-
-    }
-
+    @Override
     public boolean wasPassivated() {
         return this.prePrePassivateInvoked;
     }
 
+    @Override
     public boolean wasActivated() {
         return this.postActivateInvoked;
     }
 
+    @Override
+    public void close() {
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/NestledBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/NestledBean.java
@@ -1,5 +1,6 @@
 package org.jboss.as.test.integration.ejb.stateful.passivation;
 
+import javax.ejb.Remove;
 import javax.ejb.Stateful;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
@@ -20,5 +21,9 @@ public class NestledBean {
     public Employee get(int id) {
         return (Employee) entityManager.createQuery("select e from Employee e where e.id=:id").setParameter("id", id)
                 .getSingleResult();
+    }
+
+    @Remove
+    public void close() {
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationDisabledBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationDisabledBean.java
@@ -33,7 +33,7 @@ import org.jboss.ejb3.annotation.Cache;
  */
 @Stateful(passivationCapable = false)
 @Cache("passivating")
-public class PassivationDisabledBean {
+public class PassivationDisabledBean implements Bean {
 
     private boolean prePrePassivateInvoked;
     private boolean postActivateInvoked;
@@ -48,16 +48,17 @@ public class PassivationDisabledBean {
         this.postActivateInvoked = true;
     }
 
-    public void doNothing() {
-
-    }
-
+    @Override
     public boolean wasPassivated() {
         return this.prePrePassivateInvoked;
     }
 
+    @Override
     public boolean wasActivated() {
         return this.postActivateInvoked;
     }
 
+    @Override
+    public void close() {
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationEnabledBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/PassivationEnabledBean.java
@@ -33,7 +33,7 @@ import org.jboss.ejb3.annotation.Cache;
  */
 @Stateful(passivationCapable = true)
 @Cache("passivating")
-public class PassivationEnabledBean {
+public class PassivationEnabledBean implements Bean {
 
     private boolean prePrePassivateInvoked;
     private boolean postActivateInvoked;
@@ -48,16 +48,17 @@ public class PassivationEnabledBean {
         this.postActivateInvoked = true;
     }
 
-    public void doNothing() {
-
-    }
-
+    @Override
     public boolean wasPassivated() {
         return this.prePrePassivateInvoked;
     }
 
+    @Override
     public boolean wasActivated() {
         return this.postActivateInvoked;
     }
 
+    @Override
+    public void close() {
+    }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationBean.java
@@ -30,7 +30,6 @@ import javax.ejb.EJB;
 import javax.ejb.PostActivate;
 import javax.ejb.PrePassivate;
 import javax.ejb.Remote;
-import javax.ejb.Remove;
 import javax.ejb.Stateful;
 import javax.inject.Inject;
 import javax.interceptor.Interceptors;
@@ -67,6 +66,7 @@ public class TestPassivationBean extends PassivationSuperClass implements TestPa
     /**
      * Returns the expected result
      */
+    @Override
     public String returnTrueString() {
         return TestPassivationRemote.EXPECTED_RESULT;
     }
@@ -74,6 +74,7 @@ public class TestPassivationBean extends PassivationSuperClass implements TestPa
     /**
      * Returns whether or not this instance has been passivated
      */
+    @Override
     public boolean hasBeenPassivated() {
         return this.beenPassivated;
     }
@@ -81,6 +82,7 @@ public class TestPassivationBean extends PassivationSuperClass implements TestPa
     /**
      * Returns whether or not this instance has been activated
      */
+    @Override
     public boolean hasBeenActivated() {
         return this.beenActivated;
     }
@@ -103,10 +105,12 @@ public class TestPassivationBean extends PassivationSuperClass implements TestPa
         entityManager.flush();
     }
 
+    @Override
     public void setManagedBeanMessage(String message) {
         this.managedBean.setMessage(message);
     }
 
+    @Override
     public String getManagedBeanMessage() {
         return managedBean.getMessage();
     }
@@ -135,10 +139,9 @@ public class TestPassivationBean extends PassivationSuperClass implements TestPa
         this.beenActivated = true;
     }
 
-    @Remove
-    public void remove() {
+    @Override
+    public void close() {
         log.info("Bean [" + this.identificator + "] removing");
+        this.nestledBean.close();
     }
-
-
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationRemote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/stateful/passivation/TestPassivationRemote.java
@@ -22,10 +22,12 @@
 
 package org.jboss.as.test.integration.ejb.stateful.passivation;
 
+import javax.ejb.Remove;
+
 /**
  * @author <a href="mailto:andrew.rubinger@jboss.org">ALR</a>
  */
-public interface TestPassivationRemote {
+public interface TestPassivationRemote extends AutoCloseable {
     String EXPECTED_RESULT = "true";
 
     /**
@@ -50,11 +52,6 @@ public interface TestPassivationRemote {
 
     void addEntity(int id, String name);
 
-    /**
-     * Annotate for removing.
-     */
-    void remove();
-
     Employee getSuperEmployee();
     
     /**
@@ -63,4 +60,8 @@ public interface TestPassivationRemote {
     String getManagedBeanMessage();
     
     void setManagedBeanMessage(String message);
+
+    @Override
+    @Remove
+    void close();
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6120

Restore CURRENT_GROUP reference to Cache.
Restore group validation in SimpleCache.create(...)
Refactor eviction scheduler to be group-based instead of bean-based.
Skip scheduling for invalid sessions/beans.
Passivation tests should remove any created SFSBs.
