### PR TITLE
[WFLY-6322] The 'unsupported' classification does not apply in WildFl…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
@@ -23,9 +23,6 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="io.undertow.js">
-    <properties>
-        <property name="jboss.api" value="unsupported"/>
-    </properties>
 
     <resources>
         <artifact name="${io.undertow.js:undertow-js}"/>


### PR DESCRIPTION
…y; only in EAP
