### PR TITLE
[WFLY-5522] Split Artemis journal module

### DIFF
--- a/feature-pack/feature-pack-build.xml
+++ b/feature-pack/feature-pack-build.xml
@@ -127,7 +127,7 @@
         <copy-artifact artifact="org.jboss.seam.integration:jboss-seam-int-jbossas" to-location="modules/system/layers/base/org/jboss/integration/ext-content/main/bundled/jboss-seam-int.jar"/>
         <copy-artifact artifact="org.wildfly:wildfly-client-all" to-location="bin/client/jboss-client.jar"/>
         <copy-artifact artifact="org.wildfly.core:wildfly-cli::client" to-location="bin/client/jboss-cli-client.jar"/>
-        <copy-artifact artifact="org.apache.activemq:artemis-native" to-location="modules/system/layers/base/org/apache/activemq/artemis/main" extract="true" >
+        <copy-artifact artifact="org.apache.activemq:artemis-native" to-location="modules/system/layers/base/org/apache/activemq/artemis/journal/main" extract="true" >
             <filter pattern="lib/*" include="true" />
             <filter pattern="*" include="false"/>
         </copy-artifact>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/journal/main/module.xml
@@ -2,7 +2,7 @@
 
 <!--
   ~ JBoss, Home of Professional Open Source.
-  ~ Copyright 2010, Red Hat, Inc., and individual contributors
+  ~ Copyright 2016, Red Hat, Inc., and individual contributors
   ~ as indicated by the @author tags. See the copyright.txt file in the
   ~ distribution for a full listing of individual contributors.
   ~
@@ -22,30 +22,26 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<module xmlns="urn:jboss:module:1.3" name="org.jboss.jts">
-    <properties>
-        <property name="jboss.api" value="private"/>
-    </properties>
-
+<module xmlns="urn:jboss:module:1.3" name="org.apache.activemq.artemis.journal">
     <resources>
-        <artifact name="${org.jboss.narayana.jts:narayana-jts-idlj}"/>
+        <resource-root path="lib"/>
+        <artifact name="${org.apache.activemq:artemis-commons}"/>
+        <artifact name="${org.apache.activemq:artemis-journal}"/>
+        <artifact name="${org.apache.activemq:artemis-native}"/>
     </resources>
 
     <dependencies>
-        <module name="sun.jdk"/>
-        <module name="org.omg.api" />
-        <module name="org.apache.commons.logging"/>
-        <module name="org.jboss.logging"/>
-        <module name="org.jboss.jts.integration"/>
-        <module name="org.jboss.jboss-transaction-spi"/>
+        <!-- required for ARTEMIS-298 -->
+        <module name="com.google.guava"/>
         <module name="javax.api"/>
-        <module name="javax.transaction.api"/>
-        <module name="javax.resource.api"/>
-        <module name="org.apache.activemq.artemis.journal"/>
-        <module name="javax.orb.api"/>
-        <module name="javax.enterprise.api"/>
-        <module name="org.jboss.weld.core"/>
-        <module name="javax.annotation.api" export="true" />
-        <module name="javax.interceptor.api" export="true" />
+        <module name="org.apache.commons.beanutils" />
+        <!-- the journal module depends on org.apache.activemq.artemis so that
+             Artemis's ClassLoadingUtil (from artemis-commons.jar) can load classes
+              from the org.apache.activemq.artemis module) -->
+        <module name="org.apache.activemq.artemis" />
+        <module name="org.jboss.logging"/>
+        <module name="io.netty"/>
+        <!-- https://issues.jboss.org/browse/AS7-4936  this is to avoid an issue on IBM JDK -->
+        <module name="sun.jdk"/>
     </dependencies>
 </module>

--- a/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
+++ b/feature-pack/src/main/resources/modules/system/layers/base/org/apache/activemq/artemis/main/module.xml
@@ -24,26 +24,21 @@
 
 <module xmlns="urn:jboss:module:1.3" name="org.apache.activemq.artemis">
     <resources>
-        <resource-root path="lib"/>
         <artifact name="${org.apache.activemq:artemis-core-client}"/>
         <artifact name="${org.apache.activemq:artemis-selector}"/>
         <artifact name="${org.apache.activemq:artemis-server}"/>
         <artifact name="${org.apache.activemq:artemis-cli}"/>
-        <artifact name="${org.apache.activemq:artemis-commons}"/>
         <artifact name="${org.apache.activemq:artemis-dto}"/>
         <artifact name="${org.apache.activemq:artemis-hqclient-protocol}"/>
-        <artifact name="${org.apache.activemq:artemis-journal}"/>
         <artifact name="${org.apache.activemq:artemis-jms-client}"/>
         <artifact name="${org.apache.activemq:artemis-jms-server}"/>
-        <artifact name="${org.apache.activemq:artemis-native}"/>
     </resources>
 
     <dependencies>
-        <!-- required for ARTEMIS-298 -->
-        <module name="com.google.guava"/>
         <module name="javax.api"/>
         <module name="javax.jms.api" />
         <module name="org.apache.commons.beanutils" />
+        <module name="org.apache.activemq.artemis.journal" export="true"/>
         <module name="org.jboss.jts"/>
         <module name="org.jboss.logging"/>
         <module name="io.netty"/>


### PR DESCRIPTION
- add org.apache.activemq.artemis.journal that only provides Artemis
  journal (and its native lib)
- depend on this module for org.jboss.jts module

JIRA: https://issues.jboss.org/browse/WFLY-5522
