### PR TITLE
[WFLY-6303] RemotingLoginModuleTestCase fails with the latest IBM jdk

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/security/loginmodules/RemotingLoginModuleTestCase.java
@@ -415,7 +415,7 @@ public class RemotingLoginModuleTestCase {
             v3CertGen.setIssuerDN(dn);
             v3CertGen.setSubjectDN(dn);
             v3CertGen.setPublicKey(keyPair.getPublic());
-            v3CertGen.setSignatureAlgorithm("MD5withRSA");
+            v3CertGen.setSignatureAlgorithm("SHA256withRSA");
             final SecureRandom sr = new SecureRandom();
             v3CertGen.setSerialNumber(BigInteger.ONE);
             X509Certificate certificate = v3CertGen.generate(keyPair.getPrivate(), sr);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6303

ibm jdk 20160108_01(SR2 FP10)
