### PR TITLE
[WFLY-6302] Upgrade Artemis 1.1.0.wildfly-014

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
         <version.jsoup>1.8.3</version.jsoup>
         <version.net.jcip>1.0</version.net.jcip>
         <version.net.shibboleth.utilities.java-support>7.1.1</version.net.shibboleth.utilities.java-support>
-        <version.org.apache.activemq.artemis>1.1.0.wildfly-013</version.org.apache.activemq.artemis>
+        <version.org.apache.activemq.artemis>1.1.0.wildfly-014</version.org.apache.activemq.artemis>
         <version.org.apache.avro>1.7.6</version.org.apache.avro>
         <version.org.apache.cxf>3.1.4</version.org.apache.cxf>
         <version.org.apache.cxf.xjcplugins>3.0.5</version.org.apache.cxf.xjcplugins>


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-6302

For reference, the diff between Artemis 1.1.0.wildfly-013 and 1.1.0.wildfly-014: https://github.com/rh-messaging/jboss-activemq-artemis/compare/1.1.0.wildfly-013...1.1.0.wildfly-014

This PR also contains a fix for WFLY-6288 that was requiring the component upgrade.

> [WFLY-6288] Guard against IllegalStateException during transfer
> 
> Check if ActiveMQ remotingService is started and not paused before
> transferring the channel to its acceptor.
> The remotingService may be paused if ActiveMQ is shutting down (e.g.
> during failover) while the client performs the HTTP upgrade handshake.
> 
> JIRA: https://issues.jboss.org/browse/WFLY-6288
