### PR TITLE
WFLY-6232 Update resteasy-jettison provider module support to deprecated

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jettison-provider/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jboss/resteasy/resteasy-jettison-provider/main/module.xml
@@ -23,6 +23,11 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="org.jboss.resteasy.resteasy-jettison-provider">
+    <!-- This module is deprecated and subject to being removed in a subsequent release. -->
+    <properties>
+        <property name="jboss.api" value="deprecated"/>
+    </properties>
+
 
     <resources>
         <artifact name="${org.jboss.resteasy:resteasy-jettison-provider}"/>


### PR DESCRIPTION
jira https://issues.jboss.org/browse/WFLY-6232
