### PR TITLE
WFLY-6350 Configuration differences between default configuration and read/persisted in messaging and IIOP

### DIFF
--- a/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser.java
+++ b/iiop-openjdk/src/main/java/org/wildfly/iiop/openjdk/IIOPSubsystemParser.java
@@ -55,6 +55,7 @@ public class IIOPSubsystemParser implements XMLStreamConstants, XMLElementReader
 
     static {
         xmlDescription = builder(IIOPRootDefinition.INSTANCE)
+                .setMarshallDefaultValues(true)
                 .addAttributes(IIOPRootDefinition.ALL_ATTRIBUTES.toArray(new AttributeDefinition[0]))
                 .build();
     }

--- a/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0.xml
+++ b/iiop-openjdk/src/test/resources/org/wildfly/iiop/openjdk/subsystem-1.0.xml
@@ -1,8 +1,9 @@
 <subsystem xmlns="urn:jboss:domain:iiop-openjdk:1.0">
-   <properties>
+    <properties>
         <property name="some_property" value="some_value"/>
     </properties>
-   <orb persistent-server-id="wildfly" giop-version="1.1" socket-binding="iiop2" ssl-socket-binding="iiop-ssl2" />
+    <!-- test both values being default because there is a bug that nothing gets persisted -->
+    <orb socket-binding="iiop" ssl-socket-binding="iiop-ssl"/>
     <tcp high-water-mark="500" number-to-reclaim="30"/>
     <initializers security="client" transactions="spec"/>
     <naming root-context="JBoss/Naming/root2" export-corbaloc="false"/>

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/AddressSettingDefinition.java
@@ -172,10 +172,6 @@ public class AddressSettingDefinition extends PersistentResourceDefinition {
             .setAllowExpression(true)
             .build();
 
-
-    /**
-     * Attributes are defined in the <em>same order than in the XSD schema</em>
-     */
     static final AttributeDefinition[] ATTRIBUTES = new SimpleAttributeDefinition[] {
             DEAD_LETTER_ADDRESS,
             EXPIRY_ADDRESS,

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/MessagingSubsystemParser_1_0.java
@@ -261,41 +261,43 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                                 .addChild(
                                                         builder(SecurityRoleDefinition.INSTANCE)
                                                                 .addAttributes(
-                                                                        SecurityRoleDefinition.SEND,
-                                                                        SecurityRoleDefinition.CONSUME,
-                                                                        SecurityRoleDefinition.CREATE_DURABLE_QUEUE,
-                                                                        SecurityRoleDefinition.DELETE_DURABLE_QUEUE,
-                                                                        SecurityRoleDefinition.CREATE_NON_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.MANAGE,
                                                                         SecurityRoleDefinition.DELETE_NON_DURABLE_QUEUE,
-                                                                        SecurityRoleDefinition.MANAGE)))
+                                                                        SecurityRoleDefinition.CREATE_NON_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.DELETE_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.CREATE_DURABLE_QUEUE,
+                                                                        SecurityRoleDefinition.CONSUME,
+                                                                        SecurityRoleDefinition.SEND
+                                                                )))
                                 .addChild(
                                         builder(AddressSettingDefinition.INSTANCE)
                                                 .addAttributes(
-                                                        CommonAttributes.DEAD_LETTER_ADDRESS,
-                                                        CommonAttributes.EXPIRY_ADDRESS,
-                                                        AddressSettingDefinition.EXPIRY_DELAY,
-                                                        AddressSettingDefinition.REDELIVERY_DELAY,
-                                                        AddressSettingDefinition.REDELIVERY_MULTIPLIER,
-                                                        AddressSettingDefinition.MAX_DELIVERY_ATTEMPTS,
-                                                        AddressSettingDefinition.MAX_REDELIVERY_DELAY,
-                                                        AddressSettingDefinition.MAX_SIZE_BYTES,
-                                                        AddressSettingDefinition.PAGE_SIZE_BYTES,
-                                                        AddressSettingDefinition.PAGE_MAX_CACHE_SIZE,
-                                                        AddressSettingDefinition.ADDRESS_FULL_MESSAGE_POLICY,
-                                                        AddressSettingDefinition.MESSAGE_COUNTER_HISTORY_DAY_LIMIT,
-                                                        AddressSettingDefinition.LAST_VALUE_QUEUE,
-                                                        AddressSettingDefinition.REDISTRIBUTION_DELAY,
-                                                        AddressSettingDefinition.SEND_TO_DLA_ON_NO_ROUTE,
-                                                        AddressSettingDefinition.SLOW_CONSUMER_CHECK_PERIOD,
-                                                        AddressSettingDefinition.SLOW_CONSUMER_POLICY,
-                                                        AddressSettingDefinition.SLOW_CONSUMER_THRESHOLD,
+                                                        AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES,
                                                         AddressSettingDefinition.AUTO_CREATE_JMS_QUEUES,
-                                                        AddressSettingDefinition.AUTO_DELETE_JMS_QUEUES))
+                                                        AddressSettingDefinition.SLOW_CONSUMER_THRESHOLD,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_POLICY,
+                                                        AddressSettingDefinition.SLOW_CONSUMER_CHECK_PERIOD,
+                                                        AddressSettingDefinition.SEND_TO_DLA_ON_NO_ROUTE,
+                                                        AddressSettingDefinition.REDISTRIBUTION_DELAY,
+                                                        AddressSettingDefinition.LAST_VALUE_QUEUE,
+                                                        AddressSettingDefinition.MESSAGE_COUNTER_HISTORY_DAY_LIMIT,
+                                                        AddressSettingDefinition.ADDRESS_FULL_MESSAGE_POLICY,
+                                                        AddressSettingDefinition.PAGE_MAX_CACHE_SIZE,
+                                                        AddressSettingDefinition.PAGE_SIZE_BYTES,
+                                                        AddressSettingDefinition.MAX_SIZE_BYTES,
+                                                        AddressSettingDefinition.MAX_REDELIVERY_DELAY,
+                                                        AddressSettingDefinition.MAX_DELIVERY_ATTEMPTS,
+                                                        AddressSettingDefinition.REDELIVERY_MULTIPLIER,
+                                                        AddressSettingDefinition.REDELIVERY_DELAY,
+                                                        AddressSettingDefinition.EXPIRY_DELAY,
+                                                        CommonAttributes.EXPIRY_ADDRESS,
+                                                        CommonAttributes.DEAD_LETTER_ADDRESS
+                                                ))
                                 .addChild(
                                         builder(HTTPConnectorDefinition.INSTANCE)
                                                 .addAttributes(
-                                                        HTTPConnectorDefinition.SOCKET_BINDING,
                                                         HTTPConnectorDefinition.ENDPOINT,
+                                                        HTTPConnectorDefinition.SOCKET_BINDING,
                                                         CommonAttributes.PARAMS))
                                 .addChild(
                                         builder(RemoteTransportDefinition.CONNECTOR_INSTANCE)
@@ -354,27 +356,28 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                 .addChild(
                                         builder(ClusterConnectionDefinition.INSTANCE)
                                                 .addAttributes(
-                                                        ClusterConnectionDefinition.ADDRESS,
-                                                        ClusterConnectionDefinition.CONNECTOR_NAME,
-                                                        ClusterConnectionDefinition.CHECK_PERIOD,
-                                                        ClusterConnectionDefinition.CONNECTION_TTL,
-                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
-                                                        CommonAttributes.CALL_TIMEOUT,
-                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
-                                                        ClusterConnectionDefinition.RETRY_INTERVAL,
-                                                        ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER,
-                                                        ClusterConnectionDefinition.MAX_RETRY_INTERVAL,
+                                                        ClusterConnectionDefinition.DISCOVERY_GROUP_NAME,
+                                                        ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
+                                                        ClusterConnectionDefinition.CONNECTOR_REFS,
+                                                        ClusterConnectionDefinition.NOTIFICATION_INTERVAL,
+                                                        ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS,
+                                                        CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE,
+                                                        ClusterConnectionDefinition.MAX_HOPS,
+                                                        ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE,
+                                                        ClusterConnectionDefinition.USE_DUPLICATE_DETECTION,
                                                         ClusterConnectionDefinition.INITIAL_CONNECT_ATTEMPTS,
                                                         ClusterConnectionDefinition.RECONNECT_ATTEMPTS,
-                                                        ClusterConnectionDefinition.USE_DUPLICATE_DETECTION,
-                                                        ClusterConnectionDefinition.MESSAGE_LOAD_BALANCING_TYPE,
-                                                        ClusterConnectionDefinition.MAX_HOPS,
-                                                        CommonAttributes.BRIDGE_CONFIRMATION_WINDOW_SIZE,
-                                                        ClusterConnectionDefinition.NOTIFICATION_ATTEMPTS,
-                                                        ClusterConnectionDefinition.NOTIFICATION_INTERVAL,
-                                                        ClusterConnectionDefinition.CONNECTOR_REFS,
-                                                        ClusterConnectionDefinition.ALLOW_DIRECT_CONNECTIONS_ONLY,
-                                                        ClusterConnectionDefinition.DISCOVERY_GROUP_NAME))
+                                                        ClusterConnectionDefinition.MAX_RETRY_INTERVAL,
+                                                        ClusterConnectionDefinition.RETRY_INTERVAL_MULTIPLIER,
+                                                        ClusterConnectionDefinition.RETRY_INTERVAL,
+                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        ClusterConnectionDefinition.CONNECTION_TTL,
+                                                        ClusterConnectionDefinition.CHECK_PERIOD,
+                                                        ClusterConnectionDefinition.CONNECTOR_NAME,
+                                                        ClusterConnectionDefinition.ADDRESS
+                                                        ))
                                 .addChild(
                                         builder(GroupingHandlerDefinition.INSTANCE)
                                                 .addAttributes(
@@ -435,44 +438,46 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                 .addChild(
                                         builder(ConnectionFactoryDefinition.INSTANCE)
                                                 .addAttributes(
+                                                        // regular
+                                                        ConnectionFactoryAttributes.Regular.FACTORY_TYPE,
                                                         // common
-                                                        ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
-                                                        ConnectionFactoryAttributes.Common.CONNECTORS,
-                                                        ConnectionFactoryAttributes.Common.ENTRIES,
-                                                        CommonAttributes.HA,
-                                                        ConnectionFactoryAttributes.Common.CLIENT_FAILURE_CHECK_PERIOD,
-                                                        ConnectionFactoryAttributes.Common.CONNECTION_TTL,
-                                                        CommonAttributes.CALL_TIMEOUT,
-                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
-                                                        ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE,
-                                                        ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE,
-                                                        ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE,
-                                                        ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE,
-                                                        ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE,
-                                                        ConnectionFactoryAttributes.Common.PROTOCOL_MANAGER_FACTORY,
-                                                        ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES,
-                                                        ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT,
-                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
-                                                        CommonAttributes.CLIENT_ID,
-                                                        ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE,
-                                                        ConnectionFactoryAttributes.Common.TRANSACTION_BATCH_SIZE,
-                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE,
+                                                        ConnectionFactoryAttributes.Common.GROUP_ID,
+                                                        ConnectionFactoryAttributes.Common.THREAD_POOL_MAX_SIZE,
+                                                        ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE,
+                                                        ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS,
+                                                        ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME,
+                                                        ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION,
+                                                        ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS,
+                                                        CommonAttributes.MAX_RETRY_INTERVAL,
+                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL_MULTIPLIER,
+                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL,
+                                                        ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE,
+                                                        ConnectionFactoryAttributes.Common.AUTO_GROUP,
                                                         ConnectionFactoryAttributes.Common.BLOCK_ON_DURABLE_SEND,
                                                         ConnectionFactoryAttributes.Common.BLOCK_ON_NON_DURABLE_SEND,
-                                                        ConnectionFactoryAttributes.Common.AUTO_GROUP,
-                                                        ConnectionFactoryAttributes.Common.PRE_ACKNOWLEDGE,
-                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL,
-                                                        ConnectionFactoryAttributes.Common.RETRY_INTERVAL_MULTIPLIER,
-                                                        CommonAttributes.MAX_RETRY_INTERVAL,
-                                                        ConnectionFactoryAttributes.Common.RECONNECT_ATTEMPTS,
-                                                        ConnectionFactoryAttributes.Common.FAILOVER_ON_INITIAL_CONNECTION,
-                                                        ConnectionFactoryAttributes.Common.CONNECTION_LOAD_BALANCING_CLASS_NAME,
-                                                        ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS,
-                                                        ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE,
-                                                        ConnectionFactoryAttributes.Common.THREAD_POOL_MAX_SIZE,
-                                                        ConnectionFactoryAttributes.Common.GROUP_ID,
+                                                        ConnectionFactoryAttributes.Common.BLOCK_ON_ACKNOWLEDGE,
+                                                        ConnectionFactoryAttributes.Common.TRANSACTION_BATCH_SIZE,
+                                                        ConnectionFactoryAttributes.Common.DUPS_OK_BATCH_SIZE,
+                                                        CommonAttributes.CLIENT_ID,
+                                                        CommonAttributes.MIN_LARGE_MESSAGE_SIZE,
+                                                        ConnectionFactoryAttributes.Common.CACHE_LARGE_MESSAGE_CLIENT,
+                                                        ConnectionFactoryAttributes.Common.COMPRESS_LARGE_MESSAGES,
+                                                        ConnectionFactoryAttributes.Common.PROTOCOL_MANAGER_FACTORY,
+                                                        ConnectionFactoryAttributes.Common.PRODUCER_MAX_RATE,
+                                                        ConnectionFactoryAttributes.Common.PRODUCER_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.CONFIRMATION_WINDOW_SIZE,
+                                                        ConnectionFactoryAttributes.Common.CONSUMER_MAX_RATE,
+                                                        ConnectionFactoryAttributes.Common.CONSUMER_WINDOW_SIZE,
+                                                        CommonAttributes.CALL_FAILOVER_TIMEOUT,
+                                                        CommonAttributes.CALL_TIMEOUT,
+                                                        ConnectionFactoryAttributes.Common.CONNECTION_TTL,
+                                                        ConnectionFactoryAttributes.Common.CLIENT_FAILURE_CHECK_PERIOD,
+                                                        CommonAttributes.HA,
+                                                        ConnectionFactoryAttributes.Common.CONNECTORS,
+                                                        ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
                                                         // regular
-                                                        ConnectionFactoryAttributes.Regular.FACTORY_TYPE))
+                                                        ConnectionFactoryAttributes.Common.ENTRIES
+                                                        ))
                                 .addChild(
                                         builder(LegacyConnectionFactoryDefinition.INSTANCE)
                                                 .addAttributes(
@@ -517,6 +522,22 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                 .addChild(
                                         builder(PooledConnectionFactoryDefinition.INSTANCE)
                                                 .addAttributes(
+                                                        // pooled
+                                                        ConnectionFactoryAttributes.Pooled.USE_JNDI,
+                                                        ConnectionFactoryAttributes.Pooled.JNDI_PARAMS,
+                                                        ConnectionFactoryAttributes.Pooled.USE_LOCAL_TX,
+                                                        ConnectionFactoryAttributes.Pooled.SETUP_ATTEMPTS,
+                                                        ConnectionFactoryAttributes.Pooled.SETUP_INTERVAL,
+                                                        ConnectionFactoryAttributes.Pooled.TRANSACTION,
+                                                        ConnectionFactoryAttributes.Pooled.USER,
+                                                        ConnectionFactoryAttributes.Pooled.PASSWORD,
+                                                        ConnectionFactoryAttributes.Pooled.MIN_POOL_SIZE,
+                                                        ConnectionFactoryAttributes.Pooled.MAX_POOL_SIZE,
+                                                        ConnectionFactoryAttributes.Pooled.MANAGED_CONNECTION_POOL,
+                                                        ConnectionFactoryAttributes.Pooled.ENLISTMENT_TRACE,
+                                                        ConnectionFactoryAttributes.Pooled.USE_AUTO_RECOVERY,
+                                                        ConnectionFactoryAttributes.Pooled.INITIAL_MESSAGE_PACKET_SIZE,
+                                                        ConnectionFactoryAttributes.Pooled.INITIAL_CONNECT_ATTEMPTS,
                                                         // common
                                                         ConnectionFactoryAttributes.Common.DISCOVERY_GROUP,
                                                         ConnectionFactoryAttributes.Common.CONNECTORS,
@@ -552,23 +573,8 @@ public class MessagingSubsystemParser_1_0 implements XMLStreamConstants, XMLElem
                                                         ConnectionFactoryAttributes.Common.USE_GLOBAL_POOLS,
                                                         ConnectionFactoryAttributes.Common.SCHEDULED_THREAD_POOL_MAX_SIZE,
                                                         ConnectionFactoryAttributes.Common.THREAD_POOL_MAX_SIZE,
-                                                        ConnectionFactoryAttributes.Common.GROUP_ID,
-                                                        // pooled
-                                                        ConnectionFactoryAttributes.Pooled.USE_JNDI,
-                                                        ConnectionFactoryAttributes.Pooled.JNDI_PARAMS,
-                                                        ConnectionFactoryAttributes.Pooled.USE_LOCAL_TX,
-                                                        ConnectionFactoryAttributes.Pooled.SETUP_ATTEMPTS,
-                                                        ConnectionFactoryAttributes.Pooled.SETUP_INTERVAL,
-                                                        ConnectionFactoryAttributes.Pooled.TRANSACTION,
-                                                        ConnectionFactoryAttributes.Pooled.USER,
-                                                        ConnectionFactoryAttributes.Pooled.PASSWORD,
-                                                        ConnectionFactoryAttributes.Pooled.MIN_POOL_SIZE,
-                                                        ConnectionFactoryAttributes.Pooled.MAX_POOL_SIZE,
-                                                        ConnectionFactoryAttributes.Pooled.MANAGED_CONNECTION_POOL,
-                                                        ConnectionFactoryAttributes.Pooled.ENLISTMENT_TRACE,
-                                                        ConnectionFactoryAttributes.Pooled.USE_AUTO_RECOVERY,
-                                                        ConnectionFactoryAttributes.Pooled.INITIAL_MESSAGE_PACKET_SIZE,
-                                                        ConnectionFactoryAttributes.Pooled.INITIAL_CONNECT_ATTEMPTS)))
+                                                        ConnectionFactoryAttributes.Common.GROUP_ID
+                                                )))
                 .addChild(
                         builder(JMSBridgeDefinition.INSTANCE)
                                 .addAttributes(

--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/jms/ConnectionFactoryAttributes.java
@@ -247,9 +247,6 @@ public interface ConnectionFactoryAttributes {
                 .setAllowExpression(true)
                 .build();
 
-        /**
-         * Attributes are defined in the <em>same order than in the XSD schema</em>
-         */
         ConnectionFactoryAttribute[] ATTRIBUTES = {
                 create(DISCOVERY_GROUP, null, false),
                 create(CONNECTORS, null, false),
@@ -428,9 +425,6 @@ public interface ConnectionFactoryAttributes {
                 .addAccessConstraint(MESSAGING_SECURITY_SENSITIVE_TARGET)
                 .build();
 
-        /**
-         * Attributes are defined in the <em>same order than in the XSD schema</em>
-         */
         ConnectionFactoryAttribute[] ATTRIBUTES = {
                 /* inbound config */
                 create(USE_JNDI, USE_JNDI_PROP_NAME, true, true),

--- a/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
+++ b/messaging-activemq/src/main/resources/schema/wildfly-messaging-activemq_1_0.xsd
@@ -377,6 +377,7 @@
                     <xs:attribute name="retry-interval-multiplier" type="xs:double" use="optional" />
                     <xs:attribute name="max-retry-interval" type="xs:long" use="optional" />
                     <xs:attribute name="reconnect-attempts" type="xs:int" use="optional" />
+                    <xs:attribute name="initial-reconnect-attempts" type="xs:int" use="optional" />
                     <xs:attribute name="use-duplicate-detection" type="xs:boolean" use="optional" />
                     <xs:attribute name="message-load-balancing-type" use="optional">
                         <xs:simpleType>

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq.xml
@@ -50,13 +50,13 @@
                        entries="java:/jms/queue/DLQ" />
 
             <connection-factory name="InVmConnectionFactory"
-                                connectors="in-vm"
-                                entries="java:/ConnectionFactory" />
+                                entries="java:/ConnectionFactory"
+                                connectors="in-vm"/>
             <?REMOTE-CONNECTION-FACTORY?>
             <pooled-connection-factory name="activemq-ra"
-                                       transaction="xa"
+                                       entries="java:/JmsXA java:jboss/DefaultJMSConnectionFactory"
                                        connectors="in-vm"
-                                       entries="java:/JmsXA java:jboss/DefaultJMSConnectionFactory"/>
+                                       transaction="xa"/>
         </server>
     </subsystem>
     <supplement name="default">
@@ -70,8 +70,8 @@
         </replacement>
         <replacement placeholder="REMOTE-CONNECTION-FACTORY">
             <connection-factory name="RemoteConnectionFactory"
-                                connectors="http-connector"
-                                entries="java:jboss/exported/jms/RemoteConnectionFactory" />
+                                entries="java:jboss/exported/jms/RemoteConnectionFactory"
+                                connectors="http-connector"/>
         </replacement>
     </supplement>
     <supplement name="ha">
@@ -104,11 +104,11 @@
         </replacement>
         <replacement placeholder="REMOTE-CONNECTION-FACTORY">
             <connection-factory name="RemoteConnectionFactory"
+                                entries="java:jboss/exported/jms/RemoteConnectionFactory"
+                                connectors="http-connector"
                                 ha="true"
                                 block-on-acknowledge="true"
-                                reconnect-attempts="-1"
-                                connectors="http-connector"
-                                entries="java:jboss/exported/jms/RemoteConnectionFactory" />
+                                reconnect-attempts="-1"/>
         </replacement>
     </supplement>
 </config>


### PR DESCRIPTION
…ersisted in messaging-artemis subsystem

Jira
https://issues.jboss.org/browse/WFLY-6350

The IIOP part of this issue is blocked by wildfly-core bug https://issues.jboss.org/browse/WFCORE-1432. Tests has been changed to cover this bug and will fail until WF core upgrade. The first commit is mergeable without the second one; they are independent.
