### PR TITLE
WFLY-6102 (Removing of non-existent mapping-module finishes with outcome success)

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadRemoveHandler.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/SecurityDomainReloadRemoveHandler.java
@@ -24,7 +24,9 @@ package org.jboss.as.security;
 import org.jboss.as.controller.OperationContext;
 import org.jboss.as.controller.OperationFailedException;
 import org.jboss.as.controller.PathAddress;
+import org.jboss.as.controller.PathElement;
 import org.jboss.as.controller.RestartParentResourceRemoveHandler;
+import org.jboss.as.controller.logging.ControllerLogger;
 import org.jboss.dmr.ModelNode;
 import org.jboss.msc.service.ServiceName;
 
@@ -46,5 +48,16 @@ public class SecurityDomainReloadRemoveHandler extends RestartParentResourceRemo
     @Override
     protected ServiceName getParentServiceName(PathAddress parentAddress) {
         return SecurityDomainResourceDefinition.getSecurityDomainServiceName(parentAddress);
+    }
+
+    @Override
+    protected void updateModel(OperationContext context, ModelNode operation) throws OperationFailedException {
+        if (context.removeResource(PathAddress.EMPTY_ADDRESS) == null) {
+            PathElement path = null;
+            for (PathElement element : context.getCurrentAddress()) {
+                path = element;
+            }
+            throw new OperationFailedException(ControllerLogger.ROOT_LOGGER.childResourceNotFound(path));
+        }
     }
 }


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6102
An attempt to remove non-existent mapping-module through CLI now leads to failure message
