### PR TITLE
[WFLY-6440] Unignore DenyUncoveredHttpMethodsTestCase#testTraceMethod

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/servlet/methods/DenyUncoveredHttpMethodsTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/web/security/servlet/methods/DenyUncoveredHttpMethodsTestCase.java
@@ -46,7 +46,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import static org.junit.Assert.assertThat;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -80,7 +79,6 @@ public class DenyUncoveredHttpMethodsTestCase {
     }
 
     @Test
-    @Ignore("WFCORE-1347")
     public void testTraceMethod() throws Exception {
         HttpTrace httpTrace = new HttpTrace(getURL());
         HttpResponse response = getHttpResponse(httpTrace);


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6440

DenyUncoveredHttpMethodsTestCase#testTraceMethod was ignored in https://github.com/wildfly/wildfly/pull/8647

PR says that test should be unignored once WFCORE-1347 is fixed
