### PR TITLE
WFLY-6402 EJBs accessible too early (spec violation)

### DIFF
--- a/ee/src/main/java/org/jboss/as/ee/component/Attachments.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/Attachments.java
@@ -26,6 +26,7 @@ import java.util.Set;
 
 import org.jboss.as.ee.component.deployers.EEResourceReferenceProcessorRegistry;
 import org.jboss.as.ee.component.deployers.MessageDestinationInjectionSource;
+import org.jboss.as.ee.component.deployers.StartupCountdown;
 import org.jboss.as.server.deployment.AttachmentKey;
 import org.jboss.as.server.deployment.AttachmentList;
 import org.jboss.as.server.deployment.SetupAction;
@@ -84,5 +85,6 @@ public class Attachments {
 
     public static final AttachmentKey<EEResourceReferenceProcessorRegistry> RESOURCE_REFERENCE_PROCESSOR_REGISTRY = AttachmentKey.create(EEResourceReferenceProcessorRegistry.class);
 
+    public static final AttachmentKey<StartupCountdown> STARTUP_COUNTDOWN = AttachmentKey.create(StartupCountdown.class);
     public static final AttachmentKey<ComponentRegistry> COMPONENT_REGISTRY = AttachmentKey.create(ComponentRegistry.class);
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/EEModuleDescription.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/EEModuleDescription.java
@@ -80,6 +80,11 @@ public final class EEModuleDescription implements ResourceInjectionTarget {
     private String defaultSecurityDomain;
 
     /**
+     * The number of registered startup beans.
+     */
+    private int startupBeansCount;
+
+    /**
      * Construct a new instance.
      *
      * @param applicationName    the application name (which is same as the module name if the .ear is absent)
@@ -326,5 +331,13 @@ public final class EEModuleDescription implements ResourceInjectionTarget {
 
     public void setDefaultSecurityDomain(String defaultSecurityDomain) {
         this.defaultSecurityDomain = defaultSecurityDomain;
+    }
+
+    public int getStartupBeansCount() {
+        return this.startupBeansCount;
+    }
+
+    public int registerStartupBean() {
+        return ++this.startupBeansCount;
     }
 }

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleConfigurationProcessor.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/EEModuleConfigurationProcessor.java
@@ -63,6 +63,8 @@ public class EEModuleConfigurationProcessor implements DeploymentUnitProcessor {
             return;
         }
 
+        deploymentUnit.putAttachment(Attachments.STARTUP_COUNTDOWN, new StartupCountdown(moduleDescription.getStartupBeansCount())); // now all startup beans are counted and we can initialize a CDL to be used by interceptors
+
         final Set<ServiceName> failed = new HashSet<ServiceName>();
 
         final EEModuleConfiguration moduleConfiguration = new EEModuleConfiguration(moduleDescription);

--- a/ee/src/main/java/org/jboss/as/ee/component/deployers/StartupCountdown.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/deployers/StartupCountdown.java
@@ -1,0 +1,37 @@
+package org.jboss.as.ee.component.deployers;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * Countdown tracker with capabilities similar to SE CountDownLatch, but allowing threads
+ * to mark and unmark themselves as privileged. Privileged threads, when entering await method,
+ * will immediately proceed without checking latch's state. This reentrant behaviour allows to work around situations
+ * where there is a possibility of a deadlock.
+ * @author Fedor Gavrilov
+ */
+public final class StartupCountdown {
+  private static final ThreadLocal<Boolean> isPrivileged = new ThreadLocal<Boolean>();
+
+  private final CountDownLatch latch;
+
+  public StartupCountdown(int count) {
+    this.latch = new CountDownLatch(count);
+  }
+
+  public void countDown() {
+    latch.countDown();
+  }
+
+  public void await() throws InterruptedException {
+    if (Boolean.TRUE.equals(isPrivileged.get())) return;
+    latch.await();
+  }
+
+  public void markAsPrivileged() {
+    isPrivileged.set(Boolean.TRUE);
+  }
+
+  public void unmarkAsPrivileged() {
+    isPrivileged.set(Boolean.FALSE);
+  }
+}

--- a/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
+++ b/ee/src/main/java/org/jboss/as/ee/component/interceptors/InterceptorOrder.java
@@ -89,6 +89,7 @@ public class InterceptorOrder {
 
     public static final class ComponentPostConstruct {
 
+        public static final int STARTUP_COUNTDOWN_INTERCEPTOR = 0x050;
         public static final int PRIVILEGED_INTERCEPTOR = 0;
         public static final int TCCL_INTERCEPTOR = 0x100;
         public static final int CONCURRENT_CONTEXT = 0x180;
@@ -173,6 +174,7 @@ public class InterceptorOrder {
         public static final int GRACEFUL_SHUTDOWN = 0x218;
         public static final int SHUTDOWN_INTERCEPTOR = 0x220;
         public static final int INVALID_METHOD_EXCEPTION = 0x230;
+        public static final int STARTUP_AWAIT_INTERCEPTOR = 0x248;
         public static final int SINGLETON_CONTAINER_MANAGED_CONCURRENCY_INTERCEPTOR = 0x240;
         // Allows users to specify user application specific "container interceptors" which run before the
         // other JBoss specific container interceptors like the security interceptor

--- a/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/StartupCountDownInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/component/singleton/StartupCountDownInterceptor.java
@@ -1,0 +1,31 @@
+package org.jboss.as.ejb3.component.singleton;
+
+
+import org.jboss.as.ee.component.deployers.StartupCountdown;
+import org.jboss.invocation.Interceptor;
+import org.jboss.invocation.InterceptorContext;
+
+
+/**
+ * Interceptor decreasing value of passed CountDownLatch per invocation.
+ * Is used on @Startup @Singletons' @PostConstruct methods to signal post-construct successfuly done.
+ * @author Fedor Gavrilov
+ */
+public class StartupCountDownInterceptor implements Interceptor {
+  private final StartupCountdown countdown;
+
+  StartupCountDownInterceptor(final StartupCountdown countdown) {
+    this.countdown = countdown;
+  }
+
+  @Override
+  public Object processInvocation(final InterceptorContext context) throws Exception {
+    countdown.markAsPrivileged();
+    try {
+      return context.proceed();
+    } finally {
+      countdown.unmarkAsPrivileged();
+      countdown.countDown();
+    }
+  }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/StartupAwaitDeploymentUnitProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/StartupAwaitDeploymentUnitProcessor.java
@@ -1,0 +1,58 @@
+package org.jboss.as.ejb3.deployment.processors;
+
+import org.jboss.as.ee.component.Attachments;
+import org.jboss.as.ee.component.ComponentConfiguration;
+import org.jboss.as.ee.component.ComponentConfigurator;
+import org.jboss.as.ee.component.ComponentDescription;
+import org.jboss.as.ee.component.EEModuleDescription;
+import org.jboss.as.ee.component.ViewConfiguration;
+import org.jboss.as.ee.component.deployers.StartupCountdown;
+import org.jboss.as.ee.component.interceptors.InterceptorOrder;
+import org.jboss.as.ejb3.component.EJBComponentDescription;
+import org.jboss.as.ejb3.component.EJBViewConfiguration;
+import org.jboss.as.ejb3.component.MethodIntf;
+import org.jboss.as.server.deployment.DeploymentPhaseContext;
+import org.jboss.as.server.deployment.DeploymentUnit;
+import org.jboss.as.server.deployment.DeploymentUnitProcessingException;
+import org.jboss.as.server.deployment.DeploymentUnitProcessor;
+import org.jboss.invocation.ImmediateInterceptorFactory;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Adds  StartupAwaitInterceptor to exposed methods of EJB, forcing users to wait until all startup beans in the deployment are done with post-construct methods.
+ * @author Fedor Gavrilov
+ */
+// adding an abstraction for the whole deployment unit to depend on while blocking external client calls is a better solution probably
+// it requires a lot of rewriting in EJB code right now, hence this class to satisfy EJB 3.1 spec, section 4.8.1
+// feel free to remove this class as well as StartupAwaitInterceptor and StartupCountDownInterceptor when if easier way to satisfy spec will appear
+public class StartupAwaitDeploymentUnitProcessor implements DeploymentUnitProcessor {
+  private static final Set<MethodIntf> INTFS = EnumSet.of(MethodIntf.MESSAGE_ENDPOINT, MethodIntf.REMOTE, MethodIntf.SERVICE_ENDPOINT, MethodIntf.LOCAL);
+
+  @Override
+  public void deploy(final DeploymentPhaseContext context) throws DeploymentUnitProcessingException {
+    final DeploymentUnit deploymentUnit = context.getDeploymentUnit();
+    final EEModuleDescription moduleDescription = deploymentUnit.getAttachment(Attachments.EE_MODULE_DESCRIPTION);
+    for (ComponentDescription component : moduleDescription.getComponentDescriptions()) {
+      if (component instanceof EJBComponentDescription) {
+        component.getConfigurators().add(new ComponentConfigurator() {
+          @Override
+          public void configure(DeploymentPhaseContext context, ComponentDescription description, ComponentConfiguration configuration) {
+            StartupCountdown countdown = context.getDeploymentUnit().getAttachment(Attachments.STARTUP_COUNTDOWN);
+            for (ViewConfiguration view : configuration.getViews()) {
+              EJBViewConfiguration ejbView = (EJBViewConfiguration) view;
+              if (INTFS.contains(ejbView.getMethodIntf())) {
+                ejbView.addViewInterceptor(new ImmediateInterceptorFactory(new StartupAwaitInterceptor(countdown)), InterceptorOrder.View.STARTUP_AWAIT_INTERCEPTOR);
+              }
+            }
+          }
+        });
+      }
+    }
+  }
+
+  @Override
+  public void undeploy(DeploymentUnit context) {
+  }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/StartupAwaitInterceptor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/StartupAwaitInterceptor.java
@@ -1,0 +1,24 @@
+package org.jboss.as.ejb3.deployment.processors;
+
+import org.jboss.as.ee.component.deployers.StartupCountdown;
+import org.jboss.invocation.Interceptor;
+import org.jboss.invocation.InterceptorContext;
+
+/**
+ * Interceptor forcing invocation to wait until passed CountDownLatch value is decreased to 0.
+ * Is used to suspend external requests to EJB methods until all startup beans in the deployment are started as per spec.
+ * @author Fedor Gavrilov
+ */
+public class StartupAwaitInterceptor implements Interceptor {
+  private final StartupCountdown countdown;
+
+  StartupAwaitInterceptor(final StartupCountdown countdown) {
+    this.countdown = countdown;
+  }
+
+  @Override
+  public Object processInvocation(final InterceptorContext context) throws Exception {
+    countdown.await();
+    return context.proceed();
+  }
+}

--- a/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/StartupMergingProcessor.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/deployment/processors/merging/StartupMergingProcessor.java
@@ -51,6 +51,7 @@ public class StartupMergingProcessor extends AbstractMergingProcessor<SingletonC
             if (data != null) {
                 if (!data.getClassLevelAnnotations().isEmpty()) {
                     description.initOnStartup();
+                    description.getModuleDescription().registerStartupBean();
                 }
             }
         }
@@ -64,6 +65,7 @@ public class StartupMergingProcessor extends AbstractMergingProcessor<SingletonC
             Boolean initOnStartup = singletonBeanMetaData.isInitOnStartup();
             if (initOnStartup != null && initOnStartup) {
                 description.initOnStartup();
+                description.getModuleDescription().registerStartupBean();
             }
         }
     }

--- a/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
+++ b/ejb3/src/main/java/org/jboss/as/ejb3/subsystem/EJB3SubsystemAdd.java
@@ -64,6 +64,7 @@ import org.jboss.as.ejb3.deployment.processors.ImplicitLocalViewProcessor;
 import org.jboss.as.ejb3.deployment.processors.MdbDeliveryDependenciesProcessor;
 import org.jboss.as.ejb3.deployment.processors.PassivationAnnotationParsingProcessor;
 import org.jboss.as.ejb3.deployment.processors.SessionBeanHomeProcessor;
+import org.jboss.as.ejb3.deployment.processors.StartupAwaitDeploymentUnitProcessor;
 import org.jboss.as.ejb3.deployment.processors.TimerServiceJndiBindingProcessor;
 import org.jboss.as.ejb3.deployment.processors.annotation.EjbAnnotationProcessor;
 import org.jboss.as.ejb3.deployment.processors.dd.AssemblyDescriptorProcessor;
@@ -278,6 +279,7 @@ class EJB3SubsystemAdd extends AbstractBoottimeAddStepHandler {
                 processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EJB_DEFAULT_SECURITY_DOMAIN, EJB3SubsystemAdd.this.defaultSecurityDomainDeploymentProcessor);
                 processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EE_COMPONENT_SUSPEND, new EJBComponentSuspendDeploymentUnitProcessor());
                 processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EE_COMPONENT_SUSPEND + 1, new EjbClientContextSetupProcessor()); //TODO: real phase numbers
+                processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.POST_MODULE, Phase.POST_MODULE_EE_COMPONENT_SUSPEND + 2, new StartupAwaitDeploymentUnitProcessor());
 
                 processorTarget.addDeploymentProcessor(EJB3Extension.SUBSYSTEM_NAME, Phase.INSTALL, Phase.INSTALL_EJB_JACC_PROCESSING, new JaccEjbDeploymentProcessor());
 


### PR DESCRIPTION
https://issues.jboss.org/browse/WFLY-6402
EJBs accessible too early (spec violation)

now all startup beans in deployment should finish their postconstruct methods before external calls would be allowed to proceed
