### PR TITLE
[WFLY-6531] Unsupported is not a valid module classification upstream…

### DIFF
--- a/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/io/undertow/js/main/module.xml
@@ -23,6 +23,9 @@
   -->
 
 <module xmlns="urn:jboss:module:1.3" name="io.undertow.js">
+    <properties>
+        <property name="jboss.api" value="private"/>
+    </properties>
 
     <resources>
         <artifact name="${io.undertow.js:undertow-js}"/>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/jgroups/azure/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/jgroups/azure/main/module.xml
@@ -25,7 +25,7 @@
 <module xmlns="urn:jboss:module:1.3" name="org.jgroups.azure">
 
     <properties>
-        <property name="jboss.api" value="unsupported"/>
+        <property name="jboss.api" value="private"/>
     </properties>
 
     <resources>


### PR DESCRIPTION
…. Use private instead

https://issues.jboss.org/browse/WFLY-6531
