### PR TITLE
[WFLY-6450] Fix netty and jgroups dependencies in wildfly-jms-client-bom

### DIFF
--- a/client/jms/pom.xml
+++ b/client/jms/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-commons</artifactId>
         </dependency>
@@ -114,6 +119,11 @@
         <dependency>
             <groupId>org.jboss.xnio</groupId>
             <artifactId>xnio-nio</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jgroups</groupId>
+            <artifactId>jgroups</artifactId>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Add explicit dependencies to io.netty:netty-all and org.jgroups:jgroups
to use the same versions than in WildFly server instead of retrieving
them through Artemis transitive dependencies

JIRA: https://issues.jboss.org/browse/WFLY-6450
