### PR TITLE
WFLY-6152 internal persistence check should not log CANCELED/EXPIRED timers

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/timerservice/TimerServiceImpl.java
@@ -1114,7 +1114,8 @@ public class TimerServiceImpl implements TimerService, Service<TimerService> {
      * @return <code>true</code> if the timer is not persistent or the persistent timer should start
      */
     public boolean shouldRun(TimerImpl timer) {
-        return !timer.isPersistent() || timerPersistence.getValue().shouldRun(timer, this.transactionManager);
+        // check peristent without further check to prevent from Exception (WFLY-6152)
+        return !timer.isTimerPersistent() || timerPersistence.getValue().shouldRun(timer, this.transactionManager);
     }
 
     private class TimerCreationTransactionSynchronization implements Synchronization {


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/WFLY-6152
