### PR TITLE
[WFLY-5096] Example for standalone colocated Artemis

### DIFF
--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -50,6 +50,10 @@
         </standalone>
         <standalone
                 template="configuration/standalone/template.xml"
+                subsystems="configuration/examples/subsystems-activemq-colocated.xml"
+                output-file="docs/examples/configs/standalone-activemq-colocated.xml"/>
+        <standalone
+                template="configuration/standalone/template.xml"
                 subsystems="configuration/standalone/subsystems-full-ha.xml"
                 output-file="docs/examples/configs/standalone-ec2-full-ha.xml">
             <property name="jgroups.supplement" value="ec2" />

--- a/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
+++ b/feature-pack/src/main/resources/configuration/examples/subsystems-activemq-colocated.xml
@@ -1,0 +1,38 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <subsystems>
+        <subsystem>logging.xml</subsystem>
+        <subsystem>batch-jberet.xml</subsystem>
+        <subsystem>bean-validation.xml</subsystem>
+        <subsystem>datasources.xml</subsystem>
+        <subsystem>deployment-scanner.xml</subsystem>
+        <subsystem supplement="full">ee.xml</subsystem>
+        <subsystem supplement="full">ejb3.xml</subsystem>
+        <subsystem>io.xml</subsystem>
+        <subsystem>infinispan.xml</subsystem>
+        <subsystem>iiop-openjdk.xml</subsystem>
+        <subsystem>jaxrs.xml</subsystem>
+        <subsystem>jca.xml</subsystem>
+        <subsystem>jdr.xml</subsystem>
+        <subsystem>jgroups.xml</subsystem>
+        <subsystem>jmx.xml</subsystem>
+        <subsystem>jpa.xml</subsystem>
+        <subsystem>jsf.xml</subsystem>
+        <subsystem>jsr77.xml</subsystem>
+        <subsystem>mail.xml</subsystem>
+        <subsystem>messaging-activemq-colocated.xml</subsystem>
+        <subsystem>naming.xml</subsystem>
+        <subsystem>pojo.xml</subsystem>
+        <subsystem>remoting.xml</subsystem>
+        <subsystem>resource-adapters.xml</subsystem>
+        <subsystem>request-controller.xml</subsystem>
+        <subsystem>sar.xml</subsystem>
+        <subsystem>security-manager.xml</subsystem>
+        <subsystem>security.xml</subsystem>
+        <subsystem>transactions.xml</subsystem>
+        <subsystem>undertow.xml</subsystem>
+        <subsystem>webservices.xml</subsystem>
+        <subsystem>weld.xml</subsystem>
+    </subsystems>
+</config>

