### PR TITLE
[WFLY-6509] Increase the default forked timeout for clustering module

### DIFF
--- a/testsuite/integration/clustering/pom.xml
+++ b/testsuite/integration/clustering/pom.xml
@@ -21,6 +21,7 @@
         <jbossas.ts.integ.dir>${basedir}/..</jbossas.ts.integ.dir>
         <jbossas.ts.dir>${jbossas.ts.integ.dir}/..</jbossas.ts.dir>
         <jbossas.project.dir>${jbossas.ts.dir}/..</jbossas.project.dir>
+        <surefire.forked.process.timeout>3600</surefire.forked.process.timeout>
     </properties>
 
     <profiles>


### PR DESCRIPTION
- Clustering testsuite module fails on slower machines with "There was a timeout or other error in the fork"
- This PR increases timeout for clustering module
  Jira: https://issues.jboss.org/browse/WFLY-6509
