### PR TITLE
[WFLY-6301] Add an optional module for classes loaded by ActiveMQ

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -65,5 +65,12 @@
         <module name="org.apache.activemq.artemis.protocol.amqp" services="import" optional="true"/>
         <module name="org.apache.activemq.artemis.protocol.hornetq" services="import" optional="true"/>
         <module name="org.apache.activemq.artemis.protocol.stomp" services="import" optional="true"/>
+
+        <!--
+          WFLY-6301 This module can be used to load user-created classes that are
+          used by Artemis resources (e.g. connector-service, transformers, etc.)
+        -->
+        <module name="org.apache.activemq.artemis.addons" slot="main" optional="true"/>
+
     </dependencies>
 </module>


### PR DESCRIPTION
Add an optional org.apache.activemq.artemis.addons module to the
org.apache.activemq.artemis module definition.

This module does not exist but it can be created by the user to
be able to load user-created classes required by Artemis configuration.
The org.apache.activemq.artemis module definition must no longer be
modified for such use cases and ensure that patching will work properly.

JIRA: https://issues.jboss.org/browse/WFLY-6301
