### PR TITLE
WFLY-6197 @ClusteredSingleton support is hardcoded to use a specific singleton policy name

### DIFF
--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityReference.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/CapabilityReference.java
@@ -24,6 +24,7 @@ package org.jboss.as.clustering.controller;
 
 import org.jboss.as.controller.CapabilityReferenceRecorder;
 import org.jboss.as.controller.capability.RuntimeCapability;
+import org.wildfly.clustering.service.Requirement;
 import org.jboss.as.controller.OperationContext;
 
 /**

--- a/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequiredCapability.java
+++ b/clustering/common/src/main/java/org/jboss/as/clustering/controller/RequiredCapability.java
@@ -22,6 +22,8 @@
 
 package org.jboss.as.clustering.controller;
 
+import org.wildfly.clustering.service.Requirement;
+
 /**
  * Enumerates capability requirements for clustering resources
  * @author Paul Ferraro

--- a/clustering/common/src/test/java/org/jboss/as/clustering/subsystem/AdditionalInitialization.java
+++ b/clustering/common/src/test/java/org/jboss/as/clustering/subsystem/AdditionalInitialization.java
@@ -26,13 +26,13 @@ import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.jboss.as.clustering.controller.Requirement;
 import org.jboss.as.controller.RunningMode;
 import org.jboss.as.controller.capability.RuntimeCapability;
 import org.jboss.as.controller.capability.registry.RuntimeCapabilityRegistry;
 import org.jboss.as.controller.extension.ExtensionRegistry;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.as.controller.registry.Resource;
+import org.wildfly.clustering.service.Requirement;
 
 /**
  * {@link AdditionalInitialization} extension that simplifies setup of required capabilities.

--- a/clustering/service/src/main/java/org/wildfly/clustering/service/Requirement.java
+++ b/clustering/service/src/main/java/org/wildfly/clustering/service/Requirement.java
@@ -20,19 +20,13 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.clustering.controller;
-
-import org.jboss.as.controller.OperationContext;
-import org.wildfly.clustering.service.InjectedValueDependency;
-import org.wildfly.clustering.service.Requirement;
+package org.wildfly.clustering.service;
 
 /**
- * Service dependency whose provided value is supplied by a {@link Capability}.
+ * Identifies a requirement.
  * @author Paul Ferraro
  */
