### PR TITLE
WFLY-6228 Component upgrade to Hibernate Validator 5.2.4.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <version.org.glassfish.javax.json>1.0.3</version.org.glassfish.javax.json>
         <version.org.hibernate>5.0.7.Final</version.org.hibernate>
         <version.org.hibernate.commons.annotations>5.0.1.Final</version.org.hibernate.commons.annotations>
-        <version.org.hibernate.validator>5.2.3.Final</version.org.hibernate.validator>
+        <version.org.hibernate.validator>5.2.4.Final</version.org.hibernate.validator>
         <version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>1.0.0.Final</version.org.hibernate.javax.persistence.hibernate-jpa-2.1-api>
         <version.org.hibernate.search>5.5.1.Final</version.org.hibernate.search>
         <version.org.hornetq>2.4.7.Final</version.org.hornetq>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/CarGroupSequenceProvider.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/beanvalidation/hibernate/validator/CarGroupSequenceProvider.java
@@ -22,29 +22,30 @@
 package org.jboss.as.test.integration.beanvalidation.hibernate.validator;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.hibernate.validator.spi.group.DefaultGroupSequenceProvider;
 
 /**
- * 
+ *
  * @author Madhumita Sadhukhan
  */
 public class CarGroupSequenceProvider implements DefaultGroupSequenceProvider<Car> {
 
-    List<Class<?>> defaultGroupSequence = new ArrayList<Class<?>>();
+    private static final List<Class<?>> DEFAULT_SEQUENCE = Arrays.asList(Car.class, CarChecks.class);
 
     @Override
     public List<Class<?>> getValidationGroups(Car car) {
-
-        defaultGroupSequence.add(Car.class);
-        defaultGroupSequence.add(CarChecks.class);
-
-        if (car != null && car.inspectionCompleted()) {
-            defaultGroupSequence.add(FinalInspection.class);
-
+        if (car == null || !car.inspectionCompleted()) {
+            return DEFAULT_SEQUENCE;
         }
+        else {
+            List<Class<?>> finalInspectionSequence = new ArrayList<>(3);
+            finalInspectionSequence.addAll(DEFAULT_SEQUENCE);
+            finalInspectionSequence.add(FinalInspection.class);
 
-        return defaultGroupSequence;
+            return finalInspectionSequence;
+        }
     }
 }


### PR DESCRIPTION
- HV component upgrade
- Fix for default group sequence provider used in tests
