### PR TITLE
[WFLY-6409]:  Update default domain configuration to use http-remoting

### DIFF
--- a/feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -56,9 +56,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true" />
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>

--- a/feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -57,16 +57,17 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
         </management-interfaces>
     </management>
 
     <domain-controller>
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
+                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote+http}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}"/>
             </discovery-options>
         </remote>
     </domain-controller>

--- a/feature-pack/src/main/resources/configuration/host/host.xml
+++ b/feature-pack/src/main/resources/configuration/host/host.xml
@@ -52,9 +52,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true" />
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>
@@ -65,7 +62,7 @@
     <domain-controller>
         <local/>
         <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote protocol="remote" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+        <!-- <remote protocol="remote+http" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
+++ b/jdr/jboss-as-jdr/src/main/java/org/jboss/as/jdr/CommandLineMain.java
@@ -71,7 +71,7 @@ public class CommandLineMain {
     public static void main(String[] args) {
         int port = 9990;
         String host = "localhost";
-        String protocol = "http-remoting";
+        String protocol = "remote+http";
         String config = null;
         try {
             CommandLine line = parser.parse(options, args, false);

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-master.xml
@@ -55,9 +55,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true" />
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host-slave.xml
@@ -56,16 +56,17 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
+            <http-interface security-realm="ManagementRealm">
+                <http-upgrade enabled="true" />
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
+            </http-interface>
         </management-interfaces>
     </management>
 
     <domain-controller>
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}"/>
+                <static-discovery name="primary" protocol="${jboss.domain.master.protocol:remote+http}" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}"/>
             </discovery-options>
         </remote>
     </domain-controller>

--- a/servlet-feature-pack/src/main/resources/configuration/host/host.xml
+++ b/servlet-feature-pack/src/main/resources/configuration/host/host.xml
@@ -51,9 +51,6 @@
             </server-logger>
         </audit-log>
         <management-interfaces>
-            <native-interface security-realm="ManagementRealm">
-                <socket interface="management" port="${jboss.management.native.port:9999}"/>
-            </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true" />
                 <socket interface="management" port="${jboss.management.http.port:9990}"/>
@@ -64,7 +61,7 @@
     <domain-controller>
         <local/>
         <!-- Alternative remote domain controller configuration with a host and port -->
-        <!-- <remote protocol="remote" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9999}" security-realm="ManagementRealm"/> -->
+        <!-- <remote protocol="remote+http" host="${jboss.domain.master.address}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm"/> -->
     </domain-controller>
 
     <interfaces>

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/BuildConfigurationTestBase.java
@@ -22,14 +22,11 @@
 
 package org.jboss.as.test.integration.domain;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.Closeable;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,7 +46,7 @@ public abstract class BuildConfigurationTestBase {
     static final File CONFIG_DIR = new File("target/jbossas/domain/configuration/");
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName, final String testConfiguration) {
-        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, "master", masterAddress, 9999);
+        return createConfiguration(domainXmlName, hostXmlName, testConfiguration, "master", masterAddress, 9990);
     }
 
     static WildFlyManagedConfiguration createConfiguration(final String domainXmlName, final String hostXmlName,
@@ -59,8 +56,9 @@ public abstract class BuildConfigurationTestBase {
 
         configuration.setHostControllerManagementAddress(hostAddress);
         configuration.setHostControllerManagementPort(hostPort);
+        configuration.setHostControllerManagementProtocol("remote+http");
         configuration.setHostCommandLineProperties("-Djboss.domain.master.address=" + masterAddress +
-                " -Djboss.management.native.port=" + hostPort);
+                " -Djboss.management.http.port=" + hostPort);
         configuration.setDomainConfigFile(hackFixDomainConfig(new File(CONFIG_DIR, domainXmlName)).getAbsolutePath());
         configuration.setHostConfigFile(hackFixHostConfig(new File(CONFIG_DIR, hostXmlName), hostName, hostAddress).getAbsolutePath());
 
@@ -76,108 +74,85 @@ public abstract class BuildConfigurationTestBase {
 
     private static File hackFixHostConfig(File hostConfigFile, String hostName, String hostAddress) {
         final File file;
-        final BufferedWriter writer;
         try {
             file = File.createTempFile("host", ".xml", hostConfigFile.getAbsoluteFile().getParentFile());
             file.deleteOnExit();
-            writer = new BufferedWriter(new FileWriter(file));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+        List<String> newLines = new ArrayList<>();
         try {
-            BufferedReader reader = new BufferedReader(new FileReader(hostConfigFile));
-            try {
-                String line = reader.readLine();
-                while (line != null) {
-                    int start = line.indexOf("<host");
-                    if (start >= 0 && !line.contains(" name=")) {
+            for (String line : Files.readAllLines(hostConfigFile.toPath())) {
+                System.out.println("Current line: " + line);
+                int start = line.indexOf("<host");
+                if (start >= 0 && !line.contains(" name=")) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("<host name=\"");
+                    sb.append(hostName);
+                    sb.append('"');
+                    sb.append(line.substring(start + 5));
+                    addLine(newLines, sb.toString());
+                } else {
+                    start = line.indexOf("<inet-address value=\"");
+                    if (start >= 0) {
                         StringBuilder sb = new StringBuilder();
-                        sb.append("<host name=\"");
-                        sb.append(hostName);
-                        sb.append('"');
-                        sb.append(line.substring(start + 5));
-                        writer.write(sb.toString());
-                    } else {
-                        start = line.indexOf("<inet-address value=\"");
-                        if (start >= 0) {
-                            StringBuilder sb = new StringBuilder();
-                            sb.append(line.substring(0, start))
+                        sb.append(line.substring(0, start))
                                 .append("<inet-address value=\"")
                                 .append(hostAddress)
                                 .append("\"/>");
-                            writer.write(sb.toString());
-                        } else {
-                            start = line.indexOf("<option value=\"");
-                            if (start >= 0) {
-                                StringBuilder sb = new StringBuilder();
-                                sb.append(line.substring(0, start));
-                                List<String> opts = new ArrayList<String>();
-                                TestSuiteEnvironment.getIpv6Args(opts);
-                                for (String opt : opts) {
-                                    sb.append("<option value=\"")
-                                            .append(opt)
-                                            .append("\"/>");
-                                }
-
-                                writer.write(sb.toString());
-                            } else if (!line.contains("java.net.preferIPv4Stack")){
-                                writer.write(line);
+                        addLine(newLines, sb.toString());
+                    } else {
+                        start = line.indexOf("<option value=\"");
+                        if (start >= 0) {
+                            StringBuilder sb = new StringBuilder();
+                            sb.append(line.substring(0, start));
+                            List<String> opts = new ArrayList<String>();
+                            TestSuiteEnvironment.getIpv6Args(opts);
+                            for (String opt : opts) {
+                                sb.append("<option value=\"")
+                                        .append(opt)
+                                        .append("\"/>");
                             }
+
+                            addLine(newLines, sb.toString());
+                        } else if (!line.contains("java.net.preferIPv4Stack")) {
+                            addLine(newLines, line);
                         }
                     }
-                    writer.write("\n");
-                    line = reader.readLine();
                 }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            } finally {
-                safeClose(reader);
-                safeClose(writer);
             }
-        } catch (FileNotFoundException e) {
+            Files.write(file.toPath(), newLines);
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
         return file;
+    }
+
+    private static void addLine(List<String> newLines, String line) {
+        System.out.println("Transformed line: " + line);
+        newLines.add(line);
     }
 
     static File hackFixDomainConfig(File hostConfigFile) {
         final File file;
-        final BufferedWriter writer;
         try {
             file = File.createTempFile("domain", ".xml", hostConfigFile.getAbsoluteFile().getParentFile());
             file.deleteOnExit();
-            writer = new BufferedWriter(new FileWriter(file));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-        try {
-            BufferedReader reader = new BufferedReader(new FileReader(hostConfigFile));
-            try {
-                String line = reader.readLine();
-                while (line != null) {
-                    int start = line.indexOf("java.net.preferIPv4Stack");
-                    if (start < 0) {
-                        writer.write(line);
-                    }
-                    writer.write("\n");
-                    line = reader.readLine();
+        try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+            for (String line : Files.readAllLines(hostConfigFile.toPath())) {
+                int start = line.indexOf("java.net.preferIPv4Stack");
+                if (start < 0) {
+                    writer.write(line);
                 }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            } finally {
-                safeClose(reader);
-                safeClose(writer);
+                writer.write("\n");
+                writer.flush();
             }
-        } catch (FileNotFoundException e) {
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
         return file;
-    }
-
-    static void safeClose(Closeable c) {
-        try {
-            c.close();
-        } catch (Exception ignore) {
-        }
     }
 }

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/DefaultConfigSmokeTestCase.java
@@ -80,7 +80,7 @@ public class DefaultConfigSmokeTestCase extends BuildConfigurationTestBase {
         final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-master.xml", getClass().getSimpleName());
         final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
         final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-slave.xml", getClass().getSimpleName(),
-                "slave", slaveAddress, 19999);
+                "slave", slaveAddress, 19990);
         final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
         try {
             masterUtils.start();

--- a/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
+++ b/testsuite/domain/src/test/java/org/jboss/as/test/integration/domain/OrderedChildResourcesTestCase.java
@@ -62,7 +62,7 @@ public class OrderedChildResourcesTestCase extends BuildConfigurationTestBase {
         final WildFlyManagedConfiguration masterConfig = createConfiguration("domain.xml", "host-master.xml", getClass().getSimpleName());
         final DomainLifecycleUtil masterUtils = new DomainLifecycleUtil(masterConfig);
         final WildFlyManagedConfiguration slaveConfig = createConfiguration("domain.xml", "host-slave.xml", getClass().getSimpleName(),
-                "slave", slaveAddress, 19999);
+                "slave", slaveAddress, 19990);
         final DomainLifecycleUtil slaveUtils = new DomainLifecycleUtil(slaveConfig);
         try {
             masterUtils.start();

--- a/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover2.xml
@@ -56,7 +56,7 @@
     </management>
 
     <domain-controller>
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm"/>
+         <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="9990" security-realm="ManagementRealm"/>
     </domain-controller>
 
     <!--

--- a/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-failover3.xml
@@ -56,7 +56,7 @@
     </management>
 
     <domain-controller>
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="ignored"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-master.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-master.xml
@@ -69,7 +69,7 @@
             </native-interface>
             <http-interface security-realm="ManagementRealm">
                 <http-upgrade enabled="true" />
-                <socket interface="management" port="9990"/>
+                <socket interface="management" port="${jboss.management.http.port:9990}"/>
             </http-interface>
         </management-interfaces>
     </management>
@@ -91,15 +91,6 @@
           <environment-variables>
               <variable name="DOMAIN_TEST_JVM" value="jvm"/>
           </environment-variables>
-            <!--
-            <jvm-options>
-                <option value="-Xdebug"/>
-                <option value="-Xnoagent"/>
-                <option value="-Djava.compiler=NONE"/>
-                <option value="-agentlib:jdwp=transport=dt_socket,address=5005,server=y,suspend=y"/>
-
-            </jvm-options>
-            -->
        </jvm>
  	</jvms>
 

--- a/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-secrets.xml
@@ -56,7 +56,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm"/>
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm"/>
     </domain-controller>
 
     <interfaces>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-discovery-options.xml
@@ -81,7 +81,7 @@
         <!-- Remote domain controller configuration with a host and port -->
         <remote security-realm="ManagementRealm">
             <discovery-options>
-                <static-discovery name="start-option" host="${jboss.test.host.master.address}" port="9999" />
+                <static-discovery name="start-option" host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" />
             </discovery-options>
         </remote>
     </domain-controller>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac-properties.xml
@@ -82,7 +82,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave-rbac.xml
@@ -79,7 +79,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/domain/src/test/resources/host-configs/host-slave.xml
+++ b/testsuite/domain/src/test/resources/host-configs/host-slave.xml
@@ -79,7 +79,7 @@
 
     <domain-controller>
         <!-- Remote domain controller configuration with a host and port -->
-        <remote host="${jboss.test.host.master.address}" port="9999" security-realm="ManagementRealm">
+        <remote host="${jboss.test.host.master.address}" protocol="${jboss.domain.master.protocol:remote+http}" port="${jboss.domain.master.port:9990}" security-realm="ManagementRealm">
             <ignored-resources type="extension">
                 <instance name="org.jboss.as.jsr77"/>
             </ignored-resources>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ee/jmx/property/JMXPropertyEditorsTestCase.java
@@ -116,7 +116,7 @@ public class JMXPropertyEditorsTestCase {
 
     private MBeanServerConnection getMBeanServerConnection() throws IOException {
         final String address = managementClient.getMgmtAddress()+":"+managementClient.getMgmtPort();
-        connector = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:http-remoting-jmx://"+address), DefaultConfiguration.credentials());
+        connector = JMXConnectorFactory.connect(new JMXServiceURL("service:jmx:remote+http://"+address), DefaultConfiguration.credentials());
         return connector.getMBeanServerConnection();
     }
 

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/remote/common/EJBManagementUtil.java
@@ -267,7 +267,7 @@ public class EJBManagementUtil {
             addRemoteOutboundConnection.get("outbound-socket-binding-ref").set(outboundSocketRef);
             addRemoteOutboundConnection.get(SECURITY_REALM).set("PasswordRealm");
             addRemoteOutboundConnection.get("username").set("user1");
-            addRemoteOutboundConnection.get("protocol").set("http-remoting");
+            addRemoteOutboundConnection.get("protocol").set("remote+http");
 
             final ModelNode op = Util.getEmptyOperation(COMPOSITE, new ModelNode());
             final ModelNode steps = op.get(STEPS);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/jmx/ModelControllerMBeanTestCase.java
@@ -103,7 +103,7 @@ public class ModelControllerMBeanTestCase {
     private MBeanServerConnection setupAndGetConnection() throws Exception {
         // Make sure that we can connect to the MBean server
         String urlString = System
-                .getProperty("jmx.service.url", "service:jmx:http-remoting-jmx://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
+                .getProperty("jmx.service.url", "service:jmx:remote+http://" + managementClient.getMgmtAddress() + ":" + managementClient.getMgmtPort());
         JMXServiceURL serviceURL = new JMXServiceURL(urlString);
         connector = JMXConnectorFactory.connect(serviceURL,DefaultConfiguration.credentials());
         return connector.getMBeanServerConnection();

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/CallEjbServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/CallEjbServlet.java
@@ -28,6 +28,7 @@ public class CallEjbServlet extends HttpServlet {
             String address = System.getProperty("node0", "localhost");
             // format possible IPv6 address
             address = NetworkUtils.formatPossibleIpv6Address(address);
+            //TODO move to remote+http once wildfly naming client is merged
             env.put(Context.PROVIDER_URL, "http-remoting://" + address + ":8080");
             env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
             ctx = new InitialContext(env);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/RunRmiServlet.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/RunRmiServlet.java
@@ -37,6 +37,7 @@ public class RunRmiServlet extends HttpServlet {
             String address = System.getProperty("node0", "localhost");
             // format possible IPv6 address
             address = NetworkUtils.formatPossibleIpv6Address(address);
+            //TODO move to remote+http once wildfly naming client is merged
             env.put(Context.PROVIDER_URL, "http-remoting://" + address + ":8080");
             env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
             Context ctx = new InitialContext(env);

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
@@ -71,6 +71,7 @@ public class RemoteNamingTestCase {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         URI webUri = managementClient.getWebUri();
+        //TODO replace with remote+http once the New WildFly Naming Client is merged
         URI namingUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "" ,"");
         env.put(Context.PROVIDER_URL, namingUri.toString());
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");

--- a/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
+++ b/testsuite/integration/clustering/src/test/java/org/jboss/as/test/clustering/messaging/ClusteredMessagingTestCase.java
@@ -187,7 +187,7 @@ public class ClusteredMessagingTestCase {
     protected static InitialContext createJNDIContextFromServer0() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, "http-remoting://" + TestSuiteEnvironment.getServerAddress() + ":8080");
+        env.put(Context.PROVIDER_URL, "remote+http://" + TestSuiteEnvironment.getServerAddress() + ":8080");
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);
@@ -196,7 +196,7 @@ public class ClusteredMessagingTestCase {
     protected static  InitialContext createJNDIContextFromServer1() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, "http-remoting://" + TestSuiteEnvironment.getServerAddress() + ":8180");
+        env.put(Context.PROVIDER_URL, "remote+http://" + TestSuiteEnvironment.getServerAddress() + ":8180");
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/client/cluster/EJBClientClusterConfigurationTestCase.java
@@ -246,7 +246,7 @@ public class EJBClientClusterConfigurationTestCase {
         final int managementPort = TestSuiteEnvironment.getServerPort() + portOffset;
         final String managementAddress = getServerAddress(container);
 
-        return new ManagementClient(client, managementAddress, managementPort, "http-remoting");
+        return new ManagementClient(client, managementAddress, managementPort, "remote+http");
     }
 
     private static int getContainerPortOffset(final String container) {

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ejb/ssl/SSLEJBRemoteClientTestCase.java
@@ -134,13 +134,13 @@ public class SSLEJBRemoteClientTestCase {
             log.trace("*** starting server");
             container.start(DEFAULT_JBOSSAS);
             final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
-            log.trace("*** will configure server now");
+            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
+            log.info("*** will configure server now");
             SSLRealmSetupTool.setup(managementClient);
             log.trace("*** restarting server");
             container.stop(DEFAULT_JBOSSAS);
             container.start(DEFAULT_JBOSSAS);
-            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+            managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
             // write SSL realm config to output - debugging purposes
             SSLRealmSetupTool.readSSLRealmConfig(managementClient);
             serverConfigDone = true;
@@ -152,7 +152,7 @@ public class SSLEJBRemoteClientTestCase {
     @AfterClass
     public static void tearDown() throws Exception {
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
-        final ManagementClient mClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+        final ManagementClient mClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
         SSLRealmSetupTool.tearDown(mClient, container);
     }
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/AbstractMessagingHATestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/messaging/ha/AbstractMessagingHATestCase.java
@@ -151,7 +151,7 @@ public abstract class AbstractMessagingHATestCase {
     protected static InitialContext createJNDIContextFromServer1() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "http-remoting://127.0.0.1:8080"));
+        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "remote+http://127.0.0.1:8080"));
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);
@@ -160,7 +160,7 @@ public abstract class AbstractMessagingHATestCase {
     protected static  InitialContext createJNDIContextFromServer2() throws NamingException {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "org.jboss.naming.remote.client.InitialContextFactory");
-        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "http-remoting://127.0.0.1:8180"));
+        env.put(Context.PROVIDER_URL, System.getProperty(Context.PROVIDER_URL, "remote+http://127.0.0.1:8180"));
         env.put(Context.SECURITY_PRINCIPAL, "guest");
         env.put(Context.SECURITY_CREDENTIALS, "guest");
         return new InitialContext(env);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/OutboundLdapConnectionTestCase.java
@@ -153,7 +153,7 @@ public class OutboundLdapConnectionTestCase {
         if (containerController.isStarted(CONTAINER) && !serverConfigured) {
             final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
             ManagementClient mgmtClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                    TestSuiteEnvironment.getServerPort(), "http-remoting");
+                    TestSuiteEnvironment.getServerPort(), "remote+http");
             prepareServer(mgmtClient);
         }
     }
@@ -163,7 +163,7 @@ public class OutboundLdapConnectionTestCase {
         if (serverConfigured && containerController.isStarted(CONTAINER)) {
             final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
             ManagementClient mgmtClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                    TestSuiteEnvironment.getServerPort(), "http-remoting");
+                    TestSuiteEnvironment.getServerPort(), "remote+http");
             cleanUpServer(mgmtClient);
         }
     }

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/security/VaultSystemPropertyOnServerStartTestCase.java
@@ -107,7 +107,7 @@ public class VaultSystemPropertyOnServerStartTestCase {
 
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         serverSetup.setup(managementClient, CONTAINER);
 

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/CertificateRolesLoginModuleTestCase.java
@@ -97,7 +97,7 @@ public class CertificateRolesLoginModuleTestCase extends AbstractCertificateLogi
         containerController.start(CONTAINER);
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         LOGGER.trace("*** will configure server now");
         AbstractCertificateLoginModuleTestCase.HTTPSConnectorSetup.INSTANCE.setup(managementClient, CONTAINER);
@@ -127,7 +127,7 @@ public class CertificateRolesLoginModuleTestCase extends AbstractCertificateLogi
         deployer.undeploy(APP_NAME);
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         final ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         LOGGER.trace("*** reseting test configuration");
         AbstractCertificateLoginModuleTestCase.HTTPSConnectorSetup.INSTANCE.tearDown(managementClient, CONTAINER);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/DatabaseCertLoginModuleTestCase.java
@@ -104,7 +104,7 @@ public class DatabaseCertLoginModuleTestCase extends AbstractCertificateLoginMod
         containerController.start(CONTAINER);
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         LOGGER.trace("*** will configure server now");
         AbstractCertificateLoginModuleTestCase.HTTPSConnectorSetup.INSTANCE.setup(managementClient, CONTAINER);
@@ -136,7 +136,7 @@ public class DatabaseCertLoginModuleTestCase extends AbstractCertificateLoginMod
         deployer.undeploy(APP_NAME);
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         final ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         LOGGER.trace("*** reseting test configuration");
         AbstractCertificateLoginModuleTestCase.HTTPSConnectorSetup.INSTANCE.tearDown(managementClient, CONTAINER);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/web/ssl/HTTPSWebConnectorTestCase.java
@@ -159,7 +159,7 @@ public class HTTPSWebConnectorTestCase {
         containerController.start(CONTAINER);
         ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
 
         LOGGER.trace("*** will configure server now");
         serverSetup(managementClient);
@@ -320,8 +320,8 @@ public class HTTPSWebConnectorTestCase {
         deployer.undeploy(APP_CONTEXT);
         final ModelControllerClient client = TestSuiteEnvironment.getModelControllerClient();
         final ManagementClient managementClient = new ManagementClient(client, TestSuiteEnvironment.getServerAddress(),
-                TestSuiteEnvironment.getServerPort(), "http-remoting");
-        LOGGER.trace("*** reseting test configuration");
+                TestSuiteEnvironment.getServerPort(), "remote+http");
+        LOGGER.info("*** reseting test configuration");
         serverTearDown(managementClient);
 
         LOGGER.trace("*** stopping container");

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadRequiringChangesTestCase.java
@@ -100,7 +100,7 @@ public class ReloadRequiringChangesTestCase {
     public void testWSDLHostChangeRequiresReloadAndDoesNotAffectRuntime() throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlHost = null;
@@ -132,7 +132,7 @@ public class ReloadRequiringChangesTestCase {
     public void testWSDLHostUndefineRequiresReloadAndDoesNotAffectRuntime() throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlHost = null;

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/ReloadWSDLPublisherTestCase.java
@@ -94,7 +94,7 @@ public class ReloadWSDLPublisherTestCase {
     public void testHelloStringAfterReload() throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
         QName serviceName = new QName("http://jbossws.org/basic", "POJOService");
         URL wsdlURL = new URL(managementClient.getWebUri().toURL(), '/' + DEPLOYMENT + "/POJOService?wsdl");
         checkWsdl(wsdlURL);

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/WSAttributesChangesTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/ws/WSAttributesChangesTestCase.java
@@ -116,7 +116,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlHostAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlHost = null;
@@ -181,7 +181,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlPortAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         try {
@@ -240,7 +240,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlUriSchemeAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
         String initialWsdlUriScheme = null;
@@ -312,7 +312,7 @@ public class WSAttributesChangesTestCase {
     private void performWsdlPathRewriteRuleAttributeTest(boolean checkUpdateWithDeployedEndpoint) throws Exception {
         Assert.assertTrue(containerController.isStarted(DEFAULT_JBOSSAS));
         ManagementClient managementClient = new ManagementClient(TestSuiteEnvironment.getModelControllerClient(),
-                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "http-remoting");
+                TestSuiteEnvironment.getServerAddress(), TestSuiteEnvironment.getServerPort(), "remote+http");
 
         ModelControllerClient client = managementClient.getControllerClient();
 

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeExecutionDisabledTestCase.java
@@ -214,7 +214,7 @@ public class DatabaseTimerServiceMultiNodeExecutionDisabledTestCase {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         URI webUri = managementClient.getWebUri();
-        URI namingUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
+        URI namingUri = new URI("remote+http", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
         env.put(Context.PROVIDER_URL, namingUri.toString());
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
         env.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());

--- a/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
+++ b/testsuite/integration/multinode/src/test/java/org/jboss/as/test/multinode/ejb/timer/database/DatabaseTimerServiceMultiNodeTestCase.java
@@ -250,7 +250,7 @@ public class DatabaseTimerServiceMultiNodeTestCase {
         final Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, org.jboss.naming.remote.client.InitialContextFactory.class.getName());
         URI webUri = managementClient.getWebUri();
-        URI namingUri = new URI("http-remoting", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
+        URI namingUri = new URI("remote+http", webUri.getUserInfo(), webUri.getHost(), webUri.getPort(), "", "", "");
         env.put(Context.PROVIDER_URL, namingUri.toString());
         env.put("jboss.naming.client.connect.options.org.xnio.Options.SASL_POLICY_NOPLAINTEXT", "false");
         env.put("jboss.naming.client.security.callback.handler.class", CallbackHandler.class.getName());

--- a/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
+++ b/testsuite/integration/smoke/src/test/java/org/jboss/as/test/smoke/subsystem/xml/StandardConfigsXMLValidationUnitTestCase.java
@@ -205,7 +205,9 @@ public class StandardConfigsXMLValidationUnitTestCase extends AbstractValidation
         result = result.replace("${jboss.management.http.port:9990}", "9990");
         result = result.replace("${jboss.management.https.port:9993}", "9993");
         result = result.replace("${jboss.domain.master.protocol:remote}", "remote");
+        result = result.replace("${jboss.domain.master.protocol:remote+http}", "remote+http");
         result = result.replace("${jboss.domain.master.port:9999}", "9999");
+        result = result.replace("${jboss.domain.master.port:9990}", "9990");
         result = result.replace("${jboss.messaging.group.port:9876}", "9876");
         result = result.replace("${jboss.socket.binding.port-offset:0}", "0");
         result = result.replace("${jboss.http.port:8080}", "8080");

--- a/testsuite/integration/src/test/scripts/clustering-build.xml
+++ b/testsuite/integration/src/test/scripts/clustering-build.xml
@@ -304,8 +304,8 @@
                                                  udpMcastAddress="${mcast-clusterA}" diagnosticsMcastAddress="${mcast-clusterA}" mpingMcastAddress="${mcast-mping}" modclusterMcastAddress="${mcast-clusterA}"/>
         <ts.config-as.add-port-offset name="wildfly-clusterA-node0"/>
         <ts.config-as.configure-multicast-ttl name="wildfly-clusterA-node0" mcast.ttl="${mcast.ttl}"/>
-        <!--ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node0" node="${node2}" remotePort="8280" protocol="http-remoting"/-->
-        <ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node0" node="${node2}" remotePort="8280" protocol="http-remoting" securityRealm="PasswordRealm" userName="remoteejbuser"/>
+        <!--ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node0" node="${node2}" remotePort="8280" protocol="remote+http"/-->
+        <ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node0" node="${node2}" remotePort="8280" protocol="remote+http" securityRealm="PasswordRealm" userName="remoteejbuser"/>
         <ts.config-as.add-identity-realm name="wildfly-clusterA-node0" realmName="PasswordRealm" secret="cmVtQHRlZWpicGFzc3dkMQ=="/>
 
         <ts.config-as.change-cache-container-name name="wildfly-clusterA-node0" container="ejb" newName="ejb-forwarder"/>
@@ -322,7 +322,7 @@
                                                  udpMcastAddress="${mcast-clusterA}" diagnosticsMcastAddress="${mcast-clusterA}" mpingMcastAddress="${mcast-mping}" modclusterMcastAddress="${mcast-clusterA}"/>
         <ts.config-as.add-port-offset name="wildfly-clusterA-node1" offset="100" nativePort="9999" httpPort="9990"/>
         <ts.config-as.configure-multicast-ttl name="wildfly-clusterA-node1" mcast.ttl="${mcast.ttl}"/>
-        <ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node1" node="${node2}" remotePort="8280" protocol="http-remoting" securityRealm="PasswordRealm" userName="remoteejbuser" />
+        <ts.config-as.add-remote-outbound-connection name="wildfly-clusterA-node1" node="${node2}" remotePort="8280" protocol="remote+http" securityRealm="PasswordRealm" userName="remoteejbuser" />
         <ts.config-as.add-identity-realm name="wildfly-clusterA-node1" realmName="PasswordRealm" secret="cmVtQHRlZWpicGFzc3dkMQ=="/>
 
         <ts.config-as.change-cache-container-name name="wildfly-clusterA-node1" container="ejb" newName="ejb-forwarder"/>

--- a/testsuite/integration/src/test/scripts/common-targets.xml
+++ b/testsuite/integration/src/test/scripts/common-targets.xml
@@ -210,7 +210,7 @@
         <attribute name="remotePort" default="4447"/>
         <attribute name="securityRealm" default="NOT_DEFINED"/>
         <attribute name="userName" default="NOT_DEFINED"/>
-        <attribute name="protocol" default="http-remoting"/>
+        <attribute name="protocol" default="remote+http"/>
 
         <sequential>
             <echo message="Adding a new remote outbound connection @{connectionName} for config @{name}"/>

--- a/testsuite/integration/src/test/scripts/manualmode-build.xml
+++ b/testsuite/integration/src/test/scripts/manualmode-build.xml
@@ -68,7 +68,7 @@
 
         <!-- Connects back to original host (node0) -->
         <ts.config-as.add-remote-outbound-connection name="jbossas-with-remote-outbound-connection" node="${node0}"
-                                                     remotePort="8080" protocol="http-remoting" securityRealm="PasswordRealm" userName="user1"/>
+                                                     remotePort="8080" protocol="remote+http" securityRealm="PasswordRealm" userName="user1"/>
         <ts.config-as.add-identity-realm name="jbossas-with-remote-outbound-connection" realmName="PasswordRealm"
                                          secret="cGFzc3dvcmQx"/>
 

--- a/testsuite/integration/src/test/scripts/multinode-build.xml
+++ b/testsuite/integration/src/test/scripts/multinode-build.xml
@@ -33,7 +33,7 @@
         <copy todir="target/jbossas-multinode-client">
             <fileset dir="target/jbossas"/>
         </copy>
-        <ts.config-as.add-remote-outbound-connection name="jbossas-multinode-client" node="${node1}" remotePort="8180" protocol="http-remoting" securityRealm="PasswordRealm" userName="user1"/>
+        <ts.config-as.add-remote-outbound-connection name="jbossas-multinode-client" node="${node1}" remotePort="8180" protocol="remote+http" securityRealm="PasswordRealm" userName="user1"/>
         <ts.config-as.add-identity-realm name="jbossas-multinode-client" realmName="PasswordRealm" secret="cGFzc3dvcmQx"/>
 
         <echo message="Copying and configuring instance jbossas-multinode-server"/>

--- a/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
+++ b/testsuite/integration/src/test/xslt/addRemoteOutboundConnection.xsl
@@ -17,7 +17,7 @@
     <xsl:param name="remotePort" select="'4447'"/>
     <xsl:param name="securityRealm" select="NOT_DEFINED"/>
     <xsl:param name="userName" select="NOT_DEFINED"/>
-    <xsl:param name="protocol" select="http-remoting"/>
+    <xsl:param name="protocol" select="remote+http"/>
 
     <xsl:template name="newRemoteOutboundConnection">        
         <xsl:element name="remote-outbound-connection" namespace="{namespace-uri()}">

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/security/common/jboss-cli.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/security/common/jboss-cli.xml
@@ -7,7 +7,7 @@
 
     <!-- The default controller to connect to when 'connect' command is executed w/o arguments -->
     <default-controller>
-    	<protocol>http-remoting</protocol>
+	<protocol>remote+http</protocol>
         <host>${hostname}</host>
         <port>9990</port>
     </default-controller>

--- a/testsuite/shared/src/main/resources/org/jboss/as/test/integration/web/sso/resources/web-form-auth.xml
+++ b/testsuite/shared/src/main/resources/org/jboss/as/test/integration/web/sso/resources/web-form-auth.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN" "http://java.sun.com/dtd/web-app_2_3.dtd">
 <web-app>
-    <distributable/>
     <description>WebApp Integration Tests</description>
+    <distributable/>
     <servlet>
         <servlet-name>LogoutServlet</servlet-name>
         <servlet-class>org.jboss.as.test.integration.web.sso.LogoutServlet</servlet-class>


### PR DESCRIPTION
Updating default domain configurations.

Jira: https://issues.jboss.org/browse/WFLY-6409
JBEAP: https://issues.jboss.org/browse/JBEAP-9093
Requires merge for https://issues.jboss.org/browse/WFCORE-1444 by PR https://github.com/wildfly/wildfly-core/pull/1467
