### PR TITLE
WFLY-6198]: When a datasource has no connection-properties and its driver has defined datasource-class is defined and no connections-properties a warning should be issued.

### DIFF
--- a/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
+++ b/connector/src/main/java/org/jboss/as/connector/logging/ConnectorLogger.java
@@ -904,4 +904,7 @@ public interface ConnectorLogger extends BasicLogger {
     @Message(id = 111, value = "WorkManager hasn't elytron-enabled flag set accordingly with RA one")
     IllegalStateException invalidElytronWorkManagerSetting();
 
+    @LogMessage(level = WARN)
+    @Message(id = 112, value = "The datasource %s is using the driver datasource class \"%s\", only connection-properties are used for configuration.")
+    void usingDatasourceClassWithoutConnectionProperties(String dsName, String datasourceClassName);
 }

--- a/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
+++ b/connector/src/main/java/org/jboss/as/connector/subsystems/datasources/AbstractDataSourceService.java
@@ -378,6 +378,9 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
                                 moduleName, installedDriver.getDriverClassName(),
                                 installedDriver.getDataSourceClassName(), installedDriver.getXaDataSourceClassName());
                         drivers.put(driverName, driver);
+                        if(installedDriver.getDataSourceClassName() != null && (dataSourceConfig.getConnectionProperties() == null || dataSourceConfig.getConnectionProperties().isEmpty())) {
+                            ConnectorLogger.DS_DEPLOYER_LOGGER.usingDatasourceClassWithoutConnectionProperties(dsName, installedDriver.getDataSourceClassName());
+                        }
                     }
                     dataSources = new DatasourcesImpl(Arrays.asList(dataSourceConfig), null, drivers);
                 } else if (xaDataSourceConfig != null) {
@@ -391,6 +394,9 @@ public abstract class AbstractDataSourceService implements Service<DataSource> {
                                 installedDriver.getDriverClassName(),
                                 installedDriver.getDataSourceClassName(), installedDriver.getXaDataSourceClassName());
                         drivers.put(driverName, driver);
+                        if(installedDriver.getXaDataSourceClassName() != null && (xaDataSourceConfig.getXaDataSourceProperty() == null || xaDataSourceConfig.getXaDataSourceProperty().isEmpty())) {
+                            ConnectorLogger.DS_DEPLOYER_LOGGER.usingDatasourceClassWithoutConnectionProperties(dsName, installedDriver.getXaDataSourceClassName());
+                        }
                     }
                     dataSources = new DatasourcesImpl(null, Arrays.asList(xaDataSourceConfig), drivers);
                 }


### PR DESCRIPTION
Adding a warning when a datasource-class is used and no connection-properties are defined.

Jira: https://issues.jboss.org/browse/WFLY-6198
