### PR TITLE
[WFLY-6178] Clean shutdown of Artemis backup server

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/JMSService.java
@@ -150,7 +150,10 @@ public class JMSService implements Service<JMSServerManager> {
                     // It is possible that the activation service has already been installed but becomes passive when a backup server has failed over (-> ACTIVE) and failed back (-> PASSIVE)
                     // [WFLY-6178] check if the service container is shutdown to avoid an IllegalStateException if an
                     //   ActiveMQ backup server is activated during failover while the WildFly server is shutting down.
-                    if (activeMQActivationController == null && !serviceContainer.isShutdown()) {
+                    if (serviceContainer.isShutdown()) {
+                        return;
+                    }
+                    if (activeMQActivationController == null) {
                         activeMQActivationController = serviceContainer.addService(ActiveMQActivationService.getServiceName(serverServiceName), new ActiveMQActivationService())
                                 .setInitialMode(Mode.ACTIVE)
                                 .install();


### PR DESCRIPTION
Check if the service container is shutdown to avoid an
IllegalStateException if an ActiveMQ backup server is activated during
failover (which happens independently of the JMSService lifecycle) while
the WildFly server is shutting down.

JIRA: https://issues.jboss.org/browse/WFLY-6178
