### PR TITLE
[WFLY-6241] Setting of non-existing factory class to connector service can cause ActiveMQ crash

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -815,4 +815,8 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 86, value = "Unable to load module %s")
     OperationFailedException unableToLoadModule(String moduleName, @Cause ModuleLoadException cause);
+
+    @Message(id = 87, value = "Unable to load connector service factory class: %s")
+    OperationFailedException unableToLoadConnectorServiceFactoryClass(String factroyClass);
+
 }


### PR DESCRIPTION
Jira: https://issues.jboss.org/browse/WFLY-6241

Created new OperationHandlers to valid `factory-class` on both add and update operations.
