### PR TITLE
[WFLY-5286] Add runtime-journal-type attribute

### DIFF
--- a/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
+++ b/messaging-activemq/src/main/resources/org/wildfly/extension/messaging/activemq/LocalDescriptions.properties
@@ -424,6 +424,7 @@ server.rollback-prepared-transaction.reply=True if the transaction was successfu
 server.rollback-prepared-transaction.transaction-as-base-64=The Base64 representation of a transaction XID.
 server.rollback-prepared-transaction=Heuristically rolls back a prepared transaction.
 server.run-sync-speed-test=Whether on startup to perform a diagnostic test on how fast your disk can sync. Useful when determining performance issues.
+server.runtime-journal-type=The actual ype of journal used by ActiveMQ at runtime (if the journal-type is not supported by the underlying file system, ActiveMQ will override the configuration and use NIO).
 server.scheduled-thread-pool-max-size=The number of threads that the main scheduled thread pool has.
 server.security-domain=The security domain to use to verify user and role information
 server.security-enabled=Whether security is enabled.


### PR DESCRIPTION
The runtime-journal-type attribute returns the _actual_ journal type
attribute used at runtime by ActiveMQ if the configured journal-type is
not supported (e.g. the OS is not Linux or libAIO is not installed).

Example Output:

```
[standalone@localhost:9990 /]
/subsystem=messaging-activemq/server=default:read-resource(include-runtime=true)
{
    "outcome" => "success",
    "result" => {
        ...
        "journal-type" => "ASYNCIO",
        "runtime-journal-type" => "NIO",
    }
}
```

JIRA: https://issues.jboss.org/browse/WFLY-5286
