### PR TITLE
WFLY-6316 Deploying @Stateless EJB causes default ejb cache to start unnecessarily

### DIFF
--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessComponentCreateServiceFactory.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/stateless/StatelessComponentCreateServiceFactory.java
@@ -31,9 +31,6 @@ import org.jboss.as.ejb3.remote.EJBRemoteConnectorService;
 import org.jboss.as.ejb3.remote.RegistryInstallerService;
 import org.jboss.msc.service.ServiceBuilder;
 import org.jboss.msc.service.ServiceBuilder.DependencyType;
-import org.wildfly.clustering.ejb.BeanManagerFactoryBuilderConfiguration;
-import org.wildfly.clustering.group.Group;
-import org.wildfly.clustering.spi.CacheGroupServiceName;
 
 /**
  * User: jpai
@@ -49,7 +46,6 @@ public class StatelessComponentCreateServiceFactory extends EJBComponentCreateSe
             @Override
             public void configureDependency(ServiceBuilder<?> builder, StatelessSessionComponentCreateService service) {
                 builder.addDependency(DependencyType.OPTIONAL, RegistryInstallerService.SERVICE_NAME);
-                builder.addDependency(DependencyType.OPTIONAL, CacheGroupServiceName.GROUP.getServiceName(BeanManagerFactoryBuilderConfiguration.DEFAULT_CONTAINER_NAME), Group.class, service.getGroupInjector());
                 builder.addDependency(DependencyType.OPTIONAL, EJBRemoteConnectorService.SERVICE_NAME);
             }
         });


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6316
