### PR TITLE
[WFLY-5588] DefaultContextServiceServletTestCase fails on IBM jdk

### DIFF
--- a/testsuite/integration/web/pom.xml
+++ b/testsuite/integration/web/pom.xml
@@ -94,4 +94,29 @@
             </plugin>
         </plugins>
     </build>
+    <!-- WFLY-5588 DefaultContextServiceServletTestCase fails on IBM jdk -->
+    <profiles>
+        <profile>
+            <id>ibmjdk.profile</id>
+            <activation>
+                <property>
+                    <name>java.vendor</name>
+                    <value>IBM Corporation</value>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <jboss.args>${jboss.args} -Dcom.ibm.enableClassCaching=false</jboss.args>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-5588 - DefaultContextServiceServletTestCase fails on IBM jdk

Test still fails with the latest ibm build 8.0-2.10. Adding a workarond -Dcom.ibm.enableClassCaching=false into the test servlet.

Supersedes https://github.com/wildfly/wildfly/pull/8669
