### PR TITLE
WFLY-6565: Add and remove operation of jaxrs subsystem under deployment are useless and should not be available

### DIFF
--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
@@ -129,7 +129,11 @@ public class JaxrsDeploymentDefinition extends SimpleResourceDefinition {
         private String formatMethod(ResourceMethodInvoker resource, String servletMapping, String path, String contextRootPath) {
             StringBuilder builder = new StringBuilder();
             builder.append("%1$s ");
-            builder.append(contextRootPath).append('/').append(servletMapping.replaceAll("\\*", "")).append(path);
+            String servletPath = servletMapping.replaceAll("\\*", "");
+            if(servletPath.charAt(0) == '/') {
+                servletPath = servletPath.substring(1);
+            }
+            builder.append(contextRootPath).append('/').append(servletPath).append(path);
             builder.append(" - ").append(resource.getResourceClass().getCanonicalName()).append('.').append(resource.getMethod().getName()).append('(');
             if (resource.getMethod().getParameterTypes().length > 0) {
                 builder.append("...");

--- a/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
+++ b/jaxrs/src/main/java/org/jboss/as/jaxrs/JaxrsDeploymentDefinition.java
@@ -46,6 +46,7 @@ import org.jboss.as.controller.SimpleOperationDefinitionBuilder;
 import org.jboss.as.controller.SimpleResourceDefinition;
 import org.jboss.as.controller.descriptions.ModelDescriptionConstants;
 import org.jboss.as.controller.registry.ManagementResourceRegistration;
+import org.jboss.as.controller.registry.OperationEntry;
 import org.jboss.dmr.ModelNode;
 import org.jboss.dmr.ModelType;
 import org.jboss.msc.service.ServiceController;
@@ -65,6 +66,12 @@ public class JaxrsDeploymentDefinition extends SimpleResourceDefinition {
 
     public static final JaxrsDeploymentDefinition DEPLOYMENT_INSTANCE = new JaxrsDeploymentDefinition(true);
     public static final JaxrsDeploymentDefinition SUBSYSTEM_INSTANCE = new JaxrsDeploymentDefinition(false);
+    private static final SimpleOperationDefinition ADD_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.ADD, JaxrsExtension.getResolver())
+                .setEntryType( OperationEntry.EntryType.PRIVATE)
+                .build();
+    private static final SimpleOperationDefinition REMOVE_DEFINITION = new SimpleOperationDefinitionBuilder(ModelDescriptionConstants.REMOVE, JaxrsExtension.getResolver())
+                .setEntryType( OperationEntry.EntryType.PRIVATE)
+                .build();
 
     public static final String SHOW_RESOURCES = "show-resources";
     public static final AttributeDefinition CLASSNAME
@@ -78,16 +85,17 @@ public class JaxrsDeploymentDefinition extends SimpleResourceDefinition {
     public static final ObjectTypeAttributeDefinition JAXRS_RESOURCE
             = new ObjectTypeAttributeDefinition.Builder("jaxrs-resource", CLASSNAME, PATH, METHODS).setStorageRuntime().build();
 
-    private boolean showResources;
+    private final boolean showResources;
     private JaxrsDeploymentDefinition(boolean showResources) {
-         super(JaxrsExtension.SUBSYSTEM_PATH, JaxrsExtension.getResolver(), JaxrsSubsystemAdd.INSTANCE,
-                ReloadRequiredRemoveStepHandler.INSTANCE);
+         super(JaxrsExtension.SUBSYSTEM_PATH, JaxrsExtension.getResolver());
          this.showResources = showResources;
     }
 
     @Override
     public void registerOperations(ManagementResourceRegistration resourceRegistration) {
         super.registerOperations(resourceRegistration);
+        resourceRegistration.registerOperationHandler(ADD_DEFINITION, JaxrsSubsystemAdd.INSTANCE);
+        resourceRegistration.registerOperationHandler(REMOVE_DEFINITION, ReloadRequiredRemoveStepHandler.INSTANCE);
         if(showResources) {
             resourceRegistration.registerOperationHandler(ShowJaxrsResourcesHandler.DEFINITION, new ShowJaxrsResourcesHandler());
         }


### PR DESCRIPTION
Making add and remove operation of jaxrs subsystem private.
Fixing path in resource-methods attribute.

Jira: https://issues.jboss.org/browse/WFLY-6565
        https://issues.jboss.org/browse/WFLY-6564
