### PR TITLE
 WFLY-6196 (Tests fails in manualmode with security manager)

### DIFF
--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/weld/extension/BeforeShutdownJNDILookupTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/weld/extension/BeforeShutdownJNDILookupTestCase.java
@@ -7,6 +7,7 @@ import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.shared.integration.ejb.security.PermissionUtils;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ArchivePaths;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -19,6 +20,7 @@ import org.junit.runner.RunWith;
 
 import javax.enterprise.inject.spi.Extension;
 import java.io.File;
+import java.io.FilePermission;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -51,7 +53,11 @@ public class BeforeShutdownJNDILookupTestCase {
                 .create(WebArchive.class, DEPLOYMENT)
                 .addClasses(BeforeShutdownJNDILookupTestCase.class, BeforeShutdownExtension.class)
                 .add(EmptyAsset.INSTANCE, ArchivePaths.create("WEB-INF/beans.xml"))
-                .add(new StringAsset(BeforeShutdownExtension.class.getName()), "META-INF/services/" + Extension.class.getName());
+                .add(new StringAsset(BeforeShutdownExtension.class.getName()), "META-INF/services/" + Extension.class.getName())
+                .addAsManifestResource(PermissionUtils.createPermissionsXmlAsset(
+                        new FilePermission(TEST_PATH.getParent().toString(), "read, write"),
+                        new FilePermission(TEST_PATH.toString(), "read, write, delete")
+                ), "permissions.xml");
     }
 
     @ArquillianResource


### PR DESCRIPTION
 WFLY-6196 (Tests fails in manualmode with security manager) 

Proper file permissions are now specified in test war manifest
