### PR TITLE
[WFLY-6504] Fix messaging migration warnings

### DIFF
--- a/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
+++ b/legacy/messaging/src/main/java/org/jboss/as/messaging/logging/MessagingLogger.java
@@ -803,7 +803,7 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 79, value = "The migrate operation can not be performed: the server must be in admin-only mode")
     OperationFailedException migrateOperationAllowedOnlyInAdminOnly();
 
-    @Message(id = 80, value = "Can not migrate attribute %s from resource %s. Use instead the socket-binding attribute to configure this broadcast-group.")
+    @Message(id = 80, value = "Can not migrate attribute %s to resource %s. Use instead the socket-binding attribute to configure this broadcast-group.")
     String couldNotMigrateBroadcastGroupAttribute(String attribute, PathAddress address);
 
     @Message(id = 81, value = "Migration failed, see results for more details.")
@@ -815,18 +815,18 @@ public interface MessagingLogger extends BasicLogger {
     @Message(id = 83, value = "Can not migrate the HA configuration of %s. Its shared-store and backup attributes holds expressions and it is not possible to determine unambiguously how to create the corresponding ha-policy for the messaging-activemq's server.")
     String couldNotMigrateHA(PathAddress address);
 
-    @Message(id = 84, value = "Can not migrate attribute %s from resource %s. Use instead the socket-binding attribute to configure this discovery-group.")
+    @Message(id = 84, value = "Can not migrate attribute %s to resource %s. Use instead the socket-binding attribute to configure this discovery-group.")
     String couldNotMigrateDiscoveryGroupAttribute(String attribute, PathAddress address);
 
     @Message(id = 85, value = "Can not create a legacy-connection-factory based on connection-factory %s. It uses a HornetQ in-vm connector that is not compatible with Artemis in-vm connector ")
     String couldNotCreateLegacyConnectionFactoryUsingInVMConnector(PathAddress address);
 
-    @Message(id = 86, value = "Can not migrate attribute %s from resource %s. The attribute uses an expression that can be resolved differently depending on system properties. After migration, this attribute must be added back with an actual value instead of the expression.")
+    @Message(id = 86, value = "Can not migrate attribute %s to resource %s. The attribute uses an expression that can be resolved differently depending on system properties. After migration, this attribute must be added back with an actual value instead of the expression.")
     String couldNotMigrateResourceAttributeWithExpression(String attribute, PathAddress address);
 
-    @Message(id = 87, value = "Can not migrate attribute %s from resource %s. This attribute is not supported by the new messaging-activemq subsystem.")
+    @Message(id = 87, value = "Can not migrate attribute %s to resource %s. This attribute is not supported by the new messaging-activemq subsystem.")
     String couldNotMigrateUnsupportedAttribute(String attribute, PathAddress address);
 
-    @Message(id = 88, value = "Can not migrate attribute failback-delay from resource %s. Artemis detects failback deterministically and it no longer requires to specify a delay for failback to occur.")
+    @Message(id = 88, value = "Can not migrate attribute failback-delay to resource %s. Artemis detects failback deterministically and it no longer requires to specify a delay for failback to occur.")
     String couldNotMigrateFailbackDelayAttribute(PathAddress address);
 }


### PR DESCRIPTION
Clarify migration warnings to emphasis whether something can not be
migrated _from_ a legacy resource or _to_ a new resource.

JIRA: https://issues.jboss.org/browse/WFLY-6504
