### PR TITLE
[WFLY-6288] Guard against IllegalStateException during transfer

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/HTTPUpgradeService.java
@@ -156,8 +156,12 @@ public class HTTPUpgradeService implements Service<HTTPUpgradeService> {
                 }
                 NettyAcceptor acceptor = (NettyAcceptor) remotingService.getAcceptor(acceptorName);
                 SocketChannel channel = new WrappingXnioSocketChannel(connection);
-                acceptor.transfer(channel);
-                connection.getSourceChannel().resumeReads();
+                try {
+                    acceptor.transfer(channel);
+                    connection.getSourceChannel().resumeReads();
+                } catch (IllegalStateException e) {
+                    IoUtils.safeClose(connection);
+                }
             }
         };
     }


### PR DESCRIPTION
When the channel is transferred to the Netty acceptor, catch any
IllegalStateException thrown by the method in case the acceptor has
become unavailable and close the connection.

JIRA: https://issues.jboss.org/browse/WFLY-6288

**This PR contains the same commit than #8681 that has not been merged yet** 
