### PR TITLE
[WFLY-4882] Assign AllPermission to the maximum set only when it is u…

### DIFF
--- a/security-manager/src/main/java/org/wildfly/extension/security/manager/DeploymentPermissionsResourceDefinition.java
+++ b/security-manager/src/main/java/org/wildfly/extension/security/manager/DeploymentPermissionsResourceDefinition.java
@@ -44,6 +44,7 @@ import org.jboss.as.controller.ReloadRequiredRemoveStepHandler;
 import org.jboss.as.controller.SimpleAttributeDefinition;
 import org.jboss.as.controller.SimpleAttributeDefinitionBuilder;
 import org.jboss.as.controller.registry.AttributeAccess;
+import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 
 /**
@@ -79,9 +80,16 @@ class DeploymentPermissionsResourceDefinition extends PersistentResourceDefiniti
     private static final ObjectTypeAttributeDefinition PERMISSIONS_VALUE_TYPE =
             ObjectTypeAttributeDefinition.Builder.of(PERMISSION, CLASS, NAME, ACTIONS, MODULE).build();
 
+    private static final ModelNode DEFAULT_MAXIMUM_SET;
+    static {
+        DEFAULT_MAXIMUM_SET = new ModelNode();
+        DEFAULT_MAXIMUM_SET.add(new ModelNode().set(PERMISSION_CLASS, "java.security.AllPermission"));
+    };
+
     static final AttributeDefinition MAXIMUM_PERMISSIONS =
             ObjectListAttributeDefinition.Builder.of(Constants.MAXIMUM_PERMISSIONS, PERMISSIONS_VALUE_TYPE)
                     .setAllowNull(true)
+                    .setDefaultValue(DEFAULT_MAXIMUM_SET)
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setXmlName(MAXIMUM_SET)
                     .build();
@@ -89,6 +97,7 @@ class DeploymentPermissionsResourceDefinition extends PersistentResourceDefiniti
     static final AttributeDefinition MINIMUM_PERMISSIONS =
             ObjectListAttributeDefinition.Builder.of(Constants.MINIMUM_PERMISSIONS, PERMISSIONS_VALUE_TYPE)
                     .setAllowNull(true)
+                    .setDefaultValue(new ModelNode().setEmptyList())
                     .setFlags(AttributeAccess.Flag.RESTART_ALL_SERVICES)
                     .setXmlName(MINIMUM_SET)
                     .build();


### PR DESCRIPTION
…ndefined.

We need to differentiate empty and undefined maximum permission sets. The undefined set leads to AllPermission being used as a default value whereas an empty set is meant to be used when there is a need to reject any deployment with declared permissions.

This  commit requires a WF-core release/upgrade that includes https://github.com/wildfly/wildfly-core/pull/1463

Link to the upstream Jira:
https://issues.jboss.org/browse/WFLY-4882

Link to the WildFly Core PR that complements this PR:
https://github.com/wildfly/wildfly-core/pull/1463