-public class CapabilityDependency<T> extends InjectedValueDependency<T> {
+public interface Requirement {
 
-    public CapabilityDependency(OperationContext context, Requirement requirement, String name, Class<T> targetClass) {
-        super(context.getCapabilityServiceName(requirement.getName(), name, targetClass), targetClass);
-    }
+    String getName();
 }

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/RequiredCapability.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/RequiredCapability.java
@@ -20,13 +20,25 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.as.clustering.controller;
+package org.wildfly.clustering.singleton;
+
+import org.wildfly.clustering.service.Requirement;
 
 /**
- * Identifies a requirement.
+ * Enumerates capability requirements for singleton resources
  * @author Paul Ferraro
  */
-public interface Requirement {
+public enum RequiredCapability implements Requirement {
+    SINGLETON_POLICY("org.wildfly.clustering.singleton.policy"),
+    ;
+    private final String name;
 
-    String getName();
+    RequiredCapability(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
 }

--- a/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonPolicy.java
+++ b/clustering/singleton/api/src/main/java/org/wildfly/clustering/singleton/SingletonPolicy.java
@@ -31,8 +31,10 @@ import org.wildfly.clustering.service.Builder;
  * @author Paul Ferraro
  */
 public interface SingletonPolicy {
-
-    String CAPABILITY_NAME = "org.wildfly.clustering.singleton.policy";
+    /**
+     * @deprecated Use {@link RequiredCapability#SINGLETON_POLICY} instead.
+     */
+    @Deprecated String CAPABILITY_NAME = RequiredCapability.SINGLETON_POLICY.getName();
 
     <T> Builder<T> createSingletonServiceBuilder(ServiceName name, Service<T> service);
 }

--- a/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyResourceDefinition.java
+++ b/clustering/singleton/extension/src/main/java/org/wildfly/extension/clustering/singleton/SingletonPolicyResourceDefinition.java
@@ -36,6 +36,7 @@ import org.jboss.as.controller.registry.ManagementResourceRegistration;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.wildfly.clustering.service.SubGroupServiceNameFactory;
+import org.wildfly.clustering.singleton.RequiredCapability;
 import org.wildfly.clustering.singleton.SingletonPolicy;
 
 /**
@@ -51,7 +52,7 @@ public class SingletonPolicyResourceDefinition extends ChildResourceDefinition {
     }
 
     enum Capability implements org.jboss.as.clustering.controller.Capability {
-        POLICY(SingletonPolicy.CAPABILITY_NAME, SingletonPolicy.class),
+        POLICY(RequiredCapability.SINGLETON_POLICY.getName(), SingletonPolicy.class),
         ;
         private final RuntimeCapability<Void> definition;
 

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -25,6 +25,7 @@ package org.jboss.as.ejb3.subsystem;
 
 import com.arjuna.ats.arjuna.common.CoreEnvironmentBean;
 import com.arjuna.ats.jbossatx.jta.RecoveryManagerService;
+
 import org.jboss.as.connector.util.ConnectorServices;
 import org.jboss.as.controller.AbstractBoottimeAddStepHandler;
 import org.jboss.as.controller.OperationContext;
@@ -134,6 +135,7 @@ import org.jboss.msc.service.ServiceController;
 import org.jboss.msc.service.ServiceTarget;
 import org.jboss.remoting3.Endpoint;
 import org.omg.PortableServer.POA;
+import org.wildfly.clustering.singleton.RequiredCapability;
 import org.wildfly.clustering.singleton.SingletonPolicy;
 import org.wildfly.iiop.openjdk.rmi.DelegatingStubFactoryFactory;
 import org.wildfly.iiop.openjdk.service.CorbaPOAService;
@@ -481,10 +483,10 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
         ServiceTarget target = context.getServiceTarget();
         target.addService(RegistryCollectorService.SERVICE_NAME, new RegistryCollectorService<>()).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
         target.addService(CacheFactoryBuilderRegistryService.SERVICE_NAME, new CacheFactoryBuilderRegistryService<>()).setInitialMode(ServiceController.Mode.ON_DEMAND).install();
-        if (context.hasOptionalCapability(SingletonPolicy.CAPABILITY_NAME.concat(".default"), CLUSTERED_SINGLETON_CAPABILITY.getName(), null)) {
+        if (context.hasOptionalCapability(RequiredCapability.SINGLETON_POLICY.getName(), CLUSTERED_SINGLETON_CAPABILITY.getName(), null)) {
             final ClusteredSingletonServiceCreator singletonBarrierCreator = new ClusteredSingletonServiceCreator();
             target.addService(CLUSTERED_SINGLETON_CAPABILITY.getCapabilityServiceName().append("creator"), singletonBarrierCreator)
-                    .addDependency(context.getCapabilityServiceName(SingletonPolicy.CAPABILITY_NAME, SingletonPolicy.class),
+                    .addDependency(context.getCapabilityServiceName(RequiredCapability.SINGLETON_POLICY.getName(), SingletonPolicy.class),
                             SingletonPolicy.class, singletonBarrierCreator.getSingletonPolicy()).install();
         }
     }

--- a/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
+++ b/ejb3/src/test/java/org/jboss/as/ejb3/subsystem/Ejb3SubsystemUnitTestCase.java
@@ -23,26 +23,11 @@
 package org.jboss.as.ejb3.subsystem;
 
 import java.io.IOException;
-import java.util.List;
 
-import org.jboss.as.controller.AttributeDefinition;
-import org.jboss.as.controller.ModelVersion;
-import org.jboss.as.controller.PathAddress;
-import org.jboss.as.controller.PathElement;
-import org.jboss.as.model.test.FailedOperationTransformationConfig;
-import org.jboss.as.model.test.ModelFixer;
-import org.jboss.as.model.test.ModelTestControllerVersion;
-import org.jboss.as.model.test.ModelTestUtils;
 import org.jboss.as.subsystem.test.AbstractSubsystemBaseTest;
 import org.jboss.as.subsystem.test.AdditionalInitialization;
-import org.jboss.as.subsystem.test.KernelServices;
-import org.jboss.as.subsystem.test.KernelServicesBuilder;
-import org.jboss.dmr.ModelNode;
-import org.jboss.dmr.ModelType;
-import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
-import org.wildfly.clustering.singleton.SingletonPolicy;
+import org.wildfly.clustering.singleton.RequiredCapability;
 
 /**
  * Test case for testing the integrity of the EJB3 subsystem.
@@ -59,7 +44,7 @@ import org.wildfly.clustering.singleton.SingletonPolicy;
 public class Ejb3SubsystemUnitTestCase extends AbstractSubsystemBaseTest {
 
     private static final AdditionalInitialization ADDITIONAL_INITIALIZATION = AdditionalInitialization.withCapabilities(
-            SingletonPolicy.CAPABILITY_NAME.concat(".default"));
+            RequiredCapability.SINGLETON_POLICY.getName());
 
     public Ejb3SubsystemUnitTestCase() {
         super(EJB3Extension.SUBSYSTEM_NAME, new EJB3Extension());


### PR DESCRIPTION
Expose default singleton policy as a capability - using a capability reference to the named policy.

https://issues.jboss.org/browse/WFLY-6197
