### PR TITLE
[WFLY-5019] JMSTopicManagementTestCase intermittent failure

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSTopicManagementTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/messaging/mgmt/JMSTopicManagementTestCase.java
@@ -27,7 +27,6 @@ import static org.jboss.as.controller.client.helpers.ClientConstants.NAME;
 import static org.jboss.as.controller.client.helpers.ClientConstants.VALUE;
 import static org.jboss.as.controller.client.helpers.ClientConstants.WRITE_ATTRIBUTE_OPERATION;
 import static org.jboss.as.controller.operations.common.Util.getEmptyOperation;
-import static org.jboss.as.test.shared.IntermittentFailure.thisTestIsFailingIntermittently;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -399,8 +398,6 @@ public class JMSTopicManagementTestCase {
 
     @Test
     public void removeJMSTopicRemovesAllMessages() throws Exception {
-
-        thisTestIsFailingIntermittently("WFLY-5019");
 
         // create a durable subscriber
         final String subscriptionName = "removeJMSTopicRemovesAllMessages";


### PR DESCRIPTION
Reenable the removeJMSTopicRemovesAllMessages test after underlying
Artemis issue ARTEMIS-177 has been fixed

JIRA: https://issues.jboss.org/browse/WFLY-5019
