### PR TITLE
WFLY-6517 export JndiPermission out of org.wildfly.naming module + fi…

### DIFF
--- a/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/naming/main/module.xml
+++ b/servlet-feature-pack/src/main/resources/modules/system/layers/base/org/wildfly/naming/main/module.xml
@@ -28,7 +28,7 @@
     </properties>
 
     <dependencies>
-        <module name="org.jboss.as.naming">
+        <module name="org.jboss.as.naming" export="true">
             <imports>
                 <include-set>
                     <path name="org/wildfly/naming/java/permission"/>

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/MultipleClientRemoteJndiTestCase.java
@@ -77,8 +77,6 @@ public class MultipleClientRemoteJndiTestCase {
         return ShrinkWrap.create(WebArchive.class, "binder.war")
                 .addClasses(BindRmiServlet.class, MyObject.class)
                 .setWebXML(MultipleClientRemoteJndiTestCase.class.getPackage(), "web.xml")
-                // dependency to org.jboss.as.naming module is used to grant JndiPermission
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
                 // BindRmiServlet binds java:jboss/exported/loc/stub
                 .addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("java:jboss/exported/loc/stub", "bind")),
                         "permissions.xml");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/multiple/NestedRemoteContextTestCase.java
@@ -66,8 +66,6 @@ public class NestedRemoteContextTestCase {
         return ShrinkWrap.create(WebArchive.class, "binder.war")
                 .addClasses(BindRmiServlet.class, MyObject.class)
                 .setWebXML(MultipleClientRemoteJndiTestCase.class.getPackage(), "web.xml")
-                // dependency to org.jboss.as.naming module is used to grant JndiPermission
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
                 // BindRmiServlet binds java:jboss/exported/loc/stub
                 .addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("java:jboss/exported/loc/stub", "bind")),
                         "permissions.xml");

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/naming/remote/simple/RemoteNamingTestCase.java
@@ -59,8 +59,6 @@ public class RemoteNamingTestCase {
     public static Archive<?> deploy() {
         final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, "test.jar")
                 .addClasses(BindingEjb.class)
-                // dependency to org.jboss.as.naming module is used to grant JndiPermission
-                .addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming\n"), "MANIFEST.MF")
                 // BindingEjb binds java:jboss/exported/test and java:jboss/exported/context/test
                 .addAsManifestResource(createPermissionsXmlAsset(
                         new JndiPermission("java:jboss/exported/test", "bind"),

--- a/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/lifecycle/ServletLifecycleMethodDescriptorTestCase.java
+++ b/testsuite/integration/web/src/test/java/org/jboss/as/test/integration/web/servlet/lifecycle/ServletLifecycleMethodDescriptorTestCase.java
@@ -53,7 +53,6 @@ public class ServletLifecycleMethodDescriptorTestCase {
         WebArchive war = ShrinkWrap.create(WebArchive.class, "single.war");
         war.addClasses(HttpRequest.class, LifeCycleMethodServlet.class);
         war.addAsWebInfResource(ServletLifecycleMethodDescriptorTestCase.class.getPackage(), "web.xml", "web.xml");
-        war.addAsManifestResource(new StringAsset("Dependencies: org.jboss.as.naming meta-inf\n"), "MANIFEST.MF");
         war.addAsManifestResource(createPermissionsXmlAsset(new JndiPermission("java:global/env/foo", "bind")), "permissions.xml");
         return war;
     }


### PR DESCRIPTION
…x testcases which still depend on org.jboss.as.naming

https://issues.jboss.org/browse/WFLY-6517
