### PR TITLE
[WFLY-5588] DefaultContextServiceServletTestCase fails on IBM jdk

### DIFF
--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceServletTestCase.java
@@ -25,6 +25,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 import java.net.URL;
+import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -57,7 +58,9 @@ public class DefaultContextServiceServletTestCase {
                         // TODO (jrp) This permission needs to be removed once WFLY-4176 is resolved
                         new RuntimePermission("getClassLoader"),
                         new RuntimePermission("modifyThread"),
-                        new RuntimePermission("getBootModuleLoader")
+                        new RuntimePermission("getBootModuleLoader"),
+                        // WFLY-5588: DefaultContextServiceServletTestCase fails on IBM jdk
+                        new PropertyPermission("com.ibm.enableClassCaching", "write")
                         ), "permissions.xml");
         return war;
     }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestServlet.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/ee/concurrent/DefaultContextServiceTestServlet.java
@@ -62,6 +62,8 @@ public class DefaultContextServiceTestServlet extends HttpServlet {
         final Runnable contextualProxy = contextService.createContextualProxy(runnable,Runnable.class);
         final ExecutorService executorService = Executors.newSingleThreadExecutor();
         try {
+            // WFLY-5588: DefaultContextServiceServletTestCase fails on IBM jdk
+            System.setProperty("com.ibm.enableClassCaching", "false");
             // WFLY-4308: test serialization of contextual proxies
             final ByteArrayOutputStream bytes = new ByteArrayOutputStream();
             final ObjectOutputStream stream = new ObjectOutputStream(bytes);
@@ -73,6 +75,7 @@ public class DefaultContextServiceTestServlet extends HttpServlet {
         } catch (Throwable e) {
             throw new ServletException(e);
         } finally {
+            System.clearProperty("com.ibm.enableClassCaching");
             executorService.shutdown();
         }
     }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5588 - DefaultContextServiceServletTestCase fails on IBM jdk

Test still fails with the latest ibm build 8.0-2.10. Adding a workarond -Dcom.ibm.enableClassCaching=false into the test servlet.