--- a/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
+++ b/messaging-activemq/src/main/resources/subsystem-templates/messaging-activemq-colocated.xml
@@ -1,0 +1,108 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--  See src/resources/configuration/ReadMe.txt for how the configuration assembly works -->
+<config>
+    <!-- This is very different from the normal messaging setup, do duplicating the config is easier -->
+    <extension-module>org.wildfly.extension.messaging-activemq</extension-module>
+    <subsystem xmlns="urn:jboss:domain:messaging-activemq:1.0">
+        <server name="default"
+                persistence-enabled="true">
+            <journal type="ASYNCIO"
+                     file-size="102400"
+                     min-files="2" />
+            <cluster password="${jboss.messaging.cluster.password:CHANGE ME!!}" />
+
+            <shared-store-master />
+
+            <security-setting name="#">
+                <role name="guest"
+                      send="true"
+                      consume="true"
+                      create-non-durable-queue="true"
+                      delete-non-durable-queue="true"/>
+            </security-setting>
+
+            <address-setting name="#"
+                             dead-letter-address="jms.queue.DLQ"
+                             expiry-address="jms.queue.ExpiryQueue"
+                             max-size-bytes="10485760"
+                             page-size-bytes="2097152"
+                             message-counter-history-day-limit="10" />
+
+            <http-connector name="http-connector"
+                            socket-binding="http"
+                            endpoint="http-acceptor" />
+            <in-vm-connector name="in-vm"
+                             server-id="0"/>
+
+            <http-acceptor name="http-acceptor"
+                           http-listener="default" />
+            <in-vm-acceptor name="in-vm"
+                            server-id="0"/>
+
+            <broadcast-group name="bg-group1"
+                             connectors="http-connector"
+                             jgroups-channel="activemq-cluster"/>
+
+            <discovery-group name="dg-group1"
+                             jgroups-channel="activemq-cluster"/>
+
+            <cluster-connection name="my-cluster"
+                                address="jms"
+                                connector-name="http-connector"
+                                discovery-group="dg-group1" />
+
+            <jms-queue name="ExpiryQueue"
+                       entries="java:/jms/queue/ExpiryQueue" />
+            <jms-queue name="DLQ"
+                       entries="java:/jms/queue/DLQ" />
+            <jms-queue name="testQueue"
+                       entries="queue/test java:jboss/exported/jms/queue/test" />
+            <jms-topic name="testTopic"
+                       entries="topic/test java:jboss/exported/jms/topic/test" />
+
+            <connection-factory name="InVmConnectionFactory"
+                                connectors="in-vm"
+                                entries="java:/ConnectionFactory" />
+            <connection-factory name="RemoteConnectionFactory"
+                                connectors="http-connector"
+                                entries="java:jboss/exported/jms/RemoteConnectionFactory" />
+
+            <pooled-connection-factory name="activemq-ra"
+                                       transaction="xa"
+                                       connectors="in-vm"
+                                       entries="java:/JmsXA java:jboss/DefaultJMSConnectionFactory"/>
+        </server>
+        <server name="backuper-server"
+                persistence-enabled="true">
+            <journal type="ASYNCIO"
+                     file-size="102400"
+                     min-files="2" />
+            <cluster password="${jboss.messaging.cluster.password:CHANGE ME!!}" />
+
+            <shared-store-slave />
+
+            <bindings-directory path="activemq-backup/bindings" />
+            <journal-directory path="activemq-backup/journal" />
+            <large-messages-directory path="activemq-backup/largemessages" />
+            <paging-directory path="activemq-backup/paging" />
+
+            <http-connector name="http-connector-backup"
+                            socket-binding="http"
+                            endpoint="http-acceptor-backup" />
+            <http-acceptor name="http-acceptor-backup"
+                           http-listener="default" />
+
+            <broadcast-group name="bg-group1"
+                             connectors="http-connector-backup"
+                             jgroups-channel="activemq-cluster"/>
+
+            <discovery-group name="dg-group1"
+                             jgroups-channel="activemq-cluster"/>
+
+            <cluster-connection name="my-cluster"
+                                address="jms"
+                                connector-name="http-connector-backup"
+                                discovery-group="dg-group1" />
+        </server>
+    </subsystem>
+</config>

--- a/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
+++ b/testsuite/integration/manualmode/src/test/java/org/jboss/as/test/manualmode/parse/ParseAndMarshalModelsTestCase.java
@@ -95,6 +95,11 @@ public class ParseAndMarshalModelsTestCase {
     }
 
     @Test
+    public void testStandaloneActiveMQColocatedXml() throws Exception {
+        standaloneXmlTest(getDocsExampleConfigFile("standalone-activemq-colocated.xml"));
+    }
+
+    @Test
     public void testJBossASStandaloneXml() throws Exception {
         for (String version : AS_VERSIONS) {
             ModelNode model = standaloneXmlTest(getLegacyConfigFile("standalone", version + ".xml"));


### PR DESCRIPTION
Add a configuration example for having 2 Artemis server in a single
WildFly server. One (default) is a live server and the other
(backup-server) is the backup of _another_ live server.

JIRA: https://issues.jboss.org/browse/WFLY-5096
