### PR TITLE
[JBQA-12586] added integration testcase for checking how Container and EJB Client behave when exception is thrown

### DIFF
--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TestConfig.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TestConfig.java
@@ -1,0 +1,86 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception;
+
+/**
+ * Represents configuration for one particular test method.
+ * 
+ * @author dsimko@redhat.com
+ */
+public class TestConfig {
+
+    @FunctionalInterface
+    public static interface EjbMethod {
+        void invoke(TxManagerException txManagerException) throws Exception;
+    }
+
+    public static enum EjbType {
+        EJB2, EJB3
+    }
+
+    public static enum TxContext {
+        RUN_IN_TX_STARTED_BY_CALLER, START_CONTAINER_MANAGED_TX, START_BEAN_MANAGED_TX
+    }
+
+    public static enum TxManagerException {
+        NONE, HEURISTIC_CAUSED_BY_XA_EXCEPTION, HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION, ROLLBACK_CAUSED_BY_XA_EXCEPTION, ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION
+    }
+
+    private final EjbType ejbType;
+    private final TxContext txContext;
+    private final EjbMethod action;
+    private final TxManagerException tmException;
+
+    public TestConfig(EjbType ejbType, TxContext txContext, EjbMethod action) {
+        this(ejbType, txContext, action, TxManagerException.NONE);
+    }
+
+    public TestConfig(EjbType ejbType, TxContext txContext, EjbMethod action, TxManagerException txManagerException) {
+        this.ejbType = ejbType;
+        this.txContext = txContext;
+        this.action = action;
+        this.tmException = txManagerException;
+    }
+
+    public EjbType getEjbType() {
+        return ejbType;
+    }
+
+    public TxContext getTxContext() {
+        return txContext;
+    }
+
+    public EjbMethod getEjbMethod() {
+        return action;
+    }
+
+    public TxManagerException getTxManagerException() {
+        return tmException;
+    }
+
+    @Override
+    public String toString() {
+        return "TestConfig [ejbType=" + ejbType + ", txContext=" + txContext + ", action=" + action + ", tmException=" + tmException + "]";
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TestXAResource.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TestXAResource.java
@@ -1,0 +1,169 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2016, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception;
+
+import java.lang.reflect.Constructor;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+import org.jboss.logging.Logger;
+
+import javassist.ClassPool;
+import javassist.CtClass;
+
+/**
+ * Implementation of XAResource for use in tests.
+ * 
+ * @author dsimko@redhat.com
+ */
+public class TestXAResource implements XAResource {
+
+    private static Logger LOG = Logger.getLogger(TestXAResource.class);
+    private static XAException RM_SPECIFIC_EXCEPTION = createDriverSpecificXAException(XAException.XAER_RMERR);
+
+    public static enum CommitOperation {
+        NONE, THROW_KNOWN_XA_EXCEPTION, THROW_UNKNOWN_XA_EXCEPTION
+    }
+
+    public static enum PrepareOperation {
+        NONE, THROW_KNOWN_XA_EXCEPTION, THROW_UNKNOWN_XA_EXCEPTION
+    }
+
+    private CommitOperation commitOp = CommitOperation.NONE;
+    private PrepareOperation prepareOp = PrepareOperation.NONE;
+
+    public TestXAResource(CommitOperation commitOp) {
+        this.commitOp = commitOp;
+    }
+
+    public TestXAResource(PrepareOperation prepOp) {
+        this.prepareOp = prepOp;
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        LOG.infof("commit xid:[%s], %s one phase", xid, onePhase ? "with" : "without");
+
+        switch (commitOp) {
+        case THROW_KNOWN_XA_EXCEPTION:
+            throw new XAException(XAException.XAER_RMERR);
+        case THROW_UNKNOWN_XA_EXCEPTION:
+            throw RM_SPECIFIC_EXCEPTION;
+        case NONE:
+        default:
+            // do nothing
+        }
+    }
+
+    @Override
+    public void end(Xid xid, int flags) throws XAException {
+        LOG.infof("end xid:[%s], flag: %s", xid, flags);
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        LOG.infof("forget xid:[%s]", xid);
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        LOG.infof("getTransactionTimeout: returning timeout: %s", 0);
+        return 0;
+    }
+
+    @Override
+    public boolean isSameRM(XAResource xares) throws XAException {
+        LOG.infof("isSameRM returning false to xares: %s", xares);
+        return false;
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        LOG.infof("prepare xid: [%s]", xid);
+        switch (prepareOp) {
+        case THROW_KNOWN_XA_EXCEPTION:
+            throw new XAException(XAException.XAER_RMERR);
+        case THROW_UNKNOWN_XA_EXCEPTION:
+            throw RM_SPECIFIC_EXCEPTION;
+        case NONE:
+        default:
+            return XAResource.XA_OK;
+        }
+    }
+
+    @Override
+    public Xid[] recover(int flag) throws XAException {
+        LOG.infof("recover with flags: %s", flag);
+        return new Xid[] {};
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        LOG.infof("rollback xid: [%s]", xid);
+
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int seconds) throws XAException {
+        LOG.infof("setTransactionTimeout: setting timeout: %s", seconds);
+        return true;
+    }
+
+    @Override
+    public void start(Xid xid, int flags) throws XAException {
+        LOG.infof("start xid: [%s], flags: %s", xid, flags);
+    }
+
+    /**
+     * Creates instance of dynamically created XAException class.
+     */
+    private static XAException createDriverSpecificXAException(int xaErrorCode) {
+        try {
+            return createInstanceOfDriverSpecificXAException(xaErrorCode, createXATestExceptionClass());
+        } catch (Exception e) {
+            LOG.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Creates new instance of given class.
+     */
+    private static XAException createInstanceOfDriverSpecificXAException(int xaErrorCode, Class<?> clazz) throws Exception {
+        Constructor<?> constructor = clazz.getDeclaredConstructor(int.class);
+        constructor.setAccessible(true);
+        return (XAException) constructor.newInstance(xaErrorCode);
+    }
+
+    /**
+     * Creates new public class named org.jboss.as.test.XATestException.
+     */
+    private static Class<?> createXATestExceptionClass() throws Exception {
+        ClassPool pool = ClassPool.getDefault();
+        CtClass evalClass = pool.makeClass("org.jboss.as.test.XATestException", pool.get("javax.transaction.xa.XAException"));
+        return evalClass.toClass();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionBaseTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionBaseTestCase.java
@@ -1,0 +1,186 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception;
+
+import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.EjbType.EJB2;
+import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.EjbType.EJB3;
+import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxContext.RUN_IN_TX_STARTED_BY_CALLER;
+import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxContext.START_BEAN_MANAGED_TX;
+import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxContext.START_CONTAINER_MANAGED_TX;
+import static org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException.*;
+
+import java.rmi.RemoteException;
+
+import javax.transaction.Status;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
+import org.jboss.logging.Logger;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Base class for testing whether client gets exceptions according to the
+ * specification.
+ * 
+ * @author dsimko@redhat.com
+ */
+public abstract class TxExceptionBaseTestCase {
+
+    private static Logger LOG = Logger.getLogger(TxExceptionBaseTestCase.class);
+
+    protected static final String APP_NAME = "tx-exception-test";
+    protected static final String MODULE_NAME = "ejb";
+
+    @Deployment
+    public static Archive<?> createDeployment() {
+        final EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, APP_NAME + ".ear");
+        final JavaArchive jar = ShrinkWrap.create(JavaArchive.class, MODULE_NAME + ".jar");
+        jar.addPackages(true, TxExceptionBaseTestCase.class.getPackage());
+        jar.addPackages(true, "javassist");
+        ear.addAsModule(jar);
+        return ear;
+    }
+
+    @Test
+    public void exceptionThrownFromEjb2WhichRunsInTxStartedByCaller() throws Exception {
+        runTest(new TestConfig(EJB2, RUN_IN_TX_STARTED_BY_CALLER, tmEx -> throwExceptionFromCmtEjb2()));
+    }
+
+    @Test
+    public void exceptionThrownFromEjb3WhichRunsInTxStartedByCaller() throws Exception {
+        runTest(new TestConfig(EJB3, RUN_IN_TX_STARTED_BY_CALLER, tmEx -> throwExceptionFromCmtEjb3()));
+    }
+
+    @Test
+    public void exceptionThrownFromEjb2WhichStartsContainerManagedTx() throws Exception {
+        runTest(new TestConfig(EJB2, START_CONTAINER_MANAGED_TX, tmEx -> throwExceptionFromCmtEjb2()));
+    }
+
+    @Test
+    public void exceptionThrownFromEjb3WhichStartsContainerManagedTx() throws Exception {
+        runTest(new TestConfig(EJB3, START_CONTAINER_MANAGED_TX, tmEx -> throwExceptionFromCmtEjb3()));
+    }
+
+    @Test
+    public void exceptionThrownFromEjb2WhichStartsBeanManagedTx() throws Exception {
+        runTest(new TestConfig(EJB2, START_BEAN_MANAGED_TX, tmEx -> throwExceptionFromBmtEjb2()));
+    }
+
+    @Test
+    public void exceptionThrownFromEjb3WhichStartsBeanManagedTx() throws Exception {
+        runTest(new TestConfig(EJB3, START_BEAN_MANAGED_TX, tmEx -> throwExceptionFromBmtEjb3()));
+    }
+
+    @Test
+    public void heuristicExceptionThrownFromTmInCallerTx() throws Exception {
+        runTest(new TestConfig(EJB3, RUN_IN_TX_STARTED_BY_CALLER, tmEx -> throwExceptionFromTm(tmEx), HEURISTIC_CAUSED_BY_XA_EXCEPTION));
+    }
+
+    @Test
+    public void heuristicExceptionWithSpecificCauseThrownFromTmInCallerTx() throws Exception {
+        runTest(new TestConfig(EJB3, RUN_IN_TX_STARTED_BY_CALLER, tmEx -> throwExceptionFromTm(tmEx), HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION));
+    }
+
+    @Test
+    public void heuristicExceptionThrownFromTm() throws Exception {
+        runTest(new TestConfig(EJB3, START_CONTAINER_MANAGED_TX, tmEx -> throwExceptionFromTm(tmEx), HEURISTIC_CAUSED_BY_XA_EXCEPTION));
+    }
+
+    @Test
+    public void heuristicExceptionWithSpecificCauseThrownFromTm() throws Exception {
+        runTest(new TestConfig(EJB3, START_CONTAINER_MANAGED_TX, tmEx -> throwExceptionFromTm(tmEx), HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION));
+    }
+
+    @Test
+    public void rollbackExceptionThrownFromTm() throws Exception {
+        runTest(new TestConfig(EJB3, START_CONTAINER_MANAGED_TX, tmEx -> throwExceptionFromTm(tmEx), ROLLBACK_CAUSED_BY_XA_EXCEPTION));
+    }
+
+    @Test
+    public void rollbackExceptionWithSpecificCauseThrownFromTm() throws Exception {
+        runTest(new TestConfig(EJB3, START_CONTAINER_MANAGED_TX, tmEx -> throwExceptionFromTm(tmEx), ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION));
+    }
+
+    @Test
+    public void rollbackExceptionThrownFromTmInCallerTx() throws Exception {
+        runTest(new TestConfig(EJB3, RUN_IN_TX_STARTED_BY_CALLER, tmEx -> throwExceptionFromTm(tmEx), ROLLBACK_CAUSED_BY_XA_EXCEPTION));
+    }
+
+    @Test
+    public void rollbackExceptionWithSpecificCauseThrownFromTmInCallerTx() throws Exception {
+        runTest(new TestConfig(EJB3, RUN_IN_TX_STARTED_BY_CALLER, tmEx -> throwExceptionFromTm(tmEx), ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION));
+    }
+
+    private void runTest(TestConfig testType) throws Exception {
+        final UserTransaction userTransaction = getUserTransaction();
+        try {
+            if (testType.getTxContext() == RUN_IN_TX_STARTED_BY_CALLER) {
+                checkAndCleanTx(userTransaction);
+                userTransaction.begin();
+            }
+
+            testType.getEjbMethod().invoke(testType.getTxManagerException());
+
+            if (testType.getTxContext() == RUN_IN_TX_STARTED_BY_CALLER && testType.getTxManagerException() != NONE) {
+                userTransaction.commit();
+            }
+            Assert.fail("An exception was expected.");
+        } catch (Exception e) {
+            LOG.infof(e, "Received exception: %s. Test type %s", e.getClass(), testType);
+            checkReceivedException(testType, e);
+        } finally {
+            if (testType.getTxContext() == RUN_IN_TX_STARTED_BY_CALLER && testType.getTxManagerException() == NONE) {
+                userTransaction.rollback();
+            }
+        }
+    }
+
+    private void checkAndCleanTx(UserTransaction userTransaction) throws SystemException {
+        LOG.infof("UserTransaction status is %s.", userTransaction.getStatus());
+        if(userTransaction.getStatus() != Status.STATUS_NO_TRANSACTION){
+            userTransaction.rollback();
+        }
+    }
+
+    protected abstract UserTransaction getUserTransaction();
+
+    protected abstract void throwExceptionFromCmtEjb2() throws RemoteException;
+
+    protected abstract void throwExceptionFromCmtEjb3();
+
+    protected abstract void throwExceptionFromBmtEjb2() throws RemoteException;
+
+    protected abstract void throwExceptionFromBmtEjb3();
+
+    protected abstract void throwExceptionFromTm(TxManagerException txManagerException) throws Exception;
+
+    protected abstract void checkReceivedException(TestConfig testType, Exception receivedException);
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionEjbClientTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionEjbClientTestCase.java
@@ -1,0 +1,168 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import java.rmi.RemoteException;
+
+import javax.transaction.UserTransaction;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.as.test.integration.ejb.remote.common.EJBManagementUtil;
+import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.TestBean;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2.BmtEjb2;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2.CmtEjb2;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2.TestBean2Remote;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb3.BmtEjb3;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb3.CmtEjb3;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientTransactionContext;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that EJB client propagates appropriate exceptions.
+ * 
+ * @author dsimko@redhat.com
+ */
+@RunAsClient
+@RunWith(Arquillian.class)
+public class TxExceptionEjbClientTestCase extends TxExceptionBaseTestCase {
+
+    private static String nodeName;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        nodeName = EJBManagementUtil.getNodeName();
+    }
+    
+    /**
+     * Create and setup the EJB client context backed by the remoting receiver
+     */
+    @Before
+    public void beforeTest() throws Exception {
+        final EJBClientTransactionContext localUserTxContext = EJBClientTransactionContext.createLocal();
+        EJBClientTransactionContext.setGlobalContext(localUserTxContext);
+    }
+
+    @Override
+    protected void checkReceivedException(TestConfig testCnf, Exception receivedEx) {
+        switch (testCnf.getTxContext()) {
+        case RUN_IN_TX_STARTED_BY_CALLER:
+            switch (testCnf.getTxManagerException()) {
+            case NONE:
+                switch (testCnf.getEjbType()) {
+                case EJB2:
+                    assertThat(receivedEx.getClass(), equalTo(javax.transaction.TransactionRolledbackException.class));
+                    break;
+                case EJB3:
+                    assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBTransactionRolledbackException.class));
+                    break;
+                }
+                break;
+            case HEURISTIC_CAUSED_BY_XA_EXCEPTION:
+            case HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                // FIXME JBEAP-3665
+                // assertThat("HeuristicMixedException should be thrown.", receivedEx.getClass(), equalTo(javax.transaction.HeuristicMixedException.class));
+                // break;
+            case ROLLBACK_CAUSED_BY_XA_EXCEPTION:
+            case ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                // FIXME JBEAP-3665
+                // assertThat("RollbackException should be thrown.", receivedEx.getClass(), equalTo(javax.transaction.RollbackException.class));
+                assertThat(receivedEx.getClass(), equalTo(javax.transaction.SystemException.class));
+                break;
+            }
+            break;
+        case START_CONTAINER_MANAGED_TX:
+        case START_BEAN_MANAGED_TX:
+            switch (testCnf.getTxManagerException()) {
+            case NONE:
+                switch (testCnf.getEjbType()) {
+                case EJB2:
+                    assertThat(receivedEx.getClass(), equalTo(java.rmi.RemoteException.class));
+                    break;
+                case EJB3:
+                    assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBException.class));
+                    break;
+                }
+                break;
+            case HEURISTIC_CAUSED_BY_XA_EXCEPTION:
+                assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBException.class));
+                assertThat(receivedEx.getCause().getClass(), equalTo(javax.transaction.HeuristicMixedException.class));
+                break;
+            case HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                // FIXME JBEAP-165
+                // assertThat("EJBException should be thrown.", receivedEx.getClass(), equalTo(javax.ejb.EJBException.class));
+                // assertThat("HeuristicMixedException should be cause.", receivedEx.getCause().getClass(), equalTo(javax.transaction.HeuristicMixedException.class));
+                assertThat(receivedEx.getClass(), equalTo(java.lang.ClassNotFoundException.class));
+                break;
+            case ROLLBACK_CAUSED_BY_XA_EXCEPTION:
+            case ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBTransactionRolledbackException.class));
+                assertThat(receivedEx.getCause().getClass(), equalTo(javax.transaction.RollbackException.class));
+            }
+        }
+    }
+
+    @Override
+    protected UserTransaction getUserTransaction() {
+        return EJBClient.getUserTransaction(nodeName);
+    }
+
+    @Override
+    protected void throwExceptionFromCmtEjb2() throws RemoteException {
+        getBean(TestBean2Remote.class, CmtEjb2.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromCmtEjb3() {
+        getBean(TestBean.class, CmtEjb3.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromBmtEjb2() throws RemoteException {
+        getBean(TestBean2Remote.class, BmtEjb2.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromBmtEjb3() {
+        getBean(TestBean.class, BmtEjb3.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromTm(TxManagerException txManagerException) throws Exception {
+        getBean(TestBean.class, CmtEjb3.class.getSimpleName()).throwExceptionFromTm(txManagerException);
+    }
+
+    private <T> T getBean(Class<T> viewType, String beanName) {
+        final StatelessEJBLocator<T> remoteBeanLocator = new StatelessEJBLocator<T>(viewType, APP_NAME, MODULE_NAME, beanName, "");
+        return EJBClient.createProxy(remoteBeanLocator);
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionTestCase.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/TxExceptionTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+import javax.naming.InitialContext;
+import javax.naming.NamingException;
+import javax.transaction.UserTransaction;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.TestBean;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2.BmtEjb2;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2.CmtEjb2;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2.TestBean2Local;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb3.BmtEjb3;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb3.CmtEjb3;
+import org.junit.runner.RunWith;
+
+/**
+ * Tests that container behaves according to the specification when exception is
+ * thrown.
+ * 
+ * @author dsimko@redhat.com
+ */
+@RunWith(Arquillian.class)
+public class TxExceptionTestCase extends TxExceptionBaseTestCase {
+
+    @ArquillianResource
+    protected InitialContext iniCtx;
+
+    @Inject
+    private UserTransaction userTransaction;
+
+    @Override
+    protected void checkReceivedException(TestConfig testCnf, Exception receivedEx) {
+        switch (testCnf.getTxContext()) {
+        case RUN_IN_TX_STARTED_BY_CALLER:
+            switch (testCnf.getTxManagerException()) {
+            case NONE:
+                switch (testCnf.getEjbType()) {
+                case EJB2:
+                    assertThat(receivedEx.getClass(), equalTo(javax.ejb.TransactionRolledbackLocalException.class));
+                    break;
+                case EJB3:
+                    assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBTransactionRolledbackException.class));
+                    break;
+                }
+                break;
+            case HEURISTIC_CAUSED_BY_XA_EXCEPTION:
+            case HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                assertThat(receivedEx.getClass(), equalTo(javax.transaction.HeuristicMixedException.class));
+                break;
+            case ROLLBACK_CAUSED_BY_XA_EXCEPTION:
+            case ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                assertThat(receivedEx.getClass(), equalTo(javax.transaction.RollbackException.class));
+                break;
+            }
+            break;
+        case START_CONTAINER_MANAGED_TX:
+        case START_BEAN_MANAGED_TX:
+            switch (testCnf.getTxManagerException()) {
+            case NONE:
+                assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBException.class));
+                break;
+            case HEURISTIC_CAUSED_BY_XA_EXCEPTION:
+            case HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBException.class));
+                assertThat(receivedEx.getCause().getClass(), equalTo(javax.transaction.HeuristicMixedException.class));
+                break;
+            case ROLLBACK_CAUSED_BY_XA_EXCEPTION:
+            case ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+                assertThat(receivedEx.getClass(), equalTo(javax.ejb.EJBTransactionRolledbackException.class));
+                assertThat(receivedEx.getCause().getClass(), equalTo(javax.transaction.RollbackException.class));
+            }
+        }
+    }
+
+    @Override
+    protected UserTransaction getUserTransaction() {
+        return userTransaction;
+    }
+
+    @Override
+    protected void throwExceptionFromCmtEjb2() {
+        getBean(TestBean2Local.class, CmtEjb2.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromCmtEjb3() {
+        getBean(TestBean.class, CmtEjb3.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromBmtEjb2() {
+        getBean(TestBean2Local.class, BmtEjb2.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromBmtEjb3() {
+        getBean(TestBean.class, BmtEjb3.class.getSimpleName()).throwRuntimeException();
+    }
+
+    @Override
+    protected void throwExceptionFromTm(TxManagerException txManagerException) throws Exception {
+        getBean(TestBean.class, CmtEjb3.class.getSimpleName()).throwExceptionFromTm(txManagerException);
+    }
+
+    private <T> T getBean(Class<T> viewType, String beanName) {
+        try {
+            return viewType.cast(iniCtx.lookup("java:global/" + APP_NAME + "/" + MODULE_NAME + "/" + beanName + "!" + viewType.getName()));
+        } catch (NamingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/TestBean.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/TestBean.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception.bean;
+
+import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
+
+public interface TestBean {
+
+    void throwRuntimeException();
+
+    void throwExceptionFromTm(TxManagerException txManagerException) throws Exception;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/BmtEjb2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/BmtEjb2.java
@@ -1,0 +1,53 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2;
+
+import javax.annotation.Resource;
+import javax.ejb.Local;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.transaction.NotSupportedException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+@Local(TestBean2Local.class)
+@Remote(TestBean2Remote.class)
+@Stateless
+@TransactionManagement(TransactionManagementType.BEAN)
+public class BmtEjb2 {
+
+    @Resource  
+    private UserTransaction utx;  
+    
+    public void throwRuntimeException() {
+        try {
+            utx.begin();
+            throw new RuntimeException();
+        } catch (NotSupportedException | SystemException e) {
+            throw new IllegalStateException("Can't begin transaction!", e);
+        }
+    }
+    
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/CmtEjb2.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/CmtEjb2.java
@@ -1,0 +1,43 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2;
+
+import javax.annotation.Resource;
+import javax.ejb.Local;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.transaction.TransactionManager;
+
+@Local(TestBean2Local.class)
+@Remote(TestBean2Remote.class)
+@Stateless
+public class CmtEjb2 {
+
+    @Resource(name = "java:jboss/TransactionManager")
+    private TransactionManager tm;
+
+    public void throwRuntimeException() {
+        throw new RuntimeException();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/TestBean2Local.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/TestBean2Local.java
@@ -1,0 +1,30 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2;
+
+import javax.ejb.EJBLocalObject;
+
+public interface TestBean2Local extends EJBLocalObject {
+
+    void throwRuntimeException();
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/TestBean2Remote.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb2/TestBean2Remote.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb2;
+
+import java.rmi.RemoteException;
+
+import javax.ejb.EJBObject;
+
+public interface TestBean2Remote extends EJBObject {
+
+    void throwRuntimeException() throws RemoteException;
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb3/BmtEjb3.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb3/BmtEjb3.java
@@ -1,0 +1,62 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb3;
+
+import javax.annotation.Resource;
+import javax.ejb.LocalBean;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.ejb.TransactionManagement;
+import javax.ejb.TransactionManagementType;
+import javax.transaction.NotSupportedException;
+import javax.transaction.SystemException;
+import javax.transaction.UserTransaction;
+
+import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.TestBean;
+
+@LocalBean
+@Remote
+@Stateless
+@TransactionManagement(TransactionManagementType.BEAN)
+public class BmtEjb3 implements TestBean {
+
+    @Resource  
+    private UserTransaction utx;  
+    
+    @Override
+    public void throwRuntimeException() {
+        try {
+            utx.begin();
+            throw new RuntimeException();
+        } catch (NotSupportedException | SystemException e) {
+            throw new IllegalStateException("Can't begin transaction!", e);
+        }
+    }
+    
+    @Override
+    public void throwExceptionFromTm(TxManagerException txManagerException) throws Exception {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb3/CmtEjb3.java
+++ b/testsuite/integration/basic/src/test/java/org/jboss/as/test/integration/ejb/transaction/exception/bean/ejb3/CmtEjb3.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2011, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.as.test.integration.ejb.transaction.exception.bean.ejb3;
+
+import javax.annotation.Resource;
+import javax.ejb.LocalBean;
+import javax.ejb.Remote;
+import javax.ejb.Stateless;
+import javax.transaction.Transaction;
+import javax.transaction.TransactionManager;
+
+import org.jboss.as.test.integration.ejb.transaction.exception.TestConfig.TxManagerException;
+import org.jboss.as.test.integration.ejb.transaction.exception.TestXAResource;
+import org.jboss.as.test.integration.ejb.transaction.exception.TestXAResource.CommitOperation;
+import org.jboss.as.test.integration.ejb.transaction.exception.TestXAResource.PrepareOperation;
+import org.jboss.as.test.integration.ejb.transaction.exception.bean.TestBean;
+
+@LocalBean
+@Remote
+@Stateless
+public class CmtEjb3 implements TestBean {
+
+    @Resource(name = "java:jboss/TransactionManager")
+    private TransactionManager tm;
+
+    @Override
+    public void throwRuntimeException() {
+        throw new RuntimeException();
+    }
+    
+    @Override
+    public void throwExceptionFromTm(TxManagerException txManagerException) throws Exception {
+        Transaction txn = tm.getTransaction();
+        switch (txManagerException) {
+        case HEURISTIC_CAUSED_BY_XA_EXCEPTION:
+            txn.enlistResource(new TestXAResource(CommitOperation.NONE));
+            txn.enlistResource(new TestXAResource(CommitOperation.THROW_KNOWN_XA_EXCEPTION));
+            break;
+        case HEURISTIC_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+            txn.enlistResource(new TestXAResource(CommitOperation.NONE));
+            txn.enlistResource(new TestXAResource(CommitOperation.THROW_UNKNOWN_XA_EXCEPTION));
+            break;
+        case ROLLBACK_CAUSED_BY_XA_EXCEPTION:
+            txn.enlistResource(new TestXAResource(PrepareOperation.NONE));
+            txn.enlistResource(new TestXAResource(PrepareOperation.THROW_KNOWN_XA_EXCEPTION));
+            break;
+        case ROLLBACK_CAUSED_BY_RM_SPECIFIC_XA_EXCEPTION:
+            txn.enlistResource(new TestXAResource(PrepareOperation.NONE));
+            txn.enlistResource(new TestXAResource(PrepareOperation.THROW_UNKNOWN_XA_EXCEPTION));
+            break;
+        default:
+            throw new IllegalArgumentException("Unknown type " + txManagerException);
+        }
+        
+    }
+
+}


### PR DESCRIPTION
The testcase contains various types of scenarios (described here [https://mojo.redhat.com/docs/DOC-1071084](https://mojo.redhat.com/docs/DOC-1071084)) and tests whether client receives appropriate exception (defined by specification).

Contains also reproducer for:

[WFLY-4672 Possible trouble of exception cause during error of 2PC](https://issues.jboss.org/browse/WFLY-4672)
[EJBCLIENT-155 RollbackException is not propagated from remote EJB client](https://issues.jboss.org/browse/EJBCLIENT-155)
