### PR TITLE
Ensure server is reloaded when capabilities being tested are reload-r…

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/database/DatabaseTimerServerSetup.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/timerservice/database/DatabaseTimerServerSetup.java
@@ -22,11 +22,6 @@
 
 package org.jboss.as.test.integration.ejb.timerservice.database;
 
-import org.jboss.as.arquillian.api.ServerSetupTask;
-import org.jboss.as.arquillian.container.ManagementClient;
-import org.jboss.as.test.integration.management.ManagementOperations;
-import org.jboss.dmr.ModelNode;
-
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ADD;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ALLOW_RESOURCE_SERVICE_RESTART;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.OP;
@@ -36,6 +31,12 @@ import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.REM
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.ROLLBACK_ON_RUNTIME_FAILURE;
 import static org.jboss.as.controller.descriptions.ModelDescriptionConstants.SUBSYSTEM;
 
+import org.jboss.as.arquillian.api.ServerSetupTask;
+import org.jboss.as.arquillian.container.ManagementClient;
+import org.jboss.as.test.integration.management.ManagementOperations;
+import org.jboss.as.test.shared.ServerReload;
+import org.jboss.dmr.ModelNode;
+
 /**
  * @author Stuart Douglas
  */
@@ -43,6 +44,9 @@ class DatabaseTimerServerSetup implements ServerSetupTask {
 
     @Override
     public void setup(final ManagementClient managementClient, final String containerId) throws Exception {
+
+        ServerReload.BeforeSetupTask.INSTANCE.setup(managementClient, containerId);
+
         ModelNode op = new ModelNode();
         op.get(OP).set(ADD);
         op.get(OP_ADDR).add(SUBSYSTEM, "ejb3");

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebCERTTestsSecurityDomainSetup.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/WebCERTTestsSecurityDomainSetup.java
@@ -58,6 +58,7 @@ import org.jboss.as.test.integration.security.common.config.realm.Authentication
 import org.jboss.as.test.integration.security.common.config.realm.RealmKeystore;
 import org.jboss.as.test.integration.security.common.config.realm.SecurityRealm;
 import org.jboss.as.test.integration.security.common.config.realm.ServerIdentity;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 
@@ -166,6 +167,9 @@ public class WebCERTTestsSecurityDomainSetup extends AbstractSecurityRealmsServe
             applyUpdates(managementClient.getControllerClient(), updates);
 
             log.debug("end of the domain creation");
+
+            ServerReload.executeReloadAndWaitForCompletion(managementClient.getControllerClient());
+
         } catch (Exception e) {
             log.error("Failed to setup domain creation.",e);
         }

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/cert/WebSecurityCERTTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/security/cert/WebSecurityCERTTestCase.java
@@ -27,6 +27,7 @@ import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.net.URL;
 import java.security.cert.X509Certificate;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;

--- a/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractSecurityDomainsServerSetupTask.java
+++ b/testsuite/shared/src/main/java/org/jboss/as/test/integration/security/common/AbstractSecurityDomainsServerSetupTask.java
@@ -63,6 +63,7 @@ import org.jboss.as.test.integration.security.common.config.LoginModuleStack;
 import org.jboss.as.test.integration.security.common.config.SecureStore;
 import org.jboss.as.test.integration.security.common.config.SecurityDomain;
 import org.jboss.as.test.integration.security.common.config.SecurityModule;
+import org.jboss.as.test.shared.ServerReload;
 import org.jboss.dmr.ModelNode;
 import org.jboss.logging.Logger;
 
@@ -108,6 +109,13 @@ public abstract class AbstractSecurityDomainsServerSetupTask implements ServerSe
             LOGGER.warn("Empty security domain configuration.");
             return;
         }
+
+        // TODO remove this once security domains expose their own capability
+        // Currently subsystem=security-domain exposes one, but the individual domains don't
+        // which with WFCORE-1106 has the effect that any individual sec-domain op that puts
+        // the server in reload-required means all ops for any sec-domain won't execute Stage.RUNTIME
+        // So, for now we preemptively reload if needed
+        ServerReload.BeforeSetupTask.INSTANCE.setup(managementClient, containerId);
 
         final List<ModelNode> updates = new LinkedList<ModelNode>();
         for (final SecurityDomain securityDomain : securityDomains) {


### PR DESCRIPTION
…equired so tests still function post-WFCORE-1106

This commit tweaks the testsuite such that failures that would otherwise occur when my pending core PR for WFCORE-1106 is submitted are avoided. Merging it is required before that PR will pass CI.

The WFCORE-1106 PR will result in Stage.RUNTIME steps not being executed in some situations when a capability related to the affected address has put the server in reload-required state. This PR fixes some cases where tests were triggering reload-required and then walking away, leaving the server in a poor state for the next test.
