### PR TITLE
changed Hibernate ORM 4.1/4.3, EclipseLink, OpenJPA to be unsupported modules

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/openjpa/main/module.xml
@@ -25,7 +25,7 @@
 <!-- Represents the OpenJPA module  -->
 <module xmlns="urn:jboss:module:1.3" name="org.apache.openjpa">
     <properties>
-        <property name="jboss.api" value="private"/>
+        <property name="jboss.api" value="unsupported"/>
     </properties>
 
     <resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/persistence/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/eclipse/persistence/main/module.xml
@@ -25,7 +25,7 @@
 <!-- Represents the EclipseLink module  -->
 <module xmlns="urn:jboss:module:1.3" name="org.eclipse.persistence">
     <properties>
-        <property name="jboss.api" value="private"/>
+        <property name="jboss.api" value="unsupported"/>
     </properties>
 
     <resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.1/module.xml
@@ -24,6 +24,10 @@
 
 <!-- Represents the Hibernate 4.1.x (works with Hibernate 4.2.x jars also) module  -->
 <module xmlns="urn:jboss:module:1.3" name="org.hibernate" slot="4.1">
+    <properties>
+        <property name="jboss.api" value="unsupported"/>
+    </properties>
+
     <resources>
         <artifact name="${org.wildfly:jipijapa-hibernate4-1}"/>
     </resources>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/hibernate/4.3/module.xml
@@ -24,6 +24,10 @@
 
 <!-- Represents the Hibernate 4.3.x module  -->
 <module xmlns="urn:jboss:module:1.3" name="org.hibernate" slot="4.3">
+    <properties>
+        <property name="jboss.api" value="unsupported"/>
+    </properties>
+
    <resources>
     </resources>
 


### PR DESCRIPTION
I didn't create a jira for this as it doesn't seem like a bug fix.  More of a reclassification of the older Hibernate modules + EclipseLink/OpenJPA as unsupported modules, since they are not really private api modules.  
