### PR TITLE
WFLY-6434 Fix usage of custom JACC module classloader

### DIFF
--- a/security/subsystem/src/main/java/org/jboss/as/security/service/JaccService.java
+++ b/security/subsystem/src/main/java/org/jboss/as/security/service/JaccService.java
@@ -113,7 +113,7 @@ public abstract class JaccService<T> implements Service<PolicyConfiguration> {
         final ClassLoader originalClassLoader;
         final ClassLoader jaccClassLoader;
         if (module != null) {
-            jaccClassLoader = SecurityActions.getModuleClassLoader(JACC_MODULE);
+            jaccClassLoader = SecurityActions.getModuleClassLoader(module);
             originalClassLoader = SecurityActions.setThreadContextClassLoader(jaccClassLoader);
         } else {
             jaccClassLoader = null;


### PR DESCRIPTION
Fix invalid usage of constant JACC_MODULE as module name.

Signed-off-by: Winfried Wasser winfried.wasser@kapsch.net
