### PR TITLE
WFLY-5579/WFLY-6160 Allow @PrePassivate callback within Synchronization.afterCompletion(...) when using JTS.

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/tx/LifecycleCMTTxInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/tx/LifecycleCMTTxInterceptor.java
@@ -22,6 +22,9 @@
 package org.jboss.as.ejb3.tx;
 
 import javax.ejb.TransactionAttributeType;
+import javax.transaction.Status;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
 
 import org.jboss.as.ee.component.Component;
 import org.jboss.as.ee.component.ComponentInterceptorFactory;
@@ -38,7 +41,7 @@ import org.jboss.invocation.proxy.MethodIdentifier;
  *
  * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
  */
-public class LifecycleCMTTxInterceptor extends CMTTxInterceptor implements Interceptor {
+public class LifecycleCMTTxInterceptor extends CMTTxInterceptor {
 
     private final TransactionAttributeType transactionAttributeType;
     private final int transactionTimeout;
@@ -47,7 +50,6 @@ public class LifecycleCMTTxInterceptor extends CMTTxInterceptor implements Inter
         this.transactionAttributeType = transactionAttributeType;
         this.transactionTimeout = transactionTimeout;
     }
-
 
     @Override
     public Object processInvocation(InterceptorContext invocation) throws Exception {
@@ -68,6 +70,33 @@ public class LifecycleCMTTxInterceptor extends CMTTxInterceptor implements Inter
                 return supports(invocation, component);
             default:
                 throw EjbLogger.ROOT_LOGGER.unknownTxAttributeOnInvocation(transactionAttributeType, invocation);
+        }
+    }
+
+    @Override
+    protected Object notSupported(InterceptorContext invocation, EJBComponent component) throws Exception {
+        TransactionManager tm = component.getTransactionManager();
+        if (tm.getTransaction() == null) {
+            return this.invokeInNoTx(invocation, component);
+        }
+        Transaction tx = tm.suspend();
+        int status = (tx != null) ? tx.getStatus() : Status.STATUS_NO_TRANSACTION;
+        try {
+            return this.invokeInNoTx(invocation, component);
+        } finally {
+            // If invocation was triggered from Synchronization.afterCompletion(...)
+            // then tx is already complete, skip resume of suspended tx
+            // JTS refuses to resume a completed tx
+            switch (status) {
+                case Status.STATUS_NO_TRANSACTION:
+                case Status.STATUS_COMMITTED:
+                case Status.STATUS_ROLLEDBACK: {
+                    break;
+                }
+                default: {
+                    tm.resume(tx);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5579
https://issues.jboss.org/browse/WFLY-6160

For distributable SFSBs using persistent or replicated cache, @PrePassivate callbacks are triggered when the SFSB instance is released (to allow application to prepare for serialization of SFSB).  This is triggered within the context of StatefulSessionSynchronizationInterceptor.StatefulSessionSynchronization.afterCompletion(...).  Because @PrePassivate callbacks execute within an undefined tx context - we suspend/resume any existing tx before invoking the method.  Within the context of afterCompletion(...), the existing tx is already complete - and JTS fails to resume txs in a completed state (JTA works fine).  To work around this, we skip resume() if the tx is already complete.
