### PR TITLE
WFLY-5877 added extra permissions for some WS tests when running with…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,7 +197,7 @@
         <version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>1.0.4.Final</version.org.jboss.spec.javax.xml.bind.jboss-jaxb-api_2.2_spec>
         <version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>1.0.1.Final</version.org.jboss.spec.javax.xml.rpc.jboss-jaxrpc-api_1.1_spec>
         <version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>1.0.3.Final</version.org.jboss.spec.javax.xml.soap.jboss-saaj-api_1.3_spec>
-        <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.2.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
+        <version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>2.0.3.Final</version.org.jboss.spec.javax.xml.ws.jboss-jaxws-api_2.2_spec>
         <version.org.jboss.spec.javax.websockets>1.1.1.Final</version.org.jboss.spec.javax.websockets>
         <version.org.jboss.weld.weld>2.3.3.Final</version.org.jboss.weld.weld>
         <version.org.jboss.weld.weld-api>2.3.SP1</version.org.jboss.weld.weld-api>

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/basic/EJBEndpointTestCase.java
@@ -34,6 +34,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Before;
 import org.junit.runner.RunWith;
 
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
+
 /**
  *
  * @author <a href="mailto:rsvoboda@redhat.com">Rostislav Svoboda</a>
@@ -49,6 +51,8 @@ public class EJBEndpointTestCase extends BasicTests {
     public static Archive<?> deployment() {
         JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "jaxws-basic-ejb.jar")
                 .addClasses(EndpointIface.class, EJBEndpoint.class, HelloObject.class);
+        // EJBEndpoint#helloError needs getClassLoader permission for SOAPFactory.newInstance() invocation which is not supposed(??? at least it seems so) to be called from deployments
+        jar.addAsManifestResource(createPermissionsXmlAsset(new RuntimePermission("getClassLoader")), "permissions.xml");
         return jar;
     }
 

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefEarTestCase.java
@@ -22,9 +22,13 @@
 package org.jboss.as.test.integration.ws.serviceref;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FilePermission;
 import java.io.InputStreamReader;
+import java.net.SocketPermission;
 import java.net.URL;
 import java.util.Properties;
+import java.util.PropertyPermission;
 
 import org.junit.Assert;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -43,6 +47,8 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  * Tests for WS ServiceRef from servlet to verify access for <service-ref> in nested war
@@ -69,14 +75,26 @@ public class ServiceRefEarTestCase {
         String wsdl = FileUtils.readFile(ServiceRefEarTestCase.class, "TestService.wsdl");
         final Properties properties = new Properties();
         properties.putAll(System.getProperties());
+        final String node0 = NetworkUtils.formatPossibleIpv6Address((String)properties.get("node0"));
         if(properties.containsKey("node0")) {
-            properties.put("node0", NetworkUtils.formatPossibleIpv6Address((String) properties.get("node0")));
+            properties.put("node0", node0);
         }
         war.addAsWebInfResource(new StringAsset(PropertiesValueResolver.replaceProperties(wsdl, properties)), "wsdl/TestService.wsdl");
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "ws-serviceref-example.ear")
             .addAsModule(jar)
             .addAsModule(war);
+        // all the following permissions are needed because EndpointService directly extends javax.xml.ws.Service class
+        // and CXF guys are not willing to add more privileged blocks into their code, thus deployments need to have
+        // the following permissions (note that the wsdl.properties permission is needed by wsdl4j)
+        ear.addAsManifestResource(createPermissionsXmlAsset(
+                new FilePermission(System.getProperty("java.home") + File.separator + "lib" + File.separator + "wsdl.properties", "read"),
+                new PropertyPermission("user.dir", "read"),
+                new RuntimePermission("getClassLoader"),
+                new RuntimePermission("org.apache.cxf.permission", "resolveUri"),
+                new RuntimePermission("createClassLoader"),
+                new RuntimePermission("accessDeclaredMembers"),
+                new SocketPermission(node0 + ":8080", "connect,resolve")), "jboss-permissions.xml");
 
         return ear;
     }

--- a/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
+++ b/testsuite/integration/ws/src/test/java/org/jboss/as/test/integration/ws/serviceref/ServiceRefSevletTestCase.java
@@ -22,9 +22,13 @@
 package org.jboss.as.test.integration.ws.serviceref;
 
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FilePermission;
 import java.io.InputStreamReader;
+import java.net.SocketPermission;
 import java.net.URL;
 import java.util.Properties;
+import java.util.PropertyPermission;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
@@ -42,6 +46,8 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import static org.jboss.as.test.shared.integration.ejb.security.PermissionUtils.createPermissionsXmlAsset;
 
 /**
  *
@@ -71,10 +77,22 @@ public class ServiceRefSevletTestCase {
         String wsdl = FileUtils.readFile(ServiceRefSevletTestCase.class, "TestService.wsdl");
         final Properties properties = new Properties();
         properties.putAll(System.getProperties());
+        final String node0 = NetworkUtils.formatPossibleIpv6Address((String)properties.get("node0"));
         if(properties.containsKey("node0")) {
-            properties.put("node0", NetworkUtils.formatPossibleIpv6Address((String) properties.get("node0")));
+            properties.put("node0", node0);
         }
         war.addAsWebInfResource(new StringAsset(PropertiesValueResolver.replaceProperties(wsdl, properties)), "wsdl/TestService.wsdl");
+        // all the following permissions are needed because EndpointService directly extends javax.xml.ws.Service class
+        // and CXF guys are not willing to add more privileged blocks into their code, thus deployments need to have
+        // the following permissions (note that the wsdl.properties permission is needed by wsdl4j)
+        war.addAsManifestResource(createPermissionsXmlAsset(
+                new FilePermission(System.getProperty("java.home") + File.separator + "lib" + File.separator + "wsdl.properties", "read"),
+                new PropertyPermission("user.dir", "read"),
+                new RuntimePermission("getClassLoader"),
+                new RuntimePermission("org.apache.cxf.permission", "resolveUri"),
+                new RuntimePermission("createClassLoader"),
+                new RuntimePermission("accessDeclaredMembers"),
+                new SocketPermission(node0 + ":8080", "connect,resolve")), "jboss-permissions.xml");
         return war;
     }
 


### PR DESCRIPTION
… Security Manager enabled

Fixes for WS tests to be able to run with SM enabled. More details in jira.
https://issues.jboss.org/browse/WFLY-5877

Note: This will fail until JBEE-162 is merged.
