### PR TITLE
[WFLY-6364] Adding testcase where UserTransaction commits twice for db connection

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist/ATM.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist/ATM.java
@@ -32,6 +32,10 @@ public interface ATM {
 
     double getBalance(long id);
 
+    double depositTwice(long id, double a1, double a2);
+
+    double depositTwiceRawSQL(long id, double a1, double a2);
+
     double depositTwiceWithRollback(long id, double a1, double a2);
 
     double withdrawTwiceWithRollback(long id, double a1, double a2);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist/LazyTransactionEnlistmentUnitTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist/LazyTransactionEnlistmentUnitTestCase.java
@@ -21,7 +21,10 @@
  */
 package org.jboss.as.test.integration.ejb.transaction.bmt.lazyenlist;
 
+import java.text.MessageFormat;
+
 import javax.naming.InitialContext;
+import javax.naming.NamingException;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
@@ -55,8 +58,42 @@ public class LazyTransactionEnlistmentUnitTestCase {
     }
 
     @Test
-    public void test() throws Exception {
-        ATM atm = (ATM) ctx.lookup("ejb:/tx-lazy-enlist/" + ATMBean.class.getSimpleName() + "!" + ATM.class.getName());
+    public void testDepositTwice() throws Exception {
+        ATM atm = getAtm();
+        double deposit = 64, increase1 = 128, increase2 = 256;
+        long id = atm.createAccount(deposit);
+        double baseBalance = atm.getBalance(id);
+        Assert.assertEquals("Account should be created with input deposit",
+                deposit, baseBalance, Double.NaN);
+
+        double balanceOnDeposit = atm.depositTwice(id, increase1, increase2);
+        Assert.assertEquals("Deposit should be increased twice by " + increase1 + " and " + increase2,
+                deposit + increase1 + increase2, balanceOnDeposit, Double.NaN);
+        double balanceAfterDeposit = atm.getBalance(id);
+        Assert.assertEquals("Balance got from ATM should be equal to base deposit plus two increased deposit amounts",
+                deposit + increase1 + increase2, balanceAfterDeposit, Double.NaN);
+    }
+
+    @Test
+    public void testDepositTwiceRawSQL() throws Exception {
+        ATM atm = getAtm();
+        double deposit = 64, increase1 = 128, increase2 = 256;
+        long id = atm.createAccount(deposit);
+        double baseBalance = atm.getBalance(id);
+        Assert.assertEquals("Account should be created with input deposit",
+                deposit, baseBalance, Double.NaN);
+
+        double balanceOnDeposit = atm.depositTwiceRawSQL(id, increase1, increase2);
+        Assert.assertEquals("Deposit should be increased twice by " + increase1 + " and " + increase2,
+                deposit + increase1 + increase2, balanceOnDeposit, Double.NaN);
+        double balanceAfterDeposit = atm.getBalance(id);
+        Assert.assertEquals("Balance got from ATM should be equal to base deposit plus two increased deposit amounts",
+                deposit + increase1 + increase2, balanceAfterDeposit, Double.NaN);
+    }
+
+    @Test
+    public void testDepositeTwiceWithRollback() throws Exception {
+        ATM atm = getAtm();
         // if only
         long id = atm.createAccount(1000000);
         double balance = atm.getBalance(id);
@@ -71,7 +108,7 @@ public class LazyTransactionEnlistmentUnitTestCase {
 
     @Test
     public void testRawSQL() throws Exception {
-        ATM atm = (ATM) ctx.lookup("ejb:/tx-lazy-enlist/" + ATMBean.class.getSimpleName() + "!" + ATM.class.getName());
+        ATM atm = getAtm();
         // if only
         long id = atm.createAccount(1000000);
         double balance = atm.getBalance(id);
@@ -80,5 +117,9 @@ public class LazyTransactionEnlistmentUnitTestCase {
         balance = atm.withdrawTwiceWithRollback(id, 125000, 250000);
         balance = atm.getBalance(id);
         Assert.assertEquals(875000, balance, Double.NaN);
+    }
+
+    private ATM getAtm() throws NamingException {
+        return (ATM) ctx.lookup(MessageFormat.format("ejb:/tx-lazy-enlist/{0}!{1}", ATMBean.class.getSimpleName(), ATM.class.getName()));
     }
 }

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist/persistence.xml
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/bmt/lazyenlist/persistence.xml
@@ -8,7 +8,6 @@
       <jta-data-source>java:jboss/datasources/ExampleDS</jta-data-source>
       <properties>
           <property name="hibernate.hbm2ddl.auto" value="create"/>
-          <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
       </properties>
    </persistence-unit>
 </persistence>


### PR DESCRIPTION
Proposing a test case where `UserTransaction` is used in BMT twice for an unclosed connection.
