### PR TITLE
[WFLY-6406] Artemis AIO journal fails on zfsonlinux ZFS filesystem

### DIFF
--- a/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
+++ b/messaging-activemq/src/main/java/org/wildfly/extension/messaging/activemq/logging/MessagingLogger.java
@@ -815,4 +815,11 @@ public interface MessagingLogger extends BasicLogger {
 
     @Message(id = 86, value = "Unable to load module %s")
     OperationFailedException unableToLoadModule(String moduleName, @Cause ModuleLoadException cause);
+
+    /**
+     * Logs a info message indicating AIO was not found.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 87, value = "AIO was located on this platform but the filesystem does not support AIO, it will fall back to using pure Java NIO. Journal path: %s")
+    void aioInfoPath(String path);
 }


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/WFLY-6406

Upstream Issue: https://issues.apache.org/jira/browse/ARTEMIS-444
Upstream PR: https://github.com/apache/activemq-artemis/pull/425

Note: the fix relies on component upgrade of activemq-artemis.
